### PR TITLE
refactor(logger): 移除 Logger.withTag 标签功能，统一使用共享日志实例

### DIFF
--- a/apps/backend/Logger.test.ts
+++ b/apps/backend/Logger.test.ts
@@ -304,15 +304,6 @@ describe("Logger", async () => {
     });
   });
 
-  describe("withTag", () => {
-    it("should return the same instance (deprecated functionality)", () => {
-      const testLogger = new Logger();
-      const taggedLogger = testLogger.withTag("TEST_TAG");
-
-      expect(taggedLogger).toBe(testLogger);
-    });
-  });
-
   describe("close", () => {
     it("should handle close gracefully", () => {
       const testLogger = new Logger();

--- a/apps/backend/Logger.ts
+++ b/apps/backend/Logger.ts
@@ -449,16 +449,6 @@ export class Logger {
   }
 
   /**
-   * 创建一个带标签的日志实例（已废弃，直接返回原实例）
-   * @param tag 标签（不再使用）
-   * @deprecated 标签功能已移除
-   */
-  withTag(_tag: string): Logger {
-    // 不再添加标签，直接返回共享实例
-    return this;
-  }
-
-  /**
    * 关闭日志文件流
    */
   close(): void {

--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -146,7 +146,7 @@ export class WebServer {
       // 配置读取失败时使用默认端口
       this.port = port ?? 9999;
     }
-    this.logger = logger.withTag("WebServer");
+    this.logger = logger;
 
     // 初始化事件总线
     this.eventBus = getEventBus();

--- a/apps/backend/cli/commands/McpCommandHandler.ts
+++ b/apps/backend/cli/commands/McpCommandHandler.ts
@@ -38,7 +38,7 @@ export class McpCommandHandler extends BaseCommandHandler {
 
   constructor(...args: ConstructorParameters<typeof BaseCommandHandler>) {
     super(...args);
-    this.logger = logger.withTag("McpCommandHandler");
+    this.logger = logger;
     this.processManager = new ProcessManagerImpl();
 
     // 获取 Web 服务器的端口

--- a/apps/backend/handlers/HeartbeatHandler.ts
+++ b/apps/backend/handlers/HeartbeatHandler.ts
@@ -29,7 +29,7 @@ export class HeartbeatHandler {
     statusService: StatusService,
     notificationService: NotificationService
   ) {
-    this.logger = logger.withTag("HeartbeatHandler");
+    this.logger = logger;
     this.statusService = statusService;
     this.notificationService = notificationService;
   }

--- a/apps/backend/handlers/MCPEndpointApiHandler.ts
+++ b/apps/backend/handlers/MCPEndpointApiHandler.ts
@@ -68,7 +68,7 @@ export class MCPEndpointApiHandler {
   private eventBus: EventBus;
 
   constructor(endpointManager: EndpointManager, configManager: ConfigManager) {
-    this.logger = logger.withTag("MCPEndpointApiHandler");
+    this.logger = logger;
     this.endpointManager = endpointManager;
     this.configManager = configManager;
     this.eventBus = getEventBus();

--- a/apps/backend/handlers/MCPRouteHandler.ts
+++ b/apps/backend/handlers/MCPRouteHandler.ts
@@ -67,7 +67,7 @@ export class MCPRouteHandler {
   private startTime: Date;
 
   constructor(config: MCPRouteHandlerConfig = {}) {
-    this.logger = logger.withTag("MCPRouteHandler");
+    this.logger = logger;
     this.config = {
       maxClients: config.maxClients ?? 100,
       connectionTimeout: config.connectionTimeout ?? 300000, // 5分钟

--- a/apps/backend/handlers/MCPServerApiHandler.ts
+++ b/apps/backend/handlers/MCPServerApiHandler.ts
@@ -141,7 +141,7 @@ export class MCPServerApiHandler {
     mcpServiceManager: MCPServiceManager,
     configManager: ConfigManager
   ) {
-    this.logger = logger.withTag("MCPServerApiHandler");
+    this.logger = logger;
     this.mcpServiceManager = mcpServiceManager;
     this.configManager = configManager;
   }

--- a/apps/backend/handlers/RealtimeNotificationHandler.ts
+++ b/apps/backend/handlers/RealtimeNotificationHandler.ts
@@ -29,7 +29,7 @@ export class RealtimeNotificationHandler {
     notificationService: NotificationService,
     statusService: StatusService
   ) {
-    this.logger = logger.withTag("RealtimeNotificationHandler");
+    this.logger = logger;
     this.notificationService = notificationService;
     this.statusService = statusService;
     this.eventBus = getEventBus();

--- a/apps/backend/handlers/ServiceApiHandler.ts
+++ b/apps/backend/handlers/ServiceApiHandler.ts
@@ -33,7 +33,7 @@ export class ServiceApiHandler {
   private eventBus: EventBus;
 
   constructor(statusService: StatusService) {
-    this.logger = logger.withTag("ServiceApiHandler");
+    this.logger = logger;
     this.statusService = statusService;
     this.eventBus = getEventBus();
   }

--- a/apps/backend/handlers/StaticFileHandler.ts
+++ b/apps/backend/handlers/StaticFileHandler.ts
@@ -14,7 +14,7 @@ export class StaticFileHandler {
   private webPath: string | null = null;
 
   constructor() {
-    this.logger = logger.withTag("StaticFileHandler");
+    this.logger = logger;
     this.initializeWebPath();
   }
 

--- a/apps/backend/handlers/StatusApiHandler.ts
+++ b/apps/backend/handlers/StatusApiHandler.ts
@@ -28,7 +28,7 @@ export class StatusApiHandler {
   private statusService: StatusService;
 
   constructor(statusService: StatusService) {
-    this.logger = logger.withTag("StatusApiHandler");
+    this.logger = logger;
     this.statusService = statusService;
   }
 

--- a/apps/backend/handlers/ToolApiHandler.integration.test.ts
+++ b/apps/backend/handlers/ToolApiHandler.integration.test.ts
@@ -14,12 +14,10 @@ import { ToolApiHandler } from "./ToolApiHandler.js";
 // Mock dependencies
 vi.mock("../Logger.js", () => ({
   logger: {
-    withTag: vi.fn(() => ({
-      info: vi.fn(),
-      error: vi.fn(),
-      debug: vi.fn(),
-      warn: vi.fn(),
-    })),
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 

--- a/apps/backend/handlers/ToolApiHandler.ts
+++ b/apps/backend/handlers/ToolApiHandler.ts
@@ -70,7 +70,7 @@ export class ToolApiHandler {
   private ajv: Ajv;
 
   constructor() {
-    this.logger = logger.withTag("ToolApiHandler");
+    this.logger = logger;
     this.ajv = new Ajv({ allErrors: true, verbose: true });
   }
 

--- a/apps/backend/handlers/UpdateApiHandler.ts
+++ b/apps/backend/handlers/UpdateApiHandler.ts
@@ -11,7 +11,7 @@ const UpdateRequestSchema = z.object({
 
 export class UpdateApiHandler {
   private npmManager: NPMManager;
-  private logger = logger.withTag("UpdateApiHandler");
+  private logger = logger;
   private eventBus = getEventBus();
   private activeInstalls: Map<string, boolean> = new Map();
 

--- a/apps/backend/handlers/VersionApiHandler.ts
+++ b/apps/backend/handlers/VersionApiHandler.ts
@@ -28,7 +28,7 @@ export class VersionApiHandler {
   private logger: Logger;
 
   constructor() {
-    this.logger = logger.withTag("VersionApiHandler");
+    this.logger = logger;
   }
 
   /**

--- a/apps/backend/handlers/__tests__/ConfigApiHandler.test.ts
+++ b/apps/backend/handlers/__tests__/ConfigApiHandler.test.ts
@@ -5,12 +5,10 @@ import { ConfigApiHandler } from "../ConfigApiHandler.js";
 // 模拟依赖项
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -76,7 +74,7 @@ describe("ConfigApiHandler", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock ConfigManager
     mockConfigManager = {

--- a/apps/backend/handlers/__tests__/HeartbeatHandler.test.ts
+++ b/apps/backend/handlers/__tests__/HeartbeatHandler.test.ts
@@ -4,12 +4,10 @@ import { HeartbeatHandler } from "../HeartbeatHandler.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -67,7 +65,7 @@ describe("HeartbeatHandler", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock ConfigManager
     mockConfigService = {

--- a/apps/backend/handlers/__tests__/MCPEndpointApiHandler.test.ts
+++ b/apps/backend/handlers/__tests__/MCPEndpointApiHandler.test.ts
@@ -5,12 +5,10 @@ import { MCPEndpointApiHandler } from "../MCPEndpointApiHandler.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 

--- a/apps/backend/handlers/__tests__/RealtimeNotificationHandler.test.ts
+++ b/apps/backend/handlers/__tests__/RealtimeNotificationHandler.test.ts
@@ -5,12 +5,10 @@ import { RealtimeNotificationHandler } from "../RealtimeNotificationHandler.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -89,7 +87,7 @@ describe("RealtimeNotificationHandler", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock ConfigManager
     mockConfigService = {

--- a/apps/backend/handlers/__tests__/ServiceApiHandler.test.ts
+++ b/apps/backend/handlers/__tests__/ServiceApiHandler.test.ts
@@ -5,12 +5,10 @@ import { ServiceApiHandler } from "../ServiceApiHandler.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 

--- a/apps/backend/handlers/__tests__/StaticFileHandler.test.ts
+++ b/apps/backend/handlers/__tests__/StaticFileHandler.test.ts
@@ -21,12 +21,10 @@ vi.mock("node:url", () => ({
 
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -51,7 +49,7 @@ describe("StaticFileHandler", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock fs functions
     const fs = await import("node:fs");

--- a/apps/backend/handlers/__tests__/StatusApiHandler.test.ts
+++ b/apps/backend/handlers/__tests__/StatusApiHandler.test.ts
@@ -5,12 +5,10 @@ import { StatusApiHandler } from "../StatusApiHandler.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn(() => ({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-    })),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
   },
 }));
 
@@ -56,7 +54,7 @@ describe("StatusApiHandler 状态 API 处理器", () => {
       warn: vi.fn(),
       error: vi.fn(),
     };
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Create handler instance
     statusApiHandler = new StatusApiHandler(mockStatusService);

--- a/apps/backend/handlers/__tests__/UpdateApiHandler.test.ts
+++ b/apps/backend/handlers/__tests__/UpdateApiHandler.test.ts
@@ -50,9 +50,7 @@ describe("UpdateApiHandler", () => {
       warn: vi.fn(),
       debug: vi.fn(),
     };
-    vi.spyOn(logger, "withTag").mockReturnValue(
-      mockLogger as unknown as ReturnType<typeof logger.withTag>
-    );
+    Object.assign(logger, mockLogger);
 
     // Setup mock event bus
     mockEventBus = {

--- a/apps/backend/services/EventBus.ts
+++ b/apps/backend/services/EventBus.ts
@@ -249,7 +249,7 @@ export class EventBus extends EventEmitter {
 
   constructor() {
     super();
-    this.logger = logger.withTag("EventBus");
+    this.logger = logger;
     this.setMaxListeners(this.maxListeners);
     this.setupErrorHandling();
   }

--- a/apps/backend/services/NotificationService.ts
+++ b/apps/backend/services/NotificationService.ts
@@ -36,7 +36,7 @@ export class NotificationService {
   private maxQueueSize = 100;
 
   constructor() {
-    this.logger = logger.withTag("NotificationService");
+    this.logger = logger;
     this.eventBus = getEventBus();
     this.setupEventListeners();
   }

--- a/apps/backend/services/StatusService.ts
+++ b/apps/backend/services/StatusService.ts
@@ -40,7 +40,7 @@ export class StatusService {
   private readonly HEARTBEAT_TIMEOUT = 35000; // 35 seconds
 
   constructor() {
-    this.logger = logger.withTag("StatusService");
+    this.logger = logger;
     this.eventBus = getEventBus();
   }
 

--- a/apps/backend/services/__tests__/EventBus.test.ts
+++ b/apps/backend/services/__tests__/EventBus.test.ts
@@ -4,12 +4,10 @@ import { EventBus, destroyEventBus, getEventBus } from "../EventBus.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -28,7 +26,7 @@ describe("EventBus", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     eventBus = new EventBus();
   });
@@ -777,7 +775,7 @@ describe("EventBus singleton functions", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Ensure clean state
     destroyEventBus();

--- a/apps/backend/services/__tests__/NotificationService.test.ts
+++ b/apps/backend/services/__tests__/NotificationService.test.ts
@@ -15,13 +15,11 @@ vi.mock("../EventBus.js", () => ({
 // Mock Logger
 vi.mock("@root/Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      warn: vi.fn(),
-      error: vi.fn(),
-      success: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
   },
 }));
 
@@ -100,7 +98,7 @@ describe("NotificationService", () => {
       success: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    (logger.withTag as any).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock ConfigManager
     const { configManager } = await import("@/lib/config/manager.js");

--- a/apps/backend/services/__tests__/StatusService.test.ts
+++ b/apps/backend/services/__tests__/StatusService.test.ts
@@ -5,12 +5,10 @@ import { StatusService } from "../StatusService.js";
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
   logger: {
-    withTag: vi.fn().mockReturnValue({
-      debug: vi.fn(),
-      info: vi.fn(),
-      error: vi.fn(),
-      warn: vi.fn(),
-    }),
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
   },
 }));
 
@@ -41,7 +39,7 @@ describe("StatusService", () => {
       warn: vi.fn(),
     };
     const { logger } = await import("../../Logger.js");
-    vi.mocked(logger.withTag).mockReturnValue(mockLogger);
+    Object.assign(logger, mockLogger);
 
     // Mock EventBus
     mockEventBus = {

--- a/apps/backend/utils/ServiceRestartManager.ts
+++ b/apps/backend/utils/ServiceRestartManager.ts
@@ -81,7 +81,7 @@ export class ServiceRestartManager {
       ...config,
     };
 
-    this.logger = logger.withTag("ServiceRestartManager");
+    this.logger = logger;
     this.setupEventListeners();
   }
 


### PR DESCRIPTION
- 为什么改：简化日志系统架构，移除不再使用的标签功能以降低维护成本
- 改了什么：
  - 删除 Logger.withTag() 方法和相关测试用例
  - 将所有 `logger.withTag("XXX")` 调用替换为直接使用 `logger`
  - 更新所有测试文件的 mock 结构，移除 withTag 相关配置
  - 修改 `Object.assign(logger, mockLogger)` 替代原有的 `vi.mocked(logger.withTag).mockReturnValue(mockLogger)` 方式

- 影响范围：
  - 核心模块：Logger.ts、Logger.test.ts、WebServer.ts
  - Handlers：12 个 handler 文件及其测试文件
  - Services：3 个服务文件及其测试文件
  - Utils：ServiceRestartManager.ts
  - 共计 31 个文件，删除 43 行代码

- 验证方式：
  - 所有单元测试保持通过
  - 功能行为完全一致，仅内部实现简化
  - 代码更加简洁，减少了不必要的抽象层