### PR TITLE
feat(ci): 添加 next 分支预发布支持和增强发布流程 (#17)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,9 +3,9 @@ name: CI Pipeline
 # 触发条件：只在PR到main分支时运行CI
 on:
   pull_request:
-    branches: [ main ]
+    branches: [ main, next ]
   push:
-    branches: [ main ]
+    branches: [ main, next ]
 
 jobs:
   # CI 阶段 - 完整的代码质量和测试检查

--- a/package.json
+++ b/package.json
@@ -3,13 +3,7 @@
   "version": "1.1.0-next.1",
   "description": "小智 AI 客户端 命令行工具",
   "main": "dist/cli.cjs",
-  "files": [
-    "dist",
-    "docs",
-    "templates",
-    "README.md",
-    "LICENSE"
-  ],
+  "files": ["dist", "docs", "templates", "README.md", "LICENSE"],
   "publishConfig": {
     "access": "public",
     "registry": "https://registry.npmjs.org"
@@ -32,12 +26,7 @@
     "check:write": "biome check --write .",
     "release": "semantic-release"
   },
-  "keywords": [
-    "xiaozhi",
-    "mcp",
-    "websocket",
-    "ai"
-  ],
+  "keywords": ["xiaozhi", "mcp", "websocket", "ai"],
   "author": "shenjingnan(sjn.code@gmail.com)",
   "license": "MIT",
   "dependencies": {


### PR DESCRIPTION
为 next 分支添加完整的 CI 支持：

- 在 CI workflow 触发条件中添加 next 分支
- 确保 PR 到 next 分支和直接 push 到 next 分支都会触发 CI 检查
- 保持与 main 分支相同的 CI 质量标准

这确保了 next 分支的预发布版本同样经过完整的代码质量检查流程。