### PR TITLE
fix(tool-sync): 修复多服务工具同步逻辑错误

### DIFF
--- a/src/services/ToolSyncManager.ts
+++ b/src/services/ToolSyncManager.ts
@@ -41,10 +41,6 @@ export class ToolSyncManager {
       this.logger.debug(`服务 ${serviceName} 正在同步中，跳过`);
       return;
     }
-    if (this.configManager.getCustomMCPConfig()) {
-      this.logger.debug("已存在 customMCP 停止同步");
-      return;
-    }
 
     const syncPromise = this.doSyncTools(serviceName, tools).finally(() => {
       this.syncLocks.delete(serviceName);

--- a/src/services/__tests__/ToolSyncManager.test.ts
+++ b/src/services/__tests__/ToolSyncManager.test.ts
@@ -257,6 +257,38 @@ describe("ToolSyncManager", () => {
         `服务 ${serviceName} 正在同步中，跳过`
       );
     });
+
+    it("应该允许多个服务的工具同步即使 customMCP 已存在", async () => {
+      // Arrange
+      const serviceName1 = "calculator";
+      const serviceName2 = "datetime";
+      const tools1 = createMockTools(["calculator"]);
+      const tools2 = createMockTools(["get_current_time", "get_current_date"]);
+      
+      const serverConfig1 = createMockToolConfigs(["calculator"], true);
+      const serverConfig2 = createMockToolConfigs(["get_current_time", "get_current_date"], true);
+      
+      // 模拟 customMCP 配置已存在
+      vi.mocked(mockConfigManager.getCustomMCPConfig).mockReturnValue({
+        tools: []
+      });
+      
+      vi.mocked(mockConfigManager.getServerToolsConfig).mockImplementation((serviceName) => {
+        if (serviceName === serviceName1) return serverConfig1;
+        if (serviceName === serviceName2) return serverConfig2;
+        return {};
+      });
+      
+      vi.mocked(mockConfigManager.getCustomMCPTools).mockReturnValue([]);
+
+      // Act - 依次调用两个服务的同步
+      await toolSyncManager.syncToolsAfterConnection(serviceName1, tools1);
+      await toolSyncManager.syncToolsAfterConnection(serviceName2, tools2);
+
+      // Assert
+      expect(mockConfigManager.addCustomMCPTools).toHaveBeenCalledTimes(2);
+      expect(mockLogger.debug).not.toHaveBeenCalledWith("已存在 customMCP 停止同步");
+    });
   });
 
   describe("getEnabledTools", () => {

--- a/src/services/__tests__/ToolSyncManager.test.ts
+++ b/src/services/__tests__/ToolSyncManager.test.ts
@@ -264,21 +264,26 @@ describe("ToolSyncManager", () => {
       const serviceName2 = "datetime";
       const tools1 = createMockTools(["calculator"]);
       const tools2 = createMockTools(["get_current_time", "get_current_date"]);
-      
+
       const serverConfig1 = createMockToolConfigs(["calculator"], true);
-      const serverConfig2 = createMockToolConfigs(["get_current_time", "get_current_date"], true);
-      
+      const serverConfig2 = createMockToolConfigs(
+        ["get_current_time", "get_current_date"],
+        true
+      );
+
       // 模拟 customMCP 配置已存在
       vi.mocked(mockConfigManager.getCustomMCPConfig).mockReturnValue({
-        tools: []
+        tools: [],
       });
-      
-      vi.mocked(mockConfigManager.getServerToolsConfig).mockImplementation((serviceName) => {
-        if (serviceName === serviceName1) return serverConfig1;
-        if (serviceName === serviceName2) return serverConfig2;
-        return {};
-      });
-      
+
+      vi.mocked(mockConfigManager.getServerToolsConfig).mockImplementation(
+        (serviceName) => {
+          if (serviceName === serviceName1) return serverConfig1;
+          if (serviceName === serviceName2) return serverConfig2;
+          return {};
+        }
+      );
+
       vi.mocked(mockConfigManager.getCustomMCPTools).mockReturnValue([]);
 
       // Act - 依次调用两个服务的同步
@@ -287,7 +292,9 @@ describe("ToolSyncManager", () => {
 
       // Assert
       expect(mockConfigManager.addCustomMCPTools).toHaveBeenCalledTimes(2);
-      expect(mockLogger.debug).not.toHaveBeenCalledWith("已存在 customMCP 停止同步");
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(
+        "已存在 customMCP 停止同步"
+      );
     });
   });
 


### PR DESCRIPTION


  修复了 ToolSyncManager 中的工具同步逻辑错误，该错误导致当 customMCP 配置存在时，后续服务的工具无法同步到
  customMCP.tools 中。

  主要改动：
  - 移除了 ToolSyncManager.ts 中对 getCustomMCPConfig() 的检查逻辑
  - 该检查会阻止多个 MCP 服务的工具同步，即使这些工具尚未在 customMCP 中存在
  - 新增测试用例验证多个服务可以独立同步工具到 customMCP