### PR TITLE
refactor(handlers): 重命名 ToolApiHandler 为 MCPToolHandler

### DIFF
--- a/apps/backend/WebServer.test.ts
+++ b/apps/backend/WebServer.test.ts
@@ -357,8 +357,8 @@ vi.mock("./handlers/VersionApiHandler", () => {
   };
 });
 
-vi.mock("./handlers/ToolApiHandler", () => {
-  const mockToolApiHandler = {
+vi.mock("./handlers/mcp-tool.handler", () => {
+  const mockMCPToolHandler = {
     callTool: vi.fn((c) =>
       c.json({
         success: true,
@@ -400,7 +400,7 @@ vi.mock("./handlers/ToolApiHandler", () => {
     ),
   };
   return {
-    ToolApiHandler: vi.fn(() => mockToolApiHandler),
+    MCPToolHandler: vi.fn(() => mockMCPToolHandler),
   };
 });
 

--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -9,11 +9,11 @@ import {
   HeartbeatHandler,
   MCPHandler,
   MCPRouteHandler,
+  MCPToolHandler,
   RealtimeNotificationHandler,
   ServiceApiHandler,
   StaticFileHandler,
   StatusApiHandler,
-  ToolApiHandler,
   ToolCallLogApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
@@ -112,7 +112,7 @@ export class WebServer {
   private configApiHandler: ConfigApiHandler;
   private statusApiHandler: StatusApiHandler;
   private serviceApiHandler: ServiceApiHandler;
-  private toolApiHandler: ToolApiHandler;
+  private mcpToolHandler: MCPToolHandler;
   private toolCallLogApiHandler: ToolCallLogApiHandler;
   private versionApiHandler: VersionApiHandler;
   private staticFileHandler: StaticFileHandler;
@@ -156,7 +156,7 @@ export class WebServer {
     this.configApiHandler = new ConfigApiHandler();
     this.statusApiHandler = new StatusApiHandler(this.statusService);
     this.serviceApiHandler = new ServiceApiHandler(this.statusService);
-    this.toolApiHandler = new ToolApiHandler();
+    this.mcpToolHandler = new MCPToolHandler();
     this.toolCallLogApiHandler = new ToolCallLogApiHandler();
     this.versionApiHandler = new VersionApiHandler();
     this.staticFileHandler = new StaticFileHandler();
@@ -541,7 +541,7 @@ export class WebServer {
       configApiHandler: this.configApiHandler,
       statusApiHandler: this.statusApiHandler,
       serviceApiHandler: this.serviceApiHandler,
-      toolApiHandler: this.toolApiHandler,
+      mcpToolHandler: this.mcpToolHandler,
       toolCallLogApiHandler: this.toolCallLogApiHandler,
       versionApiHandler: this.versionApiHandler,
       staticFileHandler: this.staticFileHandler,

--- a/apps/backend/handlers/MCPToolHandler.integration.test.ts
+++ b/apps/backend/handlers/MCPToolHandler.integration.test.ts
@@ -9,7 +9,7 @@ import {
   it,
   vi,
 } from "vitest";
-import { ToolApiHandler } from "./ToolApiHandler.js";
+import { MCPToolHandler } from "./mcp-tool.handler.js";
 
 // Mock dependencies
 vi.mock("../Logger.js", () => ({
@@ -21,8 +21,8 @@ vi.mock("../Logger.js", () => ({
   },
 }));
 
-describe("ToolApiHandler - 集成测试", () => {
-  let toolApiHandler: ToolApiHandler;
+describe("MCPToolHandler - 集成测试", () => {
+  let mcpToolHandler: MCPToolHandler;
   let mockContext: any;
   let mockServiceManager: any;
   let originalConfig: any;
@@ -41,7 +41,7 @@ describe("ToolApiHandler - 集成测试", () => {
   });
 
   beforeEach(() => {
-    toolApiHandler = new ToolApiHandler();
+    mcpToolHandler = new MCPToolHandler();
 
     // 初始化 Mock ServiceManager
     mockServiceManager = {
@@ -168,7 +168,7 @@ describe("ToolApiHandler - 集成测试", () => {
       });
 
       // Act
-      await toolApiHandler.callTool(mockContext);
+      await mcpToolHandler.callTool(mockContext);
 
       // Assert
       expect(mockServiceManager.callTool).toHaveBeenCalledWith(
@@ -232,7 +232,7 @@ describe("ToolApiHandler - 集成测试", () => {
       });
 
       // Act
-      await toolApiHandler.callTool(mockContext);
+      await mcpToolHandler.callTool(mockContext);
 
       // Assert
       expect(mockServiceManager.callTool).toHaveBeenCalledWith(
@@ -295,7 +295,7 @@ describe("ToolApiHandler - 集成测试", () => {
       });
 
       // Act
-      await toolApiHandler.callTool(mockContext);
+      await mcpToolHandler.callTool(mockContext);
 
       // Assert
       expect(mockServiceManager.callTool).toHaveBeenCalledWith(
@@ -375,7 +375,7 @@ describe("ToolApiHandler - 集成测试", () => {
       mockServiceManager.getCustomMCPTools.mockReturnValue([complexToolConfig]);
 
       // Act
-      await toolApiHandler.callTool(mockContext);
+      await mcpToolHandler.callTool(mockContext);
 
       // Assert
       expect(mockContext.fail).toHaveBeenCalledWith(
@@ -449,7 +449,7 @@ describe("ToolApiHandler - 集成测试", () => {
       });
 
       // Act
-      await toolApiHandler.callTool(mockContext);
+      await mcpToolHandler.callTool(mockContext);
 
       // Assert
       expect(mockServiceManager.callTool).toHaveBeenCalledWith(
@@ -500,7 +500,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: mockWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
         expect.objectContaining({
@@ -534,7 +534,7 @@ describe("ToolApiHandler - 集成测试", () => {
         },
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "INVALID_REQUEST",
@@ -549,7 +549,7 @@ describe("ToolApiHandler - 集成测试", () => {
     it("应该在工具名称为空时返回错误", async () => {
       mockContext.req.param = vi.fn().mockReturnValue("");
 
-      const response = await toolApiHandler.removeCustomTool(mockContext);
+      const response = await mcpToolHandler.removeCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "INVALID_REQUEST",
@@ -570,7 +570,7 @@ describe("ToolApiHandler - 集成测试", () => {
         throw new Error('工具 "non_existent_tool" 不存在');
       });
 
-      const response = await toolApiHandler.removeCustomTool(mockContext);
+      const response = await mcpToolHandler.removeCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "TOOL_NOT_FOUND",
@@ -601,7 +601,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: incompleteWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "INVALID_REQUEST",
@@ -627,7 +627,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: invalidWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "VALIDATION_ERROR",
@@ -656,7 +656,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: mockWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIGURATION_ERROR",
@@ -688,7 +688,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: incompleteWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "VALIDATION_ERROR",
@@ -714,7 +714,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: invalidWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "VALIDATION_ERROR",
@@ -740,7 +740,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: longNameWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "VALIDATION_ERROR",
@@ -766,7 +766,7 @@ describe("ToolApiHandler - 集成测试", () => {
         workflow: invalidTimeWorkflow,
       });
 
-      const response = await toolApiHandler.addCustomTool(mockContext);
+      const response = await mcpToolHandler.addCustomTool(mockContext);
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "VALIDATION_ERROR",

--- a/apps/backend/handlers/__tests__/MCPToolHandler.core.test.ts
+++ b/apps/backend/handlers/__tests__/MCPToolHandler.core.test.ts
@@ -1,5 +1,5 @@
 /**
- * ToolApiHandler 核心功能测试
+ * MCPToolHandler 核心功能测试
  * 测试核心业务逻辑和边界条件处理
  */
 
@@ -7,7 +7,7 @@ import { ToolType } from "@root/types/toolApi.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ToolApiHandler } from "../ToolApiHandler.js";
+import { MCPToolHandler } from "../mcp-tool.handler.js";
 
 // Mock configManager
 vi.mock("@xiaozhi-client/config", () => ({
@@ -50,12 +50,12 @@ vi.mock("@/lib/mcp", () => ({
   })) as any,
 }));
 
-describe("ToolApiHandler - 核心功能测试", () => {
-  let handler: ToolApiHandler;
+describe("MCPToolHandler - 核心功能测试", () => {
+  let handler: MCPToolHandler;
   let mockContext: Partial<Context>;
 
   beforeEach(() => {
-    handler = new ToolApiHandler();
+    handler = new MCPToolHandler();
     mockContext = {
       req: {
         json: vi.fn(),

--- a/apps/backend/handlers/__tests__/MCPToolHandler.parameterConfig.test.ts
+++ b/apps/backend/handlers/__tests__/MCPToolHandler.parameterConfig.test.ts
@@ -1,5 +1,5 @@
 /**
- * ToolApiHandler 参数配置功能测试
+ * MCPToolHandler 参数配置功能测试
  * 测试第二阶段新增的参数配置功能
  */
 
@@ -10,7 +10,7 @@ import type {
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { ToolApiHandler } from "../ToolApiHandler.js";
+import { MCPToolHandler } from "../mcp-tool.handler.js";
 
 // Mock configManager
 vi.mock("@xiaozhi-client/config", () => ({
@@ -22,8 +22,8 @@ vi.mock("@xiaozhi-client/config", () => ({
   },
 }));
 
-describe("ToolApiHandler - 参数配置功能", () => {
-  let handler: ToolApiHandler;
+describe("MCPToolHandler - 参数配置功能", () => {
+  let handler: MCPToolHandler;
   let mockContext: Partial<Context>;
 
   // 测试用的工作流数据
@@ -66,7 +66,7 @@ describe("ToolApiHandler - 参数配置功能", () => {
   };
 
   beforeEach(() => {
-    handler = new ToolApiHandler();
+    handler = new MCPToolHandler();
     mockContext = {
       req: {
         json: vi.fn(),

--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -8,7 +8,7 @@ export * from "./RealtimeNotificationHandler.js";
 export * from "./ServiceApiHandler.js";
 export * from "./StaticFileHandler.js";
 export * from "./StatusApiHandler.js";
-export * from "./ToolApiHandler.js";
+export * from "./mcp-tool.handler.js";
 export * from "./ToolCallLogApiHandler.js";
 export * from "./UpdateApiHandler.js";
 export * from "./VersionApiHandler.js";

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -1,5 +1,5 @@
 /**
- * 工具调用 API 处理器
+ * MCP 工具调用 API 处理器
  * 处理通过 HTTP API 调用 MCP 工具的请求
  */
 
@@ -50,9 +50,9 @@ interface LegacyAddCustomToolRequest {
 }
 
 /**
- * 工具调用 API 处理器
+ * MCP 工具调用 API 处理器
  */
-export class ToolApiHandler {
+export class MCPToolHandler {
   private logger: Logger;
   private ajv: Ajv;
 

--- a/apps/backend/routes/domains/tools.route.ts
+++ b/apps/backend/routes/domains/tools.route.ts
@@ -6,7 +6,7 @@
 import type { RouteDefinition } from "../types.js";
 import { createHandler } from "../types.js";
 
-const h = createHandler("toolApiHandler");
+const h = createHandler("mcpToolHandler");
 
 /**
  * 工具调用路由定义

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -9,10 +9,10 @@ import type {
   EndpointHandler,
   MCPHandler,
   MCPRouteHandler,
+  MCPToolHandler,
   ServiceApiHandler,
   StaticFileHandler,
   StatusApiHandler,
-  ToolApiHandler,
   ToolCallLogApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
@@ -30,8 +30,8 @@ export interface HandlerDependencies {
   statusApiHandler: StatusApiHandler;
   /** 服务管理处理器 */
   serviceApiHandler: ServiceApiHandler;
-  /** 工具调用处理器 */
-  toolApiHandler: ToolApiHandler;
+  /** MCP 工具处理器 */
+  mcpToolHandler: MCPToolHandler;
   /** 工具调用日志处理器 */
   toolCallLogApiHandler: ToolCallLogApiHandler;
   /** 版本信息处理器 */


### PR DESCRIPTION
- 为什么改：统一 Handler 命名规范，提升代码可读性和一致性
- 改了什么：
  - 将 `ToolApiHandler` 类重命名为 `MCPToolHandler`
  - 将 `ToolApiHandler.ts` 文件重命名为 `mcp-tool.handler.ts`
  - 更新所有引用处的导入语句和类型定义
  - 更新 `handlers/index.ts` 导出
  - 更新 `routes/types.ts` 中的 HandlerDependencies 接口
  - 更新 `routes/domains/tools.route.ts` 中的处理器引用
  - 更新 `WebServer.ts` 和 `WebServer.test.ts` 中的实例化和依赖注入
  - 同步重命名所有测试文件
- 影响范围：
  - 代码行为无变化，纯重命名重构
  - API 端点路径和行为保持不变
  - 与其他 Handler 命名规范保持一致（如 MCPHandler、MCPRouteHandler 等）
- 验证方式：
  - 所有单元测试和集成测试已同步更新
  - TypeScript 类型检查通过
  - 功能回归测试验证 API 行为一致性