### PR TITLE
refactor(backend): 优化 configManager 类型安全和类型定义

### DIFF
--- a/apps/backend/types/coze.ts
+++ b/apps/backend/types/coze.ts
@@ -200,3 +200,26 @@ export interface WorkflowParameterConfig {
   /** 参数列表 */
   parameters: WorkflowParameter[];
 }
+
+/**
+ * 扣子工作流运行响应数据
+ */
+export interface CozeWorkflowRunResponse {
+  /** 响应状态码，0表示成功 */
+  code: number;
+  /** 响应消息 */
+  msg: string;
+  /** 调试URL */
+  debug_url: string;
+  /** 响应数据，通常为JSON字符串 */
+  data: string;
+  /** 使用量统计 */
+  usage: {
+    /** 输入token数量 */
+    input_count: number;
+    /** 输出token数量 */
+    output_count: number;
+    /** 总token数量 */
+    token_count: number;
+  };
+}


### PR DESCRIPTION
- 为什么改：提升代码类型安全性，解决 TypeScript 严格模式下的类型警告，增强代码可维护性
- 改了什么：
  - 引入 Json5Writer 类型导入，替换 any 类型
  - 将 ProxyHandlerConfig.params 类型从 Record<string, any> 改为 Record<string, string>
  - 将 FunctionHandlerConfig.context 类型从 Record<string, any> 改为 Record<string, unknown>
  - 将 CustomMCPTool.inputSchema 类型从 any 改为 unknown
  - 将 json5Writer 实例类型从 any 改为 unknown，并添加类型断言
  - 优化全局 webServer 访问的类型定义
- 影响范围：仅影响 configManager.ts 文件，对外 API 保持不变，向后兼容
- 验证方式：TypeScript 编译无类型错误，现有功能测试通过