### PR TITLE
feat(mcp): 添加工具名称前缀机制解决冲突问题

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -442,8 +442,6 @@ async function restartService(daemon = false): Promise<void> {
   await startService(daemon);
 }
 
-
-
 /**
  * 显示详细信息
  */


### PR DESCRIPTION
- 在 MCPClient 类中添加 originalTools 属性存储原始工具名称
- 实现 generatePrefixedToolName 方法为工具名称添加服务器前缀
- 实现 getOriginalToolName 方法将前缀名称转换回原始名称
- 修改 refreshTools 方法为所有工具生成带前缀的名称
- 更新 callTool 方法支持前缀名称到原始名称的转换
- 增强日志输出显示原始工具名称和前缀工具名称
- 在 MCPServerProxy 中添加工具映射调试日志
- 清理 cli.ts 中的多余空行

这个改动解决了多个 MCP 服务器中工具名称冲突的问题，通过为每个工具添加服务器名称前缀来确保工具名称的唯一性。