### PR TITLE
refactor(config): 移除 logger 依赖，统一使用 console 输出

### DIFF
--- a/apps/backend/lib/config/adapter.ts
+++ b/apps/backend/lib/config/adapter.ts
@@ -35,7 +35,7 @@ export function convertLegacyToNew(
   serviceName: string,
   legacyConfig: MCPServerConfig
 ): MCPServiceConfig {
-  console.log('转换配置', { serviceName, legacyConfig });
+  console.log("转换配置", { serviceName, legacyConfig });
 
   try {
     // 验证输入参数
@@ -58,10 +58,10 @@ export function convertLegacyToNew(
     // 验证转换后的配置
     validateNewConfig(newConfig);
 
-    console.log('配置转换成功', { serviceName, type: newConfig.type });
+    console.log("配置转换成功", { serviceName, type: newConfig.type });
     return newConfig;
   } catch (error) {
-    console.error('配置转换失败', { serviceName, error });
+    console.error("配置转换失败", { serviceName, error });
     throw error instanceof ConfigValidationError
       ? error
       : new ConfigValidationError(
@@ -144,7 +144,7 @@ function convertLocalConfig(
     // 检查是否为相对路径（以 ./ 开头或不以 / 开头且包含文件扩展名）
     if (isRelativePath(arg)) {
       const resolvedPath = resolve(workingDir, arg);
-      console.log('解析相对路径', { arg, resolvedPath });
+      console.log("解析相对路径", { arg, resolvedPath });
       return resolvedPath;
     }
     return arg;
@@ -191,7 +191,12 @@ function convertSSEConfig(
     baseConfig.modelScopeAuth = true;
   }
 
-  console.log('SSE配置转换', { serviceName, url: config.url, inferredType, isModelScope });
+  console.log("SSE配置转换", {
+    serviceName,
+    url: config.url,
+    inferredType,
+    isModelScope,
+  });
 
   return baseConfig;
 }
@@ -249,7 +254,7 @@ export function convertLegacyConfigBatch(
     throw new ConfigValidationError(`批量配置转换失败: ${errorMessages}`);
   }
 
-  console.log('批量配置转换成功', { count: Object.keys(newConfigs).length });
+  console.log("批量配置转换成功", { count: Object.keys(newConfigs).length });
   return newConfigs;
 }
 

--- a/apps/backend/lib/config/manager.ts
+++ b/apps/backend/lib/config/manager.ts
@@ -678,7 +678,7 @@ export class ConfigManager {
     });
 
     // 记录清理结果
-    console.log('成功移除 MCP 服务', { serverName });
+    console.log("成功移除 MCP 服务", { serverName });
   }
 
   /**
@@ -758,7 +758,10 @@ export class ConfigManager {
 
       this.saveConfig(config);
 
-      console.log('已清理无效的服务工具配置', { count: invalidServerNames.length, serverNames: invalidServerNames });
+      console.log("已清理无效的服务工具配置", {
+        count: invalidServerNames.length,
+        serverNames: invalidServerNames,
+      });
     }
   }
 
@@ -1001,7 +1004,7 @@ export class ConfigManager {
           this.updateCustomMCPToolStats(serverName, toolName, callTime),
         ]);
 
-        console.log('工具使用统计已更新', { serverName, toolName });
+        console.log("工具使用统计已更新", { serverName, toolName });
       } else {
         // 两个参数的情况：updateToolUsageStats(toolName, incrementUsageCount)
         const toolName = arg1;
@@ -1015,17 +1018,17 @@ export class ConfigManager {
           incrementUsageCount
         );
 
-        console.log('CustomMCP 工具使用统计已更新', { toolName });
+        console.log("CustomMCP 工具使用统计已更新", { toolName });
       }
     } catch (error) {
       // 错误不应该影响主要的工具调用流程
       if (typeof arg2 === "string" && arg3) {
         const serverName = arg1;
         const toolName = arg2;
-        console.error('更新工具使用统计失败', { serverName, toolName, error });
+        console.error("更新工具使用统计失败", { serverName, toolName, error });
       } else {
         const toolName = arg1;
-        console.error('更新 CustomMCP 工具使用统计失败', { toolName, error });
+        console.error("更新 CustomMCP 工具使用统计失败", { toolName, error });
       }
     }
   }
@@ -1157,22 +1160,28 @@ export class ConfigManager {
     for (const tool of tools) {
       // 检查必需字段
       if (!tool.name || typeof tool.name !== "string") {
-        console.warn('CustomMCP 工具缺少有效的 name 字段', { tool });
+        console.warn("CustomMCP 工具缺少有效的 name 字段", { tool });
         return false;
       }
 
       if (!tool.description || typeof tool.description !== "string") {
-        console.warn('CustomMCP 工具缺少有效的 description 字段', { toolName: tool.name });
+        console.warn("CustomMCP 工具缺少有效的 description 字段", {
+          toolName: tool.name,
+        });
         return false;
       }
 
       if (!tool.inputSchema || typeof tool.inputSchema !== "object") {
-        console.warn('CustomMCP 工具缺少有效的 inputSchema 字段', { toolName: tool.name });
+        console.warn("CustomMCP 工具缺少有效的 inputSchema 字段", {
+          toolName: tool.name,
+        });
         return false;
       }
 
       if (!tool.handler || typeof tool.handler !== "object") {
-        console.warn('CustomMCP 工具缺少有效的 handler 字段', { toolName: tool.name });
+        console.warn("CustomMCP 工具缺少有效的 handler 字段", {
+          toolName: tool.name,
+        });
         return false;
       }
 
@@ -1182,7 +1191,10 @@ export class ConfigManager {
           tool.handler.type
         )
       ) {
-        console.warn('CustomMCP 工具的 handler.type 类型无效', { toolName: tool.name, type: tool.handler.type });
+        console.warn("CustomMCP 工具的 handler.type 类型无效", {
+          toolName: tool.name,
+          type: tool.handler.type,
+        });
         return false;
       }
 
@@ -1216,7 +1228,10 @@ export class ConfigManager {
       case "mcp":
         return this.validateMCPHandler(toolName, handler);
       default:
-        console.warn('CustomMCP 工具使用了未知的处理器类型', { toolName, handlerType: (handler as HandlerConfig).type });
+        console.warn("CustomMCP 工具使用了未知的处理器类型", {
+          toolName,
+          handlerType: (handler as HandlerConfig).type,
+        });
         return false;
     }
   }
@@ -1229,24 +1244,34 @@ export class ConfigManager {
     handler: ProxyHandlerConfig
   ): boolean {
     if (!handler.platform) {
-      console.warn('CustomMCP 工具的 proxy 处理器缺少 platform 字段', { toolName });
+      console.warn("CustomMCP 工具的 proxy 处理器缺少 platform 字段", {
+        toolName,
+      });
       return false;
     }
 
     if (!["coze", "openai", "anthropic", "custom"].includes(handler.platform)) {
-      console.warn('CustomMCP 工具的 proxy 处理器使用了不支持的平台', { toolName, platform: handler.platform });
+      console.warn("CustomMCP 工具的 proxy 处理器使用了不支持的平台", {
+        toolName,
+        platform: handler.platform,
+      });
       return false;
     }
 
     if (!handler.config || typeof handler.config !== "object") {
-      console.warn('CustomMCP 工具的 proxy 处理器缺少 config 字段', { toolName });
+      console.warn("CustomMCP 工具的 proxy 处理器缺少 config 字段", {
+        toolName,
+      });
       return false;
     }
 
     // Coze 平台特定验证
     if (handler.platform === "coze") {
       if (!handler.config.workflow_id && !handler.config.bot_id) {
-        console.warn('CustomMCP 工具的 Coze 处理器必须提供 workflow_id 或 bot_id', { toolName });
+        console.warn(
+          "CustomMCP 工具的 Coze 处理器必须提供 workflow_id 或 bot_id",
+          { toolName }
+        );
         return false;
       }
     }
@@ -1262,14 +1287,19 @@ export class ConfigManager {
     handler: HttpHandlerConfig
   ): boolean {
     if (!handler.url || typeof handler.url !== "string") {
-      console.warn('CustomMCP 工具的 http 处理器缺少有效的 url 字段', { toolName });
+      console.warn("CustomMCP 工具的 http 处理器缺少有效的 url 字段", {
+        toolName,
+      });
       return false;
     }
 
     try {
       new URL(handler.url);
     } catch {
-      console.warn('CustomMCP 工具的 http 处理器 url 格式无效', { toolName, url: handler.url });
+      console.warn("CustomMCP 工具的 http 处理器 url 格式无效", {
+        toolName,
+        url: handler.url,
+      });
       return false;
     }
 
@@ -1277,7 +1307,10 @@ export class ConfigManager {
       handler.method &&
       !["GET", "POST", "PUT", "DELETE", "PATCH"].includes(handler.method)
     ) {
-      console.warn('CustomMCP 工具的 http 处理器使用了不支持的 HTTP 方法', { toolName, method: handler.method });
+      console.warn("CustomMCP 工具的 http 处理器使用了不支持的 HTTP 方法", {
+        toolName,
+        method: handler.method,
+      });
       return false;
     }
 
@@ -1292,12 +1325,16 @@ export class ConfigManager {
     handler: FunctionHandlerConfig
   ): boolean {
     if (!handler.module || typeof handler.module !== "string") {
-      console.warn('CustomMCP 工具的 function 处理器缺少有效的 module 字段', { toolName });
+      console.warn("CustomMCP 工具的 function 处理器缺少有效的 module 字段", {
+        toolName,
+      });
       return false;
     }
 
     if (!handler.function || typeof handler.function !== "string") {
-      console.warn('CustomMCP 工具的 function 处理器缺少有效的 function 字段', { toolName });
+      console.warn("CustomMCP 工具的 function 处理器缺少有效的 function 字段", {
+        toolName,
+      });
       return false;
     }
 
@@ -1312,7 +1349,9 @@ export class ConfigManager {
     handler: ScriptHandlerConfig
   ): boolean {
     if (!handler.script || typeof handler.script !== "string") {
-      console.warn('CustomMCP 工具的 script 处理器缺少有效的 script 字段', { toolName });
+      console.warn("CustomMCP 工具的 script 处理器缺少有效的 script 字段", {
+        toolName,
+      });
       return false;
     }
 
@@ -1320,7 +1359,10 @@ export class ConfigManager {
       handler.interpreter &&
       !["node", "python", "bash"].includes(handler.interpreter)
     ) {
-      console.warn('CustomMCP 工具的 script 处理器使用了不支持的解释器', { toolName, interpreter: handler.interpreter });
+      console.warn("CustomMCP 工具的 script 处理器使用了不支持的解释器", {
+        toolName,
+        interpreter: handler.interpreter,
+      });
       return false;
     }
 
@@ -1339,17 +1381,25 @@ export class ConfigManager {
       !Array.isArray(handler.tools) ||
       handler.tools.length === 0
     ) {
-      console.warn('CustomMCP 工具的 chain 处理器缺少有效的 tools 数组', { toolName });
+      console.warn("CustomMCP 工具的 chain 处理器缺少有效的 tools 数组", {
+        toolName,
+      });
       return false;
     }
 
     if (!["sequential", "parallel"].includes(handler.mode)) {
-      console.warn('CustomMCP 工具的 chain 处理器使用了不支持的执行模式', { toolName, mode: handler.mode });
+      console.warn("CustomMCP 工具的 chain 处理器使用了不支持的执行模式", {
+        toolName,
+        mode: handler.mode,
+      });
       return false;
     }
 
     if (!["stop", "continue", "retry"].includes(handler.error_handling)) {
-      console.warn('CustomMCP 工具的 chain 处理器使用了不支持的错误处理策略', { toolName, errorHandling: handler.error_handling });
+      console.warn("CustomMCP 工具的 chain 处理器使用了不支持的错误处理策略", {
+        toolName,
+        errorHandling: handler.error_handling,
+      });
       return false;
     }
 
@@ -1364,7 +1414,7 @@ export class ConfigManager {
     handler: MCPHandlerConfig
   ): boolean {
     if (!handler.config || typeof handler.config !== "object") {
-      console.warn('CustomMCP 工具的 mcp 处理器缺少 config 字段', { toolName });
+      console.warn("CustomMCP 工具的 mcp 处理器缺少 config 字段", { toolName });
       return false;
     }
 
@@ -1372,7 +1422,9 @@ export class ConfigManager {
       !handler.config.serviceName ||
       typeof handler.config.serviceName !== "string"
     ) {
-      console.warn('CustomMCP 工具的 mcp 处理器缺少有效的 serviceName', { toolName });
+      console.warn("CustomMCP 工具的 mcp 处理器缺少有效的 serviceName", {
+        toolName,
+      });
       return false;
     }
 
@@ -1380,7 +1432,9 @@ export class ConfigManager {
       !handler.config.toolName ||
       typeof handler.config.toolName !== "string"
     ) {
-      console.warn('CustomMCP 工具的 mcp 处理器缺少有效的 toolName', { toolName });
+      console.warn("CustomMCP 工具的 mcp 处理器缺少有效的 toolName", {
+        toolName,
+      });
       return false;
     }
 
@@ -1399,7 +1453,7 @@ export class ConfigManager {
 
       return this.validateCustomMCPTools(tools);
     } catch (error) {
-      console.error('检查 customMCP 工具配置时出错', { error });
+      console.error("检查 customMCP 工具配置时出错", { error });
       return false;
     }
   }
@@ -1436,7 +1490,7 @@ export class ConfigManager {
     config.customMCP.tools.unshift(tool);
     this.saveConfig(config);
 
-    console.log('成功添加自定义 MCP 工具', { toolName: tool.name });
+    console.log("成功添加自定义 MCP 工具", { toolName: tool.name });
   }
 
   /**
@@ -1481,7 +1535,10 @@ export class ConfigManager {
         timestamp: new Date(),
       });
 
-      console.log('成功批量添加自定义 MCP 工具', { count: newTools.length, toolNames: newTools.map(t => t.name) });
+      console.log("成功批量添加自定义 MCP 工具", {
+        count: newTools.length,
+        toolNames: newTools.map((t) => t.name),
+      });
     }
   }
 
@@ -1510,7 +1567,7 @@ export class ConfigManager {
     config.customMCP.tools.splice(toolIndex, 1);
     this.saveConfig(config);
 
-    console.log('成功删除自定义 MCP 工具', { toolName });
+    console.log("成功删除自定义 MCP 工具", { toolName });
   }
 
   /**
@@ -1551,7 +1608,7 @@ export class ConfigManager {
     config.customMCP.tools[toolIndex] = updatedTool;
     this.saveConfig(config);
 
-    console.log('成功更新自定义 MCP 工具', { toolName });
+    console.log("成功更新自定义 MCP 工具", { toolName });
   }
 
   /**
@@ -1583,7 +1640,7 @@ export class ConfigManager {
       timestamp: new Date(),
     });
 
-    console.log('成功更新自定义 MCP 工具配置', { count: tools.length });
+    console.log("成功更新自定义 MCP 工具配置", { count: tools.length });
   }
 
   /**
@@ -1868,10 +1925,14 @@ export class ConfigManager {
       if (typeof arg3 === "string") {
         const serverName = arg1;
         const toolName = arg2;
-        console.error('更新 customMCP 工具统计信息失败', { serverName, toolName, error });
+        console.error("更新 customMCP 工具统计信息失败", {
+          serverName,
+          toolName,
+          error,
+        });
       } else {
         const toolName = arg1;
-        console.error('更新 customMCP 工具统计信息失败', { toolName, error });
+        console.error("更新 customMCP 工具统计信息失败", { toolName, error });
       }
       // customMCP 统计更新失败不应该影响主要流程
     }
@@ -1884,7 +1945,7 @@ export class ConfigManager {
    */
   private async acquireStatsUpdateLock(toolKey: string): Promise<boolean> {
     if (this.statsUpdateLocks.has(toolKey)) {
-      console.log('工具统计更新正在进行中，跳过本次更新', { toolKey });
+      console.log("工具统计更新正在进行中，跳过本次更新", { toolKey });
       return false;
     }
 
@@ -1918,7 +1979,7 @@ export class ConfigManager {
       this.statsUpdateLockTimeouts.delete(toolKey);
     }
 
-    console.log('已释放工具的统计更新锁', { toolKey });
+    console.log("已释放工具的统计更新锁", { toolKey });
   }
 
   /**
@@ -1938,9 +1999,9 @@ export class ConfigManager {
 
     try {
       await this.updateToolUsageStats(toolName, incrementUsageCount);
-      console.log('工具统计更新完成', { toolName });
+      console.log("工具统计更新完成", { toolName });
     } catch (error) {
-      console.error('工具统计更新失败', { toolName, error });
+      console.error("工具统计更新失败", { toolName, error });
       throw error;
     } finally {
       this.releaseStatsUpdateLock(toolKey);
@@ -1973,9 +2034,13 @@ export class ConfigManager {
         callTime,
         incrementUsageCount
       );
-      console.log('MCP 服务工具统计更新完成', { serviceName, toolName });
+      console.log("MCP 服务工具统计更新完成", { serviceName, toolName });
     } catch (error) {
-      console.error('MCP 服务工具统计更新失败', { serviceName, toolName, error });
+      console.error("MCP 服务工具统计更新失败", {
+        serviceName,
+        toolName,
+        error,
+      });
       throw error;
     } finally {
       this.releaseStatsUpdateLock(toolKey);
@@ -1996,7 +2061,7 @@ export class ConfigManager {
     this.statsUpdateLockTimeouts.clear();
 
     if (lockCount > 0) {
-      console.log('已清理统计更新锁', { count: lockCount });
+      console.log("已清理统计更新锁", { count: lockCount });
     }
   }
 


### PR DESCRIPTION
- 为什么改：简化配置模块的日志系统，移除对 @root/Logger.js 的依赖，降低模块耦合度
- 改了什么：
  - 移除 adapter.ts 和 manager.ts 中的 logger 导入和初始化代码
  - 将所有 logger.debug/info 替换为 console.log
  - 将所有 logger.error 替换为 console.error
  - 将所有 logger.warn 替换为 console.warn
  - 统一输出格式为 console.log('纯字符串描述', { 变量对象 })
  - 修复 TypeScript 类型收窄问题（HandlerConfig type 访问）
- 影响范围：
  - apps/backend/lib/config/adapter.ts（8 处 logger 调用）
  - apps/backend/lib/config/manager.ts（53 处 logger 调用）
  - 共减少 66 行代码，移除了对 Logger 模块的依赖
- 验证方式：
  - pnpm type:check 通过
  - 日志输出格式保持一致，变量对象在第二个参数中结构化输出