### PR TITLE
fix(deps): 升级 form-data 到 v4.0.4 以解决安全问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@semantic-release/release-notes-generator": "^14.0.3",
     "@types/eventsource": "^3.0.0",
     "@types/node": "^24.0.1",
-    "@types/node-fetch": "2",
+    "@types/node-fetch": "^2.6.12",
     "@types/omelette": "^0.4.5",
     "@types/ws": "^8.18.1",
     "@vitest/coverage-v8": "^3.2.3",
@@ -87,5 +87,10 @@
     "tsup": "^8.5.0",
     "typescript": "^5.8.3",
     "vitest": "^3.2.3"
+  },
+  "pnpm": {
+    "overrides": {
+      "form-data": "^4.0.4"
+    }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  form-data: ^4.0.4
+
 importers:
 
   .:
@@ -82,7 +85,7 @@ importers:
         specifier: ^24.0.1
         version: 24.0.13
       '@types/node-fetch':
-        specifier: '2'
+        specifier: ^2.6.12
         version: 2.6.12
       '@types/omelette':
         specifier: ^0.4.5
@@ -1677,8 +1680,8 @@ packages:
     resolution: {integrity: sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==}
     engines: {node: '>=14'}
 
-  form-data@4.0.3:
-    resolution: {integrity: sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==}
+  form-data@4.0.4:
+    resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
   forwarded@0.2.0:
@@ -4107,7 +4110,7 @@ snapshots:
   '@types/node-fetch@2.6.12':
     dependencies:
       '@types/node': 24.0.13
-      form-data: 4.0.3
+      form-data: 4.0.4
 
   '@types/node@24.0.13':
     dependencies:
@@ -4921,7 +4924,7 @@ snapshots:
       cross-spawn: 7.0.6
       signal-exit: 4.1.0
 
-  form-data@4.0.3:
+  form-data@4.0.4:
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8


### PR DESCRIPTION
- 将 @types/node-fetch 版本从 "2" 更新为 "^2.6.12"
- 添加 pnpm overrides 强制 form-data 版本为 "^4.0.4"
- 解决了旧版本 form-data 4.0.3 的安全问题