### PR TITLE
feat(release): 增强语义化发布配置和规则

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -7,10 +7,35 @@
     }
   ],
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          {"type": "feat", "release": "patch"},
+          {"type": "fix", "release": "patch"},
+          {"type": "perf", "release": "patch"},
+          {"type": "revert", "release": "patch"},
+          {"type": "docs", "release": false},
+          {"type": "style", "release": false},
+          {"type": "chore", "release": false},
+          {"type": "refactor", "release": "patch"},
+          {"type": "test", "release": false},
+          {"type": "build", "release": false},
+          {"type": "ci", "release": false},
+          {"scope": "no-release", "release": false},
+          {"breaking": true, "release": "minor"}
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     "@semantic-release/changelog",
-    "@semantic-release/npm",
+    [
+      "@semantic-release/npm",
+      {
+        "npmPublish": true
+      }
+    ],
     "@semantic-release/github",
     [
       "@semantic-release/git",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,6 +1,7 @@
 {
   "cSpell.words": [
     "amap",
+    "conventionalcommits",
     "modelcontextprotocol",
     "modelscope",
     "nvmrc",


### PR DESCRIPTION
完善 semantic-release 配置以提供更精确的版本控制：

- 为 commit-analyzer 插件添加详细的发布规则配置：
  * feat、fix、perf、revert、refactor 类型触发 patch 版本
  * docs、style、chore、test、build、ci 类型不触发发布
  * breaking change 触发 minor 版本
  * no-release scope 强制跳过发布
- 明确配置 npm 插件启用发布（npmPublish: true）
- 更新 VSCode 拼写检查词典，添加 "conventionalcommits"

这提供了更精细的版本管理策略，确保只有实质性变更才会触发版本发布。