### PR TITLE
fix(release): 修复next分支无法发布beta版本的问题

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -70,8 +70,7 @@ jobs:
         run: |
           if [ "${{ github.event.inputs.version_type }}" = "stable" ]; then
             echo "执行稳定版发布 (main 分支)"
-            npx semantic-release --branches main
           else
             echo "执行 beta 版发布 (next 分支)"
-            npx semantic-release --branches next
           fi
+          npx semantic-release

--- a/.releaserc
+++ b/.releaserc
@@ -44,7 +44,7 @@
     },
     {
       "name": "next",
-      "prerelease": true,
+      "prerelease": "beta",
       "plugins": [
         [
           "@semantic-release/commit-analyzer",
@@ -68,13 +68,21 @@
           }
         ],
         "@semantic-release/release-notes-generator",
+        "@semantic-release/changelog",
         [
           "@semantic-release/npm",
           {
             "npmPublish": true
           }
         ],
-        "@semantic-release/github"
+        "@semantic-release/github",
+        [
+          "@semantic-release/git",
+          {
+            "assets": ["CHANGELOG.md", "package.json", "pnpm-lock.yaml"],
+            "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+          }
+        ]
       ]
     }
   ]


### PR DESCRIPTION
- 将next分支的prerelease配置从true改为"beta"以生成正确的版本号格式
- 为next分支添加changelog和git插件确保版本变更被正确记录
- 移除workflow中的--branches参数避免覆盖配置文件设置

这解决了next分支尝试创建已存在的v1.1.0标签而失败的问题