### PR TITLE
feat(mcp): 新增 MCP 工具命令行调用功能

### DIFF
--- a/docs/mcp-tool-calling.md
+++ b/docs/mcp-tool-calling.md
@@ -1,0 +1,233 @@
+# xiaozhi mcp call 命令使用说明
+
+## 概述
+
+`xiaozhi mcp call` 命令用于调用已配置的 MCP (Model Context Protocol) 服务中的工具。该命令通过 HTTP API 与后台服务通信，实现对各种 MCP 工具的统一调用接口。
+
+## 前置条件
+
+在使用 `xiaozhi mcp call` 命令之前，请确保：
+
+1. **服务已启动**：xiaozhi 后台服务必须正在运行
+   ```bash
+   # 启动后台服务
+   xiaozhi start -d
+   
+   # 检查服务状态
+   xiaozhi status
+   ```
+
+2. **MCP 服务已配置**：在配置文件中正确配置了 MCP 服务
+3. **工具已启用**：目标工具未被禁用
+
+## 命令语法
+
+```bash
+xiaozhi mcp call <服务名称> <工具名称> [选项]
+```
+
+### 参数说明
+
+#### 必需参数
+
+- `<服务名称>`：MCP 服务的名称，在配置文件中定义
+- `<工具名称>`：要调用的工具名称
+
+#### 可选参数
+
+- `--args <JSON>`：工具参数，JSON 格式字符串（默认值：`{}`）
+
+### 选项格式
+
+```bash
+--args '{"参数名1": "参数值1", "参数名2": "参数值2"}'
+```
+
+## 使用示例
+
+### 基础示例
+
+#### 1. 调用计算器工具
+
+```bash
+# 执行简单的数学计算
+xiaozhi mcp call calculator calculator --args '{"javascript_expression": "1+2"}'
+```
+
+**输出示例：**
+```
+✔ calculator/calculator: {"content":[{"type":"text","text":"{\"success\":true,\"result\":3}"}]}
+```
+
+#### 2. 调用日期时间工具
+
+```bash
+# 获取当前日期
+xiaozhi mcp call datetime get_current_date
+
+# 添加时间
+xiaozhi mcp call datetime add_time --args '{"date": "2024-01-01", "days": 7}'
+```
+
+### 复杂参数示例
+
+#### 3. 多参数工具调用
+
+```bash
+# 调用包含多个参数的工具
+xiaozhi mcp call myservice mytool --args '{
+  "param1": "value1",
+  "param2": 123,
+  "param3": true,
+  "param4": ["item1", "item2"]
+}'
+```
+
+#### 4. 嵌套对象参数
+
+```bash
+# 传递嵌套对象作为参数
+xiaozhi mcp call dataservice process --args '{
+  "config": {
+    "format": "json",
+    "options": {
+      "pretty": true,
+      "indent": 2
+    }
+  },
+  "data": ["a", "b", "c"]
+}'
+```
+
+## 常见错误和解决方法
+
+### 1. 服务未启动错误
+
+**错误信息：**
+```
+错误: xiaozhi 服务未启动。请先运行 'xiaozhi start' 或 'xiaozhi start -d' 启动服务。
+```
+
+**解决方法：**
+```bash
+# 启动后台服务
+xiaozhi start -d
+
+# 验证服务状态
+xiaozhi status
+```
+
+### 2. 服务不存在错误
+
+**错误信息：**
+```
+错误: 服务 'nonexistent' 不存在。可用服务: calculator, datetime
+```
+
+**解决方法：**
+- 检查服务名称拼写是否正确
+- 使用 `xiaozhi config show` 查看已配置的服务
+- 确认服务已在配置文件中正确定义
+
+### 3. 工具不存在错误
+
+**错误信息：**
+```
+错误: 工具 'unknown_tool' 在服务 'calculator' 中不存在。可用工具: calculator
+```
+
+**解决方法：**
+- 检查工具名称拼写是否正确
+- 查看服务文档了解可用工具列表
+- 使用正确的工具名称重新调用
+
+### 4. 工具已被禁用错误
+
+**错误信息：**
+```
+错误: 工具 'calculator' 已被禁用。请使用 'xiaozhi mcp tool calculator calculator enable' 启用该工具。
+```
+
+**解决方法：**
+```bash
+# 启用指定工具
+xiaozhi mcp tool calculator calculator enable
+
+# 重新调用工具
+xiaozhi mcp call calculator calculator --args '{"javascript_expression": "1+2"}'
+```
+
+### 5. 参数格式错误
+
+**错误信息：**
+```
+错误: 参数格式错误: Unexpected token...
+```
+
+**解决方法：**
+- 确保 JSON 格式正确
+- 使用单引号包围 JSON 字符串
+- 检查 JSON 中的引号、括号、逗号等语法
+
+**正确格式：**
+```bash
+xiaozhi mcp call service tool --args '{"param": "value"}'
+```
+
+**错误格式：**
+```bash
+xiaozhi mcp call service tool --args {"param": "value"}  # 缺少引号
+xiaozhi mcp call service tool --args '{"param": value}'  # 值缺少引号
+```
+
+## 相关命令
+
+### 服务管理命令
+
+- `xiaozhi start [-d]`：启动 xiaozhi 服务
+- `xiaozhi stop`：停止 xiaozhi 服务
+- `xiaozhi status`：查看服务状态
+- `xiaozhi restart [-d]`：重启服务
+
+### MCP 相关命令
+
+- `xiaozhi mcp list`：列出所有可用的 MCP 服务和工具
+- `xiaozhi mcp tool <服务名> <工具名> <enable|disable>`：启用或禁用工具
+- `xiaozhi config show`：查看当前配置
+
+## 技术架构说明
+
+`xiaozhi mcp call` 命令采用以下架构：
+
+1. **CLI 命令**：解析用户输入的命令和参数
+2. **HTTP API 调用**：通过 HTTP 请求调用后台服务的 `/api/tools/call` 端点
+3. **后台服务处理**：后台服务管理所有 MCP 连接并执行工具调用
+4. **结果返回**：将工具执行结果格式化后返回给用户
+
+这种架构确保了：
+- CLI 和后台服务的清晰分离
+- 统一的工具调用接口
+- 可靠的错误处理和状态管理
+
+## 最佳实践
+
+1. **参数验证**：调用前确认参数格式和内容正确
+2. **错误处理**：根据错误信息进行相应的故障排除
+3. **服务监控**：定期检查服务状态确保正常运行
+4. **配置管理**：保持 MCP 服务配置的准确性和时效性
+
+## 故障排除检查清单
+
+遇到问题时，请按以下顺序检查：
+
+- [ ] xiaozhi 服务是否正在运行（`xiaozhi status`）
+- [ ] 服务名称和工具名称是否正确
+- [ ] 参数 JSON 格式是否有效
+- [ ] 工具是否已启用
+- [ ] 网络连接是否正常
+- [ ] 配置文件是否正确
+
+如果问题仍然存在，请查看日志文件获取更详细的错误信息：
+```bash
+xiaozhi attach  # 查看实时日志
+```

