### PR TITLE
fix(cli): 修复ESM环境下模板路径解析问题

### DIFF
--- a/src/cli.test.ts
+++ b/src/cli.test.ts
@@ -421,6 +421,33 @@ describe("CLI 命令行工具", () => {
       // Test would require access to createProject function
       expect(mockFs.existsSync).toBeDefined();
     });
+
+    it("应该在ESM环境中正确解析模板路径", () => {
+      // 测试 ESM 环境下的路径解析
+      const testUrl = "file:///Users/test/project/dist/cli.js";
+
+      // 使用真实的 path 模块进行测试，而不是 mock
+      const realPath = require("node:path");
+
+      // 模拟 import.meta.url 的行为
+      const scriptDir = realPath.dirname(new URL(testUrl).pathname);
+      const expectedPaths = [
+        realPath.join(scriptDir, "..", "templates"), // 开发环境
+        realPath.join(scriptDir, "templates"), // 打包后的环境
+        realPath.join(scriptDir, "..", "..", "templates"), // npm 全局安装
+      ];
+
+      // 验证路径计算是否正确
+      expect(expectedPaths[0]).toContain("templates");
+      expect(expectedPaths[1]).toContain("templates");
+      expect(expectedPaths[2]).toContain("templates");
+
+      // 验证不包含 __dirname（这在ESM中不可用）
+      expect(scriptDir).not.toContain("__dirname");
+
+      // 验证 URL 解析正常工作
+      expect(scriptDir).toBe("/Users/test/project/dist");
+    });
   });
 
   describe("MCP 命令", () => {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -759,8 +759,8 @@ async function createProject(
         }
       }
 
-      // 获取模板路径
-      const scriptDir = __dirname;
+      // 获取模板路径 (ESM 环境)
+      const scriptDir = path.dirname(new URL(import.meta.url).pathname);
       const possiblePaths = [
         path.join(scriptDir, "..", "templates"), // 开发环境
         path.join(scriptDir, "templates"), // 打包后的环境

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -1,5 +1,6 @@
 import { copyFileSync, existsSync, mkdirSync } from "fs";
 import { join } from "path";
+import { execSync } from "child_process";
 import { defineConfig } from "tsup";
 
 export default defineConfig({
@@ -61,6 +62,16 @@ export default defineConfig({
     if (existsSync("package.json")) {
       copyFileSync("package.json", join(distDir, "package.json"));
       console.log("✅ 已复制 package.json 到 dist/");
+    }
+
+    // 复制 templates 目录到 dist 目录
+    if (existsSync("templates")) {
+      try {
+        execSync(`cp -r templates ${distDir}/`, { stdio: "inherit" });
+        console.log("✅ 已复制 templates 目录到 dist/");
+      } catch (error) {
+        console.warn("⚠️ 复制 templates 目录失败:", error);
+      }
     }
 
     console.log("✅ 构建完成，产物现在为 ESM 格式");


### PR DESCRIPTION
- 将 __dirname 替换为 import.meta.url 以适配 ESM 环境
- 在构建配置中添加 templates 目录复制逻辑
- 新增 ESM 环境下路径解析的单元测试

解决了在 ESM 模式下 __dirname 不可用导致的模板路径解析失败问题。
通过使用 import.meta.url 和 URL 构造函数正确获取脚本目录，
确保在不同安装环境（开发、打包、全局安装）下都能正确找到模板文件。