### PR TITLE
fix(mcp): 优化错误重试机制和连接稳定性

### DIFF
--- a/src/mcpServerProxy.ts
+++ b/src/mcpServerProxy.ts
@@ -177,10 +177,14 @@ export class MCPClient implements IMCPClient {
     }
 
     logger.debug(
-      `${this.name} 正在生成进程：${resolvedCommand} ${resolvedArgs.join(" ")} 工作目录：${spawnOptions.cwd}`
+      `${this.name} 正在生成进程：${resolvedCommand} ${resolvedArgs.join(
+        " "
+      )} 工作目录：${spawnOptions.cwd}`
     );
     logger.debug(
-      `${this.name} 平台：${process.platform}，shell 模式：${spawnOptions.shell || false}`
+      `${this.name} 平台：${process.platform}，shell 模式：${
+        spawnOptions.shell || false
+      }`
     );
 
     this.process = spawn(resolvedCommand, resolvedArgs, spawnOptions);
@@ -249,14 +253,19 @@ export class MCPClient implements IMCPClient {
 
         if (message.error) {
           // 对于 notifications/initialized 的 "Method not found" 错误，记录为调试信息而不是错误
-          if (message.error.code === -32601 && pendingRequest.method === "notifications/initialized") {
+          if (
+            message.error.code === -32601 &&
+            pendingRequest.method === "notifications/initialized"
+          ) {
             logger.debug(
               `${this.name} 服务器不支持 notifications/initialized 通知，这是正常的`
             );
             resolve(null); // 将其视为成功
           } else {
             reject(
-              new Error(`${message.error.message} (code: ${message.error.code})`)
+              new Error(
+                `${message.error.message} (code: ${message.error.code})`
+              )
             );
           }
         } else {
@@ -310,7 +319,9 @@ export class MCPClient implements IMCPClient {
       });
 
       logger.info(
-        `${this.name} 已初始化，能力：${JSON.stringify((initResult as any).capabilities)}`
+        `${this.name} 已初始化，能力：${JSON.stringify(
+          (initResult as any).capabilities
+        )}`
       );
 
       // Send initialized notification (ignore errors as some servers don't support it)
@@ -322,7 +333,9 @@ export class MCPClient implements IMCPClient {
         this.process?.stdin?.write(`${JSON.stringify(notification)}\n`);
       } catch (error) {
         logger.debug(
-          `${this.name} notifications/initialized 发送失败（某些服务器不支持此通知）：${
+          `${
+            this.name
+          } notifications/initialized 发送失败（某些服务器不支持此通知）：${
             error instanceof Error ? error.message : String(error)
           }`
         );
@@ -335,7 +348,9 @@ export class MCPClient implements IMCPClient {
       logger.info(`${this.name} 客户端已就绪，共 ${this.tools.length} 个工具`);
     } catch (error) {
       logger.error(
-        `初始化 ${this.name} 失败：${error instanceof Error ? error.message : String(error)}`
+        `初始化 ${this.name} 失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       throw error;
     }
@@ -359,14 +374,20 @@ export class MCPClient implements IMCPClient {
       await this.updateToolsConfig();
 
       logger.info(
-        `${this.name} 加载了 ${this.originalTools.length} 个工具：${this.originalTools.map((t) => t.name).join(", ")}`
+        `${this.name} 加载了 ${
+          this.originalTools.length
+        } 个工具：${this.originalTools.map((t) => t.name).join(", ")}`
       );
       logger.info(
-        `${this.name} 启用了 ${this.tools.length} 个工具：${this.tools.map((t) => t.name).join(", ")}`
+        `${this.name} 启用了 ${this.tools.length} 个工具：${this.tools
+          .map((t) => t.name)
+          .join(", ")}`
       );
     } catch (error) {
       logger.error(
-        `从 ${this.name} 获取工具失败：${error instanceof Error ? error.message : String(error)}`
+        `从 ${this.name} 获取工具失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       this.tools = [];
       this.originalTools = [];
@@ -419,7 +440,9 @@ export class MCPClient implements IMCPClient {
       }
     } catch (error) {
       logger.error(
-        `更新 ${this.name} 的工具配置失败：${error instanceof Error ? error.message : String(error)}`
+        `更新 ${this.name} 的工具配置失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
     }
   }
@@ -439,7 +462,11 @@ export class MCPClient implements IMCPClient {
       return result;
     } catch (error) {
       logger.error(
-        `在 ${this.name} 上调用工具 ${prefixedName} (原始名称：${this.getOriginalToolName(prefixedName)}) 失败：${error instanceof Error ? error.message : String(error)}`
+        `在 ${
+          this.name
+        } 上调用工具 ${prefixedName} (原始名称：${this.getOriginalToolName(
+          prefixedName
+        )}) 失败：${error instanceof Error ? error.message : String(error)}`
       );
       throw error;
     }
@@ -482,7 +509,9 @@ export function loadMCPConfig(): Record<string, MCPServerConfig> {
         }
 
         logger.info(
-          `从旧配置文件加载了 ${Object.keys(config.mcpServers).length} 个 MCP 服务（建议迁移到新配置格式）`
+          `从旧配置文件加载了 ${
+            Object.keys(config.mcpServers).length
+          } 个 MCP 服务（建议迁移到新配置格式）`
         );
         return config.mcpServers;
       } catch (legacyError) {
@@ -495,7 +524,9 @@ export function loadMCPConfig(): Record<string, MCPServerConfig> {
     throw new Error('配置文件不存在，请运行 "xiaozhi init" 初始化配置');
   } catch (error) {
     logger.error(
-      `加载 MCP 配置失败：${error instanceof Error ? error.message : String(error)}`
+      `加载 MCP 配置失败：${
+        error instanceof Error ? error.message : String(error)
+      }`
     );
     throw error;
   }
@@ -601,11 +632,15 @@ export class MCPServerProxy {
       this.initialized = true;
 
       logger.info(
-        `MCP 服务代理初始化成功，启动了 ${successCount}/${Object.keys(this.config).length} 个客户端`
+        `MCP 服务代理初始化成功，启动了 ${successCount}/${
+          Object.keys(this.config).length
+        } 个客户端`
       );
     } catch (error) {
       logger.error(
-        `启动 MCP 客户端失败：${error instanceof Error ? error.message : String(error)}`
+        `启动 MCP 客户端失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       throw error;
     }
@@ -620,7 +655,9 @@ export class MCPServerProxy {
         // 但我们仍然检查以防万一
         if (this.toolMap.has(tool.name)) {
           logger.error(
-            `重复的工具名称：${tool.name} (来自 ${clientName} 和 ${this.toolMap.get(tool.name)})`
+            `重复的工具名称：${
+              tool.name
+            } (来自 ${clientName} 和 ${this.toolMap.get(tool.name)})`
           );
         } else {
           this.toolMap.set(tool.name, clientName);
@@ -762,7 +799,9 @@ export class JSONRPCServer {
       throw new Error("无效的 JSON-RPC 消息");
     } catch (error) {
       logger.error(
-        `处理消息时出错：${error instanceof Error ? error.message : String(error)}`
+        `处理消息时出错：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       return JSON.stringify({
         jsonrpc: "2.0",
@@ -805,7 +844,9 @@ export class JSONRPCServer {
       };
     } catch (error) {
       logger.error(
-        `处理请求 ${method} 时出错：${error instanceof Error ? error.message : String(error)}`
+        `处理请求 ${method} 时出错：${
+          error instanceof Error ? error.message : String(error)
+        }`
       );
       return {
         jsonrpc: "2.0",
@@ -943,7 +984,9 @@ async function main() {
             }
           } catch (error) {
             logger.error(
-              `处理消息时出错：${error instanceof Error ? error.message : String(error)}`
+              `处理消息时出错：${
+                error instanceof Error ? error.message : String(error)
+              }`
             );
           }
         }
@@ -958,7 +1001,9 @@ async function main() {
     logger.info("MCP 服务代理正在通过 stdio 运行");
   } catch (error) {
     logger.error(
-      `启动 MCP 服务代理失败：${error instanceof Error ? error.message : String(error)}`
+      `启动 MCP 服务代理失败：${
+        error instanceof Error ? error.message : String(error)
+      }`
     );
     process.exit(1);
   }

--- a/src/multiEndpointMCPPipe.test.ts
+++ b/src/multiEndpointMCPPipe.test.ts
@@ -321,7 +321,7 @@ describe("MultiEndpointMCPPipe", () => {
       vi.useRealTimers();
     });
 
-    it("should not reconnect on permanent error (4004)", async () => {
+    it("should limit reconnection attempts on 4004 error", async () => {
       mcpPipe = new MultiEndpointMCPPipe("test.js", [mockEndpoints[0]]);
       const scheduleReconnectSpy = vi.spyOn(
         mcpPipe as any,
@@ -337,10 +337,11 @@ describe("MultiEndpointMCPPipe", () => {
 
       await mcpPipe.connectToEndpoint(mockEndpoints[0]);
 
-      // Simulate permanent error
-      mockWs.emit("close", 4004, "Permanent error");
+      // Simulate 4004 error - should allow limited reconnection attempts
+      mockWs.emit("close", 4004, "Internal server error");
 
-      expect(scheduleReconnectSpy).not.toHaveBeenCalled();
+      // Should schedule reconnect for 4004 error (but with limits)
+      expect(scheduleReconnectSpy).toHaveBeenCalledWith(mockEndpoints[0]);
     });
   });
 

--- a/src/multiEndpointMCPPipe.ts
+++ b/src/multiEndpointMCPPipe.ts
@@ -173,7 +173,9 @@ export class MultiEndpointMCPPipe {
         if (code === 4004) {
           if (endpoint.reconnectAttempt < endpoint.maxReconnectAttempts) {
             logger.warn(
-              `[${endpointUrl}] 服务器内部错误(4004)，将进行第 ${endpoint.reconnectAttempt + 1} 次重连尝试（最多 ${endpoint.maxReconnectAttempts} 次）`
+              `[${endpointUrl}] 服务器内部错误(4004)，将进行第 ${
+                endpoint.reconnectAttempt + 1
+              } 次重连尝试（最多 ${endpoint.maxReconnectAttempts} 次）`
             );
             this.scheduleReconnect(endpointUrl);
           } else {
@@ -221,12 +223,14 @@ export class MultiEndpointMCPPipe {
     const baseDelay = this.connectionConfig.reconnectInterval;
     const maxDelay = 60000; // 最大延迟60秒
     const exponentialDelay = Math.min(
-      baseDelay * (2 ** (endpoint.reconnectAttempt - 1)),
+      baseDelay * 2 ** (endpoint.reconnectAttempt - 1),
       maxDelay
     );
 
     logger.info(
-      `[${endpointUrl}] 计划在 ${(exponentialDelay / 1000).toFixed(2)} 秒后进行第 ${endpoint.reconnectAttempt} 次重连尝试...`
+      `[${endpointUrl}] 计划在 ${(exponentialDelay / 1000).toFixed(
+        2
+      )} 秒后进行第 ${endpoint.reconnectAttempt} 次重连尝试...`
     );
 
     endpoint.reconnectTimer = setTimeout(async () => {

--- a/src/multiEndpointMCPPipe.ts
+++ b/src/multiEndpointMCPPipe.ts
@@ -25,6 +25,7 @@ interface EndpointConnection {
   websocket: WebSocket | null;
   isConnected: boolean;
   reconnectAttempt: number;
+  maxReconnectAttempts: number; // 最大重连次数
   reconnectTimer?: NodeJS.Timeout;
   heartbeatTimer?: NodeJS.Timeout;
   heartbeatTimeoutTimer?: NodeJS.Timeout;
@@ -62,6 +63,7 @@ export class MultiEndpointMCPPipe {
         websocket: null,
         isConnected: false,
         reconnectAttempt: 0,
+        maxReconnectAttempts: 5, // 允许最多5次重连尝试
         process: null,
         stdoutBuffer: "",
       });
@@ -129,7 +131,13 @@ export class MultiEndpointMCPPipe {
     ws.on("open", () => {
       logger.info(`成功连接到 WebSocket 服务器: ${endpointUrl}`);
       endpoint.isConnected = true;
-      endpoint.reconnectAttempt = 0;
+      endpoint.reconnectAttempt = 0; // 重置重连计数器
+
+      // 清除重连定时器
+      if (endpoint.reconnectTimer) {
+        clearTimeout(endpoint.reconnectTimer);
+        endpoint.reconnectTimer = undefined;
+      }
 
       // 报告状态
       this.reportStatusToWebUI();
@@ -159,9 +167,24 @@ export class MultiEndpointMCPPipe {
       // 报告断开状态
       this.reportStatusToWebUI();
 
-      // 如果应该重连且不是永久错误
-      if (this.shouldReconnect && code !== 4004) {
-        this.scheduleReconnect(endpointUrl);
+      // 改进重连逻辑：允许对4004错误进行有限次数的重连
+      if (this.shouldReconnect) {
+        // 对于4004错误，只在重连次数未超过限制时重连
+        if (code === 4004) {
+          if (endpoint.reconnectAttempt < endpoint.maxReconnectAttempts) {
+            logger.warn(
+              `[${endpointUrl}] 服务器内部错误(4004)，将进行第 ${endpoint.reconnectAttempt + 1} 次重连尝试（最多 ${endpoint.maxReconnectAttempts} 次）`
+            );
+            this.scheduleReconnect(endpointUrl);
+          } else {
+            logger.error(
+              `[${endpointUrl}] 服务器内部错误(4004)，已达到最大重连次数(${endpoint.maxReconnectAttempts})，停止重连`
+            );
+          }
+        } else {
+          // 其他错误码正常重连
+          this.scheduleReconnect(endpointUrl);
+        }
       }
     });
 
@@ -194,21 +217,30 @@ export class MultiEndpointMCPPipe {
 
     endpoint.reconnectAttempt++;
 
-    logger.info(
-      `[${endpointUrl}] 计划在 ${(
-        this.connectionConfig.reconnectInterval / 1000
-      ).toFixed(2)} 秒后进行第 ${endpoint.reconnectAttempt} 次重连尝试...`
+    // 使用指数退避算法计算重连延迟
+    const baseDelay = this.connectionConfig.reconnectInterval;
+    const maxDelay = 60000; // 最大延迟60秒
+    const exponentialDelay = Math.min(
+      baseDelay * (2 ** (endpoint.reconnectAttempt - 1)),
+      maxDelay
     );
 
-    endpoint.reconnectTimer = setTimeout(() => {
+    logger.info(
+      `[${endpointUrl}] 计划在 ${(exponentialDelay / 1000).toFixed(2)} 秒后进行第 ${endpoint.reconnectAttempt} 次重连尝试...`
+    );
+
+    endpoint.reconnectTimer = setTimeout(async () => {
       if (this.shouldReconnect) {
+        // 在重连前清理资源
+        await this.cleanupEndpointResources(endpointUrl);
+
         // 如果MCP进程不存在，先尝试重启
         if (!endpoint.process || endpoint.process.killed) {
           logger.info(`[${endpointUrl}] MCP 进程未运行，将在重连时启动...`);
         }
         this.connectToEndpoint(endpointUrl);
       }
-    }, this.connectionConfig.reconnectInterval);
+    }, exponentialDelay);
   }
 
   startMCPProcessForEndpoint(endpointUrl: string) {
@@ -360,6 +392,67 @@ export class MultiEndpointMCPPipe {
       clearTimeout(endpoint.heartbeatTimeoutTimer);
       endpoint.heartbeatTimeoutTimer = undefined;
     }
+  }
+
+  async cleanupEndpointResources(endpointUrl: string) {
+    const endpoint = this.endpoints.get(endpointUrl);
+    if (!endpoint) return;
+
+    logger.debug(`[${endpointUrl}] 清理端点资源...`);
+
+    // 停止心跳检测
+    this.stopHeartbeat(endpointUrl);
+
+    // 清除重连定时器
+    if (endpoint.reconnectTimer) {
+      clearTimeout(endpoint.reconnectTimer);
+      endpoint.reconnectTimer = undefined;
+    }
+
+    // 关闭 WebSocket 连接
+    if (endpoint.websocket) {
+      try {
+        if (endpoint.websocket.readyState === WebSocket.OPEN) {
+          endpoint.websocket.close();
+        }
+      } catch (error) {
+        logger.debug(`[${endpointUrl}] 关闭 WebSocket 时出错: ${error}`);
+      }
+      endpoint.websocket = null;
+    }
+
+    // 终止 MCP 进程（如果存在且仍在运行）
+    if (endpoint.process && !endpoint.process.killed) {
+      try {
+        logger.debug(`[${endpointUrl}] 终止 MCP 进程...`);
+        endpoint.process.kill("SIGTERM");
+
+        // 等待进程退出，最多等待2秒
+        await new Promise<void>((resolve) => {
+          const timeout = setTimeout(() => {
+            if (endpoint.process && !endpoint.process.killed) {
+              logger.warn(`[${endpointUrl}] MCP 进程未能正常退出，强制终止`);
+              endpoint.process.kill("SIGKILL");
+            }
+            resolve();
+          }, 2000);
+
+          endpoint.process?.on("exit", () => {
+            clearTimeout(timeout);
+            resolve();
+          });
+        });
+      } catch (error) {
+        logger.warn(`[${endpointUrl}] 终止 MCP 进程时出错: ${error}`);
+      }
+      endpoint.process = null;
+    }
+
+    // 清空输出缓冲区
+    endpoint.stdoutBuffer = "";
+    endpoint.isConnected = false;
+
+    logger.debug(`[${endpointUrl}] 端点资源清理完成`);
   }
 
   cleanup() {


### PR DESCRIPTION
改进 MCP 客户端的错误处理和重连机制，解决首次启动失败问题：

- 修复 notifications/initialized 错误处理
  * 将 notifications/initialized 改为正确的通知格式（无 id 字段）
  * 添加 sendNotification 方法专门处理通知消息
  * 对 -32601 错误进行特殊处理，避免非致命错误中断连接

- 优化 WebSocket 重连策略
  * 允许对 4004 错误进行有限次数重连（最多5次）
  * 实现指数退避算法，避免频繁重连
  * 添加最大重连次数限制和智能错误分类

- 完善资源清理机制
  * 新增 cleanupEndpointResources 方法确保重连前完全清理资源
  * 改进进程终止逻辑，使用 SIGTERM 然后 SIGKILL
  * 防止资源冲突导致的连接问题

- 更新相关测试用例以适应新的错误处理逻辑

这些改进显著提高了连接稳定性，减少了首次启动失败的情况。