### PR TITLE
fix(logger): 修复守护进程模式下 EPIPE 错误导致日志文件快速膨胀问题

### DIFF
--- a/src/logger.ts
+++ b/src/logger.ts
@@ -75,7 +75,7 @@ export class Logger {
               console.error(message);
             } catch (error) {
               // 忽略 EPIPE 错误
-              if (error instanceof Error && error.message.includes('EPIPE')) {
+              if (error instanceof Error && error.message.includes("EPIPE")) {
                 return;
               }
               throw error;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -75,7 +75,7 @@ export class Logger {
               console.error(message);
             } catch (error) {
               // 忽略 EPIPE 错误
-              if (error instanceof Error && error.message.includes("EPIPE")) {
+              if (error instanceof Error && error.message?.includes("EPIPE")) {
                 return;
               }
               throw error;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -18,8 +18,11 @@ export class Logger {
   private logFilePath: string | null = null;
   private writeStream: fs.WriteStream | null = null;
   private consolaInstance: typeof consola;
+  private isDaemonMode: boolean;
 
   constructor() {
+    // 检查是否为守护进程模式
+    this.isDaemonMode = process.env.XIAOZHI_DAEMON === "true";
     // 创建自定义的 consola 实例，禁用图标并自定义格式
     this.consolaInstance = createConsola({
       formatOptions: {
@@ -29,6 +32,9 @@ export class Logger {
       },
       fancy: false,
     });
+
+    // 保存对当前实例的引用，以便在闭包中访问
+    const isDaemonMode = this.isDaemonMode;
 
     // 自定义格式化器
     this.consolaInstance.setReporters([
@@ -62,8 +68,19 @@ export class Logger {
             " "
           )}`;
 
-          // 输出到 stderr（与原来保持一致）
-          console.error(message);
+          // 守护进程模式下不输出到控制台，只写入文件
+          if (!isDaemonMode) {
+            // 输出到 stderr（与原来保持一致）
+            try {
+              console.error(message);
+            } catch (error) {
+              // 忽略 EPIPE 错误
+              if (error instanceof Error && error.message.includes('EPIPE')) {
+                return;
+              }
+              throw error;
+            }
+          }
         },
       },
     ]);

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -79,7 +79,9 @@ export class MCPPipe {
         reconnectInterval: 5000,
       };
       logger.warn(
-        `无法获取连接配置，使用默认值: ${error instanceof Error ? error.message : String(error)}`
+        `无法获取连接配置，使用默认值: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
     }
   }
@@ -181,7 +183,9 @@ export class MCPPipe {
     reconnectAttempt++;
 
     logger.info(
-      `计划在 ${(this.connectionConfig.reconnectInterval / 1000).toFixed(2)} 秒后进行第 ${reconnectAttempt} 次重连尝试...`
+      `计划在 ${(this.connectionConfig.reconnectInterval / 1000).toFixed(
+        2
+      )} 秒后进行第 ${reconnectAttempt} 次重连尝试...`
     );
 
     this.reconnectTimer = setTimeout(() => {
@@ -372,7 +376,9 @@ export class MCPPipe {
         }, 5000);
       } catch (error) {
         logger.error(
-          `终止进程时出错: ${error instanceof Error ? error.message : String(error)}`
+          `终止进程时出错: ${
+            error instanceof Error ? error.message : String(error)
+          }`
         );
       }
       this.process = null;
@@ -450,7 +456,9 @@ export class MCPPipe {
       });
     } catch (error) {
       logger.debug(
-        `向 Web UI 报告状态失败: ${error instanceof Error ? error.message : String(error)}`
+        `向 Web UI 报告状态失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
     }
   }
@@ -484,7 +492,7 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
     // 处理未捕获的异常
     process.on("uncaughtException", (error) => {
       // 如果是 EPIPE 错误（通常是因为终端关闭），静默处理
-      if (error.message && error.message.includes("EPIPE")) {
+      if (error.message?.includes("EPIPE")) {
         // EPIPE 错误在守护进程模式下是正常的，不需要记录
         return;
       }

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -484,11 +484,11 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
     // 处理未捕获的异常
     process.on("uncaughtException", (error) => {
       // 如果是 EPIPE 错误（通常是因为终端关闭），静默处理
-      if (error.message && error.message.includes('EPIPE')) {
+      if (error.message && error.message.includes("EPIPE")) {
         // EPIPE 错误在守护进程模式下是正常的，不需要记录
         return;
       }
-      
+
       // 其他错误正常记录
       try {
         logger.error(`守护进程模式下的未捕获异常: ${error.message}`);

--- a/src/mcpPipe.ts
+++ b/src/mcpPipe.ts
@@ -303,7 +303,14 @@ export class MCPPipe {
 
     // Handle process stderr - print to terminal
     this.process.stderr?.on("data", (data: Buffer) => {
-      process.stderr.write(data);
+      // 在守护进程模式下，避免写入已关闭的 stderr
+      if (process.env.XIAOZHI_DAEMON !== "true") {
+        try {
+          process.stderr.write(data);
+        } catch (error) {
+          // 忽略 EPIPE 错误
+        }
+      }
     });
 
     // Handle process exit
@@ -476,8 +483,19 @@ export function setupSignalHandlers(mcpPipe: MCPPipe): void {
 
     // 处理未捕获的异常
     process.on("uncaughtException", (error) => {
-      logger.error(`守护进程模式下的未捕获异常: ${error.message}`);
-      logger.error(error.stack || "No stack trace available");
+      // 如果是 EPIPE 错误（通常是因为终端关闭），静默处理
+      if (error.message && error.message.includes('EPIPE')) {
+        // EPIPE 错误在守护进程模式下是正常的，不需要记录
+        return;
+      }
+      
+      // 其他错误正常记录
+      try {
+        logger.error(`守护进程模式下的未捕获异常: ${error.message}`);
+        logger.error(error.stack || "No stack trace available");
+      } catch (logError) {
+        // 如果日志记录失败（可能因为另一个 EPIPE 错误），则忽略
+      }
       // 守护进程遇到未捕获的异常时不退出，而是继续运行
     });
 
@@ -506,17 +524,23 @@ async function main() {
   let endpointUrl: string;
 
   try {
-    // 调试信息 - 使用 process.stderr.write 确保能看到
-    process.stderr.write(
-      `[DEBUG] XIAOZHI_CONFIG_DIR: ${process.env.XIAOZHI_CONFIG_DIR}\n`
-    );
-    process.stderr.write(`[DEBUG] process.cwd(): ${process.cwd()}\n`);
-    process.stderr.write(
-      `[DEBUG] configManager.getConfigPath(): ${configManager.getConfigPath()}\n`
-    );
-    process.stderr.write(
-      `[DEBUG] configManager.configExists(): ${configManager.configExists()}\n`
-    );
+    // 调试信息 - 只在非守护进程模式下输出
+    if (process.env.XIAOZHI_DAEMON !== "true") {
+      try {
+        process.stderr.write(
+          `[DEBUG] XIAOZHI_CONFIG_DIR: ${process.env.XIAOZHI_CONFIG_DIR}\n`
+        );
+        process.stderr.write(`[DEBUG] process.cwd(): ${process.cwd()}\n`);
+        process.stderr.write(
+          `[DEBUG] configManager.getConfigPath(): ${configManager.getConfigPath()}\n`
+        );
+        process.stderr.write(
+          `[DEBUG] configManager.configExists(): ${configManager.configExists()}\n`
+        );
+      } catch (error) {
+        // 忽略写入错误
+      }
+    }
 
     // 首先尝试从配置文件读取
     if (configManager.configExists()) {


### PR DESCRIPTION
- 在 Logger 类中检测守护进程模式，避免向已关闭的 stderr 写入
- 守护进程模式下禁用控制台输出，仅保留文件日志
- 添加 EPIPE 错误捕获和处理机制
- 在 mcpPipe.ts 中为所有 stderr 写入操作添加保护
- 特殊处理 uncaughtException 中的 EPIPE 错误，防止无限循环

修复 #issue 守护进程模式下终端关闭后日志文件无限增长的问题