### PR TITLE
refactor(web): 统一导入路径为别名引用

### DIFF
--- a/web/biome.json
+++ b/web/biome.json
@@ -9,7 +9,17 @@
       "a11y": {
         "useValidAnchor": "off",
         "noSvgWithoutTitle": "off"
+      },
+      "style": {
+        "useImportType": "error"
       }
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "double",
+      "semicolons": "always",
+      "trailingCommas": "es5"
     }
   }
 }

--- a/web/components.json
+++ b/web/components.json
@@ -12,6 +12,14 @@
   },
   "aliases": {
     "components": "@/components",
-    "utils": "@/lib/utils"
+    "utils": "@/lib/utils",
+    "hooks": "@/hooks",
+    "services": "@/services",
+    "stores": "@/stores",
+    "types": "@/types",
+    "lib": "@/lib",
+    "pages": "@/pages",
+    "providers": "@/providers",
+    "ui": "@/components/ui"
   }
 }

--- a/web/src/components/AddMcpServerButton.tsx
+++ b/web/src/components/AddMcpServerButton.tsx
@@ -18,7 +18,7 @@ import {
 } from "@/components/ui/form";
 import { mcpServerApi } from "@/services/api";
 import { useConfig } from "@/stores/config";
-import type { MCPServerConfig } from "@/types";
+import type { MCPServerConfig } from "@/types/index";
 import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon } from "lucide-react";

--- a/web/src/components/CozeWorkflowIntegration.tsx
+++ b/web/src/components/CozeWorkflowIntegration.tsx
@@ -28,7 +28,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
 import { apiClient } from "@/services/api";
