### PR TITLE
docs(readme): 添加自建服务端 JSON-RPC 消息格式规范文档

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,126 @@ xiaozhi-client 现已支持接入 [ModelScope](https://www.modelscope.cn/mcp) �
 - 确保网络能够访问 ModelScope 的服务端点
 - SSE 类型的服务会自动识别并使用相应的连接方式
 
+## 自建服务端 JSON-RPC 消息格式规范
+
+如果您使用自建的 MCP 服务端，请确保遵循以下 JSON-RPC 2.0 消息格式规范：
+
+### 消息类型
+
+#### 1. 请求（Request）- 需要响应
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "方法名",
+  "params": {},
+  "id": 1  // 必须包含id字段，可以是数字或字符串
+}
+```
+
+支持的请求方法：
+- `initialize` - 初始化连接
+- `tools/list` - 获取工具列表
+- `tools/call` - 调用工具
+- `ping` - 连接测试
+
+#### 2. 通知（Notification）- 不需要响应
+```json
+{
+  "jsonrpc": "2.0",
+  "method": "方法名",
+  "params": {}
+  // 注意：不能包含id字段
+}
+```
+
+支持的通知方法：
+- `notifications/initialized` - 初始化完成通知
+
+#### 3. 成功响应（Response）
+```json
+{
+  "jsonrpc": "2.0",
+  "result": {},
+  "id": 1  // 必须与请求的id相同
+}
+```
+
+#### 4. 错误响应（Error）
+```json
+{
+  "jsonrpc": "2.0",
+  "error": {
+    "code": -32600,
+    "message": "错误描述"
+  },
+  "id": 1  // 必须与请求的id相同
+}
+```
+
+### 重要注意事项
+
+1. **关键区别**：请求和通知的唯一区别是是否包含 `id` 字段
+   - 有 `id` = 请求，需要响应
+   - 无 `id` = 通知，不需要响应
+
+2. **"notifications/initialized" 必须作为通知发送**：
+   ```json
+   // ✅ 正确
+   {
+     "jsonrpc": "2.0",
+     "method": "notifications/initialized"
+   }
+   
+   // ❌ 错误 - 不应包含id
+   {
+     "jsonrpc": "2.0",
+     "method": "notifications/initialized",
+     "id": 1
+   }
+   ```
+
+3. **消息分隔**：每条 JSON-RPC 消息必须以换行符 `\n` 结束
+
+4. **通信流程**：
+   1. 客户端发送 `initialize` 请求
+   2. 服务端返回 `initialize` 响应
+   3. 客户端发送 `notifications/initialized` 通知（无需响应）
+   4. 后续可进行工具列表查询和调用
+
+### 通信时序图
+
+```mermaid
+sequenceDiagram
+    participant Client as 小智客户端
+    participant Server as 自建MCP服务端
+    
+    Note over Client,Server: 初始化阶段
+    Client->>Server: {"jsonrpc":"2.0","method":"initialize","params":{...},"id":1}
+    Server->>Client: {"jsonrpc":"2.0","result":{...},"id":1}
+    Client->>Server: {"jsonrpc":"2.0","method":"notifications/initialized"}
+    Note over Server: 无需响应通知
+    
+    Note over Client,Server: 获取工具列表
+    Client->>Server: {"jsonrpc":"2.0","method":"tools/list","params":{},"id":2}
+    Server->>Client: {"jsonrpc":"2.0","result":{"tools":[...]},"id":2}
+    
+    Note over Client,Server: 调用工具
+    Client->>Server: {"jsonrpc":"2.0","method":"tools/call","params":{...},"id":3}
+    Server->>Client: {"jsonrpc":"2.0","result":{...},"id":3}
+    
+    Note over Client,Server: 保持连接
+    Client->>Server: {"jsonrpc":"2.0","method":"ping","params":{},"id":4}
+    Server->>Client: {"jsonrpc":"2.0","result":{},"id":4}
+    
+    Note over Client,Server: 错误处理示例
+    Client->>Server: {"jsonrpc":"2.0","method":"unknown_method","params":{},"id":5}
+    Server->>Client: {"jsonrpc":"2.0","error":{"code":-32601,"message":"Method not found"},"id":5}
+```
+
+### 常见错误
+
+如果您看到类似 "未知的方法：notifications/initialized" 的错误，通常是因为在通知消息中错误地包含了 `id` 字段，导致客户端将其识别为请求而非通知。
+
 ## 路线图
 
 - ✅ 支持 通过 SSE 类型的 MCP Server


### PR DESCRIPTION
为帮助自建 MCP 服务端的用户理解正确的消息格式，在 README.md 中新增了详细的 JSON-RPC 2.0 消息格式规范章节，包括：

- 四种消息类型的格式说明（请求、通知、成功响应、错误响应）
- 支持的方法列表和用途说明
- 请求与通知的关键区别（id 字段的有无）
- 完整的通信时序图（使用 Mermaid 格式）
- 常见错误的解释和解决方案

该文档特别强调了 "notifications/initialized" 必须作为通知发送（不包含 id 字段），以避免"未知的方法"错误。