### PR TITLE
feat(logger): 实现基于consola的日志系统

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "chalk": "^5.4.1",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",
+    "consola": "^3.4.2",
     "dotenv": "^16.3.1",
     "omelette": "^0.4.17",
     "ora": "^8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       commander:
         specifier: ^14.0.0
         version: 14.0.0
+      consola:
+        specifier: ^3.4.2
+        version: 3.4.2
       dotenv:
         specifier: ^16.3.1
         version: 16.5.0

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ export function getVersion(): string {
     // 如果都找不到，返回默认版本
     return "unknown";
   } catch (error) {
-    console.warn("Warning: Could not read version from package.json:", error);
+    console.warn("警告: 无法从 package.json 读取版本信息:", error);
     return "unknown";
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -49,7 +49,7 @@ export function getVersion(): string {
     // 如果都找不到，返回默认版本
     return "unknown";
   } catch (error) {
-    console.warn("警告: 无法从 package.json 读取版本信息:", error);
+    console.warn("无法从 package.json 读取版本信息:", error);
     return "unknown";
   }
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { Command } from "commander";
 import ora from "ora";
 import { setupAutoCompletion, showCompletionHelp } from "./autoCompletion";
 import { configManager } from "./configManager";
+import { logger } from "./logger";
 import { listMcpServers, listServerTools, setToolEnabled } from "./mcpCommands";
 
 const program = new Command();
@@ -55,7 +56,6 @@ export function getVersion(): string {
 
 // PID 文件路径
 const PID_FILE = path.join(os.tmpdir(), `${SERVICE_NAME}.pid`);
-const LOG_FILE = path.join(os.tmpdir(), `${SERVICE_NAME}.log`);
 
 interface ServiceStatus {
   running: boolean;
@@ -267,8 +267,14 @@ async function startService(daemon = false): Promise<void> {
       // 保存 PID 信息
       savePidInfo(child.pid!, "daemon");
 
-      // 设置日志输出
-      const logStream = fs.createWriteStream(LOG_FILE, { flags: "a" });
+      // 初始化日志文件
+      const projectDir = process.cwd();
+      logger.initLogFile(projectDir);
+      logger.enableFileLogging(true);
+
+      // 设置日志输出到文件
+      const logFilePath = path.join(projectDir, "xiaozhi.log");
+      const logStream = fs.createWriteStream(logFilePath, { flags: "a" });
       child.stdout?.pipe(logStream);
       child.stderr?.pipe(logStream);
 
@@ -276,16 +282,14 @@ async function startService(daemon = false): Promise<void> {
       child.on("exit", (code, signal) => {
         if (code !== 0 && code !== null) {
           // 进程异常退出，记录日志
-          const errorLog = `\n[${new Date().toISOString()}] 后台服务异常退出 (代码: ${code}, 信号: ${signal})\n`;
-          fs.appendFileSync(LOG_FILE, errorLog);
+          logger.error(`后台服务异常退出 (代码: ${code}, 信号: ${signal})`);
         }
         cleanupPidFile();
       });
 
       // 监听进程错误
       child.on("error", (error) => {
-        const errorLog = `\n[${new Date().toISOString()}] 后台服务启动错误: ${error.message}\n`;
-        fs.appendFileSync(LOG_FILE, errorLog);
+        logger.error(`后台服务启动错误: ${error.message}`);
         cleanupPidFile();
         spinner.fail(`后台服务启动失败: ${error.message}`);
         return;
@@ -295,7 +299,7 @@ async function startService(daemon = false): Promise<void> {
       child.unref();
 
       spinner.succeed(`服务已在后台启动 (PID: ${child.pid})`);
-      console.log(chalk.gray(`日志文件: ${LOG_FILE}`));
+      console.log(chalk.gray(`日志文件: ${logFilePath}`));
       console.log(chalk.gray(`使用 'xiaozhi attach' 可以查看实时日志`));
     } else {
       // 前台模式
@@ -427,7 +431,8 @@ async function checkStatus(): Promise<void> {
       );
 
       if (status.mode === "daemon") {
-        console.log(chalk.gray(`   日志文件: ${LOG_FILE}`));
+        const logFilePath = path.join(process.cwd(), "xiaozhi.log");
+        console.log(chalk.gray(`   日志文件: ${logFilePath}`));
       }
     } else {
       spinner.succeed("服务状态");
@@ -465,14 +470,15 @@ async function attachService(): Promise<void> {
     console.log(chalk.gray("=".repeat(50)));
 
     // 显示日志文件内容
-    if (fs.existsSync(LOG_FILE)) {
+    const logFilePath = path.join(process.cwd(), "xiaozhi.log");
+    if (fs.existsSync(logFilePath)) {
       // 跨平台的日志查看实现
       if (process.platform === "win32") {
         // Windows 使用 PowerShell 的 Get-Content -Wait
         const { spawn } = await import("node:child_process");
         const tail = spawn(
           "powershell",
-          ["-Command", `Get-Content -Path "${LOG_FILE}" -Wait`],
+          ["-Command", `Get-Content -Path "${logFilePath}" -Wait`],
           { stdio: "inherit" }
         );
 
@@ -489,7 +495,7 @@ async function attachService(): Promise<void> {
       } else {
         // Unix/Linux/macOS 使用 tail -f
         const { spawn } = await import("node:child_process");
-        const tail = spawn("tail", ["-f", LOG_FILE], { stdio: "inherit" });
+        const tail = spawn("tail", ["-f", logFilePath], { stdio: "inherit" });
 
         // 处理中断信号
         process.on("SIGINT", () => {
@@ -804,6 +810,12 @@ async function createProject(
         "pnpm-lock.yaml",
       ]);
 
+      // 创建日志文件
+      const logFilePath = path.join(targetPath, "xiaozhi.log");
+      if (!fs.existsSync(logFilePath)) {
+        fs.writeFileSync(logFilePath, "", "utf8");
+      }
+
       spinner.succeed(`项目 "${projectName}" 创建成功`);
 
       console.log(chalk.green("✅ 项目创建完成!"));
@@ -823,6 +835,10 @@ async function createProject(
 
       // 创建基本的 xiaozhi.config.json
       createBasicConfig(targetPath);
+
+      // 创建日志文件
+      const logFilePath = path.join(targetPath, "xiaozhi.log");
+      fs.writeFileSync(logFilePath, "", "utf8");
 
       spinner.succeed(`项目 "${projectName}" 创建成功`);
 

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,0 +1,148 @@
+import fs from "node:fs";
+import path from "node:path";
+import { consola } from "consola";
+
+export class Logger {
+  private logFilePath: string | null = null;
+  private writeStream: fs.WriteStream | null = null;
+
+  constructor() {
+    // 设置 consola 的格式
+    consola.options.formatOptions = {
+      date: true,
+      colors: true,
+    };
+  }
+
+  /**
+   * 初始化日志文件
+   * @param projectDir 项目目录
+   */
+  initLogFile(projectDir: string): void {
+    this.logFilePath = path.join(projectDir, "xiaozhi.log");
+
+    // 确保日志文件存在
+    if (!fs.existsSync(this.logFilePath)) {
+      fs.writeFileSync(this.logFilePath, "");
+    }
+
+    // 创建写入流，追加模式
+    this.writeStream = fs.createWriteStream(this.logFilePath, {
+      flags: "a",
+      encoding: "utf8",
+    });
+  }
+
+  /**
+   * 记录日志到文件
+   * @param level 日志级别
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  private logToFile(level: string, message: string, ...args: any[]): void {
+    if (this.writeStream) {
+      const timestamp = new Date().toISOString();
+      const formattedMessage = `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+      const fullMessage =
+        args.length > 0
+          ? `${formattedMessage} ${args
+              .map((arg) =>
+                typeof arg === "object" ? JSON.stringify(arg) : String(arg)
+              )
+              .join(" ")}`
+          : formattedMessage;
+
+      this.writeStream.write(`${fullMessage}\n`);
+    }
+  }
+
+  /**
+   * 设置是否启用文件日志
+   * @param enable 是否启用
+   */
+  enableFileLogging(enable: boolean): void {
+    if (enable && !this.writeStream && this.logFilePath) {
+      this.writeStream = fs.createWriteStream(this.logFilePath, {
+        flags: "a",
+        encoding: "utf8",
+      });
+    } else if (!enable && this.writeStream) {
+      this.writeStream.end();
+      this.writeStream = null;
+    }
+  }
+
+  /**
+   * 日志方法
+   */
+  info(message: string, ...args: any[]): void {
+    consola.info(message, ...args);
+    this.logToFile("info", message, ...args);
+  }
+
+  success(message: string, ...args: any[]): void {
+    consola.success(message, ...args);
+    this.logToFile("success", message, ...args);
+  }
+
+  warn(message: string, ...args: any[]): void {
+    consola.warn(message, ...args);
+    this.logToFile("warn", message, ...args);
+  }
+
+  error(message: string, ...args: any[]): void {
+    consola.error(message, ...args);
+    this.logToFile("error", message, ...args);
+  }
+
+  debug(message: string, ...args: any[]): void {
+    consola.debug(message, ...args);
+    this.logToFile("debug", message, ...args);
+  }
+
+  log(message: string, ...args: any[]): void {
+    consola.log(message, ...args);
+    this.logToFile("log", message, ...args);
+  }
+
+  /**
+   * 创建一个带标签的日志实例
+   * @param tag 标签
+   */
+  withTag(tag: string): Logger {
+    const taggedLogger = new Logger();
+    taggedLogger.logFilePath = this.logFilePath;
+    taggedLogger.writeStream = this.writeStream;
+
+    // 重写所有日志方法，添加标签
+    const methods = [
+      "info",
+      "success",
+      "warn",
+      "error",
+      "debug",
+      "log",
+    ] as const;
+    for (const method of methods) {
+      const originalMethod = taggedLogger[method].bind(taggedLogger);
+      (taggedLogger as any)[method] = (message: string, ...args: any[]) => {
+        originalMethod(`[${tag}] ${message}`, ...args);
+      };
+    }
+
+    return taggedLogger;
+  }
+
+  /**
+   * 关闭日志文件流
+   */
+  close(): void {
+    if (this.writeStream) {
+      this.writeStream.end();
+      this.writeStream = null;
+    }
+  }
+}
+
+// 导出单例实例
+export const logger = new Logger();

--- a/src/mcpPipe.test.ts
+++ b/src/mcpPipe.test.ts
@@ -31,7 +31,7 @@ vi.mock("./configManager", () => ({
 
 // Import after mocking
 import { configManager } from "./configManager";
-import { Logger, MCPPipe, setupSignalHandlers } from "./mcpPipe";
+import { MCPPipe, setupSignalHandlers } from "./mcpPipe";
 
 // Mock child process
 class MockChildProcess extends EventEmitter {
@@ -102,87 +102,7 @@ describe("MCP管道", () => {
     vi.unstubAllGlobals();
   });
 
-  describe("日志记录器", () => {
-    it("应该使用正确的名称创建日志记录器", () => {
-      const logger = new Logger("TEST_LOGGER");
-      expect(logger).toBeDefined();
-    });
-
-    it("应该正确记录info消息", () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const logger = new Logger("TEST");
-      logger.info("test message");
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("TEST - INFO - test message")
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it("应该正确记录error消息", () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const logger = new Logger("TEST");
-      logger.error("error message");
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("TEST - ERROR - error message")
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it("应该正确记录warning消息", () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const logger = new Logger("TEST");
-      logger.warning("warning message");
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("TEST - WARNING - warning message")
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it("应该正确记录debug消息", () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const logger = new Logger("TEST");
-      logger.debug("debug message");
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringContaining("TEST - DEBUG - debug message")
-      );
-
-      consoleSpy.mockRestore();
-    });
-
-    it("应该在消息中包含时间戳", () => {
-      const consoleSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-
-      const logger = new Logger("TEST");
-      logger.info("test message");
-
-      expect(consoleSpy).toHaveBeenCalledWith(
-        expect.stringMatching(/\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z/)
-      );
-
-      consoleSpy.mockRestore();
-    });
-  });
+  // Logger 相关测试已移除，因为我们现在使用全局 logger 模块
 
   describe("MCPPipe类", () => {
     it("应该正确创建MCPPipe实例", () => {

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -101,12 +101,12 @@ export class MCPPipe {
       return;
     }
 
-    logger.info("Connecting to WebSocket server...");
+    logger.info("正在连接 WebSocket 服务器...");
 
     this.websocket = new WebSocket(this.endpointUrl);
 
     this.websocket.on("open", () => {
-      logger.info("Successfully connected to WebSocket server");
+      logger.info("成功连接到 WebSocket 服务器");
       this.isConnected = true;
 
       // Reset reconnection counter
@@ -128,7 +128,7 @@ export class MCPPipe {
     });
 
     this.websocket.on("close", (code: number, reason: Buffer) => {
-      logger.error(`WebSocket connection closed: ${code} ${reason}`);
+      logger.error(`WebSocket 连接已关闭: ${code} ${reason}`);
       this.isConnected = false;
       this.websocket = null;
 
@@ -142,7 +142,7 @@ export class MCPPipe {
     });
 
     this.websocket.on("error", (error: Error) => {
-      logger.error(`WebSocket error: ${error.message}`);
+      logger.error(`WebSocket 错误: ${error.message}`);
       this.isConnected = false;
 
       // 网络错误时停止心跳检测
@@ -170,14 +170,14 @@ export class MCPPipe {
     reconnectAttempt++;
 
     logger.info(
-      `Scheduling reconnection attempt ${reconnectAttempt} in ${(this.connectionConfig.reconnectInterval / 1000).toFixed(2)} seconds...`
+      `计划在 ${(this.connectionConfig.reconnectInterval / 1000).toFixed(2)} 秒后进行第 ${reconnectAttempt} 次重连尝试...`
     );
 
     this.reconnectTimer = setTimeout(() => {
       if (this.shouldReconnect) {
         // 如果MCP进程不存在，先尝试重启
         if (!this.process || this.process.killed) {
-          logger.info("MCP process not running, attempting to restart...");
+          logger.info("MCP 进程未运行，正在尝试重启...");
           this.restartMCPProcess();
         }
         this.connectToServer();
@@ -198,7 +198,7 @@ export class MCPPipe {
 
         // 设置心跳超时检测
         this.heartbeatTimeoutTimer = setTimeout(() => {
-          logger.warn("Heartbeat timeout, connection may be lost");
+          logger.warn("心跳超时，连接可能已断开");
           // 心跳超时，主动关闭连接触发重连
           if (this.websocket) {
             this.websocket.terminate();
@@ -222,13 +222,13 @@ export class MCPPipe {
   // MCP进程重启功能
   private restartMCPProcess() {
     if (this.mcpProcessRestartAttempts >= 3) {
-      logger.error("MCP process restart attempts exceeded, giving up");
+      logger.error("MCP 进程重启尝试次数超限，放弃重启");
       return;
     }
 
     this.mcpProcessRestartAttempts++;
     logger.info(
-      `Attempting to restart MCP process (attempt ${this.mcpProcessRestartAttempts})`
+      `正在尝试重启 MCP 进程（第 ${this.mcpProcessRestartAttempts} 次尝试）`
     );
 
     // 清理现有进程
@@ -236,7 +236,7 @@ export class MCPPipe {
       try {
         this.process.kill("SIGTERM");
       } catch (error) {
-        logger.warn(`Error killing existing MCP process: ${error}`);
+        logger.warn(`终止现有 MCP 进程时出错: ${error}`);
       }
       this.process = null;
     }
@@ -247,11 +247,11 @@ export class MCPPipe {
 
   startMCPProcess() {
     if (this.process) {
-      logger.info(`${this.mcpScript} process already running`);
+      logger.info(`${this.mcpScript} 进程已在运行`);
       return;
     }
 
-    logger.info(`Starting ${this.mcpScript} process`);
+    logger.info(`正在启动 ${this.mcpScript} 进程`);
 
     this.process = spawn("node", [this.mcpScript], {
       stdio: ["pipe", "pipe", "pipe"],
@@ -277,7 +277,7 @@ export class MCPPipe {
       "exit",
       (code: number | null, signal: NodeJS.Signals | null) => {
         logger.warn(
-          `${this.mcpScript} process exited with code ${code}, signal ${signal}`
+          `${this.mcpScript} 进程已退出，退出码: ${code}, 信号: ${signal}`
         );
         this.process = null;
 
@@ -287,9 +287,7 @@ export class MCPPipe {
           signal !== "SIGTERM" &&
           signal !== "SIGKILL"
         ) {
-          logger.info(
-            "MCP process unexpectedly exited, will attempt restart on next reconnection"
-          );
+          logger.info("MCP 进程意外退出，将在下次重连时尝试重启");
           // 不立即重启，而是在下次重连时处理
         }
       }
@@ -297,14 +295,12 @@ export class MCPPipe {
 
     // Handle process error
     this.process.on("error", (error: Error) => {
-      logger.error(`Process error: ${error.message}`);
+      logger.error(`进程错误: ${error.message}`);
       this.process = null;
 
       // 进程错误时不停止重连，让重连机制处理
       if (this.shouldReconnect) {
-        logger.info(
-          "MCP process error occurred, will attempt restart on next reconnection"
-        );
+        logger.info("MCP 进程发生错误，将在下次重连时尝试重启");
       }
     });
   }
@@ -320,7 +316,7 @@ export class MCPPipe {
     }
 
     if (this.process) {
-      logger.info(`Terminating ${this.mcpScript} process`);
+      logger.info(`正在终止 ${this.mcpScript} 进程`);
       try {
         this.process.kill("SIGTERM");
 
@@ -332,7 +328,7 @@ export class MCPPipe {
         }, 5000);
       } catch (error) {
         logger.error(
-          `Error terminating process: ${error instanceof Error ? error.message : String(error)}`
+          `终止进程时出错: ${error instanceof Error ? error.message : String(error)}`
         );
       }
       this.process = null;
@@ -342,7 +338,7 @@ export class MCPPipe {
       try {
         this.websocket.close();
       } catch (error) {
-        logger.warn(`Error closing websocket: ${error}`);
+        logger.warn(`关闭 WebSocket 时出错: ${error}`);
       }
       this.websocket = null;
     }
@@ -355,7 +351,7 @@ export class MCPPipe {
   }
 
   shutdown() {
-    logger.info("Shutting down MCP Pipe...");
+    logger.info("正在关闭 MCP Pipe...");
     this.shouldReconnect = false;
     this.cleanup();
     if (this.websocket) {
@@ -374,12 +370,12 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
   const isDaemon = process.env.XIAOZHI_DAEMON === "true";
 
   process.on("SIGINT", () => {
-    logger.info("Received interrupt signal, shutting down...");
+    logger.info("收到中断信号，正在关闭...");
     mcpPipe.shutdown();
   });
 
   process.on("SIGTERM", () => {
-    logger.info("Received terminate signal, shutting down...");
+    logger.info("收到终止信号，正在关闭...");
     mcpPipe.shutdown();
   });
 
@@ -388,26 +384,26 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
     // 忽略 SIGHUP 信号（终端关闭）
     process.on("SIGHUP", () => {
       logger.info(
-        "Received SIGHUP signal (terminal closed), continuing in daemon mode..."
+        "收到 SIGHUP 信号（终端已关闭），继续在守护进程模式下运行..."
       );
       // 守护进程不应该因为终端关闭而退出
     });
 
     // 处理未捕获的异常
     process.on("uncaughtException", (error) => {
-      logger.error(`Uncaught exception in daemon mode: ${error.message}`);
+      logger.error(`守护进程模式下的未捕获异常: ${error.message}`);
       logger.error(error.stack || "No stack trace available");
       // 守护进程遇到未捕获的异常时不退出，而是继续运行
     });
 
     // 处理未处理的 Promise 拒绝
     process.on("unhandledRejection", (reason, promise) => {
-      logger.error(`Unhandled promise rejection in daemon mode: ${reason}`);
+      logger.error(`守护进程模式下的未处理 Promise 拒绝: ${reason}`);
       logger.error(`Promise: ${promise}`);
       // 守护进程遇到未处理的 Promise 拒绝时不退出
     });
 
-    logger.info("Daemon mode signal handlers initialized");
+    logger.info("守护进程模式信号处理器已初始化");
   }
 }
 
@@ -415,7 +411,7 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
 async function main() {
   // Check command line arguments
   if (process.argv.length < 3) {
-    logger.error("Usage: node mcp_pipe.js <mcp_script>");
+    logger.error("用法: node mcp_pipe.js <mcp_script>");
     process.exit(1);
   }
 
@@ -489,7 +485,7 @@ async function main() {
     await mcpPipe.start();
   } catch (error) {
     logger.error(
-      `Program execution error: ${error instanceof Error ? error.message : String(error)}`
+      `程序执行错误: ${error instanceof Error ? error.message : String(error)}`
     );
     process.exit(1);
   }
@@ -504,7 +500,7 @@ const argv1Path = process.argv[1];
 if (scriptPath === argv1Path) {
   main().catch((error) => {
     logger.error(
-      `Unhandled error: ${error instanceof Error ? error.message : String(error)}`
+      `未处理的错误: ${error instanceof Error ? error.message : String(error)}`
     );
     process.exit(1);
   });

--- a/src/mcpServerProxy.test.ts
+++ b/src/mcpServerProxy.test.ts
@@ -446,7 +446,7 @@ describe("MCP服务器代理", () => {
       expect(parsedResponse.jsonrpc).toBe("2.0");
       expect(parsedResponse.id).toBeNull();
       expect(parsedResponse.error.code).toBe(-32700);
-      expect(parsedResponse.error.message).toBe("Parse error");
+      expect(parsedResponse.error.message).toBe("解析错误");
     });
 
     it("应该处理未知方法", async () => {
@@ -465,7 +465,7 @@ describe("MCP服务器代理", () => {
       expect(response.jsonrpc).toBe("2.0");
       expect(response.id).toBe(5);
       expect(response.error.code).toBe(-32603);
-      expect(response.error.message).toContain("Unknown method");
+      expect(response.error.message).toContain("未知的方法");
     });
 
     it("应该处理工具列表请求当代理未初始化时", async () => {
@@ -485,7 +485,7 @@ describe("MCP服务器代理", () => {
       expect(response.jsonrpc).toBe("2.0");
       expect(response.id).toBe(6);
       expect(response.error).toBeDefined();
-      expect(response.error.message).toBe("Proxy not initialized");
+      expect(response.error.message).toBe("代理未初始化");
     });
   });
 

--- a/src/mcpServerProxy.ts
+++ b/src/mcpServerProxy.ts
@@ -117,7 +117,7 @@ export class MCPClient {
   }
 
   async start() {
-    logger.info(`Starting MCP client for ${this.name}`);
+    logger.info(`正在启动 MCP 客户端：${this.name}`);
 
     const { command, args, env } = this.config;
 
@@ -152,10 +152,10 @@ export class MCPClient {
     }
 
     logger.debug(
-      `${this.name} spawning: ${resolvedCommand} ${resolvedArgs.join(" ")} in ${spawnOptions.cwd}`
+      `${this.name} 正在生成进程：${resolvedCommand} ${resolvedArgs.join(" ")} 工作目录：${spawnOptions.cwd}`
     );
     logger.debug(
-      `${this.name} platform: ${process.platform}, shell: ${spawnOptions.shell || false}`
+      `${this.name} 平台：${process.platform}，shell 模式：${spawnOptions.shell || false}`
     );
 
     this.process = spawn(resolvedCommand, resolvedArgs, spawnOptions);
@@ -167,7 +167,7 @@ export class MCPClient {
 
     // Handle process stderr - log errors
     this.process.stderr?.on("data", (data: Buffer) => {
-      logger.debug(`${this.name} stderr: ${data.toString().trim()}`);
+      logger.debug(`${this.name} 标准错误输出：${data.toString().trim()}`);
     });
 
     // Handle process exit
@@ -175,7 +175,7 @@ export class MCPClient {
       "exit",
       (code: number | null, signal: NodeJS.Signals | null) => {
         logger.error(
-          `${this.name} process exited with code ${code}, signal ${signal}`
+          `${this.name} 进程已退出，退出码：${code}，信号：${signal}`
         );
         this.initialized = false;
       }
@@ -183,7 +183,7 @@ export class MCPClient {
 
     // Handle process error
     this.process.on("error", (error: Error) => {
-      logger.error(`${this.name} process error: ${error.message}`);
+      logger.error(`${this.name} 进程错误：${error.message}`);
       this.initialized = false;
     });
 
@@ -204,7 +204,7 @@ export class MCPClient {
           const message = JSON.parse(line.trim());
           this.handleMessage(message);
         } catch (error) {
-          logger.error(`${this.name} failed to parse message: ${line.trim()}`);
+          logger.error(`${this.name} 解析消息失败：${line.trim()}`);
         }
       }
     }
@@ -212,7 +212,7 @@ export class MCPClient {
 
   handleMessage(message: any): void {
     logger.debug(
-      `${this.name} received: ${JSON.stringify(message).substring(0, 200)}...`
+      `${this.name} 收到消息：${JSON.stringify(message).substring(0, 200)}...`
     );
 
     if (message.id && this.pendingRequests.has(message.id)) {
@@ -236,7 +236,7 @@ export class MCPClient {
 
   async sendRequest(method: string, params: any = {}): Promise<any> {
     if (!this.process || !this.process.stdin) {
-      throw new Error(`${this.name} process not available`);
+      throw new Error(`${this.name} 进程不可用`);
     }
 
     const id = this.requestId++;
@@ -254,12 +254,12 @@ export class MCPClient {
       setTimeout(() => {
         if (this.pendingRequests.has(id)) {
           this.pendingRequests.delete(id);
-          reject(new Error(`Request timeout for ${method}`));
+          reject(new Error(`请求超时：${method}`));
         }
       }, 30000); // 30 second timeout
 
       const message = `${JSON.stringify(request)}\n`;
-      logger.debug(`${this.name} sending: ${message.trim()}`);
+      logger.debug(`${this.name} 正在发送：${message.trim()}`);
       this.process?.stdin?.write(message);
     });
   }
@@ -277,7 +277,7 @@ export class MCPClient {
       });
 
       logger.info(
-        `${this.name} initialized with capabilities: ${JSON.stringify((initResult as any).capabilities)}`
+        `${this.name} 已初始化，能力：${JSON.stringify((initResult as any).capabilities)}`
       );
 
       // Send initialized notification
@@ -291,10 +291,10 @@ export class MCPClient {
       await this.refreshTools();
 
       this.initialized = true;
-      logger.info(`${this.name} client ready with ${this.tools.length} tools`);
+      logger.info(`${this.name} 客户端已就绪，共 ${this.tools.length} 个工具`);
     } catch (error) {
       logger.error(
-        `Failed to initialize ${this.name}: ${error instanceof Error ? error.message : String(error)}`
+        `初始化 ${this.name} 失败：${error instanceof Error ? error.message : String(error)}`
       );
       throw error;
     }
@@ -318,14 +318,14 @@ export class MCPClient {
       await this.updateToolsConfig();
 
       logger.info(
-        `${this.name} loaded ${this.originalTools.length} tools: ${this.originalTools.map((t) => t.name).join(", ")}`
+        `${this.name} 加载了 ${this.originalTools.length} 个工具：${this.originalTools.map((t) => t.name).join(", ")}`
       );
       logger.info(
-        `${this.name} enabled ${this.tools.length} tools: ${this.tools.map((t) => t.name).join(", ")}`
+        `${this.name} 启用了 ${this.tools.length} 个工具：${this.tools.map((t) => t.name).join(", ")}`
       );
     } catch (error) {
       logger.error(
-        `Failed to get tools from ${this.name}: ${error instanceof Error ? error.message : String(error)}`
+        `从 ${this.name} 获取工具失败：${error instanceof Error ? error.message : String(error)}`
       );
       this.tools = [];
       this.originalTools = [];
@@ -374,11 +374,11 @@ export class MCPClient {
 
       if (hasChanges || Object.keys(currentConfig).length === 0) {
         configManager.updateServerToolsConfig(this.name, toolsConfig);
-        logger.info(`${this.name} updated tools configuration`);
+        logger.info(`${this.name} 已更新工具配置`);
       }
     } catch (error) {
       logger.error(
-        `Failed to update tools config for ${this.name}: ${error instanceof Error ? error.message : String(error)}`
+        `更新 ${this.name} 的工具配置失败：${error instanceof Error ? error.message : String(error)}`
       );
     }
   }
@@ -388,7 +388,7 @@ export class MCPClient {
       // 将前缀名称转换回原始名称
       const originalName = this.getOriginalToolName(prefixedName);
       if (!originalName) {
-        throw new Error(`Invalid tool name format: ${prefixedName}`);
+        throw new Error(`无效的工具名称格式：${prefixedName}`);
       }
 
       const result = await this.sendRequest("tools/call", {
@@ -398,7 +398,7 @@ export class MCPClient {
       return result;
     } catch (error) {
       logger.error(
-        `Failed to call tool ${prefixedName} (original: ${this.getOriginalToolName(prefixedName)}) on ${this.name}: ${error instanceof Error ? error.message : String(error)}`
+        `在 ${this.name} 上调用工具 ${prefixedName} (原始名称：${this.getOriginalToolName(prefixedName)}) 失败：${error instanceof Error ? error.message : String(error)}`
       );
       throw error;
     }
@@ -406,7 +406,7 @@ export class MCPClient {
 
   stop(): void {
     if (this.process) {
-      logger.info(`Stopping ${this.name} client`);
+      logger.info(`正在停止 ${this.name} 客户端`);
       this.process.kill("SIGTERM");
       this.process = null;
     }
@@ -437,9 +437,7 @@ export function loadMCPConfig(): Record<string, MCPServerConfig> {
         const config = JSON.parse(configData);
 
         if (!config.mcpServers || typeof config.mcpServers !== "object") {
-          throw new Error(
-            "Invalid configuration: mcpServers section not found or invalid"
-          );
+          throw new Error("无效的配置：mcpServers 部分未找到或无效");
         }
 
         logger.info(
@@ -456,7 +454,7 @@ export function loadMCPConfig(): Record<string, MCPServerConfig> {
     throw new Error('配置文件不存在，请运行 "xiaozhi init" 初始化配置');
   } catch (error) {
     logger.error(
-      `Failed to load MCP configuration: ${error instanceof Error ? error.message : String(error)}`
+      `加载 MCP 配置失败：${error instanceof Error ? error.message : String(error)}`
     );
     throw error;
   }
@@ -479,7 +477,7 @@ export class MCPServerProxy {
   }
 
   async start() {
-    logger.info("Starting MCP Server Proxy");
+    logger.info("正在启动 MCP 服务代理");
 
     // Load configuration
     this.config = loadMCPConfig();
@@ -488,7 +486,7 @@ export class MCPServerProxy {
     const clientPromises = [];
 
     for (const [serverName, serverConfig] of Object.entries(this.config)) {
-      logger.info(`Initializing MCP client: ${serverName}`);
+      logger.info(`正在初始化 MCP 客户端：${serverName}`);
       const client = new MCPClient(serverName, serverConfig);
       this.clients.set(serverName, client);
       clientPromises.push(client.start());
@@ -506,10 +504,10 @@ export class MCPServerProxy {
 
         if (result.status === "fulfilled") {
           successCount++;
-          logger.info(`Successfully started MCP client: ${serverName}`);
+          logger.info(`成功启动 MCP 客户端：${serverName}`);
         } else {
           logger.error(
-            `Failed to start MCP client ${serverName}: ${result.reason.message}`
+            `启动 MCP 客户端 ${serverName} 失败：${result.reason.message}`
           );
           // Remove failed client from clients map
           this.clients.delete(serverName);
@@ -517,7 +515,7 @@ export class MCPServerProxy {
       }
 
       if (successCount === 0) {
-        throw new Error("No MCP clients started successfully");
+        throw new Error("没有成功启动任何 MCP 客户端");
       }
 
       // Build tool mapping
@@ -525,11 +523,11 @@ export class MCPServerProxy {
       this.initialized = true;
 
       logger.info(
-        `MCP Server Proxy initialized successfully with ${successCount}/${Object.keys(this.config).length} clients`
+        `MCP 服务代理初始化成功，启动了 ${successCount}/${Object.keys(this.config).length} 个客户端`
       );
     } catch (error) {
       logger.error(
-        `Failed to start MCP clients: ${error instanceof Error ? error.message : String(error)}`
+        `启动 MCP 客户端失败：${error instanceof Error ? error.message : String(error)}`
       );
       throw error;
     }
@@ -544,7 +542,7 @@ export class MCPServerProxy {
         // 但我们仍然检查以防万一
         if (this.toolMap.has(tool.name)) {
           logger.error(
-            `Duplicate tool name: ${tool.name} (from ${clientName} and ${this.toolMap.get(tool.name)})`
+            `重复的工具名称：${tool.name} (来自 ${clientName} 和 ${this.toolMap.get(tool.name)})`
           );
         } else {
           this.toolMap.set(tool.name, clientName);
@@ -552,8 +550,8 @@ export class MCPServerProxy {
       }
     }
 
-    logger.info(`Built tool map with ${this.toolMap.size} tools`);
-    logger.debug(`Tool map: ${Array.from(this.toolMap.keys()).join(", ")}`);
+    logger.info(`已构建工具映射，共 ${this.toolMap.size} 个工具`);
+    logger.debug(`工具映射：${Array.from(this.toolMap.keys()).join(", ")}`);
   }
 
   getAllTools(): Tool[] {
@@ -597,7 +595,7 @@ export class MCPServerProxy {
   ): Array<{ name: string; description: string; enabled: boolean }> {
     const client = this.clients.get(serverName);
     if (!client) {
-      throw new Error(`Server ${serverName} not found`);
+      throw new Error(`未找到服务器 ${serverName}`);
     }
 
     return client.originalTools.map((tool) => ({
@@ -613,7 +611,7 @@ export class MCPServerProxy {
   async refreshServerTools(serverName: string): Promise<void> {
     const client = this.clients.get(serverName);
     if (!client) {
-      throw new Error(`Server ${serverName} not found`);
+      throw new Error(`未找到服务器 ${serverName}`);
     }
 
     await client.refreshTools();
@@ -634,19 +632,19 @@ export class MCPServerProxy {
   async callTool(toolName: string, arguments_: any): Promise<any> {
     const clientName = this.toolMap.get(toolName);
     if (!clientName) {
-      throw new Error(`Unknown tool: ${toolName}`);
+      throw new Error(`未知的工具：${toolName}`);
     }
 
     const client = this.clients.get(clientName);
     if (!client || !client.initialized) {
-      throw new Error(`Client ${clientName} not available`);
+      throw new Error(`客户端 ${clientName} 不可用`);
     }
 
     return await client.callTool(toolName, arguments_);
   }
 
   stop() {
-    logger.info("Stopping MCP Server Proxy");
+    logger.info("正在停止 MCP 服务代理");
     for (const client of this.clients.values()) {
       client.stop();
     }
@@ -670,7 +668,7 @@ export class JSONRPCServer {
     try {
       const parsedMessage = JSON.parse(message);
       logger.debug(
-        `Received request: ${JSON.stringify(parsedMessage).substring(0, 200)}...`
+        `收到请求：${JSON.stringify(parsedMessage).substring(0, 200)}...`
       );
 
       if (parsedMessage.method) {
@@ -683,17 +681,17 @@ export class JSONRPCServer {
         await this.handleNotification(parsedMessage);
         return null; // No response for notifications
       }
-      throw new Error("Invalid JSON-RPC message");
+      throw new Error("无效的 JSON-RPC 消息");
     } catch (error) {
       logger.error(
-        `Error handling message: ${error instanceof Error ? error.message : String(error)}`
+        `处理消息时出错：${error instanceof Error ? error.message : String(error)}`
       );
       return JSON.stringify({
         jsonrpc: "2.0",
         id: null,
         error: {
           code: -32700,
-          message: "Parse error",
+          message: "解析错误",
         },
       });
     }
@@ -719,7 +717,7 @@ export class JSONRPCServer {
           result = await this.handlePing(params);
           break;
         default:
-          throw new Error(`Unknown method: ${method}`);
+          throw new Error(`未知的方法：${method}`);
       }
 
       return {
@@ -729,7 +727,7 @@ export class JSONRPCServer {
       };
     } catch (error) {
       logger.error(
-        `Error handling request ${method}: ${error instanceof Error ? error.message : String(error)}`
+        `处理请求 ${method} 时出错：${error instanceof Error ? error.message : String(error)}`
       );
       return {
         jsonrpc: "2.0",
@@ -747,18 +745,16 @@ export class JSONRPCServer {
 
     switch (method) {
       case "notifications/initialized":
-        logger.info("Client sent initialized notification");
+        logger.info("客户端发送了初始化通知");
         break;
       default:
-        logger.debug(`Received notification: ${method}`);
+        logger.debug(`收到通知：${method}`);
         break;
     }
   }
 
   async handleInitialize(params: any): Promise<any> {
-    logger.info(
-      `Initialize request from client: ${JSON.stringify(params.clientInfo)}`
-    );
+    logger.info(`收到客户端的初始化请求：${JSON.stringify(params.clientInfo)}`);
 
     return {
       protocolVersion: "2024-11-05",
@@ -776,11 +772,11 @@ export class JSONRPCServer {
 
   async handleToolsList(_params: any): Promise<any> {
     if (!this.proxy.initialized) {
-      throw new Error("Proxy not initialized");
+      throw new Error("代理未初始化");
     }
 
     const tools = this.proxy.getAllTools();
-    logger.info(`Returning ${tools.length} tools`);
+    logger.info(`返回 ${tools.length} 个工具`);
 
     return {
       tools: tools,
@@ -791,17 +787,17 @@ export class JSONRPCServer {
     const { name, arguments: args } = params;
 
     if (!name) {
-      throw new Error("Tool name is required");
+      throw new Error("工具名称是必需的");
     }
 
-    logger.info(`Calling tool: ${name} with args: ${JSON.stringify(args)}`);
+    logger.info(`调用工具：${name}，参数：${JSON.stringify(args)}`);
 
     const result = await this.proxy.callTool(name, args || {});
     return result;
   }
 
   async handlePing(_params: any): Promise<any> {
-    logger.debug("Received ping request");
+    logger.debug("收到 ping 请求");
     return {}; // Empty response for ping
   }
 }
@@ -810,7 +806,7 @@ export class JSONRPCServer {
  * Main function to start the MCP Server Proxy
  */
 async function main() {
-  logger.info("Starting MCP Server Proxy");
+  logger.info("正在启动 MCP 服务代理");
 
   // Create and start the proxy
   const proxy = new MCPServerProxy();
@@ -818,7 +814,7 @@ async function main() {
 
   // Setup graceful shutdown
   const cleanup = () => {
-    logger.info("Shutting down MCP Server Proxy");
+    logger.info("正在关闭 MCP 服务代理");
     proxy.stop();
     process.exit(0);
   };
@@ -851,7 +847,7 @@ async function main() {
             }
           } catch (error) {
             logger.error(
-              `Error processing message: ${error instanceof Error ? error.message : String(error)}`
+              `处理消息时出错：${error instanceof Error ? error.message : String(error)}`
             );
           }
         }
@@ -859,14 +855,14 @@ async function main() {
     });
 
     process.stdin.on("end", () => {
-      logger.info("stdin closed, shutting down");
+      logger.info("标准输入已关闭，正在关闭");
       cleanup();
     });
 
-    logger.info("MCP Server Proxy is running on stdio");
+    logger.info("MCP 服务代理正在通过 stdio 运行");
   } catch (error) {
     logger.error(
-      `Failed to start MCP Server Proxy: ${error instanceof Error ? error.message : String(error)}`
+      `启动 MCP 服务代理失败：${error instanceof Error ? error.message : String(error)}`
     );
     process.exit(1);
   }
@@ -881,7 +877,7 @@ const argv1Path = process.argv[1];
 if (scriptPath === argv1Path) {
   main().catch((error) => {
     logger.error(
-      `Unhandled error: ${error instanceof Error ? error.message : String(error)}`
+      `未处理的错误：${error instanceof Error ? error.message : String(error)}`
     );
     process.exit(1);
   });

--- a/src/mcpServerProxy.ts
+++ b/src/mcpServerProxy.ts
@@ -16,25 +16,19 @@ import {
   type MCPToolConfig,
   configManager,
 } from "./configManager";
+import { logger as globalLogger } from "./logger";
 
 // ESM 兼容的 __dirname
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-// Simple logger utility
-const logger = {
-  info: (message: string): void => {
-    const timestamp = new Date().toISOString();
-    console.error(`${timestamp} - MCPProxy - INFO - ${message}`);
-  },
-  error: (message: string): void => {
-    const timestamp = new Date().toISOString();
-    console.error(`${timestamp} - MCPProxy - ERROR - ${message}`);
-  },
-  debug: (message: string): void => {
-    const timestamp = new Date().toISOString();
-    console.error(`${timestamp} - MCPProxy - DEBUG - ${message}`);
-  },
-};
+// 为 MCPProxy 创建带标签的 logger
+const logger = globalLogger.withTag("MCPProxy");
+
+// 如果在守护进程模式下运行，初始化日志文件
+if (process.env.XIAOZHI_DAEMON === "true" && process.env.XIAOZHI_CONFIG_DIR) {
+  globalLogger.initLogFile(process.env.XIAOZHI_CONFIG_DIR);
+  globalLogger.enableFileLogging(true);
+}
 
 // Type definitions
 

--- a/tsup.config.ts
+++ b/tsup.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
     "src/configManager.ts",
     "src/mcpCommands.ts",
     "src/autoCompletion.ts",
+    "src/logger.ts",
   ],
   format: ["esm"],
   target: "node18",


### PR DESCRIPTION
- 创建独立的日志管理模块,支持console输出和文件写入
- 后台模式(-d)运行时自动将日志写入项目目录下的xiaozhi.log文件
- 创建项目时自动生成空的日志文件
- 将临时目录的日志文件位置改为项目目录,方便用户查看
- 统一mcpPipe和mcpServerProxy的日志输出,使用带标签的logger实例
- 修复attach命令从项目目录正确读取日志文件