### PR TITLE
refactor(handlers): 重构 ConfigApiHandler 使用响应增强中间件

### DIFF
--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -1,7 +1,3 @@
-import {
-  createErrorResponse,
-  createSuccessResponse,
-} from "@middlewares/index.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
@@ -25,14 +21,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取配置请求");
       const config = configManager.getConfig();
       logger.info("获取配置成功");
-      return c.json(createSuccessResponse(config));
+      return c.success(config);
     } catch (error) {
       logger.error("获取配置失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONFIG_READ_ERROR",
-        error instanceof Error ? error.message : "获取配置失败"
+        error instanceof Error ? error.message : "获取配置失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -70,14 +67,13 @@ export class ConfigApiHandler extends BaseHandler {
       }
 
       logger.info("配置更新成功");
-      return c.json(createSuccessResponse(null, "配置更新成功"));
+      return c.success(undefined, "配置更新成功");
     } catch (error) {
       logger.error("配置更新失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONFIG_UPDATE_ERROR",
         error instanceof Error ? error.message : "配置更新失败"
       );
-      return c.json(errorResponse, 400);
     }
   }
 
@@ -91,14 +87,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取 MCP 端点请求");
       const endpoint = configManager.getMcpEndpoint();
       logger.debug("获取 MCP 端点成功");
-      return c.json(createSuccessResponse({ endpoint }));
+      return c.success({ endpoint });
     } catch (error) {
       logger.error("获取 MCP 端点失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "MCP_ENDPOINT_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 端点失败"
+        error instanceof Error ? error.message : "获取 MCP 端点失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -112,14 +109,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取 MCP 端点列表请求");
       const endpoints = configManager.getMcpEndpoints();
       logger.debug("获取 MCP 端点列表成功");
-      return c.json(createSuccessResponse({ endpoints }));
+      return c.success({ endpoints });
     } catch (error) {
       logger.error("获取 MCP 端点列表失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "MCP_ENDPOINTS_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 端点列表失败"
+        error instanceof Error ? error.message : "获取 MCP 端点列表失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -133,14 +131,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取 MCP 服务配置请求");
       const servers = configManager.getMcpServers();
       logger.debug("获取 MCP 服务配置成功");
-      return c.json(createSuccessResponse({ servers }));
+      return c.success({ servers });
     } catch (error) {
       logger.error("获取 MCP 服务配置失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "MCP_SERVERS_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 服务配置失败"
+        error instanceof Error ? error.message : "获取 MCP 服务配置失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -154,14 +153,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取连接配置请求");
       const connection = configManager.getConnectionConfig();
       logger.debug("获取连接配置成功");
-      return c.json(createSuccessResponse({ connection }));
+      return c.success({ connection });
     } catch (error) {
       logger.error("获取连接配置失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONNECTION_CONFIG_READ_ERROR",
-        error instanceof Error ? error.message : "获取连接配置失败"
+        error instanceof Error ? error.message : "获取连接配置失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -176,14 +176,15 @@ export class ConfigApiHandler extends BaseHandler {
       configManager.reloadConfig();
       const config = configManager.getConfig();
       logger.info("重新加载配置成功");
-      return c.json(createSuccessResponse(config, "配置重新加载成功"));
+      return c.success(config, "配置重新加载成功");
     } catch (error) {
       logger.error("重新加载配置失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONFIG_RELOAD_ERROR",
-        error instanceof Error ? error.message : "重新加载配置失败"
+        error instanceof Error ? error.message : "重新加载配置失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -197,14 +198,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理获取配置文件路径请求");
       const path = configManager.getConfigPath();
       logger.debug("获取配置文件路径成功");
-      return c.json(createSuccessResponse({ path }));
+      return c.success({ path });
     } catch (error) {
       logger.error("获取配置文件路径失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONFIG_PATH_READ_ERROR",
-        error instanceof Error ? error.message : "获取配置文件路径失败"
+        error instanceof Error ? error.message : "获取配置文件路径失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 
@@ -218,14 +220,15 @@ export class ConfigApiHandler extends BaseHandler {
       logger.debug("处理检查配置是否存在请求");
       const exists = configManager.configExists();
       logger.debug(`配置存在检查结果: ${exists}`);
-      return c.json(createSuccessResponse({ exists }));
+      return c.success({ exists });
     } catch (error) {
       logger.error("检查配置是否存在失败:", error);
-      const errorResponse = createErrorResponse(
+      return c.fail(
         "CONFIG_EXISTS_CHECK_ERROR",
-        error instanceof Error ? error.message : "检查配置是否存在失败"
+        error instanceof Error ? error.message : "检查配置是否存在失败",
+        undefined,
+        500
       );
-      return c.json(errorResponse, 500);
     }
   }
 }


### PR DESCRIPTION
- 为什么改：统一项目 API 响应方式，使用响应增强中间件（responseEnhancerMiddleware）提供的 c.success 和 c.fail 方法替代原有的 createSuccessResponse/createErrorResponse 工具函数
- 改了什么：
  - 移除 `@middlewares/index.js` 中 `createSuccessResponse` 和 `createErrorResponse` 的导入
  - 将所有 8 个 API 方法的响应方式统一改为：
    - 成功响应：`c.json(createSuccessResponse(data, message))` → `c.success(data, message)`
    - 失败响应：`c.json(createErrorResponse(code, message), statusCode)` → `c.fail(code, message, undefined, statusCode)`
  - 涉及方法：getConfig、updateConfig、getMcpEndpoint、getMcpEndpoints、getMcpServers、getConnectionConfig、reloadCo nfig、getConfigPath、checkConfigExists
  - 同步更新测试文件 mock 配置，添加 c.success 和 c.fail 方法实现，更新所有测试断言
- 影响范围：仅影响 ConfigApiHandler 内部实现，API 响应格式和行为保持不变，对外部调用者无影响
- 验证方式：所有 24 个单元测试通过，类型检查和 lint 检查通过