### PR TITLE
fix(ui): 优化工作流集成对话框的宽度和高度限制

### DIFF
--- a/web/src/components/CozeWorkflowIntegration.tsx
+++ b/web/src/components/CozeWorkflowIntegration.tsx
@@ -494,7 +494,7 @@ export function CozeWorkflowIntegration({
     }
 
     return (
-      <div className="space-y-3">
+      <div className="space-y-3 max-h-[500px] overflow-auto">
         {workflows.map((workflow) => (
           <div
             key={workflow.workflow_id}
@@ -599,7 +599,7 @@ export function CozeWorkflowIntegration({
             工作流集成
           </Button>
         </DialogTrigger>
-        <DialogContent className="flex flex-col">
+        <DialogContent className="flex flex-col max-w-full w-[1000px]">
           <DialogHeader className="flex-shrink-0">
             <DialogTitle className="flex items-center gap-2">
               <Workflow className="h-5 w-5" />
@@ -611,7 +611,7 @@ export function CozeWorkflowIntegration({
           <div className="w-[120px]">{renderWorkspaceSelector()}</div>
 
           {/* 工作流列表 */}
-          <div className="flex-1 pr-2">{renderWorkflowList()}</div>
+          <div className="flex-1 pr-2 w-full">{renderWorkflowList()}</div>
 
           {/* 分页控件 */}
           {renderPagination()}


### PR DESCRIPTION
  - 将工作流集成对话框的最大宽度设置为 1000px，确保在大屏幕上获得更好的显示效果
  - 为工作流列表区域添加最大高度限制 500px 和滚动条，避免内容过长时超出屏幕范围
  - 优化工作流列表容器的宽度设置为 100%，充分利用对话框空间
  - 修复工作流集成界面在不同屏幕尺寸下的响应式布局问题