### PR TITLE
feat(frontend): 优化 Toast 通知交互体验

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -20,6 +20,8 @@ function App() {
       {/* Toast 通知容器 */}
       <Toaster
         richColors
+        closeButton={true} // 启用关闭按钮
+        swipeDirections={[]} // 禁用所有方向的滑动手势，只允许点击关闭按钮关闭
         toastOptions={{
           classNames: {
             description: "group-[.toast]:text-muted-foreground",


### PR DESCRIPTION
- 为什么改：提升 Toast 通知的用户交互体验，避免误操作导致通知被意外关闭
- 改了什么：
  - 启用 Toast 的关闭按钮（closeButton=true）
  - 禁用所有方向的滑动手势（swipeDirections=[]）
  - 仅允许通过点击关闭按钮来关闭通知
- 影响范围：仅影响前端 Toast 通知组件的交互行为，不影响功能和样式
- 验证方式：手动测试 Toast 通知的显示和关闭交互，确保只能通过关闭按钮关闭