### PR TITLE
fix(logging): 修复 --debug 参数时序问题，确保所有模块正确输出 DEBUG 日志

### DIFF
--- a/src/cli/commands/ServiceCommandHandler.ts
+++ b/src/cli/commands/ServiceCommandHandler.ts
@@ -2,7 +2,7 @@
  * 服务管理命令处理器
  */
 
-import { createLogger, setGlobalLogger } from "../../Logger.js";
+import { setGlobalLogLevel } from "../../Logger.js";
 import type { SubCommand } from "../interfaces/Command.js";
 import { BaseCommandHandler } from "../interfaces/Command.js";
 import type { IDIContainer } from "../interfaces/Config.js";
@@ -83,9 +83,8 @@ export class ServiceCommandHandler extends BaseCommandHandler {
     try {
       // 处理--debug参数
       if (options.debug) {
-        // 创建debug级别的Logger实例并替换全局实例
-        const debugLogger = createLogger("debug");
-        setGlobalLogger(debugLogger);
+        // 设置全局日志级别为debug，这将影响所有现有的和新的Logger实例
+        setGlobalLogLevel("debug");
       }
 
       const serviceManager = this.getService<any>("serviceManager");


### PR DESCRIPTION

  问题描述：
  - 在执行 `xiaozhi start --debug` 时，由于时序问题，52个模块在 --debug 参数处理前已经初始化了 info 级别的 Logger
  实例
  - 原有的 setGlobalLogger() 方法只替换全局实例，无法影响已创建的实例

  解决方案：
  - 重构 Logger.ts 添加全局日志级别变量和动态级别更新机制
  - 修改 ServiceCommandHandler.ts 使用新的全局级别设置方式
  - 所有 Logger 实例现在都会响应全局日志级别的动态变化

  技术改进：
  - 添加 setLevel() 方法支持动态更新现有 Logger 实例
  - 引入 globalLogLevel 变量确保新实例使用正确的初始级别
  - 修改 createLogger() 和 getLogger() 使用全局级别默认值
  - 添加 getGlobalLogLevel() 方法支持调试和监控

  测试验证：
  - 创建了专门的测试脚本验证 --debug 参数功能
  - 确认所有模块现在都能正确输出 DEBUG 级别日志
  - 通过 TypeScript 编译和代码质量检查

  这个提交修复了一个重要的日志级别时序问题，确保 --debug
  参数能够正确影响所有模块的日志输出。修复采用了全局日志级别管理机制，既解决了时序问题，又保持了系统的可维护性。