### PR TITLE
feat(config): 实现心跳检测和连接配置的可配置化

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -919,26 +919,48 @@ async function configCommand(key: string, value?: string): Promise<void> {
           spinner.succeed("配置信息");
           const connectionConfig = configManager.getConnectionConfig();
           console.log(chalk.green("连接配置:"));
-          console.log(chalk.gray(`  心跳检测间隔: ${connectionConfig.heartbeatInterval}ms`));
-          console.log(chalk.gray(`  心跳超时时间: ${connectionConfig.heartbeatTimeout}ms`));
-          console.log(chalk.gray(`  重连间隔: ${connectionConfig.reconnectInterval}ms`));
+          console.log(
+            chalk.gray(
+              `  心跳检测间隔: ${connectionConfig.heartbeatInterval}ms`
+            )
+          );
+          console.log(
+            chalk.gray(`  心跳超时时间: ${connectionConfig.heartbeatTimeout}ms`)
+          );
+          console.log(
+            chalk.gray(`  重连间隔: ${connectionConfig.reconnectInterval}ms`)
+          );
           break;
         }
         case "heartbeatInterval":
           spinner.succeed("配置信息");
-          console.log(chalk.green(`心跳检测间隔: ${configManager.getHeartbeatInterval()}ms`));
+          console.log(
+            chalk.green(
+              `心跳检测间隔: ${configManager.getHeartbeatInterval()}ms`
+            )
+          );
           break;
         case "heartbeatTimeout":
           spinner.succeed("配置信息");
-          console.log(chalk.green(`心跳超时时间: ${configManager.getHeartbeatTimeout()}ms`));
+          console.log(
+            chalk.green(
+              `心跳超时时间: ${configManager.getHeartbeatTimeout()}ms`
+            )
+          );
           break;
         case "reconnectInterval":
           spinner.succeed("配置信息");
-          console.log(chalk.green(`重连间隔: ${configManager.getReconnectInterval()}ms`));
+          console.log(
+            chalk.green(`重连间隔: ${configManager.getReconnectInterval()}ms`)
+          );
           break;
         default:
           spinner.fail(`未知的配置项: ${key}`);
-          console.log(chalk.yellow("支持的配置项: mcpEndpoint, mcpServers, connection, heartbeatInterval, heartbeatTimeout, reconnectInterval"));
+          console.log(
+            chalk.yellow(
+              "支持的配置项: mcpEndpoint, mcpServers, connection, heartbeatInterval, heartbeatTimeout, reconnectInterval"
+            )
+          );
           return;
       }
     } else {
@@ -980,7 +1002,11 @@ async function configCommand(key: string, value?: string): Promise<void> {
         }
         default:
           spinner.fail(`配置项 ${key} 不支持通过命令行设置`);
-          console.log(chalk.yellow("支持设置的配置项: mcpEndpoint, heartbeatInterval, heartbeatTimeout, reconnectInterval"));
+          console.log(
+            chalk.yellow(
+              "支持设置的配置项: mcpEndpoint, heartbeatInterval, heartbeatTimeout, reconnectInterval"
+            )
+          );
           return;
       }
     }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -915,9 +915,30 @@ async function configCommand(key: string, value?: string): Promise<void> {
             );
           }
           break;
+        case "connection": {
+          spinner.succeed("配置信息");
+          const connectionConfig = configManager.getConnectionConfig();
+          console.log(chalk.green("连接配置:"));
+          console.log(chalk.gray(`  心跳检测间隔: ${connectionConfig.heartbeatInterval}ms`));
+          console.log(chalk.gray(`  心跳超时时间: ${connectionConfig.heartbeatTimeout}ms`));
+          console.log(chalk.gray(`  重连间隔: ${connectionConfig.reconnectInterval}ms`));
+          break;
+        }
+        case "heartbeatInterval":
+          spinner.succeed("配置信息");
+          console.log(chalk.green(`心跳检测间隔: ${configManager.getHeartbeatInterval()}ms`));
+          break;
+        case "heartbeatTimeout":
+          spinner.succeed("配置信息");
+          console.log(chalk.green(`心跳超时时间: ${configManager.getHeartbeatTimeout()}ms`));
+          break;
+        case "reconnectInterval":
+          spinner.succeed("配置信息");
+          console.log(chalk.green(`重连间隔: ${configManager.getReconnectInterval()}ms`));
+          break;
         default:
           spinner.fail(`未知的配置项: ${key}`);
