### PR TITLE
fix(docker): 修复模板文件复制路径错误

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -62,7 +62,7 @@ RUN npx --version && echo "✓ npx is available" \
 WORKDIR /workspaces
 
 # 复制模板到备份目录（避免被卷挂载覆盖）
-COPY templates/ /templates-backup/
+COPY docker/templates/ /templates-backup/
 
 # 复制初始化脚本并设置权限
 COPY docker/scripts/entrypoint.sh /usr/local/bin/docker-entrypoint.sh


### PR DESCRIPTION
- 为什么改：修复 Docker 构建过程中模板文件复制路径不正确的问题，导致容器启动时模板文件缺失
- 改了什么：将 Dockerfile 中的模板复制路径从 `templates/` 修正为 `docker/templates/`，确保正确复制模板文件到备份目录
- 影响范围：仅影响 Docker 容器构建过程，修复后容器能够正确找到和使用模板文件，不影响应用程序功能
- 验证方式：重新构建 Docker 镜像并启动容器，确认 `/templates-backup/` 目录下包含完整的模板文件