### PR TITLE
chore(nx): 禁用 Nx 缓存功能

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -17,20 +17,20 @@
     "build": {
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
-      "cache": true
+      "cache": false
     },
     "test": {
       "inputs": ["default", "^production", "sharedGlobals"],
-      "cache": true
+      "cache": false
     },
     "lint": {
       "inputs": ["default", "{workspaceRoot}/biome.json"],
-      "cache": true
+      "cache": false
     },
     "type-check": {
       "dependsOn": ["^build"],
       "inputs": ["default", "^production"],
-      "cache": true
+      "cache": false
     }
   },
   "release": {


### PR DESCRIPTION
- 为什么改：开发过程中频繁遇到缓存问题，导致修改后未及时生效，影响开发效率
- 改了什么：将 nx.json 中所有任务（build、test、lint、type-check）的 cache 配置从 true 改为 false
- 影响范围：所有 Nx 执行的任务将不再使用缓存，每次都会重新执行；不影响生产构建和功能
- 验证方式：执行 pnpm build/test/lint 后检查 .nx/cache 目录不再增长，或删除该目录后不影响开发