### PR TITLE
fix(cli): 修复 npm 全局安装后命令无法执行的问题

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,8 +39,6 @@ async function initializeCLI(): Promise<void> {
   }
 }
 
-// 启动 CLI 应用
-// CLI 入口文件直接执行初始化（无需模块检测，兼容 npm 全局安装的符号链接）
 initializeCLI();
 
 export { initializeCLI };


### PR DESCRIPTION
- 为什么改：用户反馈通过 `npm i -g xiaozhi-client@1.9.4-beta.11` 全局安装后，执行 `xiaozhi -v`、`xiaozhi -h`、`xiaozhi create app` 等命令都没有任何输出，但本地构建后直接执行可以正常使用
- 改了什么：移除 CLI 入口文件中的模块检测逻辑（`isMainModule` 判断），改为直接执行 `initializeCLI()`
- 影响范围：修复 npm 全局安装场景下的符号链接兼容性问题，不影响本地开发和其他使用场景
- 验证方式：
  1. 本地构建测试：`node ./dist/cli/index.js -h` 正常显示帮助信息
  2. 符号链接测试：创建符号链接指向 CLI 文件并执行，命令正常工作
  3. 构建产物验证：检查 `dist/cli/index.js` 末尾确认为直接调用 `initializeCLI()`