### PR TITLE
refactor(publish): 利用 Nx 依赖图自动确定包发布顺序

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/shenjingnan/xiaozhi-client.git",
-    "directory": "packages/shared-types"
+    "directory": "packages/cli"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -5,7 +5,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/shenjingnan/xiaozhi-client.git",
-    "directory": "packages/shared-types"
+    "directory": "packages/config"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -8,7 +8,7 @@
   "repository": {
     "type": "git",
     "url": "https://github.com/shenjingnan/xiaozhi-client.git",
-    "directory": "packages/shared-types"
+    "directory": "packages/endpoint"
   },
   "exports": {
     ".": {


### PR DESCRIPTION
- 为什么改：
  - 原代码手动维护发布顺序，注释与实际依赖不符（endpoint 注释写"无内部依赖"但实际依赖 mcp-core）
  - 与 Nx project.json 中的 dependsOn 配置重复维护
  - 容易出错且维护成本高

- 改了什么：
  - 新增 `getNxDependencies()` 函数：从 Nx 获取项目构建依赖关系
  - 新增 `topologicalSort()` 函数：实现拓扑排序算法，支持循环依赖检测
  - 重构 `getPackages()` 为异步函数：自动获取依赖并排序，移除手动维护的顺序
  - 更新 `publishAllPackages()` 调用点：添加 await 关键字

- 影响范围：
  - 发布流程脚本 scripts/publish.ts
  - 包发布顺序现在由 Nx 项目配置驱动，自动适应依赖关系变化
  - 向后兼容：发布顺序结果与之前一致（shared-types → config → mcp-core → endpoint → ...）

- 验证方式：
  - 运行 `pnpm release:dry --version 1.0.0-beta.0` 验证发布顺序正确
  - 通过 `pnpm check:type` 和 `pnpm lint` 代码质量检查
  - endpoint 包正确排在 mcp-core 之后（依赖关系得到满足）