--- a/src/WebServer.ts
+++ b/src/WebServer.ts
@@ -21,6 +21,7 @@ import { RealtimeNotificationHandler } from "./handlers/RealtimeNotificationHand
 import { ServiceApiHandler } from "./handlers/ServiceApiHandler.js";
 import { StaticFileHandler } from "./handlers/StaticFileHandler.js";
 import { StatusApiHandler } from "./handlers/StatusApiHandler.js";
+import { ToolApiHandler } from "./handlers/ToolApiHandler.js";
 import { ConfigService } from "./services/ConfigService.js";
 // 导入新的服务和处理器
 import {
@@ -77,6 +78,7 @@ export class WebServer {
   private configApiHandler: ConfigApiHandler;
   private statusApiHandler: StatusApiHandler;
   private serviceApiHandler: ServiceApiHandler;
+  private toolApiHandler: ToolApiHandler;
   private staticFileHandler: StaticFileHandler;
 
   // WebSocket 处理器
@@ -156,6 +158,7 @@ export class WebServer {
     this.configApiHandler = new ConfigApiHandler();
     this.statusApiHandler = new StatusApiHandler(this.statusService);
     this.serviceApiHandler = new ServiceApiHandler(this.statusService);
+    this.toolApiHandler = new ToolApiHandler();
     this.staticFileHandler = new StaticFileHandler();
 
     // 初始化 WebSocket 处理器
@@ -510,6 +513,10 @@ export class WebServer {
     this.app?.get("/api/services/health", (c) =>
       this.serviceApiHandler.getServiceHealth(c)
     );
+
+    // 工具调用相关 API 路由
+    this.app?.post("/api/tools/call", (c) => this.toolApiHandler.callTool(c));
+    this.app?.get("/api/tools/list", (c) => this.toolApiHandler.listTools(c));
 
     // 处理未知的 API 路由
     this.app?.all("/api/*", async (c) => {

--- a/src/cli/commands/McpCommandHandler.ts
+++ b/src/cli/commands/McpCommandHandler.ts
@@ -129,8 +129,6 @@ export class McpCommandHandler extends BaseCommandHandler {
     toolName: string,
     argsString: string
   ): Promise<void> {
-    const spinner = ora(`调用工具 ${serviceName}/${toolName}...`).start();
-
     try {
       const toolCallService = new ToolCallService();
 
@@ -144,9 +142,9 @@ export class McpCommandHandler extends BaseCommandHandler {
         args
       );
 
-      spinner.succeed(`${serviceName}/${toolName}: ${toolCallService.formatOutput(result)}`);
+      console.log(toolCallService.formatOutput(result));
     } catch (error) {
-      spinner.fail(`工具调用失败: ${serviceName}/${toolName}`);
+      console.log(`工具调用失败: ${serviceName}/${toolName}`);
       console.error(chalk.red("错误:"), (error as Error).message);
 
       // 提供有用的提示

--- a/src/cli/commands/McpCommandHandler.ts
+++ b/src/cli/commands/McpCommandHandler.ts
@@ -144,15 +144,9 @@ export class McpCommandHandler extends BaseCommandHandler {
         args
       );
 
-      spinner.succeed(`工具调用成功: ${serviceName}/${toolName}`);
-
-      // 输出原始响应
-      console.log();
-      console.log(chalk.bold("调用结果:"));
-      console.log(toolCallService.formatOutput(result));
+      spinner.succeed(`${serviceName}/${toolName}: ${toolCallService.formatOutput(result)}`);
     } catch (error) {
       spinner.fail(`工具调用失败: ${serviceName}/${toolName}`);
-      console.log();
       console.error(chalk.red("错误:"), (error as Error).message);
 
       // 提供有用的提示

--- a/src/cli/commands/McpCommandHandler.ts
+++ b/src/cli/commands/McpCommandHandler.ts
@@ -3,6 +3,8 @@
  */
 
 import chalk from "chalk";
+import ora from "ora";
+import { ToolCallService } from "../../services/ToolCallService.js";
 import type { SubCommand } from "../interfaces/Command.js";
 import { BaseCommandHandler } from "../interfaces/Command.js";
 import type { IDIContainer } from "../interfaces/Config.js";
@@ -45,6 +47,22 @@ export class McpCommandHandler extends BaseCommandHandler {
 
         const enabled = action === "enable";
         await this.handleTool(serverName, toolName, enabled);
+      },
+    },
+    {
+      name: "call",
+      description: "调用指定服务的工具",
+      options: [
+        {
+          flags: "--args <json>",
+          description: "工具参数 (JSON 格式)",
+          defaultValue: "{}",
+        },
+      ],
+      execute: async (args: any[], options: any) => {
+        this.validateArgs(args, 2);
+        const [serviceName, toolName] = args;
+        await this.handleCall(serviceName, toolName, options.args);
       },
     },
   ];
@@ -100,6 +118,60 @@ export class McpCommandHandler extends BaseCommandHandler {
       await setToolEnabled(serverName, toolName, enabled);
     } catch (error) {
       this.handleError(error as Error);
+    }
+  }
+
+  /**
+   * 处理工具调用命令
+   */
+  private async handleCall(
+    serviceName: string,
+    toolName: string,
+    argsString: string
+  ): Promise<void> {
+    const spinner = ora(`调用工具 ${serviceName}/${toolName}...`).start();
+
+    try {
+      const toolCallService = new ToolCallService();
+
+      // 解析参数
+      const args = toolCallService.parseJsonArgs(argsString);
+
+      // 调用工具
+      const result = await toolCallService.callTool(
+        serviceName,
+        toolName,
+        args
+      );
+
+      spinner.succeed(`工具调用成功: ${serviceName}/${toolName}`);
+
+      // 输出原始响应
+      console.log();
+      console.log(chalk.bold("调用结果:"));
+      console.log(toolCallService.formatOutput(result));
+    } catch (error) {
+      spinner.fail(`工具调用失败: ${serviceName}/${toolName}`);
+      console.log();
+      console.error(chalk.red("错误:"), (error as Error).message);
+
+      // 提供有用的提示
+      if ((error as Error).message.includes("服务未启动")) {
+        console.log();
+        console.log(chalk.yellow("💡 请先启动服务:"));
+        console.log(chalk.gray("  xiaozhi start        # 前台启动"));
+        console.log(chalk.gray("  xiaozhi start -d     # 后台启动"));
+      } else if ((error as Error).message.includes("参数格式错误")) {
+        console.log();
+        console.log(chalk.yellow("💡 正确格式示例:"));
+        console.log(
+          chalk.gray(
+            `  xiaozhi mcp call ${serviceName} ${toolName} --args '{"param": "value"}'`
+          )
+        );
+      }
+
+      process.exit(1);
     }
   }
 }

--- a/src/cli/commands/index.ts
+++ b/src/cli/commands/index.ts
@@ -71,6 +71,8 @@ export class CommandRegistry implements ICommandRegistry {
           subcommandName = "get <key>";
         } else if (subcommand.name === "set") {
           subcommandName = "set <key> <value>";
+        } else if (subcommand.name === "call") {
+          subcommandName = "call <serviceName> <toolName>";
         }
 
         const cmd = commandGroup

--- a/src/handlers/ToolApiHandler.ts
+++ b/src/handlers/ToolApiHandler.ts
@@ -109,7 +109,7 @@ export class ToolApiHandler {
       const toolKey = `${serviceName}__${toolName}`;
       const result = await serviceManager.callTool(toolKey, args || {});
 
-      this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
+      // this.logger.debug(`工具调用成功: ${serviceName}/${toolName}`);
 
       return c.json(this.createSuccessResponse(result, "工具调用成功"));
     } catch (error) {

--- a/src/handlers/ToolApiHandler.ts
+++ b/src/handlers/ToolApiHandler.ts
@@ -5,8 +5,8 @@
 
 import type { Context } from "hono";
 import { type Logger, logger } from "../Logger.js";
-import { MCPServiceManagerSingleton } from "../services/MCPServiceManagerSingleton.js";
 import { configManager } from "../configManager.js";
+import { MCPServiceManagerSingleton } from "../services/MCPServiceManagerSingleton.js";
 
 /**
  * 工具调用请求接口
@@ -115,13 +115,17 @@ export class ToolApiHandler {
     } catch (error) {
       this.logger.error("工具调用失败:", error);
 
-      const errorMessage = error instanceof Error ? error.message : String(error);
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
       let errorCode = "TOOL_CALL_ERROR";
 
       // 根据错误类型设置不同的错误码
       if (errorMessage.includes("不存在")) {
         errorCode = "SERVICE_OR_TOOL_NOT_FOUND";
-      } else if (errorMessage.includes("未启动") || errorMessage.includes("未连接")) {
+      } else if (
+        errorMessage.includes("未启动") ||
+        errorMessage.includes("未连接")
+      ) {
         errorCode = "SERVICE_NOT_AVAILABLE";
       } else if (errorMessage.includes("已被禁用")) {
         errorCode = "TOOL_DISABLED";

--- a/src/handlers/ToolApiHandler.ts
+++ b/src/handlers/ToolApiHandler.ts
@@ -1,0 +1,246 @@
+/**
+ * 工具调用 API 处理器
+ * 处理通过 HTTP API 调用 MCP 工具的请求
+ */
+
+import type { Context } from "hono";
+import { type Logger, logger } from "../Logger.js";
+import { MCPServiceManagerSingleton } from "../services/MCPServiceManagerSingleton.js";
+import { configManager } from "../configManager.js";
+
+/**
+ * 工具调用请求接口
+ */
+interface ToolCallRequest {
+  serviceName: string;
+  toolName: string;
+  args: any;
+}
+
+/**
+ * 工具调用响应接口
+ */
+interface ToolCallResponse {
+  success: boolean;
+  data?: any;
+  error?: {
+    code: string;
+    message: string;
+  };
+  message?: string;
+}
+
+/**
+ * 工具调用 API 处理器
+ */
+export class ToolApiHandler {
+  private logger: Logger;
+
+  constructor() {
+    this.logger = logger.withTag("ToolApiHandler");
+  }
+
+  /**
+   * 创建成功响应
+   */
+  private createSuccessResponse(data: any, message?: string): ToolCallResponse {
+    return {
+      success: true,
+      data,
+      message,
+    };
+  }
+
+  /**
+   * 创建错误响应
+   */
+  private createErrorResponse(code: string, message: string): ToolCallResponse {
+    return {
+      success: false,
+      error: {
+        code,
+        message,
+      },
+    };
+  }
+
+  /**
+   * 调用 MCP 工具
+   * POST /api/tools/call
+   */
+  async callTool(c: Context): Promise<Response> {
+    try {
+      this.logger.info("处理工具调用请求");
+
+      // 解析请求体
+      const requestBody: ToolCallRequest = await c.req.json();
+      const { serviceName, toolName, args } = requestBody;
+
+      // 验证请求参数
+      if (!serviceName || !toolName) {
+        const errorResponse = this.createErrorResponse(
+          "INVALID_REQUEST",
+          "serviceName 和 toolName 是必需的参数"
+        );
+        return c.json(errorResponse, 400);
+      }
+
+      this.logger.info(
+        `准备调用工具: ${serviceName}/${toolName}，参数:`,
+        JSON.stringify(args)
+      );
+
+      // 检查 MCPServiceManager 是否已初始化
+      if (!MCPServiceManagerSingleton.isInitialized()) {
+        const errorResponse = this.createErrorResponse(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化。请检查服务状态。"
+        );
+        return c.json(errorResponse, 503);
+      }
+
+      // 获取服务管理器实例
+      const serviceManager = await MCPServiceManagerSingleton.getInstance();
+
+      // 验证服务和工具是否存在
+      await this.validateServiceAndTool(serviceManager, serviceName, toolName);
+
+      // 调用工具
+      const toolKey = `${serviceName}__${toolName}`;
+      const result = await serviceManager.callTool(toolKey, args || {});
+
+      this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
+
+      return c.json(this.createSuccessResponse(result, "工具调用成功"));
+    } catch (error) {
+      this.logger.error("工具调用失败:", error);
+
+      const errorMessage = error instanceof Error ? error.message : String(error);
+      let errorCode = "TOOL_CALL_ERROR";
+
+      // 根据错误类型设置不同的错误码
+      if (errorMessage.includes("不存在")) {
+        errorCode = "SERVICE_OR_TOOL_NOT_FOUND";
+      } else if (errorMessage.includes("未启动") || errorMessage.includes("未连接")) {
+        errorCode = "SERVICE_NOT_AVAILABLE";
+      } else if (errorMessage.includes("已被禁用")) {
+        errorCode = "TOOL_DISABLED";
+      }
+
+      const errorResponse = this.createErrorResponse(errorCode, errorMessage);
+      return c.json(errorResponse, 500);
+    }
+  }
+
+  /**
+   * 获取可用工具列表
+   * GET /api/tools/list
+   */
+  async listTools(c: Context): Promise<Response> {
+    try {
+      this.logger.info("处理获取工具列表请求");
+
+      // 检查 MCPServiceManager 是否已初始化
+      if (!MCPServiceManagerSingleton.isInitialized()) {
+        const errorResponse = this.createErrorResponse(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化。请检查服务状态。"
+        );
+        return c.json(errorResponse, 503);
+      }
+
+      // 获取服务管理器实例
+      const serviceManager = await MCPServiceManagerSingleton.getInstance();
+
+      // 获取所有工具
+      const allTools = serviceManager.getAllTools();
+
+      // 按服务分组工具
+      const toolsByService: Record<string, any[]> = {};
+      for (const tool of allTools) {
+        const [serviceName] = tool.name.split("__");
+        if (!toolsByService[serviceName]) {
+          toolsByService[serviceName] = [];
+        }
+        toolsByService[serviceName].push({
+          name: tool.name.replace(`${serviceName}__`, ""),
+          fullName: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+        });
+      }
+
+      this.logger.info(`获取工具列表成功，共 ${allTools.length} 个工具`);
+
+      return c.json(
+        this.createSuccessResponse(
+          {
+            totalTools: allTools.length,
+            services: toolsByService,
+          },
+          "获取工具列表成功"
+        )
+      );
+    } catch (error) {
+      this.logger.error("获取工具列表失败:", error);
+
+      const errorResponse = this.createErrorResponse(
+        "LIST_TOOLS_ERROR",
+        error instanceof Error ? error.message : "获取工具列表失败"
+      );
+      return c.json(errorResponse, 500);
+    }
+  }
+
+  /**
+   * 验证服务和工具是否存在
+   * @private
+   */
+  private async validateServiceAndTool(
+    serviceManager: any,
+    serviceName: string,
+    toolName: string
+  ): Promise<void> {
+    // 检查配置中是否存在该服务
+    const mcpServers = configManager.getMcpServers();
+    if (!mcpServers[serviceName]) {
+      const availableServices = Object.keys(mcpServers);
+      throw new Error(
+        `服务 '${serviceName}' 不存在。可用服务: ${availableServices.join(", ")}`
+      );
+    }
+
+    // 检查服务是否已启动并连接
+    const serviceInstance = serviceManager.getService(serviceName);
+    if (!serviceInstance) {
+      throw new Error(
+        `服务 '${serviceName}' 未启动。请检查服务配置或重新启动 xiaozhi 服务。`
+      );
+    }
+
+    if (!serviceInstance.isConnected()) {
+      throw new Error(
+        `服务 '${serviceName}' 未连接。请检查服务状态或重新启动 xiaozhi 服务。`
+      );
+    }
+
+    // 检查工具是否存在
+    const tools = serviceInstance.getTools();
+    const toolExists = tools.some((tool: any) => tool.name === toolName);
+    if (!toolExists) {
+      const availableTools = tools.map((tool: any) => tool.name);
+      throw new Error(
+        `工具 '${toolName}' 在服务 '${serviceName}' 中不存在。可用工具: ${availableTools.join(", ")}`
+      );
+    }
+
+    // 检查工具是否已启用
+    const toolsConfig = configManager.getServerToolsConfig(serviceName);
+    const toolConfig = toolsConfig[toolName];
+    if (toolConfig && !toolConfig.enable) {
+      throw new Error(
+        `工具 '${toolName}' 已被禁用。请使用 'xiaozhi mcp tool ${serviceName} ${toolName} enable' 启用该工具。`
+      );
+    }
+  }
+}

--- a/src/services/ToolCallService.test.ts
+++ b/src/services/ToolCallService.test.ts
@@ -5,10 +5,22 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ToolCallService } from "./ToolCallService.js";
 
+// Mock fetch for HTTP API calls
+global.fetch = vi.fn();
+
+// Mock ProcessManager
+vi.mock("../cli/services/ProcessManager.js", () => ({
+  ProcessManagerImpl: vi.fn().mockImplementation(() => ({
+    getServiceStatus: vi.fn().mockReturnValue({ running: false, pid: null }),
+  })),
+}));
+
 describe("ToolCallService", () => {
   let toolCallService: ToolCallService;
 
   beforeEach(() => {
+    // Reset all mocks before each test
+    vi.clearAllMocks();
     toolCallService = new ToolCallService();
   });
 
@@ -62,7 +74,7 @@ describe("ToolCallService", () => {
       };
 
       const formatted = toolCallService.formatOutput(result);
-      const expected = JSON.stringify(result, null, 2);
+      const expected = JSON.stringify(result);
       expect(formatted).toBe(expected);
     });
 
@@ -78,7 +90,7 @@ describe("ToolCallService", () => {
       };
 
       const formatted = toolCallService.formatOutput(result);
-      const expected = JSON.stringify(result, null, 2);
+      const expected = JSON.stringify(result);
       expect(formatted).toBe(expected);
     });
 
@@ -97,15 +109,140 @@ describe("ToolCallService", () => {
       };
 
       const formatted = toolCallService.formatOutput(result);
-      const expected = JSON.stringify(result, null, 2);
+      const expected = JSON.stringify(result);
       expect(formatted).toBe(expected);
     });
   });
 
   describe("getServiceStatus", () => {
-    it("应该在服务未初始化时返回正确状态", async () => {
+    it("应该在进程未运行时返回正确状态", async () => {
+      // ProcessManager is already mocked to return service not running
       const status = await toolCallService.getServiceStatus();
       expect(status).toBe("服务未启动");
+    });
+
+    it("应该在进程运行但 Web API 不可访问时返回正确状态", async () => {
+      // Mock ProcessManager to return service running for this test
+      const mockProcessManager = toolCallService["processManager"];
+      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+        running: true,
+        pid: 12345,
+      });
+
+      // Mock fetch to simulate connection failure
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockRejectedValueOnce(new Error("Connection failed"));
+
+      const status = await toolCallService.getServiceStatus();
+      expect(status).toBe("服务进程运行中 (PID: 12345)，但无法连接到 Web API");
+    });
+
+    it("应该在服务完全正常时返回正确状态", async () => {
+      // Mock ProcessManager to return service running for this test
+      const mockProcessManager = toolCallService["processManager"];
+      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+        running: true,
+        pid: 12345,
+      });
+
+      // Mock fetch to simulate successful API response
+      const mockFetch = vi.mocked(fetch);
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          success: true,
+          data: { totalTools: 5 },
+        }),
+      } as Response);
+
+      const status = await toolCallService.getServiceStatus();
+      expect(status).toBe("服务已启动 (PID: 12345, 5 个工具可用)");
+    });
+  });
+
+  describe("callTool", () => {
+    it("应该通过 HTTP API 成功调用工具", async () => {
+      // Mock ProcessManager to return service running for this test
+      const mockProcessManager = toolCallService["processManager"];
+      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+        running: true,
+        pid: 12345,
+      });
+
+      // Mock successful status check
+      const mockFetch = vi.mocked(fetch);
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        } as Response)
+        // Mock successful tool call
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({
+            success: true,
+            data: {
+              content: [{ type: "text", text: "3" }],
+            },
+          }),
+        } as Response);
+
+      const result = await toolCallService.callTool("calculator", "calculator", {
+        javascript_expression: "1+2",
+      });
+
+      expect(result).toEqual({
+        content: [{ type: "text", text: "3" }],
+      });
+
+      // Verify the correct API endpoint was called
+      expect(mockFetch).toHaveBeenCalledWith(
+        "http://localhost:9999/api/tools/call",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            serviceName: "calculator",
+            toolName: "calculator",
+            args: { javascript_expression: "1+2" },
+          }),
+        }
+      );
+    });
+
+    it("应该在 HTTP API 调用失败时抛出错误", async () => {
+      // Mock ProcessManager to return service running for this test
+      const mockProcessManager = toolCallService["processManager"];
+      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+        running: true,
+        pid: 12345,
+      });
+
+      // Mock successful status check but failed tool call
+      const mockFetch = vi.mocked(fetch);
+      mockFetch
+        .mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({ success: true }),
+        } as Response)
+        // Mock failed tool call
+        .mockResolvedValueOnce({
+          ok: false,
+          status: 500,
+          statusText: "Internal Server Error",
+          json: async () => ({
+            success: false,
+            error: { message: "工具调用失败" },
+          }),
+        } as Response);
+
+      await expect(
+        toolCallService.callTool("calculator", "calculator", {
+          javascript_expression: "1+2",
+        })
+      ).rejects.toThrow("工具调用失败");
     });
   });
 });