-import type { CozeWorkflow, WorkflowParameter } from "@/types";
+import type { CozeWorkflow, WorkflowParameter } from "@/types/index";
 import {
   AlertCircle,
   ChevronLeft,

--- a/web/src/components/InstallLogDialog.tsx
+++ b/web/src/components/InstallLogDialog.tsx
@@ -8,6 +8,7 @@
  * - 安装完成后提供操作选项
  */
 
+import { useNPMInstall } from "@hooks/useNPMInstall";
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -18,7 +19,6 @@ import {
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
-import { useNPMInstall } from "../hooks/useNPMInstall";
 import { Alert, AlertDescription } from "./ui/alert";
 import { Badge } from "./ui/badge";
 import { Button } from "./ui/button";

--- a/web/src/components/McpServerList.tsx
+++ b/web/src/components/McpServerList.tsx
@@ -18,7 +18,11 @@ import {
   useMcpServerConfig,
   useMcpServers,
 } from "@/stores/config";
-import type { CozeWorkflow, MCPServerConfig, WorkflowParameter } from "@/types";
+import type {
+  CozeWorkflow,
+  MCPServerConfig,
+  WorkflowParameter,
+} from "@/types/index";
 import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
 import {
   CoffeeIcon,

--- a/web/src/components/McpServerSettingButton.tsx
+++ b/web/src/components/McpServerSettingButton.tsx
@@ -19,7 +19,7 @@ import {
 
 import { useWebSocket } from "@/hooks/useWebSocket";
 import { useConfig } from "@/stores/config";
-import type { MCPServerConfig } from "@/types";
+import type { MCPServerConfig } from "@/types/index";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SettingsIcon } from "lucide-react";
 import { useState } from "react";

--- a/web/src/components/ToolCallLogsDialog.tsx
+++ b/web/src/components/ToolCallLogsDialog.tsx
@@ -25,7 +25,7 @@ import type {
   ApiResponse,
   ToolCallLogsResponse,
   ToolCallRecord,
-} from "@/types";
+} from "@/types/index";
 import {
   formatDuration,
   formatJson,

--- a/web/src/components/VersionManager.tsx
+++ b/web/src/components/VersionManager.tsx
@@ -8,6 +8,7 @@
  * - 显示实时安装日志
  */
 
+import { apiClient } from "@services/api";
 import {
   AlertCircle,
   Calendar,
@@ -18,7 +19,6 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
-import { apiClient } from "../services/api";
 import { InstallLogDialog } from "./InstallLogDialog";
 import { VersionDisplay } from "./VersionDisplay";
 import { Badge } from "./ui/badge";

--- a/web/src/components/__tests__/McpEndpointSettingButton.test.tsx
+++ b/web/src/components/__tests__/McpEndpointSettingButton.test.tsx
@@ -1,7 +1,8 @@
 import * as api from "@/services/api";
 import * as websocket from "@/services/websocket";
 import * as stores from "@/stores/config";
-import type { AppConfig } from "@/types";
+import type { AppConfig } from "@/types/index";
+import { McpEndpointSettingButton } from "@components/McpEndpointSettingButton";
 import {
   act,
   fireEvent,
@@ -11,7 +12,6 @@ import {
 } from "@testing-library/react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { McpEndpointSettingButton } from "../McpEndpointSettingButton";
 
 // Mock modules
 vi.mock("@/stores/config");

--- a/web/src/components/__tests__/McpServerList.test.tsx
+++ b/web/src/components/__tests__/McpServerList.test.tsx
@@ -1,7 +1,7 @@
+import { McpServerList } from "@components/McpServerList";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";
-import { McpServerList } from "../McpServerList";
 
 // Mock sonner toast
 vi.mock("sonner", () => ({
@@ -37,7 +37,7 @@ vi.mock("@/services/api", () => ({
 }));
 
 // Mock other components
-vi.mock("../AddMcpServerButton", () => ({
+vi.mock("@components/AddMcpServerButton", () => ({
   AddMcpServerButton: () => (
     <button type="button" data-testid="add-server">
       Add Server
@@ -45,7 +45,7 @@ vi.mock("../AddMcpServerButton", () => ({
   ),
 }));
 
-vi.mock("../RemoveMcpServerButton", () => ({
+vi.mock("@components/RemoveMcpServerButton", () => ({
   RemoveMcpServerButton: ({ mcpServerName, onRemoveSuccess }: any) => (
     <button
       type="button"
@@ -57,15 +57,15 @@ vi.mock("../RemoveMcpServerButton", () => ({
   ),
 }));
 
-vi.mock("../McpServerSettingButton", () => ({
+vi.mock("@components/McpServerSettingButton", () => ({
   McpServerSettingButton: () => <div>Settings</div>,
 }));
 
-vi.mock("../RestartButton", () => ({
+vi.mock("@components/RestartButton", () => ({
   RestartButton: () => <div>Restart</div>,
 }));
 
-vi.mock("../CozeWorkflowIntegration", () => ({
+vi.mock("@components/CozeWorkflowIntegration", () => ({
   CozeWorkflowIntegration: () => <div>Coze Integration</div>,
 }));
 

--- a/web/src/components/__tests__/RemoveMcpServerButton.test.tsx
+++ b/web/src/components/__tests__/RemoveMcpServerButton.test.tsx
@@ -1,7 +1,7 @@
+import { RemoveMcpServerButton } from "@components/RemoveMcpServerButton";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";
-import { RemoveMcpServerButton } from "../RemoveMcpServerButton";
 
 // Mock lucide-react to avoid icon loading issues
 vi.mock("lucide-react", () => ({

--- a/web/src/components/__tests__/VersionManager.test.tsx
+++ b/web/src/components/__tests__/VersionManager.test.tsx
@@ -2,9 +2,9 @@
  * VersionManager 组件测试
  */
 
+import { VersionManager } from "@components/VersionManager";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { VersionManager } from "../VersionManager";
 
 // Mock API client
 vi.mock("../../services/api", () => ({

--- a/web/src/components/common/WorkflowParameterConfigDialog.test.tsx
+++ b/web/src/components/common/WorkflowParameterConfigDialog.test.tsx
@@ -2,7 +2,7 @@
  * WorkflowParameterConfigDialog 组件测试
  */
 
-import type { CozeWorkflow } from "@/types";
+import type { CozeWorkflow } from "@/types/index";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";

--- a/web/src/components/common/WorkflowParameterConfigDialog.tsx
+++ b/web/src/components/common/WorkflowParameterConfigDialog.tsx
@@ -24,7 +24,7 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import type { CozeWorkflow, WorkflowParameter } from "@/types";
+import type { CozeWorkflow, WorkflowParameter } from "@/types/index";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { Plus, Trash2 } from "lucide-react";
 import { useEffect } from "react";

--- a/web/src/hooks/__tests__/useRestartNotifications.test.tsx
+++ b/web/src/hooks/__tests__/useRestartNotifications.test.tsx
@@ -2,12 +2,12 @@
  * 重启通知系统测试
  */
 
-import { render, waitFor } from "@testing-library/react";
-import { vi } from "vitest";
 import {
   RestartNotificationProvider,
   useRestartNotifications,
-} from "../useRestartNotifications";
+} from "@hooks/useRestartNotifications";
+import { render, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
 
 // Mock sonner toast
 vi.mock("sonner", () => ({

--- a/web/src/hooks/useConfigData.ts
+++ b/web/src/hooks/useConfigData.ts
@@ -5,7 +5,13 @@
  * 返回配置数据、加载状态、更新方法
  */
 
-import { useCallback } from "react";
+import type {
+  AppConfig,
+  ConnectionConfig,
+  MCPServerConfig,
+  ModelScopeConfig,
+  WebUIConfig,
+} from "@/types/index";
 import {
   useConfig,
   useConfigActions,
@@ -23,14 +29,8 @@ import {
   useModelScopeConfig,
   useSystemConfig,
   useWebUIConfig,
-} from "../stores/config";
-import type {
-  AppConfig,
-  ConnectionConfig,
-  MCPServerConfig,
-  ModelScopeConfig,
-  WebUIConfig,
-} from "../types";
+} from "@stores/config";
+import { useCallback } from "react";
 
 /**
  * 配置数据相关的 hook

--- a/web/src/hooks/useCozeWorkflows.ts
+++ b/web/src/hooks/useCozeWorkflows.ts
@@ -3,14 +3,14 @@
  * 提供工作空间和工作流数据的状态管理
  */
 
-import { useCallback, useEffect, useMemo, useState } from "react";
-import { cozeApiClient } from "../services/cozeApi";
 import type {
   CozeUIState,
   CozeWorkflow,
   CozeWorkflowsParams,
   CozeWorkspace,
-} from "../types";
+} from "@/types/index";
+import { cozeApiClient } from "@services/cozeApi";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /**
  * Hook 返回值类型

--- a/web/src/hooks/useEndpointStatus.ts
+++ b/web/src/hooks/useEndpointStatus.ts
@@ -1,12 +1,12 @@
+import {
+  type EndpointStatusChangedEvent,
+  webSocketManager,
+} from "@services/websocket";
 /**
  * 端点状态变更 Hook
  * 用于订阅和处理端点连接状态的实时变更
  */
 import { useCallback, useEffect, useState } from "react";
-import {
-  type EndpointStatusChangedEvent,
-  webSocketManager,
-} from "../services/websocket";
 
 /**
  * 端点状态回调函数类型

--- a/web/src/hooks/useNPMInstall.ts
+++ b/web/src/hooks/useNPMInstall.ts
@@ -8,8 +8,8 @@
  * - 支持安装操作触发
  */
 
+import { webSocketManager } from "@services/websocket";
 import { useCallback, useEffect, useState } from "react";
-import { webSocketManager } from "../services/websocket";
 
 /**
  * 安装日志接口

--- a/web/src/hooks/useNetworkService.ts
+++ b/web/src/hooks/useNetworkService.ts
@@ -3,12 +3,12 @@
  * 使用统一的网络服务管理器，实现 HTTP 和 WebSocket 的协调使用
  */
 
+import type { AppConfig, ClientStatus } from "@/types/index";
+import { ConnectionState, networkService } from "@services/index";
+import { useConfigStore } from "@stores/config";
+import { useStatusStore } from "@stores/status";
+import { useWebSocketActions } from "@stores/websocket";
 import { useCallback, useEffect, useRef } from "react";
-import { ConnectionState, networkService } from "../services";
-import { useConfigStore } from "../stores/config";
-import { useStatusStore } from "../stores/status";
-import { useWebSocketActions } from "../stores/websocket";
-import type { AppConfig, ClientStatus } from "../types";
 
 /**
  * 网络服务 Hook

--- a/web/src/hooks/useStatusData.ts
+++ b/web/src/hooks/useStatusData.ts
@@ -5,7 +5,6 @@
  * 返回状态数据、轮询控制、重启方法
  */
 
-import { useCallback } from "react";
 import {
   useActiveMcpServers,
   useClientStatus,
@@ -27,7 +26,8 @@ import {
   useStatusLoading,
   useStatusMcpEndpoint,
   useStatusWithLoading,
-} from "../stores/status";
+} from "@stores/status";
+import { useCallback } from "react";
 
 /**
  * 状态数据相关的 hook

--- a/web/src/hooks/useWebSocket.test.ts
+++ b/web/src/hooks/useWebSocket.test.ts
@@ -1,25 +1,25 @@
+import type { AppConfig, ClientStatus } from "@/types/index";
+import { useWebSocket } from "@hooks/useWebSocket";
 import { renderHook } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { AppConfig, ClientStatus } from "../types";
-import { useWebSocket } from "./useWebSocket";
 
 // Mock the stores and services
-vi.mock("../stores/websocket", () => ({
+vi.mock("@stores/websocket", () => ({
   useWebSocketActions: vi.fn(),
 }));
 
-vi.mock("../stores/config", () => ({
+vi.mock("@stores/config", () => ({
   useConfigActions: vi.fn(),
   useConfig: vi.fn(),
 }));
 
-vi.mock("../stores/status", () => ({
+vi.mock("@stores/status", () => ({
   useStatusActions: vi.fn(),
   useClientStatus: vi.fn(),
   useRestartStatus: vi.fn(),
 }));
 
-vi.mock("../services/websocket", () => ({
+vi.mock("@services/websocket", () => ({
   webSocketManager: {
     connect: vi.fn(),
     disconnect: vi.fn(),
@@ -31,7 +31,7 @@ vi.mock("../services/websocket", () => ({
   },
 }));
 
-vi.mock("../utils/portUtils", () => ({
+vi.mock("@utils/portUtils", () => ({
   buildWebSocketUrl: vi.fn(),
   checkPortAvailability: vi.fn(),
   extractPortFromUrl: vi.fn(),
@@ -41,16 +41,16 @@ vi.mock("../utils/portUtils", () => ({
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
-import { webSocketManager } from "../services/websocket";
-import { useConfig, useConfigActions } from "../stores/config";
+import { webSocketManager } from "@services/websocket";
+import { useConfig, useConfigActions } from "@stores/config";
 import {
   useClientStatus,
   useRestartStatus,
   useStatusActions,
-} from "../stores/status";
+} from "@stores/status";
 // Import the mocked modules
-import { useWebSocketActions } from "../stores/websocket";
-import { buildWebSocketUrl } from "../utils/portUtils";
+import { useWebSocketActions } from "@stores/websocket";
+import { buildWebSocketUrl } from "@utils/portUtils";
 
 const mockUseWebSocketActions = useWebSocketActions as ReturnType<typeof vi.fn>;
 const mockUseConfigActions = useConfigActions as ReturnType<typeof vi.fn>;

--- a/web/src/hooks/useWebSocket.ts
+++ b/web/src/hooks/useWebSocket.ts
@@ -14,21 +14,21 @@
  * - WebSocketStore: 纯连接状态管理
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
-import { webSocketManager } from "../services/websocket";
-import { useConfig, useConfigActions } from "../stores/config";
+import type { AppConfig, ClientStatus } from "@/types/index";
+import { webSocketManager } from "@services/websocket";
+import { useConfig, useConfigActions } from "@stores/config";
 import {
   useClientStatus,
   useRestartStatus,
   useStatusActions,
-} from "../stores/status";
-import { useWebSocketActions } from "../stores/websocket";
-import type { AppConfig, ClientStatus } from "../types";
+} from "@stores/status";
+import { useWebSocketActions } from "@stores/websocket";
 import {
   buildWebSocketUrl,
   checkPortAvailability,
   extractPortFromUrl,
-} from "../utils/portUtils";
+} from "@utils/portUtils";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 /**
  * 向后兼容的状态接口

--- a/web/src/hooks/useWebSocketConnection.ts
+++ b/web/src/hooks/useWebSocketConnection.ts
@@ -5,8 +5,7 @@
  * 返回连接状态、错误信息、连接控制方法
  */
 
-import { useCallback } from "react";
-import { ConnectionState, webSocketManager } from "../services/websocket";
+import { ConnectionState, webSocketManager } from "@services/websocket";
 import {
   useWebSocketActions,
   useWebSocketConnected,
@@ -14,7 +13,8 @@ import {
   useWebSocketConnectionStats,
   useWebSocketLastError,
   useWebSocketUrl,
-} from "../stores/websocket";
+} from "@stores/websocket";
+import { useCallback } from "react";
 
 /**
  * WebSocket 连接相关的 hook

--- a/web/src/pages/SettingsPage.test.tsx
+++ b/web/src/pages/SettingsPage.test.tsx
@@ -1,5 +1,5 @@
 import { NetworkServiceProvider } from "@/providers/WebSocketProvider";
-import type { AppConfig } from "@/types";
+import type { AppConfig } from "@/types/index";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import SettingsPage from "./SettingsPage";

--- a/web/src/pages/SettingsPage.tsx
+++ b/web/src/pages/SettingsPage.tsx
@@ -16,7 +16,7 @@ import { SidebarInset, SidebarProvider } from "@/components/ui/sidebar";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { useWebSocketActions } from "@/providers/WebSocketProvider";
 import { useConfig } from "@/stores/config";
-import type { AppConfig } from "@/types";
+import type { AppConfig } from "@/types/index";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";

--- a/web/src/providers/WebSocketProvider.tsx
+++ b/web/src/providers/WebSocketProvider.tsx
@@ -1,3 +1,6 @@
+import type { AppConfig } from "@/types/index";
+import { useNetworkService } from "@hooks/useNetworkService";
+import { initializeStores } from "@stores/index";
 import {
   type ReactNode,
   createContext,
@@ -5,9 +8,6 @@ import {
   useEffect,
   useState,
 } from "react";
-import { useNetworkService } from "../hooks/useNetworkService";
-import { initializeStores } from "../stores";
-import type { AppConfig } from "../types";
 
 interface NetworkServiceContextType {
   // HTTP API 方法

--- a/web/src/services/__tests__/toolsApi.parameterConfig.test.ts
+++ b/web/src/services/__tests__/toolsApi.parameterConfig.test.ts
@@ -3,12 +3,12 @@
  * 测试第二阶段新增的参数配置功能
  */
 
-import type { CozeWorkflow, WorkflowParameterConfig } from "@/types";
+import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/index";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ToolsApiService } from "../toolsApi";
 
 // Mock apiClient
-vi.mock("../api", () => ({
+vi.mock("@services/api", () => ({
   apiClient: {
     addCustomTool: vi.fn(),
     removeCustomTool: vi.fn(),
@@ -16,7 +16,7 @@ vi.mock("../api", () => ({
   },
 }));
 
-import { apiClient } from "../api";
+import { apiClient } from "@services/api";
 
 describe("ToolsApiService - 参数配置功能", () => {
   let service: ToolsApiService;

--- a/web/src/services/api.ts
+++ b/web/src/services/api.ts
@@ -13,7 +13,7 @@ import type {
   MCPServerConfig,
   MCPServerListResponse,
   MCPServerStatus,
-} from "../types";
+} from "@/types/index";
 
 /**
  * CustomMCPTool 接口定义

--- a/web/src/services/cozeApi.ts
+++ b/web/src/services/cozeApi.ts
@@ -7,7 +7,7 @@ import type {
   CozeWorkflowsParams,
   CozeWorkflowsResult,
   CozeWorkspace,
-} from "../types";
+} from "@/types/index";
 
 /**
  * API 响应格式

--- a/web/src/services/index.ts
+++ b/web/src/services/index.ts
@@ -3,7 +3,7 @@
  * 整合 HTTP API 客户端和 WebSocket 管理器
  */
 
-import type { AppConfig, ClientStatus } from "../types";
+import type { AppConfig, ClientStatus } from "@/types/index";
 import { type ApiClient, apiClient } from "./api";
 import {
   type ConnectionState,

--- a/web/src/services/toolsApi.ts
+++ b/web/src/services/toolsApi.ts
@@ -3,7 +3,7 @@
  * 专门处理自定义工具的添加、删除和管理操作
  */
 
-import type { CozeWorkflow, WorkflowParameterConfig } from "@/types";
+import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/index";
 import { apiClient } from "./api";
 
 /**

--- a/web/src/services/websocket.ts
+++ b/web/src/services/websocket.ts
@@ -7,7 +7,7 @@
  * - 支持多个 store 订阅 WebSocket 事件
  */
 
-import type { AppConfig, ClientStatus } from "../types";
+import type { AppConfig, ClientStatus } from "@/types/index";
 
 /**
  * WebSocket 消息类型

--- a/web/src/stores/__tests__/config.test.ts
+++ b/web/src/stores/__tests__/config.test.ts
@@ -1,10 +1,10 @@
+import type { AppConfig } from "@/types/index";
+import { apiClient } from "@services/api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { apiClient } from "../../services/api";
-import type { AppConfig } from "../../types";
 import { useConfigStore } from "../config";
 
 // Mock API client
-vi.mock("../../services/api", () => ({
+vi.mock("@services/api", () => ({
   apiClient: {
     getConfig: vi.fn(),
     updateConfig: vi.fn(),

--- a/web/src/stores/__tests__/status.test.ts
+++ b/web/src/stores/__tests__/status.test.ts
@@ -1,13 +1,13 @@
+import type { ClientStatus } from "@/types/index";
+import { apiClient } from "@services/api";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { apiClient } from "../../services/api";
-import type { ClientStatus } from "../../types";
 import { useStatusStore } from "../status";
 
 // 导入 API 中的 FullStatus 类型
-import type { FullStatus } from "../../services/api";
+import type { FullStatus } from "@services/api";
 
 // Mock API client
-vi.mock("../../services/api", () => ({
+vi.mock("@services/api", () => ({
   apiClient: {
     getStatus: vi.fn(),
     restartService: vi.fn(),

--- a/web/src/stores/__tests__/websocket.test.ts
+++ b/web/src/stores/__tests__/websocket.test.ts
@@ -1,5 +1,5 @@
+import { ConnectionState } from "@services/websocket";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ConnectionState } from "../../services/websocket";
 import { useWebSocketStore } from "../websocket";
 
 describe("WebSocket Store - 连接状态管理", () => {

--- a/web/src/stores/config.ts
+++ b/web/src/stores/config.ts
@@ -9,18 +9,18 @@
  * - 集成 WebSocket 事件监听
  */
 
-import { create } from "zustand";
-import { devtools } from "zustand/middleware";
-import { useShallow } from "zustand/react/shallow";
-import { apiClient } from "../services/api";
-import { webSocketManager } from "../services/websocket";
 import type {
   AppConfig,
   ConnectionConfig,
   MCPServerConfig,
   ModelScopeConfig,
   WebUIConfig,
-} from "../types";
+} from "@/types/index";
+import { apiClient } from "@services/api";
+import { webSocketManager } from "@services/websocket";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { useShallow } from "zustand/react/shallow";
 
 /**
  * 配置加载状态

--- a/web/src/stores/status.ts
+++ b/web/src/stores/status.ts
@@ -10,12 +10,12 @@
  * - 集成 WebSocket 事件监听
  */
 
+import type { ClientStatus } from "@/types/index";
+import { apiClient } from "@services/api";
+import { webSocketManager } from "@services/websocket";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-import { apiClient } from "../services/api";
-import { webSocketManager } from "../services/websocket";
-import type { ClientStatus } from "../types";
 
 /**
  * 重启状态接口

--- a/web/src/stores/websocket-compat.ts
+++ b/web/src/stores/websocket-compat.ts
@@ -5,8 +5,8 @@
  * 这些选择器将数据从新的专门 stores 中获取并以旧格式返回
  */
 
-import { ConnectionState } from "../services/websocket";
-import type { AppConfig, ClientStatus } from "../types";
+import type { AppConfig, ClientStatus } from "@/types/index";
+import { ConnectionState } from "@services/websocket";
 import { useConfigStore } from "./config";
 import { useStatusStore } from "./status";
 import { useWebSocketStore } from "./websocket";

--- a/web/src/stores/websocket.ts
+++ b/web/src/stores/websocket.ts
@@ -12,10 +12,10 @@
  * - 状态数据管理已迁移到 stores/status.ts
  */
 
+import { ConnectionState, webSocketManager } from "@services/websocket";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-import { ConnectionState, webSocketManager } from "../services/websocket";
 
 /**
  * 端口变更状态接口（保留用于端口切换功能）

--- a/web/src/test/App.test.tsx
+++ b/web/src/test/App.test.tsx
@@ -1,7 +1,7 @@
+import App from "@/App";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import App from "../App";
 
 // Mock WebSocket
 class MockWebSocket {
@@ -67,9 +67,9 @@ describe("App Routing", () => {
 
     // Reset stores using dynamic imports
     try {
-      const { useConfigStore } = await import("../stores/config");
-      const { useStatusStore } = await import("../stores/status");
-      const { useWebSocketStore } = await import("../stores/websocket");
+      const { useConfigStore } = await import("@stores/config");
+      const { useStatusStore } = await import("@stores/status");
+      const { useWebSocketStore } = await import("@stores/websocket");
 
       useConfigStore.getState().reset();
       useStatusStore.getState().reset();

--- a/web/src/test/CozeWorkflowIntegration.integration.test.tsx
+++ b/web/src/test/CozeWorkflowIntegration.integration.test.tsx
@@ -5,7 +5,7 @@
 
 import { CozeWorkflowIntegration } from "@/components/CozeWorkflowIntegration";
 import { apiClient } from "@/services/api";
-import type { CozeWorkflow } from "@/types";
+import type { CozeWorkflow } from "@/types/index";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";

--- a/web/src/test/CozeWorkflowIntegration.test.tsx
+++ b/web/src/test/CozeWorkflowIntegration.test.tsx
@@ -2,13 +2,13 @@
  * CozeWorkflowIntegration 组件测试
  */
 
+import type { CozeWorkflow, CozeWorkspace } from "@/types/index";
+import { CozeWorkflowIntegration } from "@components/CozeWorkflowIntegration";
+import * as useCozeWorkflowsModule from "@hooks/useCozeWorkflows";
+import * as toolsApiModule from "@services/api";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { CozeWorkflowIntegration } from "../components/CozeWorkflowIntegration";
-import * as useCozeWorkflowsModule from "../hooks/useCozeWorkflows";
-import * as toolsApiModule from "../services/api";
-import type { CozeWorkflow, CozeWorkspace } from "../types";
 
 // Mock toast
 vi.mock("sonner", () => ({
@@ -19,12 +19,12 @@ vi.mock("sonner", () => ({
 }));
 
 // Mock useCozeWorkflows hook
-vi.mock("../hooks/useCozeWorkflows", () => ({
+vi.mock("@hooks/useCozeWorkflows", () => ({
   useCozeWorkflows: vi.fn(),
 }));
 
 // Mock apiClient
-vi.mock("../services/api", () => ({
+vi.mock("@services/api", () => ({
   apiClient: {
     getCustomTools: vi.fn(),
     addCustomTool: vi.fn(),

--- a/web/src/test/ToolCallLogsDialog.test.tsx
+++ b/web/src/test/ToolCallLogsDialog.test.tsx
@@ -1,5 +1,5 @@
 import { ToolCallLogsDialog } from "@/components/ToolCallLogsDialog";
-import type { ToolCallRecord } from "@/types";
+import type { ToolCallRecord } from "@/types/index";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/web/src/test/compatibility.test.tsx
+++ b/web/src/test/compatibility.test.tsx
@@ -2,11 +2,8 @@
  * 兼容性测试 - 验证废弃选择器仍然正常工作
  */
 
-import { render } from "@testing-library/react";
-import type React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useConfigStore } from "../stores/config";
-import { useStatusStore } from "../stores/status";
+import { useConfigStore } from "@stores/config";
+import { useStatusStore } from "@stores/status";
 import {
   useWebSocketConfig,
   useWebSocketMcpEndpoint,
@@ -14,7 +11,10 @@ import {
   useWebSocketMcpServers,
   useWebSocketRestartStatus,
   useWebSocketStatus,
-} from "../stores/websocket";
+} from "@stores/websocket";
+import { render } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // 测试组件 - 使用废弃的选择器
 const LegacyComponent: React.FC = () => {
@@ -42,8 +42,8 @@ const LegacyComponent: React.FC = () => {
 };
 
 // 导入新的选择器
-import { useConfig } from "../stores/config";
-import { useClientStatus } from "../stores/status";
+import { useConfig } from "@stores/config";
+import { useClientStatus } from "@stores/status";
 
 // 混合使用新旧选择器的组件
 const MixedComponent: React.FC = () => {

--- a/web/src/test/cozeApi.test.ts
+++ b/web/src/test/cozeApi.test.ts
@@ -2,9 +2,9 @@
  * 扣子 API 前端服务层集成测试
  */
 
+import type { CozeWorkflowsResult, CozeWorkspace } from "@/types/index";
+import { CozeApiClient } from "@services/cozeApi";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { CozeApiClient } from "../services/cozeApi";
-import type { CozeWorkflowsResult, CozeWorkspace } from "../types";
 
 // Mock fetch
 const mockFetch = vi.fn();

--- a/web/src/test/formatUtils.test.ts
+++ b/web/src/test/formatUtils.test.ts
@@ -1,4 +1,4 @@
-import type { ToolCallRecord } from "@/types";
+import type { ToolCallRecord } from "@/types/index";
 import {
   formatDuration,
   formatError,

--- a/web/src/test/integration.test.ts
+++ b/web/src/test/integration.test.ts
@@ -2,11 +2,11 @@
  * 集成测试 - 验证 WebSocket 架构重构后的功能
  */
 
+import { ConnectionState, webSocketManager } from "@services/websocket";
+import { useConfigStore } from "@stores/config";
+import { useStatusStore } from "@stores/status";
+import { useWebSocketStore } from "@stores/websocket";
 import { beforeEach, describe, expect, it } from "vitest";
-import { ConnectionState, webSocketManager } from "../services/websocket";
-import { useConfigStore } from "../stores/config";
-import { useStatusStore } from "../stores/status";
-import { useWebSocketStore } from "../stores/websocket";
 
 describe("WebSocket 架构集成测试", () => {
   beforeEach(() => {

--- a/web/src/test/performance.test.tsx
+++ b/web/src/test/performance.test.tsx
@@ -2,26 +2,26 @@
  * 性能测试 - 验证重构后的性能优化效果
  */
 
-import { act, render } from "@testing-library/react";
-import type React from "react";
-import { useEffect } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useConfig,
   useConfigStore,
   useMcpEndpoint,
   useMcpServers,
-} from "../stores/config";
+} from "@stores/config";
 import {
   useClientStatus,
   useRestartStatus,
   useStatusStore,
-} from "../stores/status";
+} from "@stores/status";
 import {
   useWebSocketConnected,
   useWebSocketStore,
   useWebSocketUrl,
-} from "../stores/websocket";
+} from "@stores/websocket";
+import { act, render } from "@testing-library/react";
+import type React from "react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // 性能监控组件
 const PerformanceMonitor: React.FC<{
@@ -178,7 +178,7 @@ describe("性能优化验证", () => {
   });
 
   it("应该验证 WebSocket 单例模式的性能优势", async () => {
-    const { webSocketManager } = await import("../services/websocket");
+    const { webSocketManager } = await import("@services/websocket");
 
     // 多次获取实例应该返回同一个对象
     const instance1 = webSocketManager;

--- a/web/src/test/useCozeWorkflows.test.ts
+++ b/web/src/test/useCozeWorkflows.test.ts
@@ -2,14 +2,14 @@
  * useCozeWorkflows Hook 测试
  */
 
+import type { CozeWorkflowsResult, CozeWorkspace } from "@/types/index";
+import { useCozeWorkflows } from "@hooks/useCozeWorkflows";
+import { cozeApiClient } from "@services/cozeApi";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { useCozeWorkflows } from "../hooks/useCozeWorkflows";
-import { cozeApiClient } from "../services/cozeApi";
-import type { CozeWorkflowsResult, CozeWorkspace } from "../types";
 
 // Mock cozeApiClient
-vi.mock("../services/cozeApi", () => {
+vi.mock("@services/cozeApi", () => {
   const mockCozeApiClient = {
     fetchWorkspaces: vi.fn(),
     fetchWorkflows: vi.fn(),

--- a/web/src/utils/formatUtils.ts
+++ b/web/src/utils/formatUtils.ts
@@ -2,7 +2,7 @@
  * 格式化工具函数
  */
 
-import type { ToolCallRecord } from "@/types";
+import type { ToolCallRecord } from "@/types/index";
 
 /**
  * 格式化时间戳为本地化字符串

--- a/web/tsconfig.json
+++ b/web/tsconfig.json
@@ -21,7 +21,16 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": ["./src/*"],
+      "@components/*": ["./src/components/*"],
+      "@hooks/*": ["./src/hooks/*"],
+      "@services/*": ["./src/services/*"],
+      "@stores/*": ["./src/stores/*"],
+      "@utils/*": ["./src/utils/*"],
+      "@lib/*": ["./src/lib/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@providers/*": ["./src/providers/*"],
+      "@ui/*": ["./src/components/ui/*"]
     }
   },
   "include": ["src"],

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -18,6 +18,16 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@components": path.resolve(__dirname, "./src/components"),
+      "@hooks": path.resolve(__dirname, "./src/hooks"),
+      "@services": path.resolve(__dirname, "./src/services"),
+      "@stores": path.resolve(__dirname, "./src/stores"),
+      "@utils": path.resolve(__dirname, "./src/utils"),
+      "@types": path.resolve(__dirname, "./src/types"),
+      "@lib": path.resolve(__dirname, "./src/lib"),
+      "@pages": path.resolve(__dirname, "./src/pages"),
+      "@providers": path.resolve(__dirname, "./src/providers"),
+      "@ui": path.resolve(__dirname, "./src/components/ui"),
     },
   },
   server: {

--- a/web/vitest.config.ts
+++ b/web/vitest.config.ts
@@ -7,6 +7,16 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
+      "@components": path.resolve(__dirname, "./src/components"),
+      "@hooks": path.resolve(__dirname, "./src/hooks"),
+      "@services": path.resolve(__dirname, "./src/services"),
+      "@stores": path.resolve(__dirname, "./src/stores"),
+      "@utils": path.resolve(__dirname, "./src/utils"),
+      "@types": path.resolve(__dirname, "./src/types"),
+      "@lib": path.resolve(__dirname, "./src/lib"),
+      "@pages": path.resolve(__dirname, "./src/pages"),
+      "@providers": path.resolve(__dirname, "./src/providers"),
+      "@ui": path.resolve(__dirname, "./src/components/ui"),
     },
   },
   test: {


### PR DESCRIPTION
## 改动说明
- 为什么改：为了提升代码可维护性和可读性，消除相对路径导入的复杂性，统一项目导入规范
- 改了什么：将web目录下所有相对路径导入（../、./）转换为别名导入，更新构建配置以支持新的路径映射
- 影响范围：影响web目录下55个文件，包括组件、hooks、服务、stores和测试文件，更新了5个配置文件
- 验证方式：所有284个测试用例通过，类型检查无错误，构建成功完成

## 具体改动
- 配置文件更新：tsconfig.json、vite.config.ts、vitest.config.ts、biome.json、components.json
- 路径映射新增：@components、@hooks、@services、@stores、@utils、@types、@lib、@pages、@providers、@ui等别名
- 代码重构：将所有"../"和"./"相对路径替换为对应的别名导入
- 测试适配：更新所有测试文件的导入路径，确保测试环境正常工作

## 技术细节
- 保持导入顺序：类型导入在前，值导入在后
- 自动化修复：利用Biome linter自动修正导入格式
- 兼容性保证：所有现有API和组件功能保持不变