### PR TITLE
feat(ci): 实现手动触发发版workflow支持stable和beta版本选择

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,15 @@
 name: Release
 on:
-  push:
-    branches:
-      - main
-      - next
+  workflow_dispatch:
+    inputs:
+      version_type:
+        description: 'Version type to release'
+        required: true
+        default: 'stable'
+        type: choice
+        options:
+          - stable
+          - beta
 
 permissions:
   contents: read
@@ -22,6 +28,16 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          
+      - name: 切换到目标分支
+        run: |
+          if [ "${{ github.event.inputs.version_type }}" = "stable" ]; then
+            git checkout main
+            echo "切换到 main 分支用于稳定版发布"
+          else
+            git checkout next
+            echo "切换到 next 分支用于 beta 版发布"
+          fi
 
       - name: 安装 pnpm
         uses: pnpm/action-setup@v4
@@ -51,4 +67,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npx semantic-release
+        run: |
+          if [ "${{ github.event.inputs.version_type }}" = "stable" ]; then
+            echo "执行稳定版发布 (main 分支)"
+            npx semantic-release --branches main
+          else
+            echo "执行 beta 版发布 (next 分支)"
+            npx semantic-release --branches next
+          fi


### PR DESCRIPTION
- 将GitHub Actions发版流程从自动触发改为手动触发（workflow_dispatch）
- 添加版本类型选择参数：stable（主版本）、beta（预发布版本）
- 根据选择的版本类型自动切换到对应分支：stable → main，beta → next
- 支持针对不同分支执行对应的semantic-release配置
- 提供更灵活的发版控制，避免意外自动发版