### PR TITLE
refactor(mcp): 移除未使用的 modelScopeAuth 字段

### DIFF
--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -65,8 +65,6 @@ export interface MCPServiceConfig {
   // 认证配置
   apiKey?: string;
   headers?: Record<string, string>;
-  // ModelScope 内部配置（不暴露给用户配置文件）
-  modelScopeAuth?: boolean;
   customSSEOptions?: ModelScopeSSEOptions;
 }
 

--- a/packages/config/src/__tests__/adapter.test.ts
+++ b/packages/config/src/__tests__/adapter.test.ts
@@ -136,14 +136,6 @@ describe("ConfigAdapter 配置适配器测试", () => {
       expect(isModelScopeURL("https://example.com/sse")).toBe(false);
       expect(isModelScopeURL("https://mcp.amap.com/sse")).toBe(false);
     });
-
-    it("应该为 ModelScope SSE 服务添加认证标识", () => {
-      const config = {
-        url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
-      };
-      const result = convertLegacyToNew("modelscope-service", config);
-      expect(result.modelScopeAuth).toBe(true);
-    });
   });
 
   describe("本地 stdio 配置", () => {

--- a/packages/config/src/adapter.ts
+++ b/packages/config/src/adapter.ts
@@ -45,7 +45,6 @@ export interface MCPServiceConfig {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
-  modelScopeAuth?: boolean;
 }
 
 /**
@@ -249,11 +248,6 @@ function convertSSEConfig(
     url: config.url,
     headers: config.headers,
   };
-
-  // 如果是 ModelScope 服务，添加特殊配置
-  if (isModelScope) {
-    baseConfig.modelScopeAuth = true;
-  }
 
   console.log("SSE配置转换", {
     serviceName,

--- a/packages/mcp-core/examples/README.md
+++ b/packages/mcp-core/examples/README.md
@@ -334,8 +334,8 @@ await connection.disconnect();
 ```typescript
 const serviceName = "my-service";
 const config = {
-  url: "https://mcp.api-inference.modelscope.net/xxx/sse",
-  modelScopeAuth: true                          // 启用 ModelScope 认证
+  url: "https://mcp.api-inference.modelscope.net/xxx/sse"
+  // ModelScope 服务会自动识别，无需额外配置
 };
 ```
 

--- a/packages/mcp-core/src/__tests__/transport-factory.test.ts
+++ b/packages/mcp-core/src/__tests__/transport-factory.test.ts
@@ -273,17 +273,6 @@ describe("TransportFactory", () => {
       expect(() => TransportFactory.validateConfig(config)).not.toThrow();
     });
 
-    it("应该接受 modelScopeAuth 配置", () => {
-      const config: InternalMCPServiceConfig = {
-        name: "test",
-        type: MCPTransportType.SSE,
-        url: "https://mcp.api-inference.modelscope.net/test/sse",
-        modelScopeAuth: true,
-      };
-
-      expect(() => TransportFactory.validateConfig(config)).not.toThrow();
-    });
-
     it("应该接受 customSSEOptions 配置", () => {
       const config: InternalMCPServiceConfig = {
         name: "test",

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -112,8 +112,6 @@ export interface MCPServiceConfig {
   // 认证配置
   apiKey?: string;
   headers?: Record<string, string>;
-  // ModelScope 内部配置（不暴露给用户配置文件）
-  modelScopeAuth?: boolean;
   customSSEOptions?: ModelScopeSSEOptions;
 }
 


### PR DESCRIPTION
- 为什么改：`modelScopeAuth` 字段在项目中被定义和设置，但从未被实际使用，属于死代码，应予以清理
- 改了什么：
  - 从 3 个类型定义文件中移除 `modelScopeAuth?: boolean` 字段
  - 删除 `adapter.ts` 中为 ModelScope URL 设置 `modelScopeAuth = true` 的逻辑
  - 删除 2 个相关的测试用例
  - 更新示例文档，移除 `modelScopeAuth: true` 配置项
- 影响范围：
  - `packages/mcp-core/src/types.ts` - 核心类型定义
  - `packages/config/src/adapter.ts` - 配置适配器
  - `apps/backend/lib/mcp/types.ts` - 后端类型定义
  - 删除 2 个测试用例，测试覆盖率保持不变
  - 向后兼容：用户代码中不应使用此内部字段，无兼容性影响
- 验证方式：
  - 单元测试：config 包 23 个测试通过，mcp-core 包 96 个测试通过
  - 类型检查：`pnpm check:type` 通过
  - Lint 检查：`pnpm lint` 通过
  - ModelScope 服务检测逻辑（`isModelScope`）保留，不受影响