### PR TITLE
feat(web): 添加配置更新后自动重启服务功能

### DIFF
--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -59,6 +59,7 @@ export interface ModelScopeConfig {
 
 export interface WebUIConfig {
   port?: number; // Web UI 端口号，默认 9999
+  autoRestart?: boolean; // 是否在配置更新后自动重启服务，默认 true
 }
 
 export interface AppConfig {

--- a/web/package.json
+++ b/web/package.json
@@ -18,7 +18,9 @@
   },
   "dependencies": {
     "@radix-ui/react-alert-dialog": "^1.1.14",
+    "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-switch": "^1.2.5",
     "@radix-ui/react-toast": "^1.2.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -11,9 +11,15 @@ importers:
       '@radix-ui/react-alert-dialog':
         specifier: ^1.1.14
         version: 1.1.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-label':
+        specifier: ^2.1.7
+        version: 2.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-slot':
         specifier: ^1.2.3
         version: 1.2.3(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-switch':
+        specifier: ^1.2.5
+        version: 1.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@radix-ui/react-toast':
         specifier: ^1.2.14
         version: 1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -525,6 +531,19 @@ packages:
       '@types/react':
         optional: true
 
+  '@radix-ui/react-label@2.1.7':
+    resolution: {integrity: sha512-YT1GqPSL8kJn20djelMX7/cTRp/Y9w5IZHvfxQTVHrOqa2yMl7i/UfMqKRU5V7mEyKTrUVgJXhNQPVCG8PBLoQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
   '@radix-ui/react-portal@1.1.9':
     resolution: {integrity: sha512-bpIxvq03if6UNwXZ+HTK71JLh4APvnXntDc6XOX8UVq4XQOVl7lwok0AvIl+b8zgCw3fSaVTZMpAPPagXbKmHQ==}
     peerDependencies:
@@ -571,6 +590,19 @@ packages:
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
     peerDependenciesMeta:
       '@types/react':
+        optional: true
+
+  '@radix-ui/react-switch@1.2.5':
+    resolution: {integrity: sha512-5ijLkak6ZMylXsaImpZ8u4Rlf5grRmoc0p0QeX9VJtlrM4f5m3nCTX8tWga/zOA8PZYIR/t0p2Mnvd7InrJ6yQ==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
         optional: true
 
   '@radix-ui/react-toast@1.2.14':
@@ -624,6 +656,24 @@ packages:
 
   '@radix-ui/react-use-layout-effect@1.1.1':
     resolution: {integrity: sha512-RbJRS4UWQFkzHTTwVymMTUv8EqYhOp8dOOviLj2ugtTiXRaRQS7GLGxZTLL1jWhMeoSCf5zmcZkqTl9IiYfXcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-previous@1.1.1':
+    resolution: {integrity: sha512-2dHfToCj/pzca2Ck724OZ5L0EVrr3eHRNsG/b3xQJLA2hZpVCS99bLAX+hm1IHXDEnzU6by5z/5MIY794/a8NQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  '@radix-ui/react-use-size@1.1.1':
+    resolution: {integrity: sha512-ewrXRDTAqAXlkl6t/fkXWNAhFX9I+CkKlw6zjEwk86RSPKwZr3xpBRso655aqYafwtnbpHLj6toFzmd6xdVptQ==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -2320,6 +2370,15 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.3.23
 
+  '@radix-ui/react-label@2.1.7(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
+
   '@radix-ui/react-portal@1.1.9(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -2355,6 +2414,21 @@ snapshots:
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.23
+
+  '@radix-ui/react-switch@1.2.5(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.2
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-context': 1.1.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@18.3.23)(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.23
+      '@types/react-dom': 18.3.7(@types/react@18.3.23)
 
   '@radix-ui/react-toast@1.2.14(@types/react-dom@18.3.7(@types/react@18.3.23))(@types/react@18.3.23)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
     dependencies:
@@ -2406,6 +2480,19 @@ snapshots:
 
   '@radix-ui/react-use-layout-effect@1.1.1(@types/react@18.3.23)(react@18.3.1)':
     dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.23
+
+  '@radix-ui/react-use-previous@1.1.1(@types/react@18.3.23)(react@18.3.1)':
+    dependencies:
+      react: 18.3.1
+    optionalDependencies:
+      '@types/react': 18.3.23
+
+  '@radix-ui/react-use-size@1.1.1(@types/react@18.3.23)(react@18.3.1)':
+    dependencies:
+      '@radix-ui/react-use-layout-effect': 1.1.1(@types/react@18.3.23)(react@18.3.1)
       react: 18.3.1
     optionalDependencies:
       '@types/react': 18.3.23

--- a/web/src/components/ConfigEditor.tsx
+++ b/web/src/components/ConfigEditor.tsx
@@ -1,5 +1,7 @@
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
 import { useEffect, useState } from "react";
 import { toast } from "sonner";
 import type { AppConfig } from "../types";
@@ -158,6 +160,22 @@ function ConfigEditor({ config, onChange }: ConfigEditorProps) {
             />
           </div>
         )}
+
+        <div className="flex items-center justify-between space-x-2">
+          <Label htmlFor="autoRestart" className="flex flex-col space-y-1">
+            <span>自动重启服务</span>
+            <span className="text-xs text-muted-foreground">
+              配置更新后自动重启 MCP 服务以应用新配置
+            </span>
+          </Label>
+          <Switch
+            id="autoRestart"
+            checked={localConfig.webUI?.autoRestart !== false}
+            onCheckedChange={(checked) =>
+              handleChange("webUI.autoRestart", checked)
+            }
+          />
+        </div>
 
         <Button
           type="button"

--- a/web/src/components/RestartNotification.test.tsx
+++ b/web/src/components/RestartNotification.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { RestartNotification } from "./RestartNotification";
+
+// Mock sonner toast
+vi.mock("sonner", () => ({
+  toast: {
+    loading: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("RestartNotification", () => {
+  it("should render nothing when no restart status", () => {
+    const { container } = render(<RestartNotification />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should render nothing when restart is completed", () => {
+    const { container } = render(
+      <RestartNotification
+        restartStatus={{
+          status: "completed",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it("should show restarting notification", () => {
+    render(
+      <RestartNotification
+        restartStatus={{
+          status: "restarting",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByText("正在重启服务")).toBeInTheDocument();
+    expect(
+      screen.getByText("正在应用新的配置，服务将在几秒钟内重新启动...")
+    ).toBeInTheDocument();
+  });
+
+  it("should show failed notification with error message", () => {
+    const errorMessage = "无法连接到服务";
+    render(
+      <RestartNotification
+        restartStatus={{
+          status: "failed",
+          error: errorMessage,
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByText("重启失败")).toBeInTheDocument();
+    expect(screen.getByText(errorMessage)).toBeInTheDocument();
+  });
+
+  it("should show default error message when no error provided", () => {
+    render(
+      <RestartNotification
+        restartStatus={{
+          status: "failed",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    expect(screen.getByText("重启失败")).toBeInTheDocument();
+    expect(
+      screen.getByText("服务重启过程中发生错误，请检查日志")
+    ).toBeInTheDocument();
+  });
+
+  it("should trigger toast notifications", async () => {
+    const { toast } = await import("sonner");
+    const { rerender } = render(<RestartNotification />);
+
+    // Test restarting toast
+    rerender(
+      <RestartNotification
+        restartStatus={{
+          status: "restarting",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(toast.loading).toHaveBeenCalledWith(
+        "正在重启 MCP 服务...",
+        expect.objectContaining({
+          id: "restart-notification",
+          description: "服务重启中，请稍候片刻",
+        })
+      );
+    });
+
+    // Test completed toast
+    rerender(
+      <RestartNotification
+        restartStatus={{
+          status: "completed",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith(
+        "MCP 服务重启成功",
+        expect.objectContaining({
+          id: "restart-notification",
+          description: "配置已更新并成功应用",
+        })
+      );
+    });
+
+    // Test failed toast
+    rerender(
+      <RestartNotification
+        restartStatus={{
+          status: "failed",
+          error: "测试错误",
+          timestamp: Date.now(),
+        }}
+      />
+    );
+
+    await waitFor(() => {
+      expect(toast.error).toHaveBeenCalledWith(
+        "MCP 服务重启失败",
+        expect.objectContaining({
+          id: "restart-notification",
+          description: "测试错误",
+        })
+      );
+    });
+  });
+});

--- a/web/src/components/RestartNotification.tsx
+++ b/web/src/components/RestartNotification.tsx
@@ -1,0 +1,89 @@
+import { Loader2, XCircle } from "lucide-react";
+import { useEffect } from "react";
+import { toast } from "sonner";
+
+interface RestartNotificationProps {
+  restartStatus?: {
+    status: "restarting" | "completed" | "failed";
+    error?: string;
+    timestamp: number;
+  };
+}
+
+export function RestartNotification({
+  restartStatus,
+}: RestartNotificationProps) {
+  useEffect(() => {
+    if (!restartStatus) return;
+
+    switch (restartStatus.status) {
+      case "restarting":
+        toast.loading("正在重启 MCP 服务...", {
+          id: "restart-notification",
+          description: "服务重启中，请稍候片刻",
+          duration: Number.POSITIVE_INFINITY,
+        });
+        break;
+
+      case "completed":
+        toast.success("MCP 服务重启成功", {
+          id: "restart-notification",
+          description: "配置已更新并成功应用",
+          duration: 5000,
+        });
+        break;
+
+      case "failed":
+        toast.error("MCP 服务重启失败", {
+          id: "restart-notification",
+          description: restartStatus.error || "重启过程中发生错误",
+          duration: 10000,
+        });
+        break;
+    }
+  }, [restartStatus]);
+
+  // 如果没有重启状态，或者重启已完成，不显示内联通知
+  if (!restartStatus || restartStatus.status === "completed") {
+    return null;
+  }
+
+  // 对于正在重启或失败的状态，显示一个内联的提示条
+  return (
+    <div
+      className={`mb-4 p-4 rounded-lg border ${
+        restartStatus.status === "restarting"
+          ? "bg-blue-50 border-blue-200 dark:bg-blue-950 dark:border-blue-800"
+          : "bg-red-50 border-red-200 dark:bg-red-950 dark:border-red-800"
+      }`}
+    >
+      <div className="flex items-center gap-3">
+        {restartStatus.status === "restarting" ? (
+          <>
+            <Loader2 className="h-5 w-5 text-blue-600 dark:text-blue-400 animate-spin" />
+            <div>
+              <h4 className="font-medium text-blue-900 dark:text-blue-100">
+                正在重启服务
+              </h4>
+              <p className="text-sm text-blue-700 dark:text-blue-300 mt-1">
+                正在应用新的配置，服务将在几秒钟内重新启动...
+              </p>
+            </div>
+          </>
+        ) : (
+          <>
+            <XCircle className="h-5 w-5 text-red-600 dark:text-red-400" />
+            <div>
+              <h4 className="font-medium text-red-900 dark:text-red-100">
+                重启失败
+              </h4>
+              <p className="text-sm text-red-700 dark:text-red-300 mt-1">
+                {restartStatus.error || "服务重启过程中发生错误，请检查日志"}
+              </p>
+            </div>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/ui/label.tsx
+++ b/web/src/components/ui/label.tsx
@@ -1,0 +1,24 @@
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { type VariantProps, cva } from "class-variance-authority";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const labelVariants = cva(
+  "text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70"
+);
+
+const Label = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root> &
+    VariantProps<typeof labelVariants>
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn(labelVariants(), className)}
+    {...props}
+  />
+));
+Label.displayName = LabelPrimitive.Root.displayName;
+
+export { Label };

--- a/web/src/components/ui/switch.tsx
+++ b/web/src/components/ui/switch.tsx
@@ -1,0 +1,27 @@
+import * as SwitchPrimitives from "@radix-ui/react-switch";
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+const Switch = React.forwardRef<
+  React.ElementRef<typeof SwitchPrimitives.Root>,
+  React.ComponentPropsWithoutRef<typeof SwitchPrimitives.Root>
+>(({ className, ...props }, ref) => (
+  <SwitchPrimitives.Root
+    className={cn(
+      "peer inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border-2 border-transparent shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background disabled:cursor-not-allowed disabled:opacity-50 data-[state=checked]:bg-primary data-[state=unchecked]:bg-input",
+      className
+    )}
+    {...props}
+    ref={ref}
+  >
+    <SwitchPrimitives.Thumb
+      className={cn(
+        "pointer-events-none block h-4 w-4 rounded-full bg-background shadow-lg ring-0 transition-transform data-[state=checked]:translate-x-4 data-[state=unchecked]:translate-x-0"
+      )}
+    />
+  </SwitchPrimitives.Root>
+));
+Switch.displayName = SwitchPrimitives.Root.displayName;
+
+export { Switch };

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,12 +1,20 @@
 import ConfigEditor from "../components/ConfigEditor";
 import { ConnectionSettings } from "../components/ConnectionSettings";
 import MCPServerList from "../components/MCPServerList";
+import { RestartNotification } from "../components/RestartNotification";
 import StatusCard from "../components/StatusCard";
 import { useWebSocket } from "../hooks/useWebSocket";
 
 function Dashboard() {
-  const { connected, config, status, updateConfig, wsUrl, setCustomWsUrl } =
-    useWebSocket();
+  const {
+    connected,
+    config,
+    status,
+    restartStatus,
+    updateConfig,
+    wsUrl,
+    setCustomWsUrl,
+  } = useWebSocket();
 
   return (
     <div className="container mx-auto px-4 py-8">
@@ -16,6 +24,8 @@ function Dashboard() {
           管理您的小智 AI 客户端配置和 MCP 服务
         </p>
       </header>
+
+      <RestartNotification restartStatus={restartStatus} />
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-8">
         <StatusCard connected={connected} status={status} />

--- a/web/src/types/index.ts
+++ b/web/src/types/index.ts
@@ -30,12 +30,18 @@ export interface ModelScopeConfig {
   apiKey?: string;
 }
 
+export interface WebUIConfig {
+  port?: number;
+  autoRestart?: boolean;
+}
+
 export interface AppConfig {
   mcpEndpoint: string;
   mcpServers: Record<string, MCPServerConfig>;
   mcpServerConfig?: Record<string, MCPServerToolsConfig>;
   connection?: ConnectionConfig;
   modelscope?: ModelScopeConfig;
+  webUI?: WebUIConfig;
 }
 
 export interface ClientStatus {


### PR DESCRIPTION
- 在 Web UI 配置保存后自动重启 MCP 服务，无需手动操作
- 添加重启过程的实时状态提示（重启中/成功/失败）
- 提供自动重启开关，用户可选择是否启用
- 支持服务未运行时自动启动
- 完善错误处理和重试机制

新增功能：
- RestartNotification 组件：显示重启状态的友好提示
- WebSocket 消息类型：restartStatus 用于实时通知重启进度
- webUI.autoRestart 配置项：控制是否自动重启（默认启用）

测试覆盖：
- 添加 RestartNotification 组件单元测试
- 添加 WebSocket 重启状态消息处理测试
- 添加服务端自动重启功能集成测试