### PR TITLE
refactor(endpoint): 简化 ProxyMCPServer 工具管理架构

### DIFF
--- a/apps/backend/lib/endpoint/__tests__/connection.basic.test.ts
+++ b/apps/backend/lib/endpoint/__tests__/connection.basic.test.ts
@@ -236,6 +236,9 @@ describe("ProxyMCPServer 基础功能测试", () => {
     });
 
     it("应该处理不存在的工具", async () => {
+      // 模拟工具不存在的情况，返回 rejected Promise
+      mockServiceManager.callTool.mockRejectedValue(new Error("未找到工具"));
+
       const toolCallRequest = {
         jsonrpc: "2.0",
         id: "call-missing",

--- a/apps/backend/lib/endpoint/connection.ts
+++ b/apps/backend/lib/endpoint/connection.ts
@@ -97,6 +97,7 @@ export class ProxyMCPServer {
     this.serviceManager = serviceManager;
     console.info("已设置 MCPServiceManager");
   }
+
   /**
    * 获取当前所有工具列表
    * @returns 工具数组


### PR DESCRIPTION
- 为什么改：ProxyMCPServer 存在双重工具缓存问题，增加了系统复杂性和内存占用，且存在数据不一致风险
- 改了什么：
  - 移除本地工具缓存 (Map<string, Tool>) 及相关管理方法
  - 删除 addTool、addTools、removeTool、validateTool、hasTool、syncToolsFromServiceManager 等方法
  - 简化 getTools() 方法，直接从 MCPServiceManager 获取工具
  - 更新 connect() 方法验证逻辑，检查 serviceManager 而非工具数量
  - 更新 getStatus() 方法，动态获取工具数量
- 影响范围：仅影响 ProxyMCPServer 内部实现，对外接口保持兼容，工具调用功能正常
- 验证方式：所有 18 个单元测试通过，减少 136 行代码，架构更加清晰