### PR TITLE
fix(web-ui): 修复 WebSocket 日志噪音和退出卡顿问题

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1011,13 +1011,25 @@ async function startUIService(): Promise<void> {
     }
 
     // 处理退出信号
+    let isExiting = false;
     process.on("SIGINT", async () => {
+      if (isExiting) {
+        console.log(chalk.red("\n强制退出..."));
+        process.exit(1);
+      }
+      isExiting = true;
       console.log(chalk.yellow("\n正在停止 UI 服务..."));
-      await webServer.stop();
+      try {
+        await webServer.stop();
+        console.log(chalk.green("UI 服务已停止"));
+      } catch (error) {
+        console.log(chalk.red("停止服务时出错，强制退出"));
+      }
       process.exit(0);
     });
 
     process.on("SIGTERM", async () => {
+      isExiting = true;
       await webServer.stop();
       process.exit(0);
     });

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -430,7 +430,7 @@ export class MCPPipe {
           },
         };
         statusWs.send(JSON.stringify(status));
-        logger.info("已向 Web UI 报告状态");
+        logger.debug("已向 Web UI 报告状态");
 
         // Close connection after sending status
         setTimeout(() => {


### PR DESCRIPTION
问题修复：
- 将 WebSocket 连接/断开日志从 info 改为 debug 级别，减少控制台噪音
- 修复 Ctrl+C 无法正常退出的问题，添加强制断开客户端连接的逻辑
- 设置 2 秒超时机制，确保服务能够及时关闭
- 改进退出提示信息，支持二次 Ctrl+C 强制退出

技术细节：
- WebServer.stop() 方法现在会主动终止所有 WebSocket 客户端连接
- 优化了 startUIService 的信号处理，提供更友好的退出体验
- 将 mcpPipe 的状态报告日志也改为 debug 级别