### PR TITLE
refactor(docs): 重构文档结构，将更新日志迁移至文档系统

### DIFF
--- a/config/cspell.json
+++ b/config/cspell.json
@@ -108,7 +108,7 @@
     "*.log",
     "**/tmp/**",
     "pnpm-lock.yaml",
-    "CHANGELOG.md",
+    "docs/changelog.mdx",
     "config/**"
   ],
   "ignoreWords": [],

--- a/config/release-it.json
+++ b/config/release-it.json
@@ -30,7 +30,7 @@
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "conventionalcommits",
-      "infile": "CHANGELOG.md",
+      "infile": "docs/changelog.mdx",
       "header": "# 更新日志",
       "releaseCommitMessageFormat": "chore: release v${version}",
       "ignoreRecommendedBump": true,

--- a/docs/changelog.mdx
+++ b/docs/changelog.mdx
@@ -1,3 +1,8 @@
+---
+title: 更新日志
+description: Xiaozhi Client 的版本更新历史
+---
+
 # 更新日志
 
 ## [1.9.3-beta.0](https://github.com/shenjingnan/xiaozhi-client/compare/v1.9.2...v1.9.3-beta.0) (2025-11-15)
@@ -379,7 +384,7 @@
 
 - **mcp:** 修复 windows 环境中 uvx mcp 无法使用的问题 ([#73](https://github.com/shenjingnan/xiaozhi-client/issues/73)) ([d44e24e](https://github.com/shenjingnan/xiaozhi-client/commit/d44e24e59af7bfcd16623a5a8286ab3d05124d64))
 
-## [1.0.9](https://github.com/shenjingnan/xiaozhi-client/compare/v1.0.8...v1.0.9) (2025-06-23)
+## [1.0.9](https://github.com/shenjingnan/xiaozhi-client/compare/v1.0.8...v1.9.0) (2025-06-23)
 
 ### Features
 

--- a/docs/development/todo__release-guide.md
+++ b/docs/development/todo__release-guide.md
@@ -278,13 +278,13 @@ docs: 更新 API 使用文档
 1. **代码检查**：运行 `pnpm run check:all`
 2. **项目构建**：运行 `pnpm run build`
 3. **版本更新**：更新 package.json 版本号
-4. **生成变更日志**：基于 commit 历史生成 CHANGELOG.md
+4. **生成变更日志**：基于 commit 历史生成更新日志
 5. **NPM 发布**：发布到 npm registry
 6. **创建 Git 标签**：创建并推送版本标签
 7. **GitHub Release**：创建 GitHub Release 页面
 
 ### 自动生成内容
-- **CHANGELOG.md**：标准化的变更日志
+- **更新日志**：标准化的变更日志，位于 docs/changelog.mdx
 - **Git 标签**：格式为 `v1.0.0`
 - **GitHub Release**：包含变更日志和下载链接
 
@@ -312,7 +312,7 @@ docs: 更新 API 使用文档
   "plugins": {
     "@release-it/conventional-changelog": {
       "preset": "conventionalcommits",
-      "infile": "CHANGELOG.md"
+      "infile": "docs/changelog.mdx"
     }
   }
 }
@@ -366,7 +366,7 @@ docs: 更新 API 使用文档
 - [ ] **下载链接**：确认源码下载链接可用
 
 #### ✅ 文档更新验证
-- [ ] **CHANGELOG.md**：确认变更日志已更新并包含新版本
+- [ ] **更新日志**：确认变更日志已更新并包含新版本（位于 docs/changelog.mdx）
 - [ ] **变更内容**：检查变更日志内容是否准确反映了实际变更
 - [ ] **链接有效性**：确认 commit 和 PR 链接可正常访问
 
@@ -478,7 +478,7 @@ Empty release notes
 1. **检查 Commit 格式**：确保 commit 遵循 Conventional Commits 规范
 2. **手动生成**：
    ```bash
-   npx conventional-changelog -p conventionalcommits -i CHANGELOG.md -s
+   npx conventional-changelog -p conventionalcommits -i docs/changelog.mdx -s
    ```
 3. **检查配置**：确认 `.release-it.json` 配置正确
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -18,7 +18,11 @@
       "usage/use-multi-xiaozhi-mcp-endpoints",
       "usage/as-a-mcp-server",
       "reference/command",
-      "development/docker-build"
+      "development/docker-build",
+      {
+        "group": "开发",
+        "pages": ["changelog"]
+      }
     ]
   },
   "navbar": {


### PR DESCRIPTION
  ## 改动说明
  - 为什么改：
    - 根目录 CHANGELOG.md 用户访问频率低但占据显眼位置
    - 提升用户在阅读文档时查看版本历史的便利性
    - 实现更新日志与文档系统的深度集成，改善用户体验

  - 改了什么：
    - 将 CHANGELOG.md 从根目录迁移至 docs/changelog.mdx
    - 更新 release-it 配置：changelog 生成路径从 "CHANGELOG.md" 改为 "docs/changelog.mdx"
    - 更新文档导航：在 docs.json 中新增"开发"分组，包含更新日志页面
    - 更新拼写检查配置：将忽略路径从 CHANGELOG.md 调整为 docs/changelog.mdx
    - 更新发版指南：修正所有相关文档引用路径和描述

  - 影响范围：
    - 文档系统：新增更新日志页面，用户可通过文档导航访问
    - 发版流程：自动化发版流程保持不变，changelog 生成路径已适配
    - 用户体验：文档查阅时可直接访问版本历史，根目录更整洁
    - 兼容性：向后兼容，所有相关配置已同步更新

  - 验证方式：
    - 文档系统验证：确认 docs/changelog.mdx 在文档导航中正确显示
    - 发版流程验证：运行 conventional-changelog 测试确认路径配置正确
    - 拼写检查验证：pnpm spell:check 通过，无拼写错误
    - 代码质量检查：pnpm check:fix 通过，格式和配置正确