--- a/src/services/ToolCallService.test.ts
+++ b/src/services/ToolCallService.test.ts
@@ -9,7 +9,9 @@ import { ToolCallService } from "./ToolCallService.js";
 global.fetch = vi.fn();
 
 // Mock ProcessManager
-const mockGetServiceStatus = vi.fn().mockReturnValue({ running: false, pid: null });
+const mockGetServiceStatus = vi
+  .fn()
+  .mockReturnValue({ running: false, pid: null });
 
 vi.mock("../cli/services/ProcessManager.js", () => ({
   ProcessManagerImpl: vi.fn().mockImplementation(() => ({

--- a/src/services/ToolCallService.test.ts
+++ b/src/services/ToolCallService.test.ts
@@ -123,7 +123,7 @@ describe("ToolCallService", () => {
 
     it("应该在进程运行但 Web API 不可访问时返回正确状态", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService["processManager"];
+      const mockProcessManager = toolCallService.processManager;
       vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
         running: true,
         pid: 12345,
@@ -139,7 +139,7 @@ describe("ToolCallService", () => {
 
     it("应该在服务完全正常时返回正确状态", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService["processManager"];
+      const mockProcessManager = toolCallService.processManager;
       vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
         running: true,
         pid: 12345,
@@ -163,7 +163,7 @@ describe("ToolCallService", () => {
   describe("callTool", () => {
     it("应该通过 HTTP API 成功调用工具", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService["processManager"];
+      const mockProcessManager = toolCallService.processManager;
       vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
         running: true,
         pid: 12345,
@@ -187,9 +187,13 @@ describe("ToolCallService", () => {
           }),
         } as Response);
 
-      const result = await toolCallService.callTool("calculator", "calculator", {
-        javascript_expression: "1+2",
-      });
+      const result = await toolCallService.callTool(
+        "calculator",
+        "calculator",
+        {
+          javascript_expression: "1+2",
+        }
+      );
 
       expect(result).toEqual({
         content: [{ type: "text", text: "3" }],
@@ -214,7 +218,7 @@ describe("ToolCallService", () => {
 
     it("应该在 HTTP API 调用失败时抛出错误", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService["processManager"];
+      const mockProcessManager = toolCallService.processManager;
       vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
         running: true,
         pid: 12345,

--- a/src/services/ToolCallService.test.ts
+++ b/src/services/ToolCallService.test.ts
@@ -9,9 +9,11 @@ import { ToolCallService } from "./ToolCallService.js";
 global.fetch = vi.fn();
 
 // Mock ProcessManager
+const mockGetServiceStatus = vi.fn().mockReturnValue({ running: false, pid: null });
+
 vi.mock("../cli/services/ProcessManager.js", () => ({
   ProcessManagerImpl: vi.fn().mockImplementation(() => ({
-    getServiceStatus: vi.fn().mockReturnValue({ running: false, pid: null }),
+    getServiceStatus: mockGetServiceStatus,
   })),
 }));
 
@@ -21,6 +23,8 @@ describe("ToolCallService", () => {
   beforeEach(() => {
     // Reset all mocks before each test
     vi.clearAllMocks();
+    // Reset the mock to default behavior
+    mockGetServiceStatus.mockReturnValue({ running: false, pid: null });
     toolCallService = new ToolCallService();
   });
 
@@ -123,8 +127,7 @@ describe("ToolCallService", () => {
 
     it("应该在进程运行但 Web API 不可访问时返回正确状态", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService.processManager;
-      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+      mockGetServiceStatus.mockReturnValueOnce({
         running: true,
         pid: 12345,
       });
@@ -139,8 +142,7 @@ describe("ToolCallService", () => {
 
     it("应该在服务完全正常时返回正确状态", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService.processManager;
-      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+      mockGetServiceStatus.mockReturnValueOnce({
         running: true,
         pid: 12345,
       });
@@ -163,8 +165,7 @@ describe("ToolCallService", () => {
   describe("callTool", () => {
     it("应该通过 HTTP API 成功调用工具", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService.processManager;
-      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+      mockGetServiceStatus.mockReturnValueOnce({
         running: true,
         pid: 12345,
       });
@@ -218,8 +219,7 @@ describe("ToolCallService", () => {
 
     it("应该在 HTTP API 调用失败时抛出错误", async () => {
       // Mock ProcessManager to return service running for this test
-      const mockProcessManager = toolCallService.processManager;
-      vi.spyOn(mockProcessManager, "getServiceStatus").mockReturnValueOnce({
+      mockGetServiceStatus.mockReturnValueOnce({
         running: true,
         pid: 12345,
       });

--- a/src/services/ToolCallService.test.ts
+++ b/src/services/ToolCallService.test.ts
@@ -1,0 +1,111 @@
+/**
+ * ToolCallService 测试
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolCallService } from "./ToolCallService.js";
+
+describe("ToolCallService", () => {
+  let toolCallService: ToolCallService;
+
+  beforeEach(() => {
+    toolCallService = new ToolCallService();
+  });
+
+  describe("parseJsonArgs", () => {
+    it("应该正确解析有效的 JSON 字符串", () => {
+      const jsonString = '{"a": 10, "b": 20}';
+      const result = toolCallService.parseJsonArgs(jsonString);
+      expect(result).toEqual({ a: 10, b: 20 });
+    });
+
+    it("应该正确解析空对象", () => {
+      const jsonString = "{}";
+      const result = toolCallService.parseJsonArgs(jsonString);
+      expect(result).toEqual({});
+    });
+
+    it("应该正确解析复杂的 JSON 对象", () => {
+      const jsonString =
+        '{"user": {"name": "test", "age": 25}, "items": [1, 2, 3]}';
+      const result = toolCallService.parseJsonArgs(jsonString);
+      expect(result).toEqual({
+        user: { name: "test", age: 25 },
+        items: [1, 2, 3],
+      });
+    });
+
+    it("应该在 JSON 格式错误时抛出错误", () => {
+      const invalidJson = "invalid-json";
+      expect(() => toolCallService.parseJsonArgs(invalidJson)).toThrow(
+        "参数格式错误，请使用有效的 JSON 格式"
+      );
+    });
+
+    it("应该在 JSON 语法错误时抛出错误", () => {
+      const invalidJson = '{"a": 10, "b":}';
+      expect(() => toolCallService.parseJsonArgs(invalidJson)).toThrow(
+        "参数格式错误，请使用有效的 JSON 格式"
+      );
+    });
+  });
+
+  describe("formatOutput", () => {
+    it("应该正确格式化工具调用结果", () => {
+      const result = {
+        content: [
+          {
+            type: "text",
+            text: "30",
+          },
+        ],
+      };
+
+      const formatted = toolCallService.formatOutput(result);
+      const expected = JSON.stringify(result, null, 2);
+      expect(formatted).toBe(expected);
+    });
+
+    it("应该正确格式化包含错误的结果", () => {
+      const result = {
+        content: [
+          {
+            type: "text",
+            text: "Error occurred",
+          },
+        ],
+        isError: true,
+      };
+
+      const formatted = toolCallService.formatOutput(result);
+      const expected = JSON.stringify(result, null, 2);
+      expect(formatted).toBe(expected);
+    });
+
+    it("应该正确格式化复杂的结果对象", () => {
+      const result = {
+        content: [
+          {
+            type: "text",
+            text: "Result 1",
+          },
+          {
+            type: "json",
+            text: '{"data": "value"}',
+          },
+        ],
+      };
+
+      const formatted = toolCallService.formatOutput(result);
+      const expected = JSON.stringify(result, null, 2);
+      expect(formatted).toBe(expected);
+    });
+  });
+
+  describe("getServiceStatus", () => {
+    it("应该在服务未初始化时返回正确状态", async () => {
+      const status = await toolCallService.getServiceStatus();
+      expect(status).toBe("服务未启动");
+    });
+  });
+});

--- a/src/services/ToolCallService.ts
+++ b/src/services/ToolCallService.ts
@@ -50,10 +50,10 @@ export class ToolCallService {
     toolName: string,
     args: any
   ): Promise<ToolCallResult> {
-    this.logger.info(
-      `准备调用工具: ${serviceName}/${toolName}，参数:`,
-      JSON.stringify(args)
-    );
+    // this.logger.info(
+    //   `准备调用工具: ${serviceName}/${toolName}，参数:`,
+    //   JSON.stringify(args)
+    // );
 
     // 1. 检查服务状态
     await this.validateServiceStatus();
@@ -85,7 +85,7 @@ export class ToolCallService {
         throw new Error(responseData.error?.message || "工具调用失败");
       }
 
-      this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
+      // this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
       return responseData.data;
     } catch (error) {
       this.logger.error(
@@ -148,16 +148,13 @@ export class ToolCallService {
     }
   }
 
-
-
   /**
    * 格式化输出结果
    * @param result 工具调用结果
    * @returns 格式化后的字符串
    */
   formatOutput(result: ToolCallResult): string {
-    // 直接返回原始 JSON 格式
-    return JSON.stringify(result, null, 2);
+    return JSON.stringify(result);
   }
 
   /**

--- a/src/services/ToolCallService.ts
+++ b/src/services/ToolCallService.ts
@@ -5,8 +5,8 @@
 
 import chalk from "chalk";
 import { type Logger, logger } from "../Logger.js";
-import { configManager } from "../configManager.js";
 import { ProcessManagerImpl } from "../cli/services/ProcessManager.js";
+import { configManager } from "../configManager.js";
 
 // 工具调用结果接口
 export interface ToolCallResult {
@@ -70,7 +70,8 @@ export class ToolCallService {
       if (!response.ok) {
         const errorData = await response.json();
         throw new Error(
-          errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`
+          errorData.error?.message ||
+            `HTTP ${response.status}: ${response.statusText}`
         );
       }
 

--- a/src/services/ToolCallService.ts
+++ b/src/services/ToolCallService.ts
@@ -50,11 +50,6 @@ export class ToolCallService {
     toolName: string,
     args: any
   ): Promise<ToolCallResult> {
-    // this.logger.info(
-    //   `准备调用工具: ${serviceName}/${toolName}，参数:`,
-    //   JSON.stringify(args)
-    // );
-
     // 1. 检查服务状态
     await this.validateServiceStatus();
 
@@ -85,7 +80,6 @@ export class ToolCallService {
         throw new Error(responseData.error?.message || "工具调用失败");
       }
 
-      // this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
       return responseData.data;
     } catch (error) {
       this.logger.error(

--- a/src/services/ToolCallService.ts
+++ b/src/services/ToolCallService.ts
@@ -1,0 +1,199 @@
+/**
+ * MCP 工具调用服务
+ * 负责处理手动工具调用的核心逻辑
+ */
+
+import chalk from "chalk";
+import { type Logger, logger } from "../Logger.js";
+import { configManager } from "../configManager.js";
+import { ProcessManagerImpl } from "../cli/services/ProcessManager.js";
+
+// 工具调用结果接口
+export interface ToolCallResult {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  isError?: boolean;
+}
+
+/**
+ * 工具调用服务类
+ */
+export class ToolCallService {
+  private logger: Logger;
+  private processManager: ProcessManagerImpl;
+  private baseUrl: string;
+
+  constructor() {
+    this.logger = logger.withTag("ToolCallService");
+    this.processManager = new ProcessManagerImpl();
+
+    // 获取 Web 服务器的端口
+    try {
+      const webPort = configManager.getWebUIPort() ?? 9999;
+      this.baseUrl = `http://localhost:${webPort}`;
+    } catch (error) {
+      this.baseUrl = "http://localhost:9999";
+    }
+  }
+
+  /**
+   * 调用 MCP 工具
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param args 工具参数
+   * @returns 工具调用结果
+   */
+  async callTool(
+    serviceName: string,
+    toolName: string,
+    args: any
+  ): Promise<ToolCallResult> {
+    this.logger.info(
+      `准备调用工具: ${serviceName}/${toolName}，参数:`,
+      JSON.stringify(args)
+    );
+
+    // 1. 检查服务状态
+    await this.validateServiceStatus();
+
+    // 2. 通过 HTTP API 调用工具
+    try {
+      const response = await fetch(`${this.baseUrl}/api/tools/call`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          serviceName,
+          toolName,
+          args,
+        }),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(
+          errorData.error?.message || `HTTP ${response.status}: ${response.statusText}`
+        );
+      }
+
+      const responseData = await response.json();
+
+      if (!responseData.success) {
+        throw new Error(responseData.error?.message || "工具调用失败");
+      }
+
+      this.logger.info(`工具调用成功: ${serviceName}/${toolName}`);
+      return responseData.data;
+    } catch (error) {
+      this.logger.error(
+        `工具调用失败: ${serviceName}/${toolName}`,
+        error instanceof Error ? error.message : String(error)
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 解析 JSON 参数
+   * @param argsString JSON 字符串
+   * @returns 解析后的参数对象
+   */
+  parseJsonArgs(argsString: string): any {
+    try {
+      return JSON.parse(argsString);
+    } catch (error) {
+      throw new Error(
+        `参数格式错误，请使用有效的 JSON 格式。错误详情: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * 验证服务状态
+   * @private
+   */
+  private async validateServiceStatus(): Promise<void> {
+    // 检查进程级别的服务状态
+    const processStatus = this.processManager.getServiceStatus();
+    if (!processStatus.running) {
+      throw new Error(
+        "xiaozhi 服务未启动。请先运行 'xiaozhi start' 或 'xiaozhi start -d' 启动服务。"
+      );
+    }
+
+    // 检查 Web 服务器是否可访问
+    try {
+      const response = await fetch(`${this.baseUrl}/api/status`, {
+        method: "GET",
+        signal: AbortSignal.timeout(5000), // 5秒超时
+      });
+
+      if (!response.ok) {
+        throw new Error(`Web 服务器响应错误: ${response.status}`);
+      }
+    } catch (error) {
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error("连接 xiaozhi 服务超时。请检查服务是否正常运行。");
+      }
+      throw new Error(
+        `无法连接到 xiaozhi 服务。请检查服务状态。错误详情: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+
+
+  /**
+   * 格式化输出结果
+   * @param result 工具调用结果
+   * @returns 格式化后的字符串
+   */
+  formatOutput(result: ToolCallResult): string {
+    // 直接返回原始 JSON 格式
+    return JSON.stringify(result, null, 2);
+  }
+
+  /**
+   * 获取服务状态信息
+   * @returns 服务状态描述
+   */
+  async getServiceStatus(): Promise<string> {
+    try {
+      // 首先检查进程状态
+      const processStatus = this.processManager.getServiceStatus();
+      if (!processStatus.running) {
+        return "服务未启动";
+      }
+
+      // 然后通过 HTTP API 检查服务状态
+      try {
+        const response = await fetch(`${this.baseUrl}/api/tools/list`, {
+          method: "GET",
+          signal: AbortSignal.timeout(3000), // 3秒超时
+        });
+
+        if (response.ok) {
+          const data = await response.json();
+          if (data.success) {
+            return `服务已启动 (PID: ${processStatus.pid}, ${data.data.totalTools} 个工具可用)`;
+          }
+        }
+
+        return `服务进程运行中 (PID: ${processStatus.pid})，但 MCP 服务可能未完全初始化`;
+      } catch (error) {
+        return `服务进程运行中 (PID: ${processStatus.pid})，但无法连接到 Web API`;
+      }
+    } catch (error) {
+      return `服务状态检查失败: ${
+        error instanceof Error ? error.message : String(error)
+      }`;
+    }
+  }
+}


### PR DESCRIPTION
- 新增 `xiaozhi mcp call` CLI 命令，支持直接调用 MCP 服务工具
- 实现 ToolCallService 核心服务，处理工具调用逻辑和状态验证
- 新增 ToolApiHandler 处理器，提供 /api/tools/call 和 /api/tools/list HTTP API
- 完善错误处理机制，提供友好的用户提示和故障排除指导
- 添加完整的单元测试覆盖，确保功能稳定性
- 更新文档，详细说明 MCP 工具调用的使用方法和最佳实践