### PR TITLE
fix(deps): 升级 Hono 版本修复 Vary Header 注入漏洞

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",
     "express": "^5.1.0",
-    "hono": "^4.9.7",
+    "hono": "^4.10.3",
     "json5": "^2.2.3",
     "json5-writer": "^0.2.0",
     "jsonc-parser": "^3.3.1",
@@ -115,7 +115,7 @@
       "axios": ">=1.12.0",
       "@conventional-changelog/git-client": ">=2.0.0",
       "vite@>=7.1.0 <=7.1.10": ">=7.1.11",
-      "hono@>=1.1.0 <4.10.2": ">=4.10.2"
+      "hono@>=1.1.0 <4.10.3": ">=4.10.3"
     }
   },
   "packageManager": "pnpm@10.13.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,7 +11,7 @@ overrides:
   axios: '>=1.12.0'
   '@conventional-changelog/git-client': '>=2.0.0'
   vite@>=7.1.0 <=7.1.10: '>=7.1.11'
-  hono@>=1.1.0 <4.10.2: '>=4.10.2'
+  hono@>=1.1.0 <4.10.3: '>=4.10.3'
 
 importers:
 
@@ -19,7 +19,7 @@ importers:
     dependencies:
       '@hono/node-server':
         specifier: ^1.17.1
-        version: 1.19.5(hono@4.10.2)
+        version: 1.19.5(hono@4.10.3)
       '@modelcontextprotocol/sdk':
         specifier: ^1.17.4
         version: 1.20.0
@@ -57,8 +57,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       hono:
-        specifier: '>=4.10.2'
-        version: 4.10.2
+        specifier: ^4.10.3
+        version: 4.10.3
       json5:
         specifier: ^2.2.3
         version: 2.2.3
@@ -1274,7 +1274,7 @@ packages:
     resolution: {integrity: sha512-iBuhh+uaaggeAuf+TftcjZyWh2GEgZcVGXkNtskLVoWaXhnJtC5HLHrU8W1KHDoucqO1MswwglmkWLFyiDn4WQ==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.10.2'
+      hono: '>=4.10.3'
 
   '@hutson/parse-repository-url@5.0.0':
     resolution: {integrity: sha512-e5+YUKENATs1JgYHMzTr2MW/NDcXGfYFAuOQU8gJgF/kEh4EqKgfGrfLI67bMD4tbhZVlkigz/9YYwWcbOFthg==}
@@ -4058,8 +4058,8 @@ packages:
     resolution: {integrity: sha512-NQO+lgVUCtHxZ792FodgW0zflK+ozS9X9dwGp9XvvmPlH7pyxd588cn24TD3rmPm/N0AIRXF10Otah8yKqGw4w==}
     engines: {node: '>=12'}
 
-  hono@4.10.2:
-    resolution: {integrity: sha512-p6fyzl+mQo6uhESLxbF5WlBOAJMDh36PljwlKtP5V1v09NxlqGru3ShK+4wKhSuhuYf8qxMmrivHOa/M7q0sMg==}
+  hono@4.10.3:
+    resolution: {integrity: sha512-2LOYWUbnhdxdL8MNbNg9XZig6k+cZXm5IjHn2Aviv7honhBMOHb+jxrKIeJRZJRmn+htUCKhaicxwXuUDlchRA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@7.0.2:
@@ -8048,9 +8048,9 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@hono/node-server@1.19.5(hono@4.10.2)':
+  '@hono/node-server@1.19.5(hono@4.10.3)':
     dependencies:
-      hono: 4.10.2
+      hono: 4.10.3
 
   '@hutson/parse-repository-url@5.0.0': {}
 
@@ -11516,7 +11516,7 @@ snapshots:
 
   hex-rgb@5.0.0: {}
 
-  hono@4.10.2: {}
+  hono@4.10.3: {}
 
   hosted-git-info@7.0.2:
     dependencies:


### PR DESCRIPTION
将 Hono 框架从 4.10.2 升级到 4.10.3，修复了 CVSS 6.5 分数的中等严重性安全漏洞 (GHSA-q7jf-gf43-6x6p)。

此次更新解决了 Vary Header 注入漏洞，同时更新了 pnpm overrides 配置以确保依赖版本一致性。

修改内容：
- package.json: 升级 hono 依赖版本到 ^4.10.3
- pnpm-lock.yaml: 更新锁定的依赖版本
- 更新 pnpm overrides 配置以匹配新的版本要求

安全影响：
- 修复了可能导致 HTTP 响应头注入的安全漏洞
- 提高了应用程序的整体安全性