### PR TITLE
feat(mcp): 添加 MCP 工具管理功能

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -85,6 +85,12 @@ vi.mock("./configManager.js", () => ({
   },
 }));
 
+vi.mock("./mcpCommands.js", () => ({
+  listMcpServers: vi.fn(),
+  listServerTools: vi.fn(),
+  setToolEnabled: vi.fn(),
+}));
+
 // Mock child process
 class MockChildProcess extends EventEmitter {
   pid = 12345;
@@ -410,6 +416,83 @@ describe("CLI", () => {
     });
   });
 
+  describe("MCP Commands", () => {
+    let mockMcpCommands: any;
+
+    beforeEach(async () => {
+      const mcpCommandsModule = await import("./mcpCommands.js");
+      mockMcpCommands = vi.mocked(mcpCommandsModule);
+    });
+
+    it("should list MCP servers", async () => {
+      mockMcpCommands.listMcpServers.mockResolvedValue(undefined);
+
+      // Test would require access to MCP list command
+      expect(mockMcpCommands.listMcpServers).toBeDefined();
+    });
+
+    it("should list MCP servers with tools", async () => {
+      mockMcpCommands.listMcpServers.mockResolvedValue(undefined);
+
+      // Test would require access to MCP list command with --tools option
+      expect(mockMcpCommands.listMcpServers).toBeDefined();
+    });
+
+    it("should list server tools", async () => {
+      mockMcpCommands.listServerTools.mockResolvedValue(undefined);
+
+      // Test would require access to MCP server command
+      expect(mockMcpCommands.listServerTools).toBeDefined();
+    });
+
+    it("should enable tool", async () => {
+      mockMcpCommands.setToolEnabled.mockResolvedValue(undefined);
+
+      // Test would require access to MCP tool enable command
+      expect(mockMcpCommands.setToolEnabled).toBeDefined();
+    });
+
+    it("should disable tool", async () => {
+      mockMcpCommands.setToolEnabled.mockResolvedValue(undefined);
+
+      // Test would require access to MCP tool disable command
+      expect(mockMcpCommands.setToolEnabled).toBeDefined();
+    });
+
+    it("should handle invalid tool action", () => {
+      // Test would require access to MCP tool command validation
+      const validActions = ["enable", "disable"];
+      const invalidAction = "invalid";
+
+      expect(validActions).not.toContain(invalidAction);
+    });
+  });
+
+  describe("Command Structure", () => {
+    it("should have MCP command group", () => {
+      // Test that MCP commands are properly structured
+      const expectedCommands = [
+        "list",
+        "server <serverName>",
+        "tool <serverName> <toolName> <action>",
+      ];
+
+      expect(expectedCommands).toContain("list");
+      expect(expectedCommands).toContain("server <serverName>");
+      expect(expectedCommands).toContain(
+        "tool <serverName> <toolName> <action>"
+      );
+    });
+
+    it("should validate tool action parameters", () => {
+      const validActions = ["enable", "disable"];
+
+      expect(validActions).toHaveLength(2);
+      expect(validActions).toContain("enable");
+      expect(validActions).toContain("disable");
+    });
+  });
+
   describe("Utility Functions", () => {
     it("should show detailed info", () => {
       // Test would require access to showDetailedInfo function
@@ -421,6 +504,22 @@ describe("CLI", () => {
     it("should show help", () => {
       // Test would require access to showHelp function
       expect(console.log).toBeDefined();
+    });
+
+    it("should include MCP commands in help", () => {
+      // Test that help includes MCP command examples
+      const expectedHelpContent = [
+        "xiaozhi mcp list",
+        "xiaozhi mcp list --tools",
+        "xiaozhi mcp server <name>",
+        "xiaozhi mcp tool <server> <tool> enable",
+        "xiaozhi mcp tool <server> <tool> disable",
+      ];
+
+      expect(expectedHelpContent).toContain("xiaozhi mcp list");
+      expect(expectedHelpContent).toContain(
+        "xiaozhi mcp tool <server> <tool> enable"
+      );
     });
   });
 });

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,6 +8,11 @@ import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
 import { configManager } from "./configManager.js";
+import {
+  listMcpServers,
+  listServerTools,
+  setToolEnabled,
+} from "./mcpCommands.js";
 
 const program = new Command();
 const VERSION = "0.0.1";
@@ -894,6 +899,13 @@ function showHelp(): void {
   console.log("  xiaozhi status               # 检查服务状态");
   console.log("  xiaozhi attach               # 查看后台服务日志");
   console.log("  xiaozhi stop                 # 停止服务");
+  console.log();
+  console.log(chalk.yellow("MCP 管理示例:"));
+  console.log("  xiaozhi mcp list             # 列出所有 MCP 服务");
+  console.log("  xiaozhi mcp list --tools     # 列出所有服务的工具");
+  console.log("  xiaozhi mcp server <name>    # 列出指定服务的工具");
+  console.log("  xiaozhi mcp tool <server> <tool> enable   # 启用工具");
+  console.log("  xiaozhi mcp tool <server> <tool> disable  # 禁用工具");
 }
 
 // 配置 Commander 程序
@@ -968,6 +980,40 @@ program
   .option("-d, --daemon", "在后台运行服务")
   .action(async (options) => {
     await restartService(options.daemon);
+  });
+
+// mcp 命令组
+const mcpCommand = program.command("mcp").description("MCP 服务和工具管理");
+
+// mcp list 命令
+mcpCommand
+  .command("list")
+  .description("列出 MCP 服务")
+  .option("--tools", "显示所有服务的工具列表")
+  .action(async (options) => {
+    await listMcpServers(options);
+  });
+
+// mcp <server> list 命令
+mcpCommand
+  .command("server <serverName>")
+  .description("管理指定的 MCP 服务")
+  .action(async (serverName) => {
+    await listServerTools(serverName);
+  });
+
+// mcp <server> <tool> enable/disable 命令
+mcpCommand
+  .command("tool <serverName> <toolName> <action>")
+  .description("启用或禁用指定服务的工具")
+  .action(async (serverName, toolName, action) => {
+    if (action !== "enable" && action !== "disable") {
+      console.error(chalk.red("错误: 操作必须是 'enable' 或 'disable'"));
+      process.exit(1);
+    }
+
+    const enabled = action === "enable";
+    await setToolEnabled(serverName, toolName, enabled);
   });
 
 // -V 选项 (详细信息)

--- a/src/mcpCommands.test.ts
+++ b/src/mcpCommands.test.ts
@@ -1,0 +1,482 @@
+import chalk from "chalk";
+import ora from "ora";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configManager } from "./configManager.js";
+import {
+  listMcpServers,
+  listServerTools,
+  setToolEnabled,
+} from "./mcpCommands.js";
+
+// Mock dependencies
+vi.mock("chalk", () => ({
+  default: {
+    cyan: vi.fn((text) => text),
+    bold: vi.fn((text) => text),
+    green: vi.fn((text) => text),
+    red: vi.fn((text) => text),
+    yellow: vi.fn((text) => text),
+    gray: vi.fn((text) => text),
+  },
+}));
+
+vi.mock("ora", () => ({
+  default: vi.fn(() => ({
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  })),
+}));
+
+vi.mock("./configManager.js", () => ({
+  configManager: {
+    getMcpServers: vi.fn(),
+    getMcpServerConfig: vi.fn(),
+    getServerToolsConfig: vi.fn(),
+    setToolEnabled: vi.fn(),
+  },
+}));
+
+// Mock console methods
+const mockConsoleLog = vi.spyOn(console, "log").mockImplementation(() => {});
+const mockConsoleError = vi
+  .spyOn(console, "error")
+  .mockImplementation(() => {});
+const mockProcessExit = vi.spyOn(process, "exit").mockImplementation(() => {
+  throw new Error("process.exit called");
+});
+
+describe("mcpCommands", () => {
+  const mockSpinner = {
+    start: vi.fn().mockReturnThis(),
+    succeed: vi.fn().mockReturnThis(),
+    fail: vi.fn().mockReturnThis(),
+    warn: vi.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (ora as any).mockReturnValue(mockSpinner);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("listMcpServers", () => {
+    const mockServers = {
+      calculator: {
+        command: "node",
+        args: ["./mcpServers/calculator.js"],
+      },
+      datetime: {
+        command: "node",
+        args: ["./mcpServers/datetime.js"],
+      },
+    };
+
+    const mockServerConfig = {
+      calculator: {
+        tools: {
+          calculator: {
+            description: "Mathematical calculation tool",
+            enable: true,
+          },
+        },
+      },
+      datetime: {
+        tools: {
+          get_current_time: {
+            description: "Get current time",
+            enable: true,
+          },
+          get_current_date: {
+            description: "Get current date",
+            enable: false,
+          },
+        },
+      },
+    };
+
+    beforeEach(() => {
+      (configManager.getMcpServers as any).mockReturnValue(mockServers);
+      (configManager.getMcpServerConfig as any).mockReturnValue(
+        mockServerConfig
+      );
+      (configManager.getServerToolsConfig as any).mockImplementation(
+        (serverName: string) => {
+          return mockServerConfig[serverName]?.tools || {};
+        }
+      );
+    });
+
+    it("should list servers without tools option", async () => {
+      await listMcpServers();
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith("找到 2 个 MCP 服务");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("MCP 服务列表:")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("calculator")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("datetime")
+      );
+    });
+
+    it("should list servers with tools option", async () => {
+      await listMcpServers({ tools: true });
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith("找到 2 个 MCP 服务");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("MCP 服务工具列表:")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("服务名称")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("工具名称")
+      );
+    });
+
+    it("should handle empty servers list", async () => {
+      (configManager.getMcpServers as any).mockReturnValue({});
+
+      await listMcpServers();
+
+      expect(mockSpinner.warn).toHaveBeenCalledWith("未配置任何 MCP 服务");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("提示: 使用 'xiaozhi config' 命令配置 MCP 服务")
+      );
+    });
+
+    it("should handle servers with no tools", async () => {
+      (configManager.getServerToolsConfig as any).mockReturnValue({});
+
+      await listMcpServers({ tools: true });
+
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("(无工具)")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("请先启动服务扫描工具")
+      );
+    });
+
+    it("should handle errors gracefully", async () => {
+      (configManager.getMcpServers as any).mockImplementation(() => {
+        throw new Error("Config error");
+      });
+
+      await expect(async () => {
+        await listMcpServers();
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith("获取 MCP 服务列表失败");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("错误: Config error")
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("listServerTools", () => {
+    const mockServers = {
+      datetime: {
+        command: "node",
+        args: ["./mcpServers/datetime.js"],
+      },
+    };
+
+    const mockToolsConfig = {
+      get_current_time: {
+        description: "Get current time",
+        enable: true,
+      },
+      get_current_date: {
+        description: "Get current date",
+        enable: false,
+      },
+    };
+
+    beforeEach(() => {
+      (configManager.getMcpServers as any).mockReturnValue(mockServers);
+      (configManager.getServerToolsConfig as any).mockReturnValue(
+        mockToolsConfig
+      );
+    });
+
+    it("should list tools for existing server", async () => {
+      await listServerTools("datetime");
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        "服务 'datetime' 共有 2 个工具"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("datetime 服务工具列表:")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("get_current_time")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("get_current_date")
+      );
+    });
+
+    it("should handle non-existent server", async () => {
+      (configManager.getMcpServers as any).mockReturnValue({});
+
+      await listServerTools("non-existent");
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        "服务 'non-existent' 不存在"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "提示: 使用 'xiaozhi mcp list' 查看所有可用服务"
+        )
+      );
+    });
+
+    it("should handle server with no tools", async () => {
+      (configManager.getServerToolsConfig as any).mockReturnValue({});
+
+      await listServerTools("datetime");
+
+      expect(mockSpinner.warn).toHaveBeenCalledWith(
+        "服务 'datetime' 暂无工具信息"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("提示: 请先启动服务以扫描工具列表")
+      );
+    });
+
+    it("should handle errors gracefully", async () => {
+      (configManager.getMcpServers as any).mockImplementation(() => {
+        throw new Error("Config error");
+      });
+
+      await expect(async () => {
+        await listServerTools("datetime");
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith("获取工具列表失败");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("错误: Config error")
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("setToolEnabled", () => {
+    const mockServers = {
+      datetime: {
+        command: "node",
+        args: ["./mcpServers/datetime.js"],
+      },
+    };
+
+    const mockToolsConfig = {
+      get_current_time: {
+        description: "Get current time",
+        enable: true,
+      },
+    };
+
+    beforeEach(() => {
+      (configManager.getMcpServers as any).mockReturnValue(mockServers);
+      (configManager.getServerToolsConfig as any).mockReturnValue(
+        mockToolsConfig
+      );
+    });
+
+    it("should enable tool successfully", async () => {
+      await setToolEnabled("datetime", "get_current_time", true);
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        expect.stringContaining("成功启用工具")
+      );
+      expect(configManager.setToolEnabled).toHaveBeenCalledWith(
+        "datetime",
+        "get_current_time",
+        true,
+        "Get current time"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("提示: 工具状态更改将在下次启动服务时生效")
+      );
+    });
+
+    it("should disable tool successfully", async () => {
+      await setToolEnabled("datetime", "get_current_time", false);
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith(
+        expect.stringContaining("成功禁用工具")
+      );
+      expect(configManager.setToolEnabled).toHaveBeenCalledWith(
+        "datetime",
+        "get_current_time",
+        false,
+        "Get current time"
+      );
+    });
+
+    it("should handle non-existent server", async () => {
+      (configManager.getMcpServers as any).mockReturnValue({});
+
+      await setToolEnabled("non-existent", "tool", true);
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        "服务 'non-existent' 不存在"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "提示: 使用 'xiaozhi mcp list' 查看所有可用服务"
+        )
+      );
+    });
+
+    it("should handle non-existent tool", async () => {
+      (configManager.getServerToolsConfig as any).mockReturnValue({});
+
+      await setToolEnabled("datetime", "non-existent-tool", true);
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith(
+        "工具 'non-existent-tool' 在服务 'datetime' 中不存在"
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "提示: 使用 'xiaozhi mcp datetime list' 查看该服务的所有工具"
+        )
+      );
+    });
+
+    it("should handle errors gracefully", async () => {
+      (configManager.getMcpServers as any).mockImplementation(() => {
+        throw new Error("Config error");
+      });
+
+      await expect(async () => {
+        await setToolEnabled("datetime", "tool", true);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith("启用工具失败");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("错误: Config error")
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+
+    it("should handle disable action errors gracefully", async () => {
+      (configManager.getMcpServers as any).mockImplementation(() => {
+        throw new Error("Config error");
+      });
+
+      await expect(async () => {
+        await setToolEnabled("datetime", "tool", false);
+      }).rejects.toThrow("process.exit called");
+
+      expect(mockSpinner.fail).toHaveBeenCalledWith("禁用工具失败");
+      expect(mockConsoleError).toHaveBeenCalledWith(
+        expect.stringContaining("错误: Config error")
+      );
+      expect(mockProcessExit).toHaveBeenCalledWith(1);
+    });
+  });
+
+  describe("Edge cases and error handling", () => {
+    it("should handle very long tool descriptions", async () => {
+      const longDescription = "A".repeat(100);
+      const mockToolsConfig = {
+        "long-desc-tool": {
+          description: longDescription,
+          enable: true,
+        },
+      };
+
+      (configManager.getMcpServers as any).mockReturnValue({
+        "test-server": {},
+      });
+      (configManager.getServerToolsConfig as any).mockReturnValue(
+        mockToolsConfig
+      );
+
+      await listServerTools("test-server");
+
+      expect(mockSpinner.succeed).toHaveBeenCalled();
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("long-desc-tool")
+      );
+    });
+
+    it("should handle servers with special characters in names", async () => {
+      const specialServerName = "test-server_with.special-chars";
+      const mockServers = {
+        [specialServerName]: {
+          command: "node",
+          args: ["test.js"],
+        },
+      };
+
+      (configManager.getMcpServers as any).mockReturnValue(mockServers);
+      (configManager.getServerToolsConfig as any).mockReturnValue({});
+
+      await listMcpServers();
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith("找到 1 个 MCP 服务");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining(specialServerName)
+      );
+    });
+
+    it("should handle mixed enabled/disabled tools display", async () => {
+      const mockServers = {
+        "mixed-server": {
+          command: "node",
+          args: ["test.js"],
+        },
+      };
+
+      const mockServerConfig = {
+        "mixed-server": {
+          tools: {
+            "enabled-tool": {
+              description: "Enabled tool",
+              enable: true,
+            },
+            "disabled-tool": {
+              description: "Disabled tool",
+              enable: false,
+            },
+            "another-enabled": {
+              description: "Another enabled tool",
+              enable: true,
+            },
+          },
+        },
+      };
+
+      (configManager.getMcpServers as any).mockReturnValue(mockServers);
+      (configManager.getMcpServerConfig as any).mockReturnValue(
+        mockServerConfig
+      );
+      (configManager.getServerToolsConfig as any).mockImplementation(
+        (serverName: string) => {
+          return mockServerConfig[serverName]?.tools || {};
+        }
+      );
+
+      await listMcpServers({ tools: true });
+
+      expect(mockSpinner.succeed).toHaveBeenCalledWith("找到 1 个 MCP 服务");
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("enabled-tool")
+      );
+      expect(mockConsoleLog).toHaveBeenCalledWith(
+        expect.stringContaining("disabled-tool")
+      );
+    });
+  });
+});

--- a/src/mcpCommands.ts
+++ b/src/mcpCommands.ts
@@ -1,0 +1,273 @@
+import chalk from "chalk";
+import ora from "ora";
+import { configManager } from "./configManager.js";
+
+/**
+ * MCP 相关的命令行功能
+ */
+
+/**
+ * 列出所有 MCP 服务
+ */
+export async function listMcpServers(
+  options: { tools?: boolean } = {}
+): Promise<void> {
+  const spinner = ora("获取 MCP 服务列表...").start();
+
+  try {
+    const mcpServers = configManager.getMcpServers();
+    const serverNames = Object.keys(mcpServers);
+
+    if (serverNames.length === 0) {
+      spinner.warn("未配置任何 MCP 服务");
+      console.log(
+        chalk.yellow("💡 提示: 使用 'xiaozhi config' 命令配置 MCP 服务")
+      );
+      return;
+    }
+
+    spinner.succeed(`找到 ${serverNames.length} 个 MCP 服务`);
+
+    if (options.tools) {
+      // 显示所有服务的工具列表
+      console.log();
+      console.log(chalk.bold("MCP 服务工具列表:"));
+      console.log();
+
+      // 表头
+      const headers = ["服务名称", "工具名称", "工具描述", "状态"];
+      const colWidths = [20, 30, 40, 8];
+
+      console.log(
+        headers
+          .map((header, i) => chalk.bold(header.padEnd(colWidths[i])))
+          .join(" | ")
+      );
+      console.log(headers.map((_, i) => "-".repeat(colWidths[i])).join("-|-"));
+
+      for (const serverName of serverNames) {
+        const toolsConfig = configManager.getServerToolsConfig(serverName);
+        const toolNames = Object.keys(toolsConfig);
+
+        if (toolNames.length === 0) {
+          console.log(
+            [
+              serverName.padEnd(colWidths[0]),
+              chalk.gray("(无工具)").padEnd(colWidths[1]),
+              chalk.gray("请先启动服务扫描工具").padEnd(colWidths[2]),
+              chalk.gray("-").padEnd(colWidths[3]),
+            ].join(" | ")
+          );
+        } else {
+          let displayServerName = serverName;
+          for (const toolName of toolNames) {
+            const toolConfig = toolsConfig[toolName];
+            const status = toolConfig.enable
+              ? chalk.green("启用")
+              : chalk.red("禁用");
+            const description = (toolConfig.description || "").substring(0, 35);
+
+            console.log(
+              [
+                displayServerName.padEnd(colWidths[0]),
+                toolName.padEnd(colWidths[1]),
+                description.padEnd(colWidths[2]),
+                status.padEnd(colWidths[3]),
+              ].join(" | ")
+            );
+
+            // 只显示第一行服务名称
+            displayServerName = "";
+          }
+        }
+      }
+    } else {
+      // 只显示服务列表
+      console.log();
+      console.log(chalk.bold("MCP 服务列表:"));
+      console.log();
+
+      for (const serverName of serverNames) {
+        const serverConfig = mcpServers[serverName];
+        const toolsConfig = configManager.getServerToolsConfig(serverName);
+        const toolCount = Object.keys(toolsConfig).length;
+        const enabledCount = Object.values(toolsConfig).filter(
+          (t) => t.enable !== false
+        ).length;
+
+        console.log(`${chalk.cyan("•")} ${chalk.bold(serverName)}`);
+        console.log(
+          `  命令: ${chalk.gray(serverConfig.command)} ${chalk.gray(serverConfig.args.join(" "))}`
+        );
+        if (toolCount > 0) {
+          console.log(
+            `  工具: ${chalk.green(enabledCount)} 启用 / ${chalk.yellow(toolCount)} 总计`
+          );
+        } else {
+          console.log(`  工具: ${chalk.gray("未扫描 (请先启动服务)")}`);
+        }
+        console.log();
+      }
+    }
+
+    console.log(chalk.gray("💡 提示:"));
+    console.log(chalk.gray("  - 使用 'xiaozhi mcp list --tools' 查看所有工具"));
+    console.log(
+      chalk.gray("  - 使用 'xiaozhi mcp <服务名> list' 查看指定服务的工具")
+    );
+    console.log(
+      chalk.gray(
+        "  - 使用 'xiaozhi mcp <服务名> <工具名> enable/disable' 启用/禁用工具"
+      )
+    );
+  } catch (error) {
+    spinner.fail("获取 MCP 服务列表失败");
+    console.error(
+      chalk.red(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * 列出指定服务的工具
+ */
+export async function listServerTools(serverName: string): Promise<void> {
+  const spinner = ora(`获取 ${serverName} 服务的工具列表...`).start();
+
+  try {
+    const mcpServers = configManager.getMcpServers();
+
+    if (!mcpServers[serverName]) {
+      spinner.fail(`服务 '${serverName}' 不存在`);
+      console.log(
+        chalk.yellow("💡 提示: 使用 'xiaozhi mcp list' 查看所有可用服务")
+      );
+      return;
+    }
+
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+    const toolNames = Object.keys(toolsConfig);
+
+    if (toolNames.length === 0) {
+      spinner.warn(`服务 '${serverName}' 暂无工具信息`);
+      console.log(chalk.yellow("💡 提示: 请先启动服务以扫描工具列表"));
+      return;
+    }
+
+    spinner.succeed(`服务 '${serverName}' 共有 ${toolNames.length} 个工具`);
+
+    console.log();
+    console.log(chalk.bold(`${serverName} 服务工具列表:`));
+    console.log();
+
+    // 表头
+    const headers = ["工具名称", "工具描述", "状态"];
+    const colWidths = [30, 50, 8];
+
+    console.log(
+      headers
+        .map((header, i) => chalk.bold(header.padEnd(colWidths[i])))
+        .join(" | ")
+    );
+    console.log(headers.map((_, i) => "-".repeat(colWidths[i])).join("-|-"));
+
+    for (const toolName of toolNames) {
+      const toolConfig = toolsConfig[toolName];
+      const status = toolConfig.enable
+        ? chalk.green("启用")
+        : chalk.red("禁用");
+      const description = (toolConfig.description || "").substring(0, 45);
+
+      console.log(
+        [
+          toolName.padEnd(colWidths[0]),
+          description.padEnd(colWidths[1]),
+          status.padEnd(colWidths[2]),
+        ].join(" | ")
+      );
+    }
+
+    console.log();
+    console.log(chalk.gray("💡 提示:"));
+    console.log(
+      chalk.gray(
+        `  - 使用 'xiaozhi mcp ${serverName} <工具名> enable' 启用工具`
+      )
+    );
+    console.log(
+      chalk.gray(
+        `  - 使用 'xiaozhi mcp ${serverName} <工具名> disable' 禁用工具`
+      )
+    );
+  } catch (error) {
+    spinner.fail("获取工具列表失败");
+    console.error(
+      chalk.red(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+    process.exit(1);
+  }
+}
+
+/**
+ * 启用或禁用工具
+ */
+export async function setToolEnabled(
+  serverName: string,
+  toolName: string,
+  enabled: boolean
+): Promise<void> {
+  const action = enabled ? "启用" : "禁用";
+  const spinner = ora(`${action}工具 ${serverName}/${toolName}...`).start();
+
+  try {
+    const mcpServers = configManager.getMcpServers();
+
+    if (!mcpServers[serverName]) {
+      spinner.fail(`服务 '${serverName}' 不存在`);
+      console.log(
+        chalk.yellow("💡 提示: 使用 'xiaozhi mcp list' 查看所有可用服务")
+      );
+      return;
+    }
+
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+
+    if (!toolsConfig[toolName]) {
+      spinner.fail(`工具 '${toolName}' 在服务 '${serverName}' 中不存在`);
+      console.log(
+        chalk.yellow(
+          `💡 提示: 使用 'xiaozhi mcp ${serverName} list' 查看该服务的所有工具`
+        )
+      );
+      return;
+    }
+
+    // 更新工具状态
+    configManager.setToolEnabled(
+      serverName,
+      toolName,
+      enabled,
+      toolsConfig[toolName].description
+    );
+
+    spinner.succeed(
+      `成功${action}工具 ${chalk.cyan(serverName)}/${chalk.cyan(toolName)}`
+    );
+
+    console.log();
+    console.log(chalk.gray("💡 提示: 工具状态更改将在下次启动服务时生效"));
+  } catch (error) {
+    spinner.fail(`${action}工具失败`);
+    console.error(
+      chalk.red(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
+      )
+    );
+    process.exit(1);
+  }
+}

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
 		"src/mcpServerProxy.ts",
 		"src/cli.ts",
 		"src/configManager.ts",
+		"src/mcpCommands.ts",
 	],
 	format: ["cjs"],
 	target: "node18",


### PR DESCRIPTION
新增完整的 MCP 服务和工具管理命令行界面：

- 新增 mcpCommands.ts 模块，提供 MCP 服务管理核心功能
- 添加 CLI 命令：
  * xiaozhi mcp list：列出所有 MCP 服务
  * xiaozhi mcp list --tools：显示所有服务的工具列表
  * xiaozhi mcp server <name>：查看指定服务的工具详情
  * xiaozhi mcp tool <server> <tool> enable/disable：启用/禁用指定工具
- 扩展 ConfigManager 添加工具配置管理：
  * 新增 MCPToolConfig 和 MCPServerToolsConfig 类型定义
  * 添加工具启用状态检查和配置更新方法
  * 支持工具描述和启用状态的持久化存储
- 增强 MCPServerProxy 支持工具过滤：
  * 根据配置动态过滤启用的工具
  * 自动更新配置文件中的工具列表
  * 添加服务器信息查询和工具刷新功能
- 更新构建配置将新模块包含到打包输出中

这为用户提供了完整的 MCP 生态管理能力，可以精确控制每个服务的工具启用状态。