### PR TITLE
feat(cli): 实现动态版本号读取机制

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+## [1.0.2](https://github.com/shenjingnan/xiaozhi-client/compare/v1.0.1...v1.0.2) (2025-06-14)
+
+
+### Features
+
+* **ci:** 添加 next 分支预发布支持和增强发布流程 ([#17](https://github.com/shenjingnan/xiaozhi-client/issues/17)) ([c156904](https://github.com/shenjingnan/xiaozhi-client/commit/c15690427fbef51b8e935cd9295da3b125debf03))
+* **ci:** 添加 next 分支预发布支持和增强发布流程 ([#17](https://github.com/shenjingnan/xiaozhi-client/issues/17)) ([#19](https://github.com/shenjingnan/xiaozhi-client/issues/19)) ([db10935](https://github.com/shenjingnan/xiaozhi-client/commit/db109352082f3ddfbbb82080ea5f4a89a6137887))
+* **ci:** 集成 Codecov 代码覆盖率报告 ([#24](https://github.com/shenjingnan/xiaozhi-client/issues/24)) ([0500866](https://github.com/shenjingnan/xiaozhi-client/commit/05008666a706ac3fc9e5bedc4d20be05258f1928))
+* **release:** 增强语义化发布配置和规则 ([#22](https://github.com/shenjingnan/xiaozhi-client/issues/22)) ([b010246](https://github.com/shenjingnan/xiaozhi-client/commit/b010246d62984651e9099393b72ddbdbe3542d6b))
+
 # [1.1.0-next.4](https://github.com/shenjingnan/xiaozhi-client/compare/v1.1.0-next.3...v1.1.0-next.4) (2025-06-14)
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaozhi-client",
-  "version": "1.1.0-next.4",
+  "version": "1.0.2",
   "description": "小智 AI 客户端 命令行工具",
   "main": "dist/cli.cjs",
   "files": [

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -71,6 +71,12 @@ export default defineConfig({
       console.log("✅ 已复制 xiaozhi.config.default.json 到 dist/");
     }
 
+    // 复制 package.json 到 dist 目录，以便运行时能读取版本号
+    if (existsSync("package.json")) {
+      copyFileSync("package.json", join(distDir, "package.json"));
+      console.log("✅ 已复制 package.json 到 dist/");
+    }
+
     console.log("✅ 构建完成，mcpServers 现在位于 templates/ 目录中");
   },
 });


### PR DESCRIPTION
- 添加 getVersion() 函数，支持从 package.json 动态读取版本号
- 替换硬编码的版本号常量，使用动态版本获取
- 支持多种运行环境：开发环境、构建后环境、全局安装环境
- 添加错误处理，版本读取失败时返回 "unknown"
- 在构建过程中自动复制 package.json 到 dist 目录
- 新增完整的版本管理相关单元测试，覆盖各种场景
- 更新 chalk mock 配置以支持新的样式组合