### PR TITLE
test(handlers): 将 MCPToolLogHandler 测试迁移至 __tests__ 目录

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
@@ -5,7 +5,7 @@
 
 import { PAGINATION_CONSTANTS } from "@constants/ApiConstants.js";
 import { describe, expect, it } from "vitest";
-import { MCPToolLogHandler } from "./mcp-tool-log.handler.js";
+import { MCPToolLogHandler } from "../mcp-tool-log.handler.js";
 
 describe("MCPToolLogHandler - 基本功能测试", () => {
   it("应该能够创建处理器实例", () => {


### PR DESCRIPTION
- 为什么改：遵循项目测试规范（CLAUDE.md 规定测试文件应位于源文件旁的 __tests__ 目录），当前测试文件位置不一致
- 改了什么：
  - 将 `handlers/mcp-tool-log.handler.simple.test.ts` 移动到 `handlers/__tests__/mcp-tool-log.handler.test.ts`
  - 更新导入路径：`./mcp-tool-log.handler.js` → `../mcp-tool-log.handler.js`
  - 简化文件名，移除 `.simple` 后缀
- 影响范围：仅测试文件位置变更，不影响业务逻辑；测试从 handlers 根目录迁移到 __tests__ 子目录
- 验证方式：运行 `pnpm test mcp-tool-log.handler.test.ts`，2个测试用例全部通过