### PR TITLE
fix(config): 修复配置文件包含BOM字符导致解析失败的问题

### DIFF
--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -208,7 +208,7 @@ export class ConfigManager {
       // 移除可能存在的UTF-8 BOM字符（\uFEFF）
       // BOM字符在某些编辑器中不可见，但会导致JSON解析失败
       // 这个过滤确保即使文件包含BOM字符也能正常解析
-      const configData = rawConfigData.replace(/^\uFEFF/, '');
+      const configData = rawConfigData.replace(/^\uFEFF/, "");
 
       let config: AppConfig;
 

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -203,7 +203,12 @@ export class ConfigManager {
       const configPath = this.getConfigFilePath();
       this.currentConfigPath = configPath; // 记录当前使用的配置文件路径
       const configFileFormat = this.getConfigFileFormat(configPath);
-      const configData = readFileSync(configPath, "utf8");
+      const rawConfigData = readFileSync(configPath, "utf8");
+
+      // 移除可能存在的UTF-8 BOM字符（\uFEFF）
+      // BOM字符在某些编辑器中不可见，但会导致JSON解析失败
+      // 这个过滤确保即使文件包含BOM字符也能正常解析
+      const configData = rawConfigData.replace(/^\uFEFF/, '');
 
       let config: AppConfig;
 
@@ -220,6 +225,7 @@ export class ConfigManager {
           config = commentJson.parse(configData) as unknown as AppConfig;
           break;
         default:
+          console.log(configData);
           config = JSON.parse(configData) as AppConfig;
           break;
       }

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -225,7 +225,6 @@ export class ConfigManager {
           config = commentJson.parse(configData) as unknown as AppConfig;
           break;
         default:
-          console.log(configData);
           config = JSON.parse(configData) as AppConfig;
           break;
       }


### PR DESCRIPTION
- 添加UTF-8 BOM字符（\uFEFF）过滤逻辑，确保兼容带BOM的配置文件
- 移除BOM字符后再进行JSON解析，避免解析错误
- 保留原有的配置文件格式识别和处理逻辑