### PR TITLE
feat(service): 优化服务启动体验，支持自动重启已运行服务

### DIFF
--- a/src/cli/errors/index.test.ts
+++ b/src/cli/errors/index.test.ts
@@ -79,6 +79,18 @@ describe("ServiceError", () => {
 
     expect(error.message).toBe("服务已经在运行 (PID: 1234)");
     expect(error.suggestions).toContain('请先运行 "xiaozhi stop" 停止现有服务');
+    expect(error.suggestions).toContain('或者使用 "xiaozhi restart" 重启服务');
+  });
+
+  it("should create auto restarting error", () => {
+    const error = ServiceError.autoRestarting(1234);
+
+    expect(error.message).toBe(
+      "检测到服务已在运行 (PID: 1234)，正在自动重启..."
+    );
+    expect(error.suggestions).toContain(
+      "如果不希望自动重启，请使用 xiaozhi stop 手动停止服务"
+    );
   });
 
   it("should create not running error", () => {

--- a/src/cli/errors/index.ts
+++ b/src/cli/errors/index.ts
@@ -69,7 +69,15 @@ export class ServiceError extends CLIError {
   static alreadyRunning(pid: number): ServiceError {
     return new ServiceError(`服务已经在运行 (PID: ${pid})`, [
       '请先运行 "xiaozhi stop" 停止现有服务',
+      '或者使用 "xiaozhi restart" 重启服务',
     ]);
+  }
+
+  static autoRestarting(pid: number): ServiceError {
+    return new ServiceError(
+      `检测到服务已在运行 (PID: ${pid})，正在自动重启...`,
+      ["如果不希望自动重启，请使用 xiaozhi stop 手动停止服务"]
+    );
   }
 
   static notRunning(): ServiceError {


### PR DESCRIPTION
- 修改服务启动逻辑，当检测到服务已在运行时自动重启而非抛出错误
- 新增 ServiceError.autoRestarting 错误类型，提供更友好的提示信息
- 在 ServiceManager.start 中实现优雅停止现有服务并重新启动的流程
- 添加相应的测试用例覆盖新的自动重启逻辑
- 改善用户体验，避免用户需要手动停止服务再重新启动

这个改动解决了用户在服务已运行情况下重复执行启动命令的痛点，
提供了更加智能和用户友好的服务管理体验。