### PR TITLE
refactor(handlers): 重命名 ToolCallLogApiHandler 为 MCPToolLogHandler

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -10,11 +10,11 @@ import {
   MCPHandler,
   MCPRouteHandler,
   MCPToolHandler,
+  MCPToolLogHandler,
   RealtimeNotificationHandler,
   ServiceApiHandler,
   StaticFileHandler,
   StatusApiHandler,
-  ToolCallLogApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
 } from "@handlers/index.js";
@@ -113,7 +113,7 @@ export class WebServer {
   private statusApiHandler: StatusApiHandler;
   private serviceApiHandler: ServiceApiHandler;
   private mcpToolHandler: MCPToolHandler;
-  private toolCallLogApiHandler: ToolCallLogApiHandler;
+  private mcpToolLogHandler: MCPToolLogHandler;
   private versionApiHandler: VersionApiHandler;
   private staticFileHandler: StaticFileHandler;
   private mcpRouteHandler: MCPRouteHandler;
@@ -157,7 +157,7 @@ export class WebServer {
     this.statusApiHandler = new StatusApiHandler(this.statusService);
     this.serviceApiHandler = new ServiceApiHandler(this.statusService);
     this.mcpToolHandler = new MCPToolHandler();
-    this.toolCallLogApiHandler = new ToolCallLogApiHandler();
+    this.mcpToolLogHandler = new MCPToolLogHandler();
     this.versionApiHandler = new VersionApiHandler();
     this.staticFileHandler = new StaticFileHandler();
     this.mcpRouteHandler = new MCPRouteHandler();
@@ -542,7 +542,7 @@ export class WebServer {
       statusApiHandler: this.statusApiHandler,
       serviceApiHandler: this.serviceApiHandler,
       mcpToolHandler: this.mcpToolHandler,
-      toolCallLogApiHandler: this.toolCallLogApiHandler,
+      mcpToolLogHandler: this.mcpToolLogHandler,
       versionApiHandler: this.versionApiHandler,
       staticFileHandler: this.staticFileHandler,
       mcpRouteHandler: this.mcpRouteHandler,

--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -9,6 +9,6 @@ export * from "./ServiceApiHandler.js";
 export * from "./StaticFileHandler.js";
 export * from "./StatusApiHandler.js";
 export * from "./mcp-tool.handler.js";
-export * from "./ToolCallLogApiHandler.js";
+export * from "./mcp-tool-log.handler.js";
 export * from "./UpdateApiHandler.js";
 export * from "./VersionApiHandler.js";

--- a/apps/backend/handlers/mcp-tool-log.handler.simple.test.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.simple.test.ts
@@ -5,17 +5,17 @@
 
 import { PAGINATION_CONSTANTS } from "@constants/ApiConstants.js";
 import { describe, expect, it } from "vitest";
-import { ToolCallLogApiHandler } from "./ToolCallLogApiHandler.js";
+import { MCPToolLogHandler } from "./mcp-tool-log.handler.js";
 
-describe("ToolCallLogApiHandler - 基本功能测试", () => {
+describe("MCPToolLogHandler - 基本功能测试", () => {
   it("应该能够创建处理器实例", () => {
-    const handler = new ToolCallLogApiHandler();
+    const handler = new MCPToolLogHandler();
     expect(handler).toBeDefined();
-    expect(handler).toBeInstanceOf(ToolCallLogApiHandler);
+    expect(handler).toBeInstanceOf(MCPToolLogHandler);
   });
 
   it("应该能够解析和验证查询参数", () => {
-    const handler = new ToolCallLogApiHandler();
+    const handler = new MCPToolLogHandler();
     const parseAndValidateQueryParams = (
       handler as any
     ).parseAndValidateQueryParams.bind(handler);

--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -81,7 +81,7 @@ const ToolCallQuerySchema = z
 /**
  * 工具调用日志 API 处理器
  */
-export class ToolCallLogApiHandler {
+export class MCPToolLogHandler {
   private toolCallLogService: ToolCallLogService;
 
   constructor() {

--- a/apps/backend/routes/domains/tool-logs.route.ts
+++ b/apps/backend/routes/domains/tool-logs.route.ts
@@ -6,7 +6,7 @@
 import type { RouteDefinition } from "../types.js";
 import { createHandler } from "../types.js";
 
-const h = createHandler("toolCallLogApiHandler");
+const h = createHandler("mcpToolLogHandler");
 
 export const toolLogsRoutes: RouteDefinition[] = [
   {

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -10,10 +10,10 @@ import type {
   MCPHandler,
   MCPRouteHandler,
   MCPToolHandler,
+  MCPToolLogHandler,
   ServiceApiHandler,
   StaticFileHandler,
   StatusApiHandler,
-  ToolCallLogApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
 } from "@handlers/index.js";
@@ -33,7 +33,7 @@ export interface HandlerDependencies {
   /** MCP 工具处理器 */
   mcpToolHandler: MCPToolHandler;
   /** 工具调用日志处理器 */
-  toolCallLogApiHandler: ToolCallLogApiHandler;
+  mcpToolLogHandler: MCPToolLogHandler;
   /** 版本信息处理器 */
   versionApiHandler: VersionApiHandler;
   /** 静态文件处理器 */


### PR DESCRIPTION
- 为什么改：统一 MCP handler 命名规范，采用 `mcp-*` 前缀 + `.handler.ts` 后缀格式，提升代码可维护性
- 改了什么：
  - 重命名文件：`ToolCallLogApiHandler.ts` → `mcp-tool-log.handler.ts`
  - 重命名类：`ToolCallLogApiHandler` → `MCPToolLogHandler`
  - 更新所有引用：`handlers/index.ts`、`routes/types.ts`、`WebServer.ts`、`tool-logs.route.ts`
  - 同步更新测试文件导入和类名引用
- 影响范围：
  - 删除 2 个旧文件（~226 行）
  - 新增 2 个新文件（功能等价）
  - 修改 4 个引用文件
  - API 接口 `/api/tool-calls/logs` 行为不变，对外完全兼容
- 验证方式：
  - TypeScript 类型检查通过
  - 49 个测试文件、936 个测试用例全部通过
  - Biome 代码风格检查通过（138 个文件）