### PR TITLE
refactor(handlers): 重命名 AbstractApiHandler 为 BaseHandler

### DIFF
--- a/apps/backend/handlers/ConfigApiHandler.ts
+++ b/apps/backend/handlers/ConfigApiHandler.ts
@@ -5,12 +5,12 @@ import {
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
-import { AbstractApiHandler } from "./AbstractApiHandler.js";
+import { BaseHandler } from "./base.handler.js";
 
 /**
  * 配置 API 处理器
  */
-export class ConfigApiHandler extends AbstractApiHandler {
+export class ConfigApiHandler extends BaseHandler {
   constructor() {
     super();
   }

--- a/apps/backend/handlers/StatusApiHandler.ts
+++ b/apps/backend/handlers/StatusApiHandler.ts
@@ -1,11 +1,11 @@
 import type { StatusService } from "@services/StatusService.js";
 import type { Context } from "hono";
-import { AbstractApiHandler } from "./AbstractApiHandler.js";
+import { BaseHandler } from "./base.handler.js";
 
 /**
  * 状态 API 处理器
  */
-export class StatusApiHandler extends AbstractApiHandler {
+export class StatusApiHandler extends BaseHandler {
   private statusService: StatusService;
 
   constructor(statusService: StatusService) {

--- a/apps/backend/handlers/UpdateApiHandler.ts
+++ b/apps/backend/handlers/UpdateApiHandler.ts
@@ -2,7 +2,7 @@ import { NPMManager } from "@/lib/npm";
 import { getEventBus } from "@services/EventBus.js";
 import type { Context } from "hono";
 import { z } from "zod";
-import { AbstractApiHandler } from "./AbstractApiHandler.js";
+import { BaseHandler } from "./base.handler.js";
 
 // 版本号请求格式验证
 const UpdateRequestSchema = z.object({
@@ -12,7 +12,7 @@ const UpdateRequestSchema = z.object({
 /**
  * 更新 API 处理器
  */
-export class UpdateApiHandler extends AbstractApiHandler {
+export class UpdateApiHandler extends BaseHandler {
   private npmManager: NPMManager;
   private eventBus = getEventBus();
   private activeInstalls: Map<string, boolean> = new Map();

--- a/apps/backend/handlers/VersionApiHandler.ts
+++ b/apps/backend/handlers/VersionApiHandler.ts
@@ -1,12 +1,12 @@
 import { NPMManager } from "@/lib/npm";
 import { VersionUtils } from "@utils/VersionUtils.js";
 import type { Context } from "hono";
-import { AbstractApiHandler } from "./AbstractApiHandler.js";
+import { BaseHandler } from "./base.handler.js";
 
 /**
  * 版本 API 处理器
  */
-export class VersionApiHandler extends AbstractApiHandler {
+export class VersionApiHandler extends BaseHandler {
   /**
    * 获取版本信息
    * GET /api/version

--- a/apps/backend/handlers/base.handler.ts
+++ b/apps/backend/handlers/base.handler.ts
@@ -5,7 +5,7 @@ import type { Context } from "hono";
  * 抽象 API Handler 基类
  * 提供统一的 Logger 获取方法和便捷的响应方法
  */
-export abstract class AbstractApiHandler {
+export abstract class BaseHandler {
   /**
    * 从 context 获取 logger 实例
    * @param c - Hono context


### PR DESCRIPTION
- 为什么改：统一 handler 命名规范，将 PascalCase 类名的基类文件改为 kebab-case 风格，与项目中其他 handler 文件（如 coze.handler.ts、endpoint.handler.ts）保持命名一致性
- 改了什么：
  - 文件重命名：AbstractApiHandler.ts → base.handler.ts
  - 类名重命名：AbstractApiHandler → BaseHandler
  - 更新 4 个子类的 import 和 extends 语句（StatusApiHandler、UpdateApiHandler、ConfigApiHandler、VersionApiHandler）
- 影响范围：仅影响 handlers 模块内部，不涉及对外 API 和功能逻辑，完全向后兼容
- 验证方式：
  - 类型检查通过（pnpm check:type）
  - Lint 检查通过（pnpm lint）
  - 567 个单元测试全部通过（pnpm test）