### PR TITLE
feat(ci): 增强语义化发布配置并添加分支同步工作流

### DIFF
--- a/.github/workflows/sync-main-to-next.yml
+++ b/.github/workflows/sync-main-to-next.yml
@@ -1,0 +1,34 @@
+name: Sync main to next after release
+on:
+  push:
+    branches: [main]
+    paths: ["package.json", "CHANGELOG.md", "pnpm-lock.yaml"]
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    # 只在 semantic-release 提交时触发
+    if: contains(github.event.head_commit.message, 'chore(release):')
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      - name: Configure git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Sync main to next
+        run: |
+          git checkout next
+          git pull origin next
+          if git merge main --no-edit --strategy-option=theirs; then
+            git push origin next
+            echo "✅ Successfully synced main to next"
+          else
+            echo "❌ Merge conflict occurred, manual intervention required"
+            exit 1
+          fi

--- a/.releaserc
+++ b/.releaserc
@@ -1,48 +1,81 @@
 {
   "branches": [
-    "main",
+    {
+      "name": "main",
+      "plugins": [
+        [
+          "@semantic-release/commit-analyzer",
+          {
+            "preset": "conventionalcommits",
+            "releaseRules": [
+              {"type": "feat", "release": "patch"},
+              {"type": "fix", "release": "patch"},
+              {"type": "perf", "release": "patch"},
+              {"type": "revert", "release": "patch"},
+              {"type": "docs", "release": false},
+              {"type": "style", "release": false},
+              {"type": "chore", "release": false},
+              {"type": "refactor", "release": "patch"},
+              {"type": "test", "release": false},
+              {"type": "build", "release": false},
+              {"type": "ci", "release": false},
+              {"scope": "no-release", "release": false},
+              {"breaking": true, "release": "minor"}
+            ]
+          }
+        ],
+        "@semantic-release/release-notes-generator",
+        "@semantic-release/changelog",
+        [
+          "@semantic-release/npm",
+          {
+            "npmPublish": true
+          }
+        ],
+        "@semantic-release/github",
+        [
+          "@semantic-release/git",
+          {
+            "assets": ["CHANGELOG.md", "package.json", "pnpm-lock.yaml"],
+            "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+          }
+        ]
+      ]
+    },
     {
       "name": "next",
-      "prerelease": true
+      "prerelease": true,
+      "plugins": [
+        [
+          "@semantic-release/commit-analyzer",
+          {
+            "preset": "conventionalcommits",
+            "releaseRules": [
+              {"type": "feat", "release": "patch"},
+              {"type": "fix", "release": "patch"},
+              {"type": "perf", "release": "patch"},
+              {"type": "revert", "release": "patch"},
+              {"type": "docs", "release": false},
+              {"type": "style", "release": false},
+              {"type": "chore", "release": false},
+              {"type": "refactor", "release": "patch"},
+              {"type": "test", "release": false},
+              {"type": "build", "release": false},
+              {"type": "ci", "release": false},
+              {"scope": "no-release", "release": false},
+              {"breaking": true, "release": "minor"}
+            ]
+          }
+        ],
+        "@semantic-release/release-notes-generator",
+        [
+          "@semantic-release/npm",
+          {
+            "npmPublish": true
+          }
+        ],
+        "@semantic-release/github"
+      ]
     }
-  ],
-  "plugins": [
-    [
-      "@semantic-release/commit-analyzer",
-      {
-        "preset": "conventionalcommits",
-        "releaseRules": [
-          {"type": "feat", "release": "patch"},
-          {"type": "fix", "release": "patch"},
-          {"type": "perf", "release": "patch"},
-          {"type": "revert", "release": "patch"},
-          {"type": "docs", "release": false},
-          {"type": "style", "release": false},
-          {"type": "chore", "release": false},
-          {"type": "refactor", "release": "patch"},
-          {"type": "test", "release": false},
-          {"type": "build", "release": false},
-          {"type": "ci", "release": false},
-          {"scope": "no-release", "release": false},
-          {"breaking": true, "release": "minor"}
-        ]
-      }
-    ],
-    "@semantic-release/release-notes-generator",
-    "@semantic-release/changelog",
-    [
-      "@semantic-release/npm",
-      {
-        "npmPublish": true
-      }
-    ],
-    "@semantic-release/github",
-    [
-      "@semantic-release/git",
-      {
-        "assets": ["CHANGELOG.md", "package.json", "pnpm-lock.yaml"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
-      }
-    ]
   ]
 }


### PR DESCRIPTION
- 重构 .releaserc 配置，为 main 和 next 分支分别定义插件配置
- main 分支支持完整发布流程：changelog、npm 发布、git 提交
- next 分支支持预发布流程：仅 npm 发布和 GitHub 发布
- 新增 GitHub Actions 工作流自动同步 main 到 next 分支
- 工作流在语义化发布完成后自动触发，确保分支同步
- 添加冲突处理机制，失败时需要手动干预
- 优化发布规则，统一使用 conventionalcommits 预设