-          console.log(chalk.yellow("支持的配置项: mcpEndpoint, mcpServers"));
+          console.log(chalk.yellow("支持的配置项: mcpEndpoint, mcpServers, connection, heartbeatInterval, heartbeatTimeout, reconnectInterval"));
           return;
       }
     } else {
@@ -927,9 +948,39 @@ async function configCommand(key: string, value?: string): Promise<void> {
           configManager.updateMcpEndpoint(value);
           spinner.succeed(`MCP 端点已更新为: ${value}`);
           break;
+        case "heartbeatInterval": {
+          const heartbeatInterval = Number.parseInt(value, 10);
+          if (Number.isNaN(heartbeatInterval) || heartbeatInterval <= 0) {
+            spinner.fail("心跳检测间隔必须是大于0的数字（毫秒）");
+            return;
+          }
+          configManager.setHeartbeatInterval(heartbeatInterval);
+          spinner.succeed(`心跳检测间隔已更新为: ${heartbeatInterval}ms`);
+          break;
+        }
+        case "heartbeatTimeout": {
+          const heartbeatTimeout = Number.parseInt(value, 10);
+          if (Number.isNaN(heartbeatTimeout) || heartbeatTimeout <= 0) {
+            spinner.fail("心跳超时时间必须是大于0的数字（毫秒）");
+            return;
+          }
+          configManager.setHeartbeatTimeout(heartbeatTimeout);
+          spinner.succeed(`心跳超时时间已更新为: ${heartbeatTimeout}ms`);
+          break;
+        }
+        case "reconnectInterval": {
+          const reconnectInterval = Number.parseInt(value, 10);
+          if (Number.isNaN(reconnectInterval) || reconnectInterval <= 0) {
+            spinner.fail("重连间隔必须是大于0的数字（毫秒）");
+            return;
+          }
+          configManager.setReconnectInterval(reconnectInterval);
+          spinner.succeed(`重连间隔已更新为: ${reconnectInterval}ms`);
+          break;
+        }
         default:
           spinner.fail(`配置项 ${key} 不支持通过命令行设置`);
-          console.log(chalk.yellow("支持设置的配置项: mcpEndpoint"));
+          console.log(chalk.yellow("支持设置的配置项: mcpEndpoint, heartbeatInterval, heartbeatTimeout, reconnectInterval"));
           return;
       }
     }

--- a/src/configManager.test.ts
+++ b/src/configManager.test.ts
@@ -4,10 +4,10 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AppConfig,
   ConfigManager,
+  type ConnectionConfig,
   type MCPServerConfig,
   type MCPServerToolsConfig,
   type MCPToolConfig,
-  type ConnectionConfig,
 } from "./configManager";
 
 // Mock fs module
