### PR TITLE
feat(backend): 集成 Dify Workflow API 客户端

### DIFF
--- a/apps/backend/lib/dify/client.ts
+++ b/apps/backend/lib/dify/client.ts
@@ -1,0 +1,18 @@
+/**
+ * Dify API 客户端封装
+ * 提供统一的客户端创建和配置
+ */
+
+import { WorkflowClient } from "dify-client";
+
+/**
+ * 创建 Dify Workflow 客户端
+ * @param apiKey - API 访问密钥
+ */
+export function createDifyClient(apiKey: string): WorkflowClient {
+  if (!apiKey || typeof apiKey !== "string" || apiKey.trim() === "") {
+    throw new Error("Dify API Key 不能为空");
+  }
+
+  return new WorkflowClient(apiKey.trim());
+}

--- a/apps/backend/lib/dify/config.ts
+++ b/apps/backend/lib/dify/config.ts
@@ -1,0 +1,6 @@
+/**
+ * Dify API 配置
+ */
+export default {
+  BASE_URL: "https://api.dify.ai",
+};

--- a/apps/backend/lib/dify/index.ts
+++ b/apps/backend/lib/dify/index.ts
@@ -1,0 +1,5 @@
+export { default as config } from "./config";
+export * from "dify-client";
+export { createDifyClient } from "./client";
+export { DifyApiService } from "./service";
+export type { DifyWorkflowParams } from "./service";

--- a/apps/backend/lib/dify/service.ts
+++ b/apps/backend/lib/dify/service.ts
@@ -1,0 +1,44 @@
+/**
+ * Dify API 服务类
+ * 负责与 Dify API 的交互，主要是工作流的调用
+ */
+
+import { createDifyClient } from "./client";
+
+/**
+ * 运行工作流的参数
+ */
+export interface DifyWorkflowParams {
+  inputs: Record<string, unknown>;
+  user?: string;
+  response_mode?: "blocking" | "streaming";
+}
+
+/**
+ * Dify API 服务类
+ */
+export class DifyApiService {
+  private client: ReturnType<typeof createDifyClient>;
+
+  constructor(apiKey: string) {
+    this.client = createDifyClient(apiKey);
+  }
+
+  /**
+   * 运行工作流
+   * @param inputs - 输入参数
+   * @param user - 用户标识
+   * @param responseMode - 响应模式，默认为 "blocking"
+   */
+  async runWorkflow(
+    inputs: Record<string, unknown>,
+    user = "xiaozhi-client",
+    responseMode: "blocking" | "streaming" = "blocking"
+  ) {
+    return this.client.run({
+      inputs,
+      user,
+      response_mode: responseMode,
+    });
+  }
+}

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "comment-json": "^4.2.5",
     "consola": "^3.4.2",
     "dayjs": "^1.11.13",
+    "dify-client": "^3.0.0",
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",
     "express": "^5.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
+      dify-client:
+        specifier: ^3.0.0
+        version: 3.0.0
       dotenv:
         specifier: ^17.2.1
         version: 17.2.3
@@ -4241,6 +4244,10 @@ packages:
   diff@4.0.2:
     resolution: {integrity: sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==}
     engines: {node: '>=0.3.1'}
+
+  dify-client@3.0.0:
+    resolution: {integrity: sha512-4ybDLP3GTysaMM93Sex9u/LF7mTNNVuwwhtk9LzK4AUtw721AUIW+jgSE5CzEJj9iflaiK9aswd0pSI/qyLOzQ==}
+    engines: {node: '>=18.0.0'}
 
   dlv@1.1.3:
     resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
@@ -11197,6 +11204,12 @@ snapshots:
   didyoumean@1.2.2: {}
 
   diff@4.0.2: {}
+
+  dify-client@3.0.0:
+    dependencies:
+      axios: 1.13.2
+    transitivePeerDependencies:
+      - debug
 
   dlv@1.1.3: {}
 


### PR DESCRIPTION
- 为什么改：实现对 Dify 平台的 Workflow API 集成，支持调用 Dify 工作流
- 改了什么：
  - 新增 apps/backend/lib/dify 模块，参考 coze 实现架构
  - 创建 config.ts、client.ts、service.ts、index.ts 四个核心文件
  - 添加 dify-client@3.0.0 依赖包
  - 实现 DifyApiService.runWorkflow() 方法，支持 blocking/streaming 模式
- 影响范围：
  - 新增 @/lib/dify 模块，不影响现有功能
  - 提供与 coze 一致的 API 设计，便于使用和维护
  - 兼容 Node.js 18+ 环境
- 验证方式：
  - TypeScript 类型检查通过（pnpm check:type）
  - Biome 代码规范检查通过（pnpm lint）
  - 可通过 DifyApiService 实例调用 runWorkflow() 方法验证