### PR TITLE
test(frontend): 修复 WebUrlSettingButton 测试文件的类型安全问题

### DIFF
--- a/apps/frontend/src/components/WebUrlSettingButton.test.tsx
+++ b/apps/frontend/src/components/WebUrlSettingButton.test.tsx
@@ -1,8 +1,9 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import type { ReactElement } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { WebUrlSettingButton } from "./WebUrlSettingButton";
 
-// Mock react-hook-form
+// 模拟 react-hook-form
 vi.mock("react-hook-form", () => ({
   useForm: () => ({
     control: {},
@@ -11,15 +12,44 @@ vi.mock("react-hook-form", () => ({
     formState: { errors: {} },
   }),
   FormProvider: ({ children }: { children: React.ReactNode }) => children,
-  Controller: ({ render }: { render: any }) =>
-    render({ field: {}, fieldState: {}, formState: {} }),
+  Controller: ({
+    render,
+  }: {
+    render: (props: {
+      field: {
+        onChange: () => void;
+        onBlur: () => void;
+        value: string;
+        name: string;
+        ref: () => void;
+      };
+      fieldState: {
+        invalid: boolean;
+        isTouched: boolean;
+        isDirty: boolean;
+        error?: { message?: string };
+      };
+      formState: { errors: Record<string, unknown> };
+    }) => ReactElement;
+  }) =>
+    render({
+      field: {
+        onChange: vi.fn(),
+        onBlur: vi.fn(),
+        value: "",
+        name: "test",
+        ref: vi.fn(),
+      },
+      fieldState: { invalid: false, isTouched: false, isDirty: false },
+      formState: { errors: {} },
+    }),
   useFormContext: () => ({
     getFieldState: vi.fn(() => ({})),
     formState: { errors: {} },
   }),
 }));
 
-// Mock the hooks
+// 模拟 hooks
 vi.mock("@/providers/WebSocketProvider", () => ({
   useNetworkServiceActions: () => ({
     updateConfig: vi.fn(),
@@ -40,7 +70,7 @@ vi.mock("@/stores/websocket", () => ({
   useWebSocketPortChangeStatus: vi.fn(() => undefined),
 }));
 
-// Mock sonner toast
+// 模拟 sonner toast 组件
 vi.mock("sonner", () => ({
   toast: {
     success: vi.fn(),
@@ -54,14 +84,14 @@ describe("WebUrlSettingButton", () => {
     vi.clearAllMocks();
   });
 
-  it("renders the settings button", () => {
+  it("渲染设置按钮", () => {
     render(<WebUrlSettingButton />);
 
     const button = screen.getByRole("button");
     expect(button).toBeInTheDocument();
   });
 
-  it("opens dialog when button is clicked", async () => {
+  it("点击按钮时打开对话框", async () => {
     render(<WebUrlSettingButton />);
 
     const button = screen.getByRole("button");
@@ -72,7 +102,7 @@ describe("WebUrlSettingButton", () => {
     });
   });
 
-  it("displays dialog title and description", async () => {
+  it("显示对话框标题和描述", async () => {
     render(<WebUrlSettingButton />);
 
     const button = screen.getByRole("button");


### PR DESCRIPTION
- 为什么改：解决测试文件中 Controller 组件的类型安全问题，提升测试代码的类型安全性
- 改了什么：为 Controller 组件的 render 参数添加了完整的 TypeScript 类型定义，修复了 any 类型的使用
- 影响范围：仅影响 WebUrlSettingButton.test.tsx 测试文件，不涉及生产代码
- 验证方式：运行 `pnpm test` 验证测试用例通过，执行 `pnpm type:check` 确认无类型错误