### PR TITLE
fix(docker): 修复容器启动脚本路径错误

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -65,7 +65,7 @@ WORKDIR /workspaces
 COPY templates/ /templates-backup/
 
 # 复制初始化脚本并设置权限
-COPY scripts/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+COPY docker/scripts/entrypoint.sh /usr/local/bin/docker-entrypoint.sh
 
 # 安装模板项目的依赖到备份目录（用于初始化时复制）
 # 使用国内镜像源安装依赖


### PR DESCRIPTION
- 为什么改：Docker 容器启动时找不到 entrypoint.sh 脚本，导致容器启动失败
- 改了什么：将脚本路径从 scripts/entrypoint.sh 修正为 docker/scripts/entrypoint.sh
- 影响范围：仅影响 Docker 容器构建和启动过程，不影响应用功能
- 验证方式：构建 Docker 镜像并验证容器能够正常启动