### PR TITLE
fix(ci): 修复发布工作流包管理器不一致问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
         run: pnpm run build
 
       - name: 验证已安装依赖项的来源证明和注册中心签名的完整性
-        run: npm audit signatures
+        run: pnpm audit signatures
       - name: Release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -3,13 +3,11 @@
   "version": "1.0.0",
   "description": "小智 AI 客户端 命令行工具",
   "main": "dist/cli.cjs",
-  "files": [
-    "dist",
-    "docs",
-    "templates",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "docs", "templates", "README.md", "LICENSE"],
+  "publishConfig": {
+    "access": "public",
+    "registry": "https://registry.npmjs.org"
+  },
   "bin": {
     "xiaozhi": "./dist/cli.cjs",
     "xiaozhi-client": "./dist/cli.cjs"
@@ -28,12 +26,7 @@
     "check:write": "biome check --write .",
     "release": "semantic-release"
   },
-  "keywords": [
-    "xiaozhi",
-    "mcp",
-    "websocket",
-    "ai"
-  ],
+  "keywords": ["xiaozhi", "mcp", "websocket", "ai"],
   "author": "shenjingnan(sjn.code@gmail.com)",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
统一发布工作流中的包管理器使用：

- 修复 release.yml 中 audit signatures 步骤使用 npm 而非 pnpm 的不一致问题
- 在 package.json 中添加 publishConfig 配置：
  * 明确设置为公开发布 (access: "public")
  * 指定使用官方 npm 注册表

这确保了整个 CI/CD 流程中包管理器使用的一致性，避免潜在的发布问题。