### PR TITLE
feat(stats): 添加MCP工具使用统计功能

### DIFF
--- a/src/configManager.test.ts
+++ b/src/configManager.test.ts
@@ -6,6 +6,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { resolve } from "node:path";
+import JSON5 from "json5";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type AppConfig,
@@ -1793,6 +1794,130 @@ describe("ConfigManager", () => {
         expect(() => configManager.removeMcpEndpoint("")).toThrow(
           "MCP 端点必须是非空字符串"
         );
+      });
+    });
+  });
+
+  describe("工具使用统计", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValue(true);
+      mockReadFileSync.mockReturnValue(JSON.stringify(mockConfig));
+      mockResolve.mockImplementation((...args) => args.join("/"));
+    });
+
+    describe("updateToolUsageStats", () => {
+      it("应该为新工具初始化使用统计", async () => {
+        const callTime = "2023-12-01T10:00:00.000Z";
+
+        await configManager.updateToolUsageStats(
+          "test-server",
+          "new-tool",
+          callTime
+        );
+
+        expect(mockWriteFileSync).toHaveBeenCalled();
+        const savedConfig = JSON5.parse(
+          mockWriteFileSync.mock.calls[0][1] as string
+        );
+
+        expect(
+          savedConfig.mcpServerConfig["test-server"].tools["new-tool"]
+        ).toEqual({
+          enable: true,
+          usageCount: 1,
+          lastUsedTime: callTime,
+        });
+      });
+
+      it("应该增加现有工具的使用次数", async () => {
+        const initialConfig = {
+          ...mockConfig,
+          mcpServerConfig: {
+            "test-server": {
+              tools: {
+                "existing-tool": {
+                  enable: true,
+                  usageCount: 5,
+                  lastUsedTime: "2023-11-01T10:00:00.000Z",
+                },
+              },
+            },
+          },
+        };
+        mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+
+        const callTime = "2023-12-01T10:00:00.000Z";
+        await configManager.updateToolUsageStats(
+          "test-server",
+          "existing-tool",
+          callTime
+        );
+
+        expect(mockWriteFileSync).toHaveBeenCalled();
+        const savedConfig = JSON5.parse(
+          mockWriteFileSync.mock.calls[0][1] as string
+        );
+
+        expect(
+          savedConfig.mcpServerConfig["test-server"].tools["existing-tool"]
+        ).toEqual({
+          enable: true,
+          usageCount: 6,
+          lastUsedTime: callTime,
+        });
+      });
+
+      it("应该在新时间早于现有时间时跳过 lastUsedTime 更新", async () => {
+        const initialConfig = {
+          ...mockConfig,
+          mcpServerConfig: {
+            "test-server": {
+              tools: {
+                "existing-tool": {
+                  enable: true,
+                  usageCount: 5,
+                  lastUsedTime: "2023-12-01T10:00:00.000Z",
+                },
+              },
+            },
+          },
+        };
+        mockReadFileSync.mockReturnValue(JSON.stringify(initialConfig));
+
+        const earlierTime = "2023-11-01T10:00:00.000Z";
+        await configManager.updateToolUsageStats(
+          "test-server",
+          "existing-tool",
+          earlierTime
+        );
+
+        expect(mockWriteFileSync).toHaveBeenCalled();
+        const savedConfig = JSON5.parse(
+          mockWriteFileSync.mock.calls[0][1] as string
+        );
+
+        expect(
+          savedConfig.mcpServerConfig["test-server"].tools["existing-tool"]
+        ).toEqual({
+          enable: true,
+          usageCount: 6,
+          lastUsedTime: "2023-12-01T10:00:00.000Z", // 应该保持原来的时间
+        });
+      });
+
+      it("应该处理配置文件不存在的情况", async () => {
+        mockExistsSync.mockReturnValue(false);
+
+        const callTime = "2023-12-01T10:00:00.000Z";
+
+        // 应该不抛出异常
+        await expect(
+          configManager.updateToolUsageStats(
+            "test-server",
+            "test-tool",
+            callTime
+          )
+        ).resolves.not.toThrow();
       });
     });
   });

--- a/src/configManager.ts
+++ b/src/configManager.ts
@@ -4,6 +4,7 @@ import { fileURLToPath } from "node:url";
 import * as commentJson from "comment-json";
 import JSON5 from "json5";
 import * as json5Writer from "json5-writer";
+import { logger } from "./logger";
 import { validateMcpServerConfig } from "./utils/mcpServerUtils";
 
 // 在 ESM 中，需要从 import.meta.url 获取当前文件目录
@@ -45,6 +46,8 @@ export type MCPServerConfig =
 export interface MCPToolConfig {
   description?: string;
   enable: boolean;
+  usageCount?: number; // 工具使用次数
+  lastUsedTime?: string; // 最后使用时间（ISO 8601 格式）
 }
 
 export interface MCPServerToolsConfig {
@@ -723,6 +726,68 @@ export class ConfigManager {
     // 直接修改现有的 connection 对象以保留注释
     Object.assign(config.connection, connectionConfig);
     this.saveConfig(config);
+  }
+
+  /**
+   * 更新工具使用统计信息
+   * @param serverName 服务名称
+   * @param toolName 工具名称
+   * @param callTime 调用时间（ISO 8601 格式）
+   */
+  public async updateToolUsageStats(
+    serverName: string,
+    toolName: string,
+    callTime: string
+  ): Promise<void> {
+    try {
+      const config = this.getMutableConfig();
+
+      // 确保 mcpServerConfig 存在
+      if (!config.mcpServerConfig) {
+        config.mcpServerConfig = {};
+      }
+
+      // 确保服务配置存在
+      if (!config.mcpServerConfig[serverName]) {
+        config.mcpServerConfig[serverName] = { tools: {} };
+      }
+
+      // 确保工具配置存在
+      if (!config.mcpServerConfig[serverName].tools[toolName]) {
+        config.mcpServerConfig[serverName].tools[toolName] = {
+          enable: true, // 默认启用
+        };
+      }
+
+      const toolConfig = config.mcpServerConfig[serverName].tools[toolName];
+      const currentUsageCount = toolConfig.usageCount || 0;
+      const currentLastUsedTime = toolConfig.lastUsedTime;
+
+      // 更新使用次数
+      toolConfig.usageCount = currentUsageCount + 1;
+
+      // 时间校验：只有新时间晚于现有时间才更新 lastUsedTime
+      if (
+        !currentLastUsedTime ||
+        new Date(callTime) > new Date(currentLastUsedTime)
+      ) {
+        toolConfig.lastUsedTime = callTime;
+      }
+
+      // 保存配置
+      this.saveConfig(config);
+
+      logger.debug(
+        `工具使用统计已更新: ${serverName}/${toolName}, 使用次数: ${toolConfig.usageCount}`
+      );
+    } catch (error) {
+      // 错误不应该影响主要的工具调用流程
+      logger.error(
+        `更新工具使用统计失败 (${serverName}/${toolName}): ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
- 在ConfigManager中添加updateToolUsageStats方法用于更新工具使用统计
- 在MCPServerProxy中添加异步工具使用统计更新逻辑
- 新增工具使用次数和最后使用时间的记录功能
- 添加完整的单元测试覆盖新功能
- 优化工具名称前缀处理，确保正确映射原始工具名称

工具使用统计包括：
- usageCount: 工具被调用的总次数
- lastUsedTime: 工具最后被调用的ISO 8601格式时间戳

统计更新采用异步方式，不阻塞主工具调用流程，即使更新失败也不会影响工具正常使用。