### PR TITLE
feat(build): 完成ESM模块系统迁移并启用bundling

### DIFF
--- a/src/autoCompletion.test.ts
+++ b/src/autoCompletion.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion.js";
-import { configManager } from "./configManager.js";
+import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion";
+import { configManager } from "./configManager";
 
 // Mock configManager
-vi.mock("./configManager.js", () => ({
+vi.mock("./configManager", () => ({
   configManager: {
     configExists: vi.fn(),
     getMcpServers: vi.fn(),

--- a/src/autoCompletion.ts
+++ b/src/autoCompletion.ts
@@ -1,5 +1,5 @@
 import omelette from "omelette";
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 
 /**
  * 自动补全功能模块

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -8,13 +8,9 @@ import { fileURLToPath } from "node:url";
 import chalk from "chalk";
 import { Command } from "commander";
 import ora from "ora";
-import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion.js";
-import { configManager } from "./configManager.js";
-import {
-  listMcpServers,
-  listServerTools,
-  setToolEnabled,
-} from "./mcpCommands.js";
+import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion";
+import { configManager } from "./configManager";
+import { listMcpServers, listServerTools, setToolEnabled } from "./mcpCommands";
 
 const program = new Command();
 const SERVICE_NAME = "xiaozhi-mcp-service";
@@ -24,21 +20,9 @@ const SERVICE_NAME = "xiaozhi-mcp-service";
  */
 function getVersion(): string {
   try {
-    let currentDir: string;
-
-    // 检查是否在 ES 模块环境中
-    if (typeof import.meta !== "undefined" && import.meta.url) {
-      // ES 模块环境
-      const __filename = fileURLToPath(import.meta.url);
-      currentDir = path.dirname(__filename);
-    } else {
-      // CommonJS 环境，使用 require.main 或 process.cwd()
-      if (require.main?.filename) {
-        currentDir = path.dirname(require.main.filename);
-      } else {
-        currentDir = process.cwd();
-      }
-    }
+    // 在 ES 模块环境中获取当前目录
+    const __filename = fileURLToPath(import.meta.url);
+    const currentDir = path.dirname(__filename);
 
     // 尝试多个可能的 package.json 路径
     const possiblePaths = [

--- a/src/mcpCommands.test.ts
+++ b/src/mcpCommands.test.ts
@@ -1,14 +1,14 @@
 import chalk from "chalk";
 import ora from "ora";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 import {
   getDisplayWidth,
   listMcpServers,
   listServerTools,
   setToolEnabled,
   truncateToWidth,
-} from "./mcpCommands.js";
+} from "./mcpCommands";
 
 // Mock dependencies
 vi.mock("chalk", () => ({
@@ -31,7 +31,7 @@ vi.mock("ora", () => ({
   })),
 }));
 
-vi.mock("./configManager.js", () => ({
+vi.mock("./configManager", () => ({
   configManager: {
     getMcpServers: vi.fn(),
     getMcpServerConfig: vi.fn(),

--- a/src/mcpCommands.ts
+++ b/src/mcpCommands.ts
@@ -1,7 +1,7 @@
 import chalk from "chalk";
 import Table from "cli-table3";
 import ora from "ora";
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 
 /**
  * MCP 相关的命令行功能

--- a/src/mcpPipe.test.ts
+++ b/src/mcpPipe.test.ts
@@ -21,7 +21,7 @@ vi.mock("dotenv", () => ({
 }));
 
 // Mock configManager
-vi.mock("./configManager.js", () => ({
+vi.mock("./configManager", () => ({
   configManager: {
     configExists: vi.fn(),
     getMcpEndpoint: vi.fn(),
@@ -30,7 +30,7 @@ vi.mock("./configManager.js", () => ({
 }));
 
 // Import after mocking
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 
 // Mock child process
 class MockChildProcess extends EventEmitter {
@@ -109,7 +109,7 @@ describe("MCP管道", () => {
         .mockImplementation(() => {});
 
       // 导入模块以触发日志记录器创建
-      await import("./mcpPipe.js");
+      await import("./mcpPipe");
 
       // 日志记录器应该被创建（我们无法直接测试，因为它没有被导出）
       expect(true).toBe(true); // 占位符断言

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -15,7 +15,7 @@ import { type ChildProcess, spawn } from "node:child_process";
 import process from "node:process";
 import { config } from "dotenv";
 import WebSocket from "ws";
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 
 // Load environment variables
 config();
@@ -350,7 +350,7 @@ async function main() {
 }
 
 // Run if this file is executed directly
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((error) => {
     logger.error(
       `Unhandled error: ${error instanceof Error ? error.message : String(error)}`

--- a/src/mcpServerProxy.test.ts
+++ b/src/mcpServerProxy.test.ts
@@ -14,7 +14,7 @@ vi.mock("node:fs", () => ({
 }));
 
 // Mock configManager
-vi.mock("./configManager.js", () => ({
+vi.mock("./configManager", () => ({
   configManager: {
     configExists: vi.fn(),
     getMcpServers: vi.fn(),
@@ -25,7 +25,7 @@ vi.mock("./configManager.js", () => ({
 }));
 
 // Import after mocking
-import { configManager } from "./configManager.js";
+import { configManager } from "./configManager";
 
 // Mock child process
 class MockChildProcess extends EventEmitter {

--- a/src/mcpServerProxy.ts
+++ b/src/mcpServerProxy.ts
@@ -10,14 +10,15 @@ import { type ChildProcess, spawn } from "node:child_process";
 import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import process from "node:process";
+import { fileURLToPath } from "node:url";
 import {
   type MCPServerConfig,
   type MCPToolConfig,
   configManager,
-} from "./configManager.js";
+} from "./configManager";
 
-// CommonJS 兼容的 __dirname
-const __dirname = dirname(__filename);
+// ESM 兼容的 __dirname
+const __dirname = dirname(fileURLToPath(import.meta.url));
 
 // Simple logger utility
 const logger = {
@@ -832,7 +833,7 @@ async function main() {
 }
 
 // Run the server if this file is executed directly
-if (require.main === module) {
+if (import.meta.url === `file://${process.argv[1]}`) {
   main().catch((error) => {
     logger.error(
       `Unhandled error: ${error instanceof Error ? error.message : String(error)}`

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
   dts: true,
   minify: true,
   splitting: false,
-  bundle: false,
+  bundle: true,
   keepNames: true,
   platform: "node",
   outExtension() {


### PR DESCRIPTION
- 移除所有相对导入的 .js 扩展名以符合 TypeScript ESM 标准
- 在 tsup.config.ts 中启用 bundle: true 以解决模块依赖问题
- 简化 getVersion 函数，移除 CommonJS 兼容代码，专注于 ESM 环境
- 更新所有测试文件的导入语句和相关测试逻辑
- 修复动态导入语句中的扩展名问题

此次迁移将项目完全转换为现代 ESM 模块系统，提高了代码的一致性和可维护性。
通过启用 bundling，解决了在不同环境下的模块加载问题。