### PR TITLE
chore(package): 重新组织 package.json 字段顺序和结构

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [1.7.12-beta.2](https://github.com/shenjingnan/xiaozhi-client/compare/v1.7.9...v1.7.12-beta.2) (2025-10-17)
+
+### Features
+
+* **api:** 实现Docker容器版本更新API功能 ([#361](https://github.com/shenjingnan/xiaozhi-client/issues/361)) ([0ff76ec](https://github.com/shenjingnan/xiaozhi-client/commit/0ff76ec2c29bdee212d4ea58c50bc32134669084))
+* **ci:** 优化 NPM 发布工作流支持自定义版本号 ([#365](https://github.com/shenjingnan/xiaozhi-client/issues/365)) ([0a9fa0b](https://github.com/shenjingnan/xiaozhi-client/commit/0a9fa0b1bb863a4d169decff40d04e03686369c2))
+
+### Bug Fixes
+
+* **security:** 修复 happy-dom 关键安全漏洞 CVE GHSA-qpm2-6cq5-7pq5 ([#363](https://github.com/shenjingnan/xiaozhi-client/issues/363)) ([d743254](https://github.com/shenjingnan/xiaozhi-client/commit/d74325498ee7f1ce7eacb906d6fcddbbd0e9c60e))
+
 ## [1.7.12-beta.1](https://github.com/shenjingnan/xiaozhi-client/compare/v1.7.9...v1.7.12-beta.1) (2025-10-17)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "xiaozhi-client",
-  "version": "1.7.12-beta.1",
+  "version": "1.7.12-beta.2",
   "description": "小智 AI 客户端 命令行工具",
   "repository": {
     "type": "git",


### PR DESCRIPTION
- 将 repository、author、license、keywords 字段移动到文件开头
- 移除重复的 keywords、author、license 字段定义
- 优化 package.json 的可读性和结构组织
- 统一仓库地址为 https://github.com/shenjingnan/home-mcp.git