### PR TITLE
chore(deps): 添加约定式提交预设依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/node": "^24.0.1",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.3",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "esbuild": "^0.25.5",
     "glob": "^11.0.3",
     "semantic-release": "^24.2.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,6 +60,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.3
         version: 3.2.3(vitest@3.2.3(@types/node@24.0.1))
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.0.0
+        version: 9.0.0
       esbuild:
         specifier: ^0.25.5
         version: 0.25.5
@@ -866,6 +869,10 @@ packages:
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.0.0:
+    resolution: {integrity: sha512-5e48V0+DsWvQBEnnbBFhYQwYDzFPXVrakGPP1uSxekDkr5d7YWrmaWsgJpKFR0SkXmxK6qQr9O42uuLb9wpKxA==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.1.0:
@@ -3244,6 +3251,10 @@ snapshots:
   content-type@1.0.5: {}
 
   conventional-changelog-angular@8.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.0.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
为 semantic-release 添加约定式提交支持：

- 添加 conventional-changelog-conventionalcommits 依赖
- 支持 semantic-release 中的约定式提交规范解析
- 更新 pnpm-lock.yaml 锁定新依赖版本

这个依赖为 semantic-release 的 commit-analyzer 插件提供了约定式提交的预设配置，确保版本发布规则能够正确解析提交消息。