### PR TITLE
refactor(handlers): 重命名 CozeApiHandler 为 CozeHandler

### DIFF
--- a/apps/backend/WebServer.test.ts
+++ b/apps/backend/WebServer.test.ts
@@ -404,8 +404,8 @@ vi.mock("./handlers/mcp-tool.handler", () => {
   };
 });
 
-vi.mock("./handlers/CozeApiHandler", () => {
-  const mockCozeApiHandler = {
+vi.mock("./handlers/coze.handler", () => {
+  const mockCozeHandler = {
     getWorkspaces: vi.fn((c) =>
       c.json({
         success: true,
@@ -432,7 +432,7 @@ vi.mock("./handlers/CozeApiHandler", () => {
     ),
   };
   return {
-    CozeApiHandler: vi.fn(() => mockCozeApiHandler),
+    CozeHandler: vi.fn(() => mockCozeHandler),
   };
 });
 

--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -5,7 +5,7 @@ import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
 import {
   ConfigApiHandler,
-  CozeApiHandler,
+  CozeHandler,
   HeartbeatHandler,
   MCPHandler,
   MCPRouteHandler,
@@ -119,7 +119,7 @@ export class WebServer {
   private mcpRouteHandler: MCPRouteHandler;
   private mcpHandler?: MCPHandler;
   private updateApiHandler: UpdateApiHandler;
-  private cozeApiHandler: CozeApiHandler;
+  private cozeHandler: CozeHandler;
 
   // WebSocket 处理器
   private realtimeNotificationHandler: RealtimeNotificationHandler;
@@ -162,7 +162,7 @@ export class WebServer {
     this.staticFileHandler = new StaticFileHandler();
     this.mcpRouteHandler = new MCPRouteHandler();
     this.updateApiHandler = new UpdateApiHandler();
-    this.cozeApiHandler = new CozeApiHandler();
+    this.cozeHandler = new CozeHandler();
 
     // MCPServerApiHandler 将在 start() 方法中初始化，因为它需要 mcpServiceManager
 
@@ -548,7 +548,7 @@ export class WebServer {
       mcpRouteHandler: this.mcpRouteHandler,
       mcpHandler: this.mcpHandler,
       updateApiHandler: this.updateApiHandler,
-      cozeApiHandler: this.cozeApiHandler,
+      cozeHandler: this.cozeHandler,
       // endpointHandler 通过中间件动态注入，不在此初始化
     };
   }

--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -67,7 +67,7 @@ function getCozeApiService(): CozeApiService {
 /**
  * 扣子 API 路由处理器类
  */
-export class CozeApiHandler {
+export class CozeHandler {
   /**
    * 获取工作空间列表
    * GET /api/coze/workspaces

--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -1,5 +1,5 @@
 export * from "./ConfigApiHandler.js";
-export * from "./CozeApiHandler.js";
+export { CozeHandler } from "./coze.handler.js";
 export * from "./HeartbeatHandler.js";
 export { EndpointHandler } from "./endpoint.handler.js";
 export * from "./mcp.handler.js";

--- a/apps/backend/routes/domains/coze.route.ts
+++ b/apps/backend/routes/domains/coze.route.ts
@@ -6,7 +6,7 @@
 import type { RouteDefinition } from "../types.js";
 import { createHandler } from "../types.js";
 
-const h = createHandler("cozeApiHandler");
+const h = createHandler("cozeHandler");
 
 export const cozeRoutes: RouteDefinition[] = [
   {

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -5,7 +5,7 @@
 
 import type {
   ConfigApiHandler,
-  CozeApiHandler,
+  CozeHandler,
   EndpointHandler,
   MCPHandler,
   MCPRouteHandler,
@@ -45,7 +45,7 @@ export interface HandlerDependencies {
   /** 更新管理处理器 */
   updateApiHandler: UpdateApiHandler;
   /** 扣子 API 处理器 */
-  cozeApiHandler: CozeApiHandler;
+  cozeHandler: CozeHandler;
   /** 小智接入点处理器（通过中间件动态注入） */
   endpointHandler?: EndpointHandler;
 }


### PR DESCRIPTION
- 为什么改：持续统一项目 handler 命名规范，与已完成的 PR #614（StaticFileHandler → static-file.handler）和 PR
- 改了什么：
  - 文件重命名：CozeApiHandler.ts → coze.handler.ts
  - 类名简化：CozeApiHandler → CozeHandler（去掉冗余的 Api 后缀）
  - 统一导出方式：handlers/index.ts 从通配符导出改为具名导出
  - 更新所有引用：WebServer.ts、routes/types.ts、coze.route.ts、WebServer.test.ts
- 影响范围：
  - 核心变更：handlers 层命名规范统一
  - 路由系统：依赖注入键名从 cozeApiHandler 改为 cozeHandler
  - 测试文件：mock 路径和变量名同步更新
  - 向后兼容：API 接口和功能行为完全不变
- 验证方式：
  - 类型检查通过（pnpm check:type）
  - 代码风格检查通过（pnpm lint）
  - 全部 567 个测试用例通过
  - 构建成功（pnpm build）