### PR TITLE
fix(release): 添加缺失的semantic-release依赖包

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "@types/omelette": "^0.4.5",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.3",
+    "conventional-changelog-conventionalcommits": "^9.0.0",
     "cspell": "^9.1.1",
     "esbuild": "^0.25.5",
     "glob": "^11.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -72,6 +72,9 @@ importers:
       '@vitest/coverage-v8':
         specifier: ^3.2.3
         version: 3.2.3(vitest@3.2.3(@types/node@24.0.1)(yaml@2.8.0))
+      conventional-changelog-conventionalcommits:
+        specifier: ^9.0.0
+        version: 9.0.0
       cspell:
         specifier: ^9.1.1
         version: 9.1.1
@@ -1249,6 +1252,10 @@ packages:
 
   conventional-changelog-angular@8.0.0:
     resolution: {integrity: sha512-CLf+zr6St0wIxos4bmaKHRXWAcsCXrJU6F4VdNDrGRK3B8LDLKoX3zuMV5GhtbGkVR/LohZ6MT6im43vZLSjmA==}
+    engines: {node: '>=18'}
+
+  conventional-changelog-conventionalcommits@9.0.0:
+    resolution: {integrity: sha512-5e48V0+DsWvQBEnnbBFhYQwYDzFPXVrakGPP1uSxekDkr5d7YWrmaWsgJpKFR0SkXmxK6qQr9O42uuLb9wpKxA==}
     engines: {node: '>=18'}
 
   conventional-changelog-writer@8.1.0:
@@ -4292,6 +4299,10 @@ snapshots:
   content-type@1.0.5: {}
 
   conventional-changelog-angular@8.0.0:
+    dependencies:
+      compare-func: 2.0.0
+
+  conventional-changelog-conventionalcommits@9.0.0:
     dependencies:
       compare-func: 2.0.0
 


### PR DESCRIPTION
- 添加 conventional-changelog-conventionalcommits 依赖到 devDependencies
- 修复 GitHub Actions 发布流程中 semantic-release 执行失败的问题
- 解决 "Cannot find module 'conventional-changelog-conventionalcommits'" 错误
- 确保 .releaserc 中的 conventionalcommits 预设能够正常工作
- 更新 pnpm-lock.yaml 锁定依赖版本为 9.0.0