### PR TITLE
fix(mcp): 修复 Streamable HTTP MCP 服务工具列表不显示的问题

### DIFF
--- a/src/mcpCommands.ts
+++ b/src/mcpCommands.ts
@@ -182,11 +182,17 @@ export async function listMcpServers(
 
         console.log(`${chalk.cyan("•")} ${chalk.bold(serverName)}`);
 
-        // 检查是否是 SSE 类型
-        if ("type" in serverConfig && serverConfig.type === "sse") {
-          console.log(`  类型: ${chalk.gray("SSE")}`);
+        // 检查服务类型并显示相应信息
+        if ("url" in serverConfig) {
+          // URL 类型的服务（SSE 或 Streamable HTTP）
+          if ("type" in serverConfig && serverConfig.type === "sse") {
+            console.log(`  类型: ${chalk.gray("SSE")}`);
+          } else {
+            console.log(`  类型: ${chalk.gray("Streamable HTTP")}`);
+          }
           console.log(`  URL: ${chalk.gray(serverConfig.url)}`);
         } else {
+          // 本地服务
           console.log(
             `  命令: ${chalk.gray((serverConfig as any).command)} ${chalk.gray(
               (serverConfig as any).args.join(" ")


### PR DESCRIPTION
- 为 StreamableHTTPMCPClient 添加 updateToolsConfig 方法，确保工具配置被正确写入配置文件
- 修复 mcpCommands.ts 中服务类型判断逻辑，正确处理没有 type 字段的 streamable HTTP 服务
- 添加对应的单元测试覆盖 updateToolsConfig 方法调用
- 修复了 amap-maps-streamableHTTP 等服务在 `xiaozhi mcp list --tools` 中不显示工具的问题

Fixes: StreamableHTTP 类型的 MCP 服务工具配置未被持久化到配置文件，导致工具列表显示为空