### PR TITLE
refactor(mcp): 移除 log.ts 中的 logger 依赖，统一使用 console

### DIFF
--- a/apps/backend/lib/mcp/__tests__/log.test.ts
+++ b/apps/backend/lib/mcp/__tests__/log.test.ts
@@ -22,22 +22,6 @@ import {
   type ToolCallRecord,
 } from "../log.js";
 
-// Mock logger
-vi.mock("@root/Logger.js", () => ({
-  logger: {
-    debug: vi.fn(),
-    info: vi.fn(),
-    warn: vi.fn(),
-    error: vi.fn(),
-    withTag: vi.fn(() => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    })),
-  },
-}));
-
 // ==================== ToolCallLogger 测试 ====================
 
 describe("ToolCallLogger", () => {
@@ -446,15 +430,19 @@ describe("ToolCallLogger", () => {
         duration: 50,
       };
 
-      const { logger } = await import("@root/Logger.js");
-      const mockInfo = vi.mocked(logger.info);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       await toolCallLogger.recordToolCall(record);
 
       // 检查是否调用了控制台日志
-      expect(mockInfo).toHaveBeenCalledWith(
-        expect.stringContaining("[工具调用] ✅ test_tool (50ms)")
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[工具调用]",
+        expect.objectContaining({
+          message: expect.stringContaining("✅ test_tool (50ms)"),
+        })
       );
+
+      consoleSpy.mockRestore();
     });
 
     it("应该为失败的调用显示失败表情符号", async () => {
@@ -465,15 +453,19 @@ describe("ToolCallLogger", () => {
         duration: 30,
       };
 
-      const { logger } = await import("@root/Logger.js");
-      const mockInfo = vi.mocked(logger.info);
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
 
       await toolCallLogger.recordToolCall(record);
 
       // 检查是否调用了控制台日志
-      expect(mockInfo).toHaveBeenCalledWith(
-        expect.stringContaining("[工具调用] ❌ failing_tool (30ms)")
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[工具调用]",
+        expect.objectContaining({
+          message: expect.stringContaining("❌ failing_tool (30ms)"),
+        })
       );
+
+      consoleSpy.mockRestore();
     });
   });
 


### PR DESCRIPTION
- 为什么改：简化日志模块依赖，log.ts 作为基础日志模块不应依赖复杂的 logger 系统，使用原生 console 更轻量直接
- 改了什么：
  - 移除 `@root/Logger.js` 依赖导入
  - ToolCallLogger 类：将 `logger.debug/info/error` 替换为 `console.log/error`
  - ToolCallLogService 类：删除 `logger` 属性，将 `this.logger.debug/warn/error` 替换为 `console.log/warn/error`
  - 测试文件：移除 logger mock，改用 `vi.spyOn(console, "log")` 监控输出
- 影响范围：
  - 仅影响 `apps/backend/lib/mcp/log.ts` 及其测试文件
  - 对外 API 保持不变，兼容性无损
  - Console 输出格式统一为：`console.log('描述', { 变量 })`
- 验证方式：
  - type:check ✓ 通过
  - lint ✓ 通过
  - 全部测试通过（84 个测试文件，2015 个测试用例）