### PR TITLE
feat(ci/cd): 分离 Docker 和 NPM 发布流程并优化部署体验

### DIFF
--- a/.github/workflows/docker-release.yml
+++ b/.github/workflows/docker-release.yml
@@ -1,0 +1,165 @@
+name: Docker 发布
+
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "要发布的版本号（不带 'v' 前缀，例如：1.2.3）"
+        required: false
+        type: string
+      branch:
+        description: "发布源分支"
+        required: true
+        default: "main"
+        type: choice
+        options:
+          - main
+          - beta
+      force_latest:
+        description: "强制更新 latest 标签（即使是 beta 版本）"
+        required: false
+        default: false
+        type: boolean
+  workflow_run:
+    workflows: ["NPM 发布"]
+    types:
+      - completed
+    branches: [main, beta]
+
+permissions:
+  contents: read
+
+jobs:
+  docker-release:
+    name: Docker 发布
+    runs-on: ubuntu-latest
+    # 只有在 NPM 发布成功完成或手动触发时才运行
+    if: |
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_run' && github.event.workflow_run.conclusion == 'success')
+    steps:
+      - name: 检出代码
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch || github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      - name: 确认触发方式和分支
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            echo "手动触发 Docker 发布，从分支 ${{ github.event.inputs.branch }} 发布"
+            echo "指定版本: ${{ github.event.inputs.version || '自动获取' }}"
+            echo "强制更新 latest: ${{ github.event.inputs.force_latest }}"
+          else
+            echo "由 NPM 发布工作流自动触发 Docker 发布"
+            echo "触发分支: ${{ github.event.workflow_run.head_branch }}"
+          fi
+
+      - name: 安装 pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: latest
+
+      - name: 设置 Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: ".nvmrc"
+          cache: "pnpm"
+
+      - name: 安装依赖
+        run: pnpm install --frozen-lockfile
+
+      - name: 构建项目
+        run: pnpm run build
+
+      - name: 获取版本号
+        id: get_version
+        run: |
+          if [ -n "${{ github.event.inputs.version }}" ]; then
+            # 手动指定版本号
+            VERSION="${{ github.event.inputs.version }}"
+            echo "使用手动指定的版本号: $VERSION"
+          else
+            # 从 package.json 自动获取版本号
+            VERSION=$(node -p "require('./package.json').version")
+            echo "从 package.json 获取版本号: $VERSION"
+          fi
+
+          # 生成带 v 前缀的版本号用于 Docker 标签
+          VERSION_WITH_V="v$VERSION"
+
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "version_with_v=$VERSION_WITH_V" >> $GITHUB_OUTPUT
+          echo "Docker 发布版本: $VERSION_WITH_V"
+
+      - name: 确定分支类型
+        id: branch_info
+        run: |
+          if [ "${{ github.event.inputs.branch }}" = "main" ] || [ "${{ github.event.workflow_run.head_branch }}" = "main" ]; then
+            echo "branch_type=stable" >> $GITHUB_OUTPUT
+            echo "is_main_branch=true" >> $GITHUB_OUTPUT
+            echo "分支类型: stable (main)"
+          else
+            echo "branch_type=beta" >> $GITHUB_OUTPUT
+            echo "is_main_branch=false" >> $GITHUB_OUTPUT
+            echo "分支类型: beta"
+          fi
+
+      - name: 设置 Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: 登录 Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_TOKEN }}
+
+      - name: 生成 Docker 标签
+        id: docker_tags
+        run: |
+          USERNAME="${{ secrets.DOCKER_USERNAME }}"
+          VERSION="${{ steps.get_version.outputs.version }}"
+          VERSION_WITH_V="${{ steps.get_version.outputs.version_with_v }}"
+          BRANCH_TYPE="${{ steps.branch_info.outputs.branch_type }}"
+          IS_MAIN="${{ steps.branch_info.outputs.is_main_branch }}"
+          FORCE_LATEST="${{ github.event.inputs.force_latest }}"
+
+          # 基础标签：版本号（带 v 前缀）和分支类型
+          TAGS="$USERNAME/xiaozhi-client:$VERSION_WITH_V,$USERNAME/xiaozhi-client:$BRANCH_TYPE"
+
+          # 如果是 main 分支或强制更新 latest，添加 latest 标签
+          if [ "$IS_MAIN" = "true" ] || [ "$FORCE_LATEST" = "true" ]; then
+            TAGS="$TAGS,$USERNAME/xiaozhi-client:latest"
+          fi
+
+          echo "tags=$TAGS" >> $GITHUB_OUTPUT
+          echo "生成的 Docker 标签:"
+          echo "$TAGS" | tr ',' '\n' | sed 's/^/  - /'
+
+      - name: 构建并推送 Docker 镜像
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          build-args: |
+            XIAOZHI_VERSION=${{ steps.get_version.outputs.version }}
+          tags: ${{ steps.docker_tags.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: 发布总结
+        run: |
+          echo "🎉 Docker 镜像发布完成！"
+          echo ""
+          echo "📦 发布信息:"
+          echo "  版本号: ${{ steps.get_version.outputs.version_with_v }}"
+          echo "  分支: ${{ github.event.inputs.branch || github.event.workflow_run.head_branch }}"
+          echo "  分支类型: ${{ steps.branch_info.outputs.branch_type }}"
+          echo ""
+          echo "🏷️ Docker 标签:"
+          echo "${{ steps.docker_tags.outputs.tags }}" | tr ',' '\n' | sed 's/^/  - /'
+          echo ""
+          echo "🚀 使用方法:"
+          echo "  docker pull ${{ secrets.DOCKER_USERNAME }}/xiaozhi-client:${{ steps.get_version.outputs.version_with_v }}"
+          echo "  docker run -it ${{ secrets.DOCKER_USERNAME }}/xiaozhi-client:${{ steps.get_version.outputs.version_with_v }}"

--- a/.github/workflows/npm-release.yml
+++ b/.github/workflows/npm-release.yml
@@ -1,9 +1,10 @@
-name: Release
+name: NPM 发布
+
 on:
   workflow_dispatch:
     inputs:
       branch:
-        description: "Branch to release from"
+        description: "发布源分支"
         required: true
         default: "main"
         type: choice
@@ -11,7 +12,7 @@ on:
           - main
           - beta
       dry_run:
-        description: "Dry run mode (preview only, no actual release)"
+        description: "预演模式（仅预览，不实际发布）"
         required: true
         default: false
         type: boolean
@@ -20,14 +21,17 @@ permissions:
   contents: read
 
 jobs:
-  release:
-    name: Release
+  npm-release:
+    name: NPM 发布
     runs-on: ubuntu-latest
     permissions:
       contents: write
       issues: write
       pull-requests: write
       id-token: write
+    outputs:
+      version: ${{ steps.get_version.outputs.version }}
+      release_created: ${{ steps.release_check.outputs.release_created }}
     steps:
       - name: 检出代码
         uses: actions/checkout@v4
@@ -37,8 +41,8 @@ jobs:
 
       - name: 确认当前分支
         run: |
-          echo "手动触发发布，从分支 ${{ github.event.inputs.branch }} 发布"
-          echo "Dry run 模式: ${{ github.event.inputs.dry_run }}"
+          echo "手动触发 NPM 发布，从分支 ${{ github.event.inputs.branch }} 发布"
+          echo "预演模式: ${{ github.event.inputs.dry_run }}"
 
       - name: 安装 pnpm
         uses: pnpm/action-setup@v4
@@ -64,39 +68,28 @@ jobs:
       - name: 验证已安装依赖项的来源证明和注册中心签名的完整性
         run: pnpm audit signatures
 
-      - name: Release
+      - name: NPM 发布
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           if [ "${{ github.event.inputs.dry_run }}" = "true" ]; then
             if [ "${{ github.event.inputs.branch }}" = "main" ]; then
-              echo "手动触发稳定版 Dry Run（预览模式）"
+              echo "手动触发稳定版预演（预览模式）"
               pnpm run release:dry
             else
-              echo "手动触发 beta 版 Dry Run（预览模式）"
+              echo "手动触发 beta 版预演（预览模式）"
               pnpm run release:dry:beta
             fi
           else
             if [ "${{ github.event.inputs.branch }}" = "main" ]; then
               echo "手动触发稳定版实际发布"
-              # pnpm run release
+              pnpm run release
             else
               echo "手动触发 beta 版实际发布"
               pnpm run release:beta
             fi
           fi
-
-      - name: 设置 Docker Buildx
-        if: success() && github.event.inputs.dry_run == 'false'
-        uses: docker/setup-buildx-action@v3
-
-      - name: 登录 Docker Hub
-        if: success() && github.event.inputs.dry_run == 'false'
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_TOKEN }}
 
       - name: 获取发布版本号
         if: success() && github.event.inputs.dry_run == 'false'
