### PR TITLE
feat(endpoint): 添加 MCP 服务后自动重连接入点

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -715,14 +715,16 @@ export class WebServer {
         try {
           // 获取当前连接的端点数量
           const connectionStatuses = this.endpointManager.getConnectionStatus();
-          const endpointCount = connectionStatuses.length;
+          const connectedEndpointCount = connectionStatuses.filter(
+            (status) => status.connected
+          ).length;
 
-          if (endpointCount === 0) {
+          if (connectedEndpointCount === 0) {
             this.logger.debug("当前没有已连接的端点，跳过重连");
             return;
           }
 
-          this.logger.info(`开始重连 ${endpointCount} 个接入点...`);
+          this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
 
           // 重连所有端点
           await this.endpointManager.reconnect();
@@ -733,8 +735,8 @@ export class WebServer {
           this.eventBus.emitEvent("endpoint:reconnect:completed", {
             trigger: "mcp_server_added",
             serverName: eventData.serverName,
-            endpointCount,
-            timestamp: new Date(),
+            endpointCount: connectedEndpointCount,
+            timestamp: Date.now(),
           });
         } catch (error) {
           this.logger.error("接入点重连失败:", error);
@@ -744,7 +746,7 @@ export class WebServer {
             trigger: "mcp_server_added",
             serverName: eventData.serverName,
             error: error instanceof Error ? error.message : String(error),
-            timestamp: new Date(),
+            timestamp: Date.now(),
           });
         }
       }
@@ -765,14 +767,16 @@ export class WebServer {
         try {
           // 获取当前连接的端点数量
           const connectionStatuses = this.endpointManager.getConnectionStatus();
-          const endpointCount = connectionStatuses.length;
+          const connectedEndpointCount = connectionStatuses.filter(
+            (status) => status.connected
+          ).length;
 
-          if (endpointCount === 0) {
+          if (connectedEndpointCount === 0) {
             this.logger.debug("当前没有已连接的端点，跳过重连");
             return;
           }
 
-          this.logger.info(`开始重连 ${endpointCount} 个接入点...`);
+          this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
 
           // 重连所有端点
           await this.endpointManager.reconnect();
@@ -783,8 +787,8 @@ export class WebServer {
           this.eventBus.emitEvent("endpoint:reconnect:completed", {
             trigger: "mcp_server_batch_added",
             serverName: undefined,
-            endpointCount,
-            timestamp: new Date(),
+            endpointCount: connectedEndpointCount,
+            timestamp: Date.now(),
           });
         } catch (error) {
           this.logger.error("接入点重连失败:", error);
@@ -794,7 +798,7 @@ export class WebServer {
             trigger: "mcp_server_batch_added",
             serverName: undefined,
             error: error instanceof Error ? error.message : String(error),
-            timestamp: new Date(),
+            timestamp: Date.now(),
           });
         }
       }

--- a/apps/backend/services/EventBus.ts
+++ b/apps/backend/services/EventBus.ts
@@ -36,13 +36,13 @@ export interface EventBusEvents {
     trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
     serverName?: string;
     endpointCount: number;
-    timestamp: Date;
+    timestamp: number;
   };
   "endpoint:reconnect:failed": {
     trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
     serverName?: string;
     error: string;
-    timestamp: Date;
+    timestamp: number;
   };
 
   // 服务相关事件


### PR DESCRIPTION
- 为什么改：通过 API 动态添加 MCP 服务后，小智平台无法感知新增的工具。原因是 WebSocket 连接在初始化时建立，工具列表在握手阶段发送，不重连则新服务工具无法同步
- 改了什么：
  1. 在 EventBus 中新增 `endpoint:reconnect:completed` 和 `endpoint:reconnect:failed` 事件类型
  2. 在 WebServer 中新增 `setupMCPServerAddedListener()` 方法，监听 `mcp:server:added` 和 `mcp:server:batch_added` 事件
  3. 当检测到服务添加时，自动调用 `endpointManager.reconnect()` 重连所有接入点
- 影响范围：
  - 新增事件类型：`endpoint:reconnect:completed`、`endpoint:reconnect:failed`
  - WebServer 构造函数新增事件监听器注册
  - 边界情况处理：无端点时跳过、重连失败记录错误但不影响服务添加
- 验证方式：
  1. 启动服务后通过 API 添加单个 MCP 服务，观察日志确认重连发生
  2. 通过 API 批量添加 MCP 服务，验证重连只触发一次
  3. 在无端点连接时添加服务，确认跳过重连并记录 debug 日志
  4. 已通过 TypeScript 类型检查和 Biome lint 验证