### PR TITLE
chore(biome): 将 package.json 添加到忽略列表

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -14,7 +14,8 @@
       "*.d.ts",
       "pnpm-lock.yaml",
       "templates/**/*.js",
-      "tsup.config.ts"
+      "tsup.config.ts",
+      "package.json"
     ]
   },
   "formatter": {


### PR DESCRIPTION
优化 Biome 配置以避免不必要的格式化：

- 将 package.json 添加到 Biome 的忽略文件列表
- 避免 Biome 对 package.json 进行自动格式化和检查
- 保持 package.json 的原有格式，特别是当它由包管理工具或发布工具管理时

这确保了构建和发布过程中文件格式的一致性。