### PR TITLE
fix(cli): 修复自动补全模块导入路径缺少文件扩展名

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,7 +8,7 @@ import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
-import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion";
+import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion.js";
 import { configManager } from "./configManager.js";
 import {
   listMcpServers,


### PR DESCRIPTION
- 为 autoCompletion 模块导入添加 .js 扩展名
- 确保 ES 模块导入的一致性和规范性
- 修复可能的模块解析问题