### PR TITLE
chore(deps): 增强 renovate 配置并添加自动合并功能

### DIFF
--- a/renovate.json5
+++ b/renovate.json5
@@ -1,26 +1,38 @@
 {
-  $schema: 'https://docs.renovatebot.com/renovate-schema.json',
-  extends: [
-    'config:recommended',
-  ],
-  labels: [
-    'dependencies',
-  ],
-  assignees: [
-    'shenjingnan',
-  ],
-  packageRules: [
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:base"],
+  "labels": ["dependencies"],
+  "assignees": ["shenjingnan"],
+  "timezone": "Asia/Shanghai",
+  "schedule": ["before 6am on monday"],
+  "rangeStrategy": "bump",
+  "lockFileMaintenance": {
+    "enabled": true,
+    "schedule": ["before 6am on monday"]
+  },
+  "includePaths": ["package.json", "web/package.json"],
+  "packageRules": [
     {
-      matchUpdateTypes: [
-        'patch',
-        'minor',
-      ],
+      "matchUpdateTypes": ["patch", "minor"],
+      "automerge": true,
+      "automergeType": "pr",
+      "platformAutomerge": true
     },
     {
-      matchUpdateTypes: [
-        'major',
-      ],
-      dependencyDashboardApproval: true,
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": true
     },
-  ],
+    {
+      "matchManagers": ["npm"],
+      "matchPackagePatterns": ["^@types/"],
+      "automerge": true,
+      "automergeType": "pr"
+    },
+    {
+      "matchDepTypes": ["devDependencies"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "automerge": true,
+      "automergeType": "pr"
+    }
+  ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -4,19 +4,18 @@
   "labels": ["dependencies"],
   "assignees": ["shenjingnan"],
   "timezone": "Asia/Shanghai",
-  "schedule": ["before 9am"],
+  "schedule": ["before 9am every weekday"],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 9am"]
+    "schedule": ["before 9am every weekday"]
   },
   "includePaths": ["package.json", "web/package.json"],
   "packageRules": [
     {
       "matchUpdateTypes": ["patch", "minor"],
       "automerge": true,
-      "automergeType": "pr",
-      "platformAutomerge": true
+      "automergeType": "pr"
     },
     {
       "matchUpdateTypes": ["major"],
@@ -30,9 +29,9 @@
     },
     {
       "matchDepTypes": ["devDependencies"],
-      "matchUpdateTypes": ["minor", "patch"],
-      "automerge": true,
-      "automergeType": "pr"
+      "matchUpdateTypes": ["major"],
+      "dependencyDashboardApproval": false,
+      "automerge": false
     }
   ]
 }

--- a/renovate.json5
+++ b/renovate.json5
@@ -1,14 +1,14 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base"],
+  "extends": ["config:recommended"],
   "labels": ["dependencies"],
   "assignees": ["shenjingnan"],
   "timezone": "Asia/Shanghai",
-  "schedule": ["before 6am on monday"],
+  "schedule": ["before 9am"],
   "rangeStrategy": "bump",
   "lockFileMaintenance": {
     "enabled": true,
-    "schedule": ["before 6am on monday"]
+    "schedule": ["before 9am"]
   },
   "includePaths": ["package.json", "web/package.json"],
   "packageRules": [


### PR DESCRIPTION
- 添加亚洲/上海时区配置
- 为 patch 和 minor 更新启用自动合并功能
- 配置锁文件维护，设置每日调度任务
- 为 @types/ 包添加特殊的自动合并规则
- 为开发依赖的 minor/patch 更新启用自动合并
- 限制扫描范围仅包含根目录和 web 目录的 package.json
- 改进配置文件格式和可读性
- 添加 rangeStrategy 为 bump 策略