### PR TITLE
config(vscode): 优化 TypeScript 配置，启用工作区类型定义

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,12 +1,5 @@
 {
-  "cSpell.words": [
-    "amap",
-    "conventionalcommits",
-    "modelcontextprotocol",
-    "modelscope",
-    "nvmrc",
-    "postbuild",
-    "Xiaozhi",
-    "xzcli"
-  ]
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "typescript.enablePromptUseWorkspaceTsdk": true,
+  "typescript.preferences.includePackageJsonAutoImports": "on"
 }


### PR DESCRIPTION
  ## 改动说明
  - 为什么改：提升 TypeScript 开发体验，确保使用项目本地安装的 TypeScript 版本，避免版本不一致问题
  - 改了什么：移除 VSCode 拼写检查配置，新增 TypeScript 工作区配置，包括 TSDK 路径和自动导入设置
  - 影响范围：仅影响 VSCode 编辑器的 TypeScript 体验，不影响项目构建和运行时行为
  - 验证方式：VSCode 打开项目时自动使用本地 TypeScript 版本，类型检查和智能提示正常工作