### PR TITLE
fix(docker): 移除Docker容器中的非root用户限制

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,9 +38,7 @@ RUN apt-get update && apt-get install -y \
     && ln -sf /usr/bin/pip3 /usr/bin/pip \
     && pip3 install --break-system-packages uv \
     && npm install -g pnpm xiaozhi-client@${XIAOZHI_VERSION} \
-    && pnpm config set registry https://registry.npmmirror.com \
-    && groupadd -g 1001 xiaozhi \
-    && useradd -u 1001 -g xiaozhi -m xiaozhi
+    && pnpm config set registry https://registry.npmmirror.com
 
 # 验证工具可用性
 RUN npx --version && echo "✓ npx is available" \
@@ -61,12 +59,9 @@ COPY scripts/docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 # 使用国内镜像源安装依赖
 RUN cd /templates-backup && npm install --registry=https://registry.npmmirror.com
 
-# 设置脚本权限和目录权限
-RUN chmod +x /usr/local/bin/docker-entrypoint.sh \
-    && chown -R xiaozhi:xiaozhi /workspaces /templates-backup
+# 设置脚本权限
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
 
-# 切换到非 root 用户
-USER xiaozhi
 
 # 暴露端口
 EXPOSE 9999 3000

--- a/scripts/docker-entrypoint.sh
+++ b/scripts/docker-entrypoint.sh
@@ -25,11 +25,6 @@ if [ ! -f "/workspaces/xiaozhi.config.json" ] || [ ! -f "/workspaces/package.jso
         exit 1
     fi
 
-    # 设置正确的权限（仅在有权限时执行）
-    if [ "$(id -u)" = "0" ]; then
-        chown -R xiaozhi:xiaozhi /workspaces
-    fi
-
     log "工作目录初始化完成"
     log "配置文件位置: ~/xiaozhi-client/xiaozhi.config.json"
 else


### PR DESCRIPTION
- 移除了xiaozhi用户和用户组的创建逻辑
- 移除了USER xiaozhi指令，容器将以root用户运行
- 移除了工作目录权限设置的逻辑
- 简化了Dockerfile和entrypoint脚本
- 解决了权限问题，使容器能够正常访问和修改工作目录