### PR TITLE
fix(endpoint): 修复 ProxyMCPServer 连接状态流转问题

### DIFF
--- a/apps/backend/lib/endpoint/connection.ts
+++ b/apps/backend/lib/endpoint/connection.ts
@@ -254,6 +254,9 @@ export class ProxyMCPServer {
     // 重置连接状态
     this.connectionStatus = false;
     this.serverInitialized = false;
+
+    // 重置连接状态为已断开
+    this.connectionState = ConnectionState.DISCONNECTED;
   }
 
   private handleMessage(message: MCPMessage): void {
@@ -388,9 +391,6 @@ export class ProxyMCPServer {
 
     // 清理连接资源
     this.cleanupConnection();
-
-    // 设置状态为已断开
-    this.connectionState = ConnectionState.DISCONNECTED;
   }
 
   /**


### PR DESCRIPTION
- 为什么改：连接失败后 connectionState 仍然保持 CONNECTING 状态，导致无法重新连接，阻塞后续连接请求
- 改了什么：在 cleanupConnection() 方法中添加 connectionState = ConnectionState.DISCONNECTED 状态重置，并优化
disconnect() 方法移除重复的状态设置
- 影响范围：仅影响 ProxyMCPServer 类的内部状态管理，对外接口保持完全兼容
- 验证方式：全量测试通过（连接失败后可正常重新连接），类型检查和代码质量检查全部通过