@@ -104,20 +97,38 @@ jobs:
         run: |
           VERSION=$(node -p "require('./package.json').version")
           echo "version=$VERSION" >> $GITHUB_OUTPUT
-          echo "发布版本: $VERSION"
+          echo "NPM 发布版本: $VERSION"
 
-      - name: 构建并推送 Docker 镜像
+      - name: 检查是否有新版本发布
         if: success() && github.event.inputs.dry_run == 'false'
-        uses: docker/build-push-action@v5
+        id: release_check
+        run: |
+          # 检查是否有新的 release 被创建（通过检查最新的 git tag）
+          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+          CURRENT_VERSION="${{ steps.get_version.outputs.version }}"
+
+          if [ "$LATEST_TAG" = "v$CURRENT_VERSION" ]; then
+            echo "release_created=true" >> $GITHUB_OUTPUT
+            echo "✅ 新版本 v$CURRENT_VERSION 已发布"
+          else
+            echo "release_created=false" >> $GITHUB_OUTPUT
+            echo "ℹ️ 没有新版本发布"
+          fi
+
+      - name: 触发 Docker 发布
+        if: success() && github.event.inputs.dry_run == 'false' && steps.release_check.outputs.release_created == 'true'
+        uses: actions/github-script@v7
         with:
-          context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
-          build-args: |
-            XIAOZHI_VERSION=${{ steps.get_version.outputs.version }}
-          tags: |
-            ${{ secrets.DOCKER_USERNAME }}/xiaozhi-client:latest
-            ${{ secrets.DOCKER_USERNAME }}/xiaozhi-client:${{ steps.get_version.outputs.version }}
-            ${{ secrets.DOCKER_USERNAME }}/xiaozhi-client:${{ github.event.inputs.branch == 'main' && 'stable' || 'beta' }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          github-token: ${{ secrets.GH_TOKEN }}
+          script: |
+            const result = await github.rest.actions.createWorkflowDispatch({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              workflow_id: 'docker-release.yml',
+              ref: '${{ github.event.inputs.branch }}',
+              inputs: {
+                version: '${{ steps.get_version.outputs.version }}',
+                branch: '${{ github.event.inputs.branch }}'
+              }
+            });
+            console.log('✅ 已触发 Docker 发布工作流');

--- a/README.md
+++ b/README.md
@@ -140,6 +140,12 @@ npx -y xiaozhi-client start
 curl -fsSL https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docker-start.sh | bash
 ```
 
+> 无法访问 `Github` 可以使用 `Gitee` 替代
+
+```bash
+curl -fsSL https://gitee.com/shenjingnan/xiaozhi-client/raw/main/docker-start.sh | bash
+```
+
 **指定版本运行：**
 
 启动脚本现在支持灵活的版本指定方式：
@@ -147,6 +153,11 @@ curl -fsSL https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/doc
 ```bash
 # 下载脚本
 curl -fsSL https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docker-start.sh -o docker-start.sh
+
+# 下载脚本（Gitee）
+curl -fsSL https://gitee.com/shenjingnan/xiaozhi-client/raw/main/docker-start.sh | bash
+
+# 为脚本设置可执行权限
 chmod +x docker-start.sh
 
 # 使用默认版本 (latest)
@@ -166,6 +177,9 @@ chmod +x docker-start.sh
 ```bash
 # 下载 docker-compose.yml 文件
 curl -O https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docker-compose.yml
+
+# 下载 docker-compose.yml 文件（Gitee）
+curl -O https://gitee.com/shenjingnan/xiaozhi-client/raw/main/docker-compose.yml
 
 # 使用 Docker Compose 启动
 docker-compose up -d

--- a/cspell.json
+++ b/cspell.json
@@ -2,7 +2,6 @@
   "version": "0.2",
   "language": "en",
   "words": [
-    "findstr",
     "addgroup",
     "adduser",
     "amap",
@@ -12,7 +11,9 @@
     "EPIPE",
     "eventsource",
     "EventSource",
+    "findstr",
     "gaode",
+    "Gitee",
     "healthcheck",
     "HTTPMCP",
     "IMCP",


### PR DESCRIPTION
- 创建独立的 Docker 发布工作流 (docker-release.yml)，支持手动触发和自动触发
- 重命名 release.yml 为 npm-release.yml，专注于 NPM 包发布
- 优化 Docker 发布流程，支持版本号自定义、分支选择和 latest 标签控制
- 更新 README 文档，增加 Gitee 镜像源支持，提升国内用户访问体验
- 更新 cspell 字典，增加 Gitee 相关词汇