### PR TITLE
docs(readme): 修复文档图片路径错误

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,9 @@
 - 支持 通过模板创建 xiaozhi-client 项目 (xiaozhi create \<my-app\> --template hello-world)
 - 支持 后台运行(xiaozhi start -d)
 
-![Web UI 配置界面](https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docs/images/web-ui-preview.png)
+![Web UI 配置界面](https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docs/public/images/web-ui-preview.png)
 
-![效果图](https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docs/images/preview.png)
+![效果图](https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docs/public/images/preview.png)
 
 ## 快速上手
 


### PR DESCRIPTION
- 为什么改：README 中的图片引用路径与实际文件路径不匹配，导致图片无法正常显示
- 改了什么：将图片路径从 `docs/images/` 更正为 `docs/public/images/`，共修复2处引用
  - Web UI 配置界面预览图
  - 效果图展示
- 影响范围：仅影响 README.md 的图片显示，不影响代码功能
- 验证方式：本地查看 README 确认图片能正常加载，访问 GitHub 仓库页面验证图片显示正常