### PR TITLE
refactor(handlers): 统一 Handler 命名规范

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -7,8 +7,8 @@ import {
   ConfigApiHandler,
   CozeApiHandler,
   HeartbeatHandler,
+  MCPHandler,
   MCPRouteHandler,
-  MCPServerApiHandler,
   RealtimeNotificationHandler,
   ServiceApiHandler,
   StaticFileHandler,
@@ -117,7 +117,7 @@ export class WebServer {
   private versionApiHandler: VersionApiHandler;
   private staticFileHandler: StaticFileHandler;
   private mcpRouteHandler: MCPRouteHandler;
-  private mcpServerApiHandler?: MCPServerApiHandler;
+  private mcpHandler?: MCPHandler;
   private updateApiHandler: UpdateApiHandler;
   private cozeApiHandler: CozeApiHandler;
 
@@ -210,10 +210,7 @@ export class WebServer {
       const config = await this.loadConfiguration();
 
       // 2.1. 初始化 MCP 服务器 API 处理器
-      this.mcpServerApiHandler = new MCPServerApiHandler(
-        this.mcpServiceManager,
-        configManager
-      );
+      this.mcpHandler = new MCPHandler(this.mcpServiceManager, configManager);
 
       // 3. 从配置加载 MCP 服务
       await this.loadMCPServicesFromConfig(config.mcpServers);
@@ -549,7 +546,7 @@ export class WebServer {
       versionApiHandler: this.versionApiHandler,
       staticFileHandler: this.staticFileHandler,
       mcpRouteHandler: this.mcpRouteHandler,
-      mcpServerApiHandler: this.mcpServerApiHandler,
+      mcpHandler: this.mcpHandler,
       updateApiHandler: this.updateApiHandler,
       cozeApiHandler: this.cozeApiHandler,
       // endpointHandler 通过中间件动态注入，不在此初始化

--- a/apps/backend/handlers/__tests__/mcp.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp.handler.test.ts
@@ -7,10 +7,7 @@ import type { ConfigManager } from "@xiaozhi-client/config";
 import type { MCPServerConfig } from "@xiaozhi-client/config";
 import type { Context } from "hono";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import {
-  MCPServerApiHandler,
-  MCPServerConfigValidator,
-} from "../MCPServerApiHandler.js";
+import { MCPHandler, MCPServerConfigValidator } from "../mcp.handler.js";
 
 // 创建模拟对象
 const createMockConfigManager = (): Partial<ConfigManager> => ({
@@ -51,8 +48,8 @@ const testConfigDir = path.resolve(...testConfigDirParts);
 const getExpectedPath = (filename: string) =>
   path.join(testConfigDir, filename);
 
-describe("MCPServerApiHandler", () => {
-  let handler: MCPServerApiHandler;
+describe("MCPHandler", () => {
+  let handler: MCPHandler;
   let mockConfigManager: Partial<ConfigManager>;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockEventBus: Partial<EventBus>;
@@ -66,7 +63,7 @@ describe("MCPServerApiHandler", () => {
     mockEventBus = createMockEventBus();
 
     // 创建处理器实例
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );
@@ -74,14 +71,14 @@ describe("MCPServerApiHandler", () => {
 
   describe("构造函数和依赖注入", () => {
     it("应该正确创建处理器实例", () => {
-      expect(handler).toBeInstanceOf(MCPServerApiHandler);
+      expect(handler).toBeInstanceOf(MCPHandler);
       expect(handler).toBeDefined();
     });
 
     it("应该正确注入依赖", () => {
       // 通过测试处理器创建成功间接验证依赖注入成功
       expect(handler).toBeDefined();
-      expect(handler).toBeInstanceOf(MCPServerApiHandler);
+      expect(handler).toBeInstanceOf(MCPHandler);
     });
   });
 
@@ -135,7 +132,7 @@ describe("MCPServerApiHandler", () => {
 });
 
 describe("addMCPServer", () => {
-  let handler: MCPServerApiHandler;
+  let handler: MCPHandler;
   let mockConfigManager: Partial<ConfigManager>;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockEventBus: Partial<EventBus>;
@@ -157,7 +154,7 @@ describe("addMCPServer", () => {
 
     // mockConfigManager 和 mockMCPServiceManager 已经在 createMock 函数中配置了
 
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );
@@ -437,7 +434,7 @@ describe("addMCPServer", () => {
 });
 
 describe("removeMCPServer", () => {
-  let handler: MCPServerApiHandler;
+  let handler: MCPHandler;
   let mockConfigManager: Partial<ConfigManager>;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockEventBus: Partial<EventBus>;
@@ -450,7 +447,7 @@ describe("removeMCPServer", () => {
     mockMCPServiceManager = createMockMCPServiceManager();
     mockEventBus = createMockEventBus();
 
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );
@@ -844,7 +841,7 @@ describe("MCPServerConfigValidator", () => {
 
 // 测试 getMCPServerStatus 方法
 describe("getMCPServerStatus", () => {
-  let handler: MCPServerApiHandler;
+  let handler: MCPHandler;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockConfigManager: Partial<ConfigManager>;
   let mockContext: Partial<Context>;
@@ -852,7 +849,7 @@ describe("getMCPServerStatus", () => {
   beforeEach(() => {
     mockMCPServiceManager = createMockMCPServiceManager();
     mockConfigManager = createMockConfigManager();
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );
@@ -998,7 +995,7 @@ describe("getMCPServerStatus", () => {
 
 // 测试 listMCPServers 方法
 describe("listMCPServers", () => {
-  let handler: MCPServerApiHandler;
+  let handler: MCPHandler;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockConfigManager: Partial<ConfigManager>;
   let mockContext: Partial<Context>;
@@ -1006,7 +1003,7 @@ describe("listMCPServers", () => {
   beforeEach(() => {
     mockMCPServiceManager = createMockMCPServiceManager();
     mockConfigManager = createMockConfigManager();
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );
@@ -1313,7 +1310,7 @@ describe("TypeFieldNormalizer", () => {
 
 // 测试集成：验证 addMCPServer 中的 type 字段标准化
 describe("addMCPServer with type field normalization", () => {
-  let handler: MCPServerApiHandler;
+  let handler: MCPHandler;
   let mockConfigManager: Partial<ConfigManager>;
   let mockMCPServiceManager: Partial<MCPServiceManager>;
   let mockEventBus: Partial<EventBus>;
@@ -1326,7 +1323,7 @@ describe("addMCPServer with type field normalization", () => {
     mockMCPServiceManager = createMockMCPServiceManager();
     mockEventBus = createMockEventBus();
 
-    handler = new MCPServerApiHandler(
+    handler = new MCPHandler(
       mockMCPServiceManager as MCPServiceManager,
       mockConfigManager as ConfigManager
     );

--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -3,7 +3,7 @@ export * from "./CozeApiHandler.js";
 export * from "./HeartbeatHandler.js";
 export { EndpointHandler } from "./endpoint.handler.js";
 export * from "./MCPRouteHandler.js";
-export * from "./MCPServerApiHandler.js";
+export { MCPHandler } from "./mcp.handler.js";
 export * from "./RealtimeNotificationHandler.js";
 export * from "./ServiceApiHandler.js";
 export * from "./StaticFileHandler.js";

--- a/apps/backend/handlers/mcp.handler.ts
+++ b/apps/backend/handlers/mcp.handler.ts
@@ -23,9 +23,9 @@ interface MCPServiceManagerAccess {
 }
 
 /**
- * MCPServerApiHandler 扩展接口，用于动态状态缓存
+ * MCPHandler 扩展接口，用于动态状态缓存
  */
-interface MCPServerApiHandlerWithCache {
+interface MCPHandlerWithCache {
   statusCache?: Map<string, MCPServerStatus>;
 }
 
@@ -118,7 +118,7 @@ export interface ValidationResult {
 /**
  * MCP 服务 API 处理器
  */
-export class MCPServerApiHandler {
+export class MCPHandler {
   protected logger: Logger;
   private mcpServiceManager: MCPServiceManager;
   private configManager: ConfigManager;
@@ -508,7 +508,7 @@ export class MCPServerApiHandler {
   private getPreviousStatus(serverName: string): MCPServerStatus | null {
     // 这里使用一个简单的Map来缓存状态
     // 在实际生产环境中，可能需要更持久化的缓存方案
-    const handlerWithCache = this as MCPServerApiHandlerWithCache;
+    const handlerWithCache = this as MCPHandlerWithCache;
     if (!handlerWithCache.statusCache) {
       handlerWithCache.statusCache = new Map();
     }
@@ -519,7 +519,7 @@ export class MCPServerApiHandler {
    * 更新状态缓存
    */
   private updateStatusCache(serverName: string, status: MCPServerStatus): void {
-    const handlerWithCache = this as MCPServerApiHandlerWithCache;
+    const handlerWithCache = this as MCPHandlerWithCache;
     if (!handlerWithCache.statusCache) {
       handlerWithCache.statusCache = new Map();
     }

--- a/apps/backend/routes/domains/mcpserver.route.ts
+++ b/apps/backend/routes/domains/mcpserver.route.ts
@@ -13,11 +13,11 @@ import type { HandlerDependencies, RouteDefinition } from "../types.js";
 const withMCPServerHandler = async (
   c: Context,
   handlerFn: (
-    handler: NonNullable<HandlerDependencies["mcpServerApiHandler"]>
+    handler: NonNullable<HandlerDependencies["mcpHandler"]>
   ) => Promise<Response>
 ): Promise<Response> => {
   const dependencies = c.get("dependencies") as HandlerDependencies;
-  const handler = dependencies.mcpServerApiHandler;
+  const handler = dependencies.mcpHandler;
 
   if (!handler) {
     return c.json({ error: "MCP Server API Handler not initialized" }, 503);

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -7,8 +7,8 @@ import type {
   ConfigApiHandler,
   CozeApiHandler,
   EndpointHandler,
+  MCPHandler,
   MCPRouteHandler,
-  MCPServerApiHandler,
   ServiceApiHandler,
   StaticFileHandler,
   StatusApiHandler,
@@ -41,7 +41,7 @@ export interface HandlerDependencies {
   /** MCP 路由处理器 */
   mcpRouteHandler: MCPRouteHandler;
   /** MCP 服务器管理处理器（可选） */
-  mcpServerApiHandler?: MCPServerApiHandler;
+  mcpHandler?: MCPHandler;
   /** 更新管理处理器 */
   updateApiHandler: UpdateApiHandler;
   /** 扣子 API 处理器 */


### PR DESCRIPTION
- 为什么改：当前 handlers 目录命名风格不统一（MCPServerApiHandler vs EndpointHandler），影响代码可读性和一致性。参考 endpoint.handler.ts 的简洁命名风格，统一所有 Handler 的命名规范。
- 改了什么：
  - 文件重命名：MCPServerApiHandler.ts → mcp.handler.ts
  - 类名重构：MCPServerApiHandler → MCPHandler
  - 接口重构：MCPServerApiHandlerWithCache → MCPHandlerWithCache
  - 属性重构：mcpServerApiHandler → mcpHandler
  - 导出优化：从通配符导出改为具名导出，提高可读性
- 影响范围：
  - 核心模块：WebServer.ts、handlers/index.ts
  - 路由系统：routes/types.ts、routes/domains/mcpserver.route.ts
  - 测试文件：handlers/__tests__/mcp.handler.test.ts
  - API 接口保持不变，不影响前端调用
- 验证方式：
  - 类型检查通过：pnpm check:type
  - 代码规范通过：pnpm lint:fix
  - 单元测试通过：所有测试用例正常运行