@@ -656,7 +656,7 @@ describe("ConfigManager", () => {
     describe("getConnectionConfig", () => {
       it("应该返回完整的连接配置", () => {
         const config = configManager.getConnectionConfig();
-        
+
         expect(config).toEqual({
           heartbeatInterval: 30000,
           heartbeatTimeout: 10000,
@@ -669,10 +669,12 @@ describe("ConfigManager", () => {
           mcpEndpoint: "wss://api.example.com/mcp",
           mcpServers: mockConfig.mcpServers,
         };
-        mockReadFileSync.mockReturnValue(JSON.stringify(configWithoutConnection));
-        
+        mockReadFileSync.mockReturnValue(
+          JSON.stringify(configWithoutConnection)
+        );
+
         const config = configManager.getConnectionConfig();
-        
+
         expect(config).toEqual({
           heartbeatInterval: 30000,
           heartbeatTimeout: 10000,
@@ -687,14 +689,16 @@ describe("ConfigManager", () => {
             heartbeatInterval: 15000, // 只设置了一个值
           },
         };
-        mockReadFileSync.mockReturnValue(JSON.stringify(configWithPartialConnection));
-        
+        mockReadFileSync.mockReturnValue(
+          JSON.stringify(configWithPartialConnection)
+        );
+
         const config = configManager.getConnectionConfig();
-        
+
         expect(config).toEqual({
           heartbeatInterval: 15000, // 用户设置的值
-          heartbeatTimeout: 10000,  // 默认值
-          reconnectInterval: 5000,  // 默认值
+          heartbeatTimeout: 10000, // 默认值
+          reconnectInterval: 5000, // 默认值
         });
       });
     });
@@ -740,11 +744,11 @@ describe("ConfigManager", () => {
         const writtenConfig = JSON.parse(
           (mockWriteFileSync.mock.calls[0] as any)[1]
         );
-        
+
         expect(writtenConfig.connection).toEqual({
           heartbeatInterval: 45000, // 更新的值
-          heartbeatTimeout: 10000,  // 保留的值
-          reconnectInterval: 5000,  // 保留的值
+          heartbeatTimeout: 10000, // 保留的值
+          reconnectInterval: 5000, // 保留的值
         });
       });
     });
@@ -752,7 +756,7 @@ describe("ConfigManager", () => {
     describe("设置单个连接配置项", () => {
       it("应该正确设置心跳检测间隔", () => {
         configManager.setHeartbeatInterval(45000);
-        
+
         expect(mockWriteFileSync).toHaveBeenCalledWith(
           "/test/cwd/xiaozhi.config.json",
           expect.stringContaining('"heartbeatInterval": 45000'),
@@ -762,7 +766,7 @@ describe("ConfigManager", () => {
 
       it("应该正确设置心跳超时时间", () => {
         configManager.setHeartbeatTimeout(15000);
-        
+
         expect(mockWriteFileSync).toHaveBeenCalledWith(
           "/test/cwd/xiaozhi.config.json",
           expect.stringContaining('"heartbeatTimeout": 15000'),
@@ -772,7 +776,7 @@ describe("ConfigManager", () => {
 
       it("应该正确设置重连间隔", () => {
         configManager.setReconnectInterval(3000);
-        
+
         expect(mockWriteFileSync).toHaveBeenCalledWith(
           "/test/cwd/xiaozhi.config.json",
           expect.stringContaining('"reconnectInterval": 3000'),

--- a/src/configManager.test.ts
+++ b/src/configManager.test.ts
@@ -7,6 +7,7 @@ import {
   type MCPServerConfig,
   type MCPServerToolsConfig,
   type MCPToolConfig,
+  type ConnectionConfig,
 } from "./configManager";
 
 // Mock fs module
@@ -58,6 +59,11 @@ describe("ConfigManager", () => {
           },
         },
       },
+    },
+    connection: {
+      heartbeatInterval: 30000,
+      heartbeatTimeout: 10000,
+      reconnectInterval: 5000,
     },
   };
 
@@ -638,6 +644,168 @@ describe("ConfigManager", () => {
       expect(() => configManager.getConfig()).toThrow(
         "配置文件格式错误：mcpServers.invalid-server.command 无效"
       );
+    });
+  });
+
+  describe("连接配置管理", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+    });
+
+    describe("getConnectionConfig", () => {
+      it("应该返回完整的连接配置", () => {
+        const config = configManager.getConnectionConfig();
+        
+        expect(config).toEqual({
+          heartbeatInterval: 30000,
+          heartbeatTimeout: 10000,
+          reconnectInterval: 5000,
+        });
+      });
+
+      it("应该为缺少连接配置的情况提供默认值", () => {
+        const configWithoutConnection = {
+          mcpEndpoint: "wss://api.example.com/mcp",
+          mcpServers: mockConfig.mcpServers,
+        };
+        mockReadFileSync.mockReturnValue(JSON.stringify(configWithoutConnection));
+        
+        const config = configManager.getConnectionConfig();
+        
+        expect(config).toEqual({
+          heartbeatInterval: 30000,
+          heartbeatTimeout: 10000,
+          reconnectInterval: 5000,
+        });
+      });
+
+      it("应该为部分连接配置提供默认值", () => {
+        const configWithPartialConnection = {
+          ...mockConfig,
+          connection: {
+            heartbeatInterval: 15000, // 只设置了一个值
+          },
+        };
+        mockReadFileSync.mockReturnValue(JSON.stringify(configWithPartialConnection));
+        
+        const config = configManager.getConnectionConfig();
+        
+        expect(config).toEqual({
+          heartbeatInterval: 15000, // 用户设置的值
+          heartbeatTimeout: 10000,  // 默认值
+          reconnectInterval: 5000,  // 默认值
+        });
+      });
+    });
+
+    describe("获取单个连接配置项", () => {
+      it("应该正确获取心跳检测间隔", () => {
+        expect(configManager.getHeartbeatInterval()).toBe(30000);
+      });
+
+      it("应该正确获取心跳超时时间", () => {
+        expect(configManager.getHeartbeatTimeout()).toBe(10000);
+      });
+
+      it("应该正确获取重连间隔", () => {
+        expect(configManager.getReconnectInterval()).toBe(5000);
+      });
+    });
+
+    describe("updateConnectionConfig", () => {
+      it("应该正确更新连接配置", () => {
+        const newConnectionConfig: Partial<ConnectionConfig> = {
+          heartbeatInterval: 45000,
+          reconnectInterval: 3000,
+        };
+
+        configManager.updateConnectionConfig(newConnectionConfig);
+
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          "/test/cwd/xiaozhi.config.json",
+          expect.stringContaining('"heartbeatInterval": 45000'),
+          "utf8"
+        );
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          "/test/cwd/xiaozhi.config.json",
+          expect.stringContaining('"reconnectInterval": 3000'),
+          "utf8"
+        );
+      });
+
+      it("应该保留现有连接配置的其他值", () => {
+        configManager.updateConnectionConfig({ heartbeatInterval: 45000 });
+
+        const writtenConfig = JSON.parse(
+          (mockWriteFileSync.mock.calls[0] as any)[1]
+        );
+        
+        expect(writtenConfig.connection).toEqual({
+          heartbeatInterval: 45000, // 更新的值
+          heartbeatTimeout: 10000,  // 保留的值
+          reconnectInterval: 5000,  // 保留的值
+        });
+      });
+    });
+
+    describe("设置单个连接配置项", () => {
+      it("应该正确设置心跳检测间隔", () => {
+        configManager.setHeartbeatInterval(45000);
+        
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          "/test/cwd/xiaozhi.config.json",
+          expect.stringContaining('"heartbeatInterval": 45000'),
+          "utf8"
+        );
+      });
+
+      it("应该正确设置心跳超时时间", () => {
+        configManager.setHeartbeatTimeout(15000);
+        
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          "/test/cwd/xiaozhi.config.json",
+          expect.stringContaining('"heartbeatTimeout": 15000'),
+          "utf8"
+        );
+      });
+
+      it("应该正确设置重连间隔", () => {
+        configManager.setReconnectInterval(3000);
+        
+        expect(mockWriteFileSync).toHaveBeenCalledWith(
+          "/test/cwd/xiaozhi.config.json",
+          expect.stringContaining('"reconnectInterval": 3000'),
+          "utf8"
+        );
+      });
+
+      it("应该为无效的心跳检测间隔抛出错误", () => {
+        expect(() => configManager.setHeartbeatInterval(0)).toThrow(
+          "心跳检测间隔必须大于0"
+        );
+        expect(() => configManager.setHeartbeatInterval(-1000)).toThrow(
+          "心跳检测间隔必须大于0"
+        );
+      });
+
+      it("应该为无效的心跳超时时间抛出错误", () => {
+        expect(() => configManager.setHeartbeatTimeout(0)).toThrow(
+          "心跳超时时间必须大于0"
+        );
+        expect(() => configManager.setHeartbeatTimeout(-500)).toThrow(
+          "心跳超时时间必须大于0"
+        );
+      });
+
+      it("应该为无效的重连间隔抛出错误", () => {
+        expect(() => configManager.setReconnectInterval(0)).toThrow(
+          "重连间隔必须大于0"
+        );
+        expect(() => configManager.setReconnectInterval(-2000)).toThrow(
+          "重连间隔必须大于0"
+        );
+      });
     });
   });
 });

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -5,6 +5,13 @@ import { fileURLToPath } from "node:url";
 // 在 ESM 中，需要从 import.meta.url 获取当前文件目录
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
+// 默认连接配置
+const DEFAULT_CONNECTION_CONFIG: Required<ConnectionConfig> = {
+  heartbeatInterval: 30000, // 30秒心跳间隔
+  heartbeatTimeout: 10000, // 10秒心跳超时
+  reconnectInterval: 5000, // 5秒重连间隔
+};
+
 // 配置文件接口定义
 export interface MCPServerConfig {
   command: string;
@@ -21,10 +28,17 @@ export interface MCPServerToolsConfig {
   tools: Record<string, MCPToolConfig>;
 }
 
+export interface ConnectionConfig {
+  heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
+  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000  
+  reconnectInterval?: number; // 重连间隔（毫秒），默认5000
+}
+
 export interface AppConfig {
   mcpEndpoint: string;
   mcpServers: Record<string, MCPServerConfig>;
   mcpServerConfig?: Record<string, MCPServerToolsConfig>;
+  connection?: ConnectionConfig; // 连接配置（可选，用于向后兼容）
 }
 
 /**
@@ -380,6 +394,91 @@ export class ConfigManager {
    */
   public getDefaultConfigPath(): string {
     return this.defaultConfigPath;
+  }
+
+  /**
+   * 获取连接配置（包含默认值）
+   */
+  public getConnectionConfig(): Required<ConnectionConfig> {
+    const config = this.getConfig();
+    const connectionConfig = config.connection || {};
+    
+    return {
+      heartbeatInterval: connectionConfig.heartbeatInterval ?? DEFAULT_CONNECTION_CONFIG.heartbeatInterval,
+      heartbeatTimeout: connectionConfig.heartbeatTimeout ?? DEFAULT_CONNECTION_CONFIG.heartbeatTimeout,
+      reconnectInterval: connectionConfig.reconnectInterval ?? DEFAULT_CONNECTION_CONFIG.reconnectInterval,
+    };
+  }
+
+  /**
+   * 获取心跳检测间隔（毫秒）
+   */
+  public getHeartbeatInterval(): number {
+    return this.getConnectionConfig().heartbeatInterval;
+  }
+
+  /**
+   * 获取心跳超时时间（毫秒）
+   */
+  public getHeartbeatTimeout(): number {
+    return this.getConnectionConfig().heartbeatTimeout;
+  }
+
+  /**
+   * 获取重连间隔（毫秒）
+   */
+  public getReconnectInterval(): number {
+    return this.getConnectionConfig().reconnectInterval;
+  }
+
+  /**
+   * 更新连接配置
+   */
+  public updateConnectionConfig(connectionConfig: Partial<ConnectionConfig>): void {
+    const config = this.getConfig();
+    const currentConnectionConfig = config.connection || {};
+    
+    const newConnectionConfig = {
+      ...currentConnectionConfig,
+      ...connectionConfig,
+    };
+    
+    const newConfig = {
+      ...config,
+      connection: newConnectionConfig,
+    };
+    
+    this.saveConfig(newConfig);
+  }
+
+  /**
+   * 设置心跳检测间隔
+   */
+  public setHeartbeatInterval(interval: number): void {
+    if (interval <= 0) {
+      throw new Error("心跳检测间隔必须大于0");
+    }
+    this.updateConnectionConfig({ heartbeatInterval: interval });
+  }
+
+  /**
+   * 设置心跳超时时间
+   */
+  public setHeartbeatTimeout(timeout: number): void {
+    if (timeout <= 0) {
+      throw new Error("心跳超时时间必须大于0");
+    }
+    this.updateConnectionConfig({ heartbeatTimeout: timeout });
+  }
+
+  /**
+   * 设置重连间隔
+   */
+  public setReconnectInterval(interval: number): void {
+    if (interval <= 0) {
+      throw new Error("重连间隔必须大于0");
+    }
+    this.updateConnectionConfig({ reconnectInterval: interval });
   }
 }
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -30,7 +30,7 @@ export interface MCPServerToolsConfig {
 
 export interface ConnectionConfig {
   heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
-  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000  
+  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000
   reconnectInterval?: number; // 重连间隔（毫秒），默认5000
 }
 
@@ -402,11 +402,17 @@ export class ConfigManager {
   public getConnectionConfig(): Required<ConnectionConfig> {
     const config = this.getConfig();
     const connectionConfig = config.connection || {};
-    
+
     return {
-      heartbeatInterval: connectionConfig.heartbeatInterval ?? DEFAULT_CONNECTION_CONFIG.heartbeatInterval,
-      heartbeatTimeout: connectionConfig.heartbeatTimeout ?? DEFAULT_CONNECTION_CONFIG.heartbeatTimeout,
-      reconnectInterval: connectionConfig.reconnectInterval ?? DEFAULT_CONNECTION_CONFIG.reconnectInterval,
+      heartbeatInterval:
+        connectionConfig.heartbeatInterval ??
+        DEFAULT_CONNECTION_CONFIG.heartbeatInterval,
+      heartbeatTimeout:
+        connectionConfig.heartbeatTimeout ??
+        DEFAULT_CONNECTION_CONFIG.heartbeatTimeout,
+      reconnectInterval:
+        connectionConfig.reconnectInterval ??
+        DEFAULT_CONNECTION_CONFIG.reconnectInterval,
     };
   }
 
@@ -434,20 +440,22 @@ export class ConfigManager {
   /**
    * 更新连接配置
    */
-  public updateConnectionConfig(connectionConfig: Partial<ConnectionConfig>): void {
+  public updateConnectionConfig(
+    connectionConfig: Partial<ConnectionConfig>
+  ): void {
     const config = this.getConfig();
     const currentConnectionConfig = config.connection || {};
-    
+
     const newConnectionConfig = {
       ...currentConnectionConfig,
       ...connectionConfig,
     };
-    
+
     const newConfig = {
       ...config,
       connection: newConnectionConfig,
     };
-    
+
     this.saveConfig(newConfig);
   }
 

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -81,14 +81,14 @@ export class MCPPipe {
     this.shouldReconnect = true;
     this.isConnected = false;
     this.mcpProcessRestartAttempts = 0;
-    
+
     // 获取连接配置，如果配置文件不存在则使用默认值
     try {
       this.connectionConfig = configManager.getConnectionConfig();
       logger.info(
         `连接配置: 心跳间隔=${this.connectionConfig.heartbeatInterval}ms, ` +
-        `心跳超时=${this.connectionConfig.heartbeatTimeout}ms, ` +
-        `重连间隔=${this.connectionConfig.reconnectInterval}ms`
+          `心跳超时=${this.connectionConfig.heartbeatTimeout}ms, ` +
+          `重连间隔=${this.connectionConfig.reconnectInterval}ms`
       );
     } catch (error) {
       // 如果无法获取配置（如配置文件不存在），使用默认值

--- a/templates/hello-world/xiaozhi.config.json
+++ b/templates/hello-world/xiaozhi.config.json
@@ -9,5 +9,10 @@
       "command": "node",
       "args": ["./mcpServers/datetime.js"]
     }
+  },
+  "connection": {
+    "heartbeatInterval": 30000,
+    "heartbeatTimeout": 10000,
+    "reconnectInterval": 5000
   }
 }

--- a/xiaozhi.config.default.json
+++ b/xiaozhi.config.default.json
@@ -9,5 +9,10 @@
       "command": "node",
       "args": ["./mcpServers/datetime.js"]
     }
+  },
+  "connection": {
+    "heartbeatInterval": 30000,
+    "heartbeatTimeout": 10000,
+    "reconnectInterval": 5000
   }
 }


### PR DESCRIPTION
- 新增 ConnectionConfig 接口支持心跳间隔、超时时间和重连间隔配置
- 在 configManager 中实现连接配置管理，包含默认值和向后兼容性
- 重构 mcpPipe.ts 从硬编码改为动态读取配置，配置文件不存在时使用默认值
- 扩展 CLI config 命令支持查看和设置连接配置参数
- 更新配置模板文件包含连接配置示例
- 新增 14 个测试用例覆盖连接配置功能，确保向后兼容性