### PR TITLE
refactor(lib): 移除 NPMManager 的 Logger 依赖，统一使用 console 输出

### DIFF
--- a/apps/backend/lib/npm/__tests__/manager.test.ts
+++ b/apps/backend/lib/npm/__tests__/manager.test.ts
@@ -4,23 +4,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 vi.mock("node:child_process");
 vi.mock("node:util");
 vi.mock("semver");
-vi.mock("../../../Logger.js");
 vi.mock("../../../services/EventBus.js");
 
 import { NPMManager } from "@/lib/npm";
 // Import after mocking
 import type { EventBus } from "@services/EventBus.js";
-
-/**
- * Mock Logger 类型接口
- * 用于测试中模拟 Logger 对象
- */
-interface MockLogger {
-  info: ReturnType<typeof vi.fn>;
-  error: ReturnType<typeof vi.fn>;
-  warn: ReturnType<typeof vi.fn>;
-  debug: ReturnType<typeof vi.fn>;
-}
 
 /**
  * Mock EventBus 类型接口
@@ -63,7 +51,6 @@ type MockExecAsync = ReturnType<typeof vi.fn>;
 
 describe("NPMManager", () => {
   let npmManager: NPMManager;
-  let mockLogger: MockLogger;
   let mockEventBus: MockEventBus;
   let mockSpawn: MockSpawn;
   let mockExecAsync: MockExecAsync;
@@ -71,14 +58,6 @@ describe("NPMManager", () => {
   beforeEach(async () => {
     // Reset all mocks
     vi.clearAllMocks();
-
-    // Setup mock logger
-    mockLogger = {
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-      debug: vi.fn(),
-    };
 
     // Setup mock event bus
     mockEventBus = {
@@ -92,9 +71,6 @@ describe("NPMManager", () => {
     mockExecAsync = vi.fn();
 
     // Mock the imports
-    const { logger } = await import("../../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger as never);
-
     const { getEventBus } = await import("../../../services/EventBus.js");
     vi.mocked(getEventBus).mockReturnValue(mockEventBus as never);
 
@@ -201,12 +177,6 @@ describe("NPMManager", () => {
           duration: expect.any(Number),
           timestamp: expect.any(Number),
         }
-      );
-
-      expect(mockLogger.info).toHaveBeenCalledWith(
-        expect.stringMatching(
-          /^开始安装: xiaozhi-client@1\.7\.9 \[install-\d+-[a-z0-9]+\]$/
-        )
       );
     });
 

--- a/apps/backend/lib/npm/index.ts
+++ b/apps/backend/lib/npm/index.ts
@@ -1,5 +1,1 @@
-/**
- * NPM 包管理模块
- */
-
-export { NPMManager } from "./manager.js";
+export * from "./manager.js";

--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -1,6 +1,5 @@
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
-import { logger } from "@root/Logger.js";
 import type { EventBus } from "@services/EventBus.js";
 import { getEventBus } from "@services/EventBus.js";
 import semver from "semver";
@@ -8,7 +7,6 @@ import semver from "semver";
 const execAsync = promisify(exec);
 
 export class NPMManager {
-  private logger = logger.withTag("NPMManager");
   private eventBus: EventBus;
 
   constructor(eventBus?: EventBus) {
@@ -22,7 +20,7 @@ export class NPMManager {
     const installId = `install-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
     const startTime = Date.now();
 
-    this.logger.info(`开始安装: xiaozhi-client@${version} [${installId}]`);
+    console.log("开始安装", { version, installId });
 
     // 发射安装开始事件
     this.eventBus.emitEvent("npm:install:started", {
@@ -170,7 +168,7 @@ export class NPMManager {
       // 进行降序排列（最新的在前）
       return filteredVersions.sort((a, b) => semver.rcompare(a, b));
     } catch (error) {
-      this.logger.error("获取版本列表失败:", error);
+      console.log("获取版本列表失败", { error });
       // 如果获取失败，返回一些默认版本
       return [];
     }
@@ -221,14 +219,12 @@ export class NPMManager {
         // 使用 semver 比较版本
         hasUpdate = semver.gt(latestVersion, currentVersion);
       } catch (error) {
-        this.logger.warn("版本比较失败:", error);
+        console.log("版本比较失败", { error });
         // 如果比较失败，尝试字符串比较
         hasUpdate = latestVersion !== currentVersion;
       }
 
-      this.logger.info(
-        `版本检查完成: 当前版本 ${currentVersion}, 最新版本 ${latestVersion}, 有更新: ${hasUpdate}`
-      );
+      console.log("版本检查完成", { currentVersion, latestVersion, hasUpdate });
 
       return {
         currentVersion,
@@ -236,7 +232,7 @@ export class NPMManager {
         hasUpdate,
       };
     } catch (error) {
-      this.logger.error("检查最新版本失败:", error);
+      console.log("检查最新版本失败", { error });
       return {
         currentVersion: "unknown",
         latestVersion: null,


### PR DESCRIPTION
- 为什么改：简化依赖关系，降低模块耦合度，移除对 Logger.js 的强依赖
- 改了什么：
  - 移除 `NPMManager` 中的 logger 实例化和所有 logger 调用
  - 将 `logger.info/warn/error` 统一替换为 `console.log`
  - 更新测试文件，移除 Logger Mock 和相关断言
  - 优化日志输出格式为 `console.log('描述', { 变量 })`
- 影响范围：
  - `apps/backend/lib/npm/manager.ts` - 源代码
  - `apps/backend/lib/npm/__tests__/manager.test.ts` - 测试代码
  - 不影响对外 API 和功能行为
- 验证方式：现有测试用例可正常通过，控制台输出格式清晰可读