### PR TITLE
feat(mcp): 添加 SSE 方式通信的 MCP 服务支持

### DIFF
--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -20,7 +20,7 @@ export interface LocalMCPServerConfig {
   env?: Record<string, string>;
 }
 
-// ModelScope SSE MCP 服务配置
+// SSE MCP 服务配置（支持 ModelScope、高德地图等 SSE 服务）
 export interface SSEMCPServerConfig {
   type: "sse";
   url: string;

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -20,7 +20,7 @@ export interface LocalMCPServerConfig {
   env?: Record<string, string>;
 }
 
-// SSE MCP 服务配置（支持 ModelScope、高德地图等 SSE 服务）
+// SSE MCP 服务配置
 export interface SSEMCPServerConfig {
   type: "sse";
   url: string;

--- a/src/sseMCPClient.test.ts
+++ b/src/sseMCPClient.test.ts
@@ -1,0 +1,254 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { SSEMCPServerConfig } from "./configManager";
+import { SSEMCPClient } from "./sseMCPClient";
+
+// Mock dependencies
+vi.mock("@modelcontextprotocol/sdk/client/index.js", () => ({
+  Client: vi.fn().mockImplementation(() => ({
+    connect: vi.fn(),
+    listTools: vi.fn(),
+    callTool: vi.fn(),
+    close: vi.fn(),
+  })),
+}));
+
+vi.mock("@modelcontextprotocol/sdk/client/sse.js", () => ({
+  SSEClientTransport: vi.fn(),
+}));
+
+vi.mock("eventsource", () => ({
+  EventSource: vi.fn(),
+}));
+
+vi.mock("./configManager", () => ({
+  configManager: {
+    isToolEnabled: vi.fn().mockReturnValue(true),
+    getServerToolsConfig: vi.fn().mockReturnValue({}),
+    updateServerToolsConfig: vi.fn(),
+  },
+}));
+
+vi.mock("./logger", () => ({
+  logger: {
+    withTag: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    }),
+  },
+}));
+
+describe("SSEMCPClient", () => {
+  let client: SSEMCPClient;
+  let mockConfig: SSEMCPServerConfig;
+
+  beforeEach(() => {
+    mockConfig = {
+      type: "sse",
+      url: "https://example.com/sse",
+    };
+    client = new SSEMCPClient("test-sse", mockConfig);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("构造函数", () => {
+    it("应该正确初始化客户端", () => {
+      expect(client).toBeDefined();
+      expect(client.initialized).toBe(false);
+      expect(client.tools).toEqual([]);
+      expect(client.originalTools).toEqual([]);
+    });
+  });
+
+  describe("getOriginalToolName", () => {
+    it("应该正确提取原始工具名称", () => {
+      const prefixedName = "test_sse_xzcli_search";
+      const originalName = client.getOriginalToolName(prefixedName);
+      expect(originalName).toBe("search");
+    });
+
+    it("应该处理带连字符的服务名称", () => {
+      const clientWithHyphens = new SSEMCPClient(
+        "test-sse-service",
+        mockConfig
+      );
+      const prefixedName = "test_sse_service_xzcli_search";
+      const originalName = clientWithHyphens.getOriginalToolName(prefixedName);
+      expect(originalName).toBe("search");
+    });
+
+    it("应该对无效格式返回 null", () => {
+      const invalidName = "invalid_tool_name";
+      const originalName = client.getOriginalToolName(invalidName);
+      expect(originalName).toBeNull();
+    });
+  });
+
+  describe("start", () => {
+    it("应该成功启动 SSE 客户端", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const { SSEClientTransport } = await import(
+        "@modelcontextprotocol/sdk/client/sse.js"
+      );
+
+      const mockClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [
+            { name: "search", description: "Search tool" },
+            { name: "weather", description: "Weather tool" },
+          ],
+        }),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+      vi.mocked(SSEClientTransport).mockImplementation(() => ({}) as any);
+
+      await client.start();
+
+      expect(client.initialized).toBe(true);
+      expect(client.originalTools).toHaveLength(2);
+      expect(client.tools).toHaveLength(2);
+      expect(SSEClientTransport).toHaveBeenCalledWith(new URL(mockConfig.url));
+      expect(mockClient.connect).toHaveBeenCalled();
+    });
+
+    it("应该处理启动失败的情况", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+
+      const mockClient = {
+        connect: vi.fn().mockRejectedValue(new Error("Connection failed")),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+
+      await expect(client.start()).rejects.toThrow("Connection failed");
+      expect(client.initialized).toBe(false);
+    });
+  });
+
+  describe("callTool", () => {
+    beforeEach(async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const mockClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({
+          tools: [{ name: "search", description: "Search tool" }],
+        }),
+        callTool: vi.fn().mockResolvedValue({ result: "success" }),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+      await client.start();
+    });
+
+    it("应该成功调用工具", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const mockClient = vi.mocked(Client).mock.results[0].value;
+
+      const result = await client.callTool("test_sse_xzcli_search", {
+        query: "test",
+      });
+
+      expect(mockClient.callTool).toHaveBeenCalledWith({
+        name: "search",
+        arguments: { query: "test" },
+      });
+      expect(result).toEqual({ result: "success" });
+    });
+
+    it("应该处理无效工具名称", async () => {
+      await expect(client.callTool("invalid_tool", {})).rejects.toThrow(
+        "无效的工具名称格式：invalid_tool"
+      );
+    });
+
+    it("应该处理未初始化的客户端", async () => {
+      const uninitializedClient = new SSEMCPClient("test", mockConfig);
+
+      await expect(
+        uninitializedClient.callTool("test_sse_xzcli_search", {})
+      ).rejects.toThrow("客户端未初始化");
+    });
+  });
+
+  describe("stop", () => {
+    it("应该成功停止客户端", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const mockClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        close: vi.fn().mockResolvedValue(undefined),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+      await client.start();
+      await client.stop();
+
+      expect(mockClient.close).toHaveBeenCalled();
+      expect(client.initialized).toBe(false);
+    });
+
+    it("应该处理停止过程中的错误", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const mockClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi.fn().mockResolvedValue({ tools: [] }),
+        close: vi.fn().mockRejectedValue(new Error("Close failed")),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+      await client.start();
+
+      // 应该不抛出错误，只是记录日志
+      await expect(client.stop()).resolves.not.toThrow();
+      expect(client.initialized).toBe(false);
+    });
+  });
+
+  describe("refreshTools", () => {
+    it("应该成功刷新工具列表", async () => {
+      const { Client } = await import(
+        "@modelcontextprotocol/sdk/client/index.js"
+      );
+      const mockClient = {
+        connect: vi.fn().mockResolvedValue(undefined),
+        listTools: vi
+          .fn()
+          .mockResolvedValueOnce({ tools: [{ name: "tool1" }] })
+          .mockResolvedValueOnce({
+            tools: [{ name: "tool1" }, { name: "tool2" }],
+          }),
+      };
+
+      vi.mocked(Client).mockImplementation(() => mockClient as any);
+      await client.start();
+
+      expect(client.originalTools).toHaveLength(1);
+
+      await client.refreshTools();
+
+      expect(client.originalTools).toHaveLength(2);
+      expect(mockClient.listTools).toHaveBeenCalledTimes(2);
+    });
+
+    it("应该处理未初始化的客户端", async () => {
+      await expect(client.refreshTools()).rejects.toThrow("客户端未初始化");
+    });
+  });
+});

--- a/src/sseMCPClient.ts
+++ b/src/sseMCPClient.ts
@@ -1,0 +1,253 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import { EventSource } from "eventsource";
+import {
+  type MCPToolConfig,
+  type SSEMCPServerConfig,
+  configManager,
+} from "./configManager";
+import { logger as globalLogger } from "./logger";
+import type { IMCPClient } from "./mcpServerProxy";
+
+// 全局 polyfill EventSource
+(global as any).EventSource = EventSource;
+
+// 为通用 SSE MCP 创建带标签的 logger
+const logger = globalLogger.withTag("SSEMCP");
+
+interface Tool {
+  name: string;
+  description?: string;
+  inputSchema?: any;
+}
+
+/**
+ * 通用 SSE MCP Client
+ * 用于连接基于 SSE 的 MCP 服务，支持不需要特殊认证的服务
+ */
+export class SSEMCPClient implements IMCPClient {
+  private name: string;
+  private config: SSEMCPServerConfig;
+  private client: Client | null = null;
+  private transport: SSEClientTransport | null = null;
+  public initialized = false;
+  public tools: Tool[] = [];
+  public originalTools: Tool[] = [];
+
+  constructor(name: string, config: SSEMCPServerConfig) {
+    this.name = name;
+    this.config = config;
+  }
+
+  /**
+   * 生成带前缀的工具名称
+   */
+  private generatePrefixedToolName(originalToolName: string): string {
+    const normalizedServerName = this.name.replace(/-/g, "_");
+    return `${normalizedServerName}_xzcli_${originalToolName}`;
+  }
+
+  /**
+   * 过滤启用的工具
+   */
+  private filterEnabledTools(allTools: Tool[]): Tool[] {
+    return allTools.filter((tool) => {
+      // 从前缀名称中提取原始名称
+      const originalName = this.getOriginalToolName(tool.name);
+      if (!originalName) return false;
+
+      return configManager.isToolEnabled(this.name, originalName);
+    });
+  }
+
+  /**
+   * 更新配置文件中的工具列表
+   */
+  private async updateToolsConfig(): Promise<void> {
+    try {
+      const currentConfig = configManager.getServerToolsConfig(this.name);
+      const newToolsConfig: Record<string, MCPToolConfig> = {};
+
+      // 为每个工具创建配置项（如果不存在）
+      for (const tool of this.originalTools) {
+        const existingConfig = currentConfig[tool.name];
+        newToolsConfig[tool.name] = {
+          description: tool.description || existingConfig?.description || "",
+          enable: existingConfig?.enable !== false, // 默认启用
+        };
+      }
+
+      // 保留现有工具的配置
+      for (const [toolName, toolConfig] of Object.entries(currentConfig)) {
+        if (!newToolsConfig[toolName]) {
+          newToolsConfig[toolName] = toolConfig;
+        }
+      }
+
+      configManager.updateServerToolsConfig(this.name, newToolsConfig);
+    } catch (error) {
+      logger.debug(
+        `更新 ${this.name} 工具配置失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  async start(): Promise<void> {
+    logger.info(`正在启动 SSE MCP 客户端：${this.name}`);
+
+    try {
+      // 创建 SSE 传输层（不需要特殊认证）
+      this.transport = new SSEClientTransport(new URL(this.config.url));
+
+      // 创建 MCP 客户端
+      this.client = new Client(
+        {
+          name: "xiaozhi-sse-client",
+          version: "1.0.0",
+        },
+        {
+          capabilities: {},
+        }
+      );
+
+      // 连接到服务器
+      logger.info(`正在连接到 ${this.config.url}`);
+      await this.client.connect(this.transport);
+      logger.info(`成功连接到 SSE MCP 服务器：${this.name}`);
+
+      // 获取工具列表
+      await this.refreshTools();
+
+      this.initialized = true;
+      logger.info(
+        `${this.name} SSE 客户端已就绪，共 ${this.tools.length} 个工具`
+      );
+    } catch (error) {
+      logger.error(
+        `启动 SSE MCP 客户端 ${this.name} 失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      throw error;
+    }
+  }
+
+  async refreshTools(): Promise<void> {
+    try {
+      if (!this.client) {
+        throw new Error("客户端未初始化");
+      }
+
+      const result = await this.client.listTools();
+      this.originalTools = result.tools || [];
+
+      // 为每个工具生成带前缀的名称
+      const allPrefixedTools = this.originalTools.map((tool) => ({
+        ...tool,
+        name: this.generatePrefixedToolName(tool.name),
+      }));
+
+      // 根据配置过滤工具
+      this.tools = this.filterEnabledTools(allPrefixedTools);
+
+      // 更新配置文件中的工具列表（如果需要）
+      await this.updateToolsConfig();
+
+      logger.info(
+        `${this.name} 加载了 ${
+          this.originalTools.length
+        } 个工具：${this.originalTools.map((t) => t.name).join(", ")}`
+      );
+      logger.info(
+        `${this.name} 启用了 ${this.tools.length} 个工具：${this.tools
+          .map((t) => t.name)
+          .join(", ")}`
+      );
+    } catch (error) {
+      logger.error(
+        `刷新 ${this.name} 工具列表失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 从带前缀的工具名称中提取原始工具名称
+   */
+  getOriginalToolName(prefixedName: string): string | null {
+    const normalizedServerName = this.name.replace(/-/g, "_");
+    const prefix = `${normalizedServerName}_xzcli_`;
+
+    if (prefixedName.startsWith(prefix)) {
+      return prefixedName.substring(prefix.length);
+    }
+
+    return null;
+  }
+
+  async callTool(prefixedName: string, arguments_: any): Promise<any> {
+    try {
+      if (!this.client) {
+        throw new Error("客户端未初始化");
+      }
+
+      // 将前缀名称转换回原始名称
+      const originalName = this.getOriginalToolName(prefixedName);
+      if (!originalName) {
+        throw new Error(`无效的工具名称格式：${prefixedName}`);
+      }
+
+      logger.info(
+        `调用 SSE 工具 ${originalName}，参数：${JSON.stringify(arguments_)}`
+      );
+
+      const result = await this.client.callTool({
+        name: originalName,
+        arguments: arguments_,
+      });
+
+      logger.info(
+        `SSE 工具调用返回: ${JSON.stringify(result).substring(0, 500)}...`
+      );
+
+      return result;
+    } catch (error) {
+      logger.error(
+        `在 ${this.name} 上调用工具 ${prefixedName} 失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      throw error;
+    }
+  }
+
+  async stop(): Promise<void> {
+    logger.info(`正在停止 SSE MCP 客户端：${this.name}`);
+
+    try {
+      if (this.client) {
+        await this.client.close();
+        this.client = null;
+      }
+
+      if (this.transport) {
+        this.transport = null;
+      }
+
+      logger.info(`SSE MCP 客户端 ${this.name} 已停止`);
+    } catch (error) {
+      logger.error(
+        `停止 SSE MCP 客户端 ${this.name} 失败：${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    } finally {
+      // 无论是否出错，都要将状态设置为未初始化
+      this.initialized = false;
+    }
+  }
+}


### PR DESCRIPTION
- 新增通用 SSE MCP 客户端 (SSEMCPClient)，支持不需要特殊认证的 SSE 服务
- 修复 SSE 服务识别逻辑，正确解析带查询参数的 /sse 路径
- 区分 ModelScope SSE 服务和通用 SSE 服务的处理方式
- 更新配置类型定义，支持通用 SSE 服务配置
- 添加完整的单元测试覆盖 SSE 识别逻辑和客户端功能

修复问题：
- 解决高德地图等 SSE 服务被错误识别为 streamableHttp 导致的 404 错误
- 支持 URL 路径以 /sse 结尾的服务自动识别为 SSE 类型
- 保持 ModelScope 服务的向后兼容性

测试：
- 新增 13 个 SSEMCPClient 单元测试
- 新增 7 个 SSE 识别逻辑测试用例
- 所有测试通过，代码质量检查通过