### PR TITLE
feat(ci): 实现 PR 合并后自动发布正式版

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,8 @@
 name: Release
 on:
+  push:
+    branches:
+      - main
   workflow_dispatch:
     inputs:
       version_type:
@@ -31,7 +34,11 @@ jobs:
           
       - name: 确认当前分支
         run: |
-          echo "当前在 main 分支，准备发布 ${{ github.event.inputs.version_type }} 版本"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "PR 合并到 main 分支，准备自动发布正式版"
+          else
+            echo "手动触发发布，准备发布 ${{ github.event.inputs.version_type }} 版本"
+          fi
 
       - name: 安装 pnpm
         uses: pnpm/action-setup@v4
@@ -62,10 +69,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
-          if [ "${{ github.event.inputs.version_type }}" = "stable" ]; then
-            echo "执行稳定版发布 (main 分支)"
+          if [ "${{ github.event_name }}" = "push" ]; then
+            echo "PR 合并触发，执行稳定版发布"
+            npx semantic-release
+          elif [ "${{ github.event.inputs.version_type }}" = "stable" ]; then
+            echo "手动触发稳定版发布"
             npx semantic-release
           else
-            echo "执行 beta 版发布 (main 分支)"
+            echo "手动触发 beta 版发布"
             npx semantic-release --extends ./.releaserc.beta.json
           fi


### PR DESCRIPTION
- 添加 push 事件触发器，当代码推送到 main 分支时自动触发发布流程
- 优化发布逻辑，区分 PR 合并自动触发和手动触发两种场景
- PR 合并到 main 分支时自动执行正式版发布
- 保留手动触发功能，支持选择发布正式版或 beta 版