### PR TITLE
refactor(handlers): 移除 BaseHandler 冗余响应方法

### DIFF
--- a/apps/backend/handlers/base.handler.ts
+++ b/apps/backend/handlers/base.handler.ts
@@ -3,7 +3,7 @@ import type { Context } from "hono";
 
 /**
  * 抽象 API Handler 基类
- * 提供统一的 Logger 获取方法和便捷的响应方法
+ * 提供统一的 Logger 获取方法和便捷的辅助方法
  */
 export abstract class BaseHandler {
   /**
@@ -20,45 +20,6 @@ export abstract class BaseHandler {
       );
     }
     return logger as Logger;
-  }
-
-  /**
-   * 返回成功响应（Context.success 的包装器）
-   * @param c - Hono context
-   * @param data - 响应数据
-   * @param message - 响应消息
-   * @param status - HTTP 状态码（默认 200）
-   * @returns JSON 响应
-   */
-  protected success<T>(
-    c: Context,
-    data?: T,
-    message?: string,
-    status?: number
-  ): Response {
-    // 只有当 status 明确指定时才传递，否则使用默认值
-    return status !== undefined
-      ? c.success(data, message, status)
-      : c.success(data, message);
-  }
-
-  /**
-   * 返回错误响应（Context.fail 的包装器）
-   * @param c - Hono context
-   * @param code - 错误码
-   * @param message - 错误消息
-   * @param details - 错误详情
-   * @param statusCode - HTTP 状态码（默认 400）
-   * @returns JSON 响应
-   */
-  protected fail(
-    c: Context,
-    code: string,
-    message: string,
-    details?: unknown,
-    statusCode?: number
-  ): Response {
-    return c.fail(code, message, details, statusCode);
   }
 
   /**
@@ -89,8 +50,7 @@ export abstract class BaseHandler {
 
     logger.error(`${operation}失败:`, error);
 
-    return this.fail(
-      c,
+    return c.fail(
       errorCode,
       errorMessage || defaultMessage,
       undefined,

--- a/apps/backend/handlers/status.handler.ts
+++ b/apps/backend/handlers/status.handler.ts
@@ -23,7 +23,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理获取状态请求");
       const status = this.statusService.getFullStatus();
       logger.debug("获取状态成功");
-      return this.success(c, status);
+      return c.success(status);
     } catch (error) {
       return this.handleError(c, error, "获取状态", "STATUS_READ_ERROR");
     }
@@ -39,7 +39,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理获取客户端状态请求");
       const clientStatus = this.statusService.getClientStatus();
       logger.debug("获取客户端状态成功");
-      return this.success(c, clientStatus);
+      return c.success(clientStatus);
     } catch (error) {
       return this.handleError(
         c,
@@ -60,7 +60,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理获取重启状态请求");
       const restartStatus = this.statusService.getRestartStatus();
       logger.debug("获取重启状态成功");
-      return this.success(c, restartStatus);
+      return c.success(restartStatus);
     } catch (error) {
       return this.handleError(
         c,
@@ -81,7 +81,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理检查客户端连接请求");
       const connected = this.statusService.isClientConnected();
       logger.debug(`客户端连接状态: ${connected}`);
-      return this.success(c, { connected });
+      return c.success({ connected });
     } catch (error) {
       return this.handleError(
         c,
@@ -102,7 +102,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理获取最后心跳时间请求");
       const lastHeartbeat = this.statusService.getLastHeartbeat();
       logger.debug("获取最后心跳时间成功");
-      return this.success(c, { lastHeartbeat });
+      return c.success({ lastHeartbeat });
     } catch (error) {
       return this.handleError(
         c,
@@ -123,7 +123,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.debug("处理获取活跃 MCP 服务器请求");
       const servers = this.statusService.getActiveMCPServers();
       logger.debug("获取活跃 MCP 服务器成功");
-      return this.success(c, { servers });
+      return c.success({ servers });
     } catch (error) {
       return this.handleError(
         c,
@@ -149,8 +149,7 @@ export class StatusApiHandler extends BaseHandler {
 
       // 验证请求体
       if (!statusUpdate || typeof statusUpdate !== "object") {
-        return this.fail(
-          c,
+        return c.fail(
           "INVALID_REQUEST_BODY",
           "请求体必须是有效的状态对象",
           undefined,
@@ -161,7 +160,7 @@ export class StatusApiHandler extends BaseHandler {
       this.statusService.updateClientInfo(statusUpdate, "http-api");
       logger.info("客户端状态更新成功");
 
-      return this.success(c, undefined, "客户端状态更新成功");
+      return c.success(undefined, "客户端状态更新成功");
     } catch (error) {
       return this.handleError(
         c,
@@ -189,8 +188,7 @@ export class StatusApiHandler extends BaseHandler {
 
       // 验证请求体
       if (!Array.isArray(servers)) {
-        return this.fail(
-          c,
+        return c.fail(
           "INVALID_REQUEST_BODY",
           "servers 必须是字符串数组",
           undefined,
@@ -201,7 +199,7 @@ export class StatusApiHandler extends BaseHandler {
       this.statusService.setActiveMCPServers(servers);
       logger.info("活跃 MCP 服务器设置成功");
 
-      return this.success(c, undefined, "活跃 MCP 服务器设置成功");
+      return c.success(undefined, "活跃 MCP 服务器设置成功");
     } catch (error) {
       return this.handleError(
         c,
@@ -224,7 +222,7 @@ export class StatusApiHandler extends BaseHandler {
       logger.info("处理重置状态请求");
       this.statusService.reset();
       logger.info("状态重置成功");
-      return this.success(c, undefined, "状态重置成功");
+      return c.success(undefined, "状态重置成功");
     } catch (error) {
       return this.handleError(c, error, "重置状态", "STATUS_RESET_ERROR");
     }

--- a/apps/backend/handlers/update.handler.ts
+++ b/apps/backend/handlers/update.handler.ts
@@ -38,8 +38,7 @@ export class UpdateApiHandler extends BaseHandler {
       // 使用 zod 进行参数验证
       const parseResult = UpdateRequestSchema.safeParse(body);
       if (!parseResult.success) {
-        return this.fail(
-          c,
+        return c.fail(
           "INVALID_VERSION",
           "请求参数格式错误",
           parseResult.error.errors.map((err) => ({
@@ -57,8 +56,7 @@ export class UpdateApiHandler extends BaseHandler {
         (v) => v
       );
       if (hasActiveInstall) {
-        return this.fail(
-          c,
+        return c.fail(
           "INSTALL_IN_PROGRESS",
           "已有安装进程正在进行，请等待完成后再试",
           undefined,
@@ -71,8 +69,7 @@ export class UpdateApiHandler extends BaseHandler {
         logger.error("安装过程失败:", error);
       });
 
-      return this.success(
-        c,
+      return c.success(
         {
           version: version,
           message: "安装已启动，请查看实时日志",

--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -21,7 +21,7 @@ export class VersionApiHandler extends BaseHandler {
 
       logger.debug("获取版本信息成功:", versionInfo);
 
-      return this.success(c, versionInfo);
+      return c.success(versionInfo);
     } catch (error) {
       return this.handleError(c, error, "获取版本信息", "VERSION_READ_ERROR");
     }
@@ -39,7 +39,7 @@ export class VersionApiHandler extends BaseHandler {
       const version = VersionUtils.getVersion();
       logger.debug(`获取版本号成功: ${version}`);
 
-      return this.success(c, { version });
+      return c.success({ version });
     } catch (error) {
       return this.handleError(c, error, "获取版本号", "VERSION_READ_ERROR");
     }
@@ -57,7 +57,7 @@ export class VersionApiHandler extends BaseHandler {
       VersionUtils.clearCache();
       logger.info("版本缓存已清除");
 
-      return this.success(c, undefined, "版本缓存已清除");
+      return c.success(undefined, "版本缓存已清除");
     } catch (error) {
       return this.handleError(c, error, "清除版本缓存", "CACHE_CLEAR_ERROR");
     }
@@ -78,8 +78,7 @@ export class VersionApiHandler extends BaseHandler {
       // 验证版本类型参数
       const validTypes = ["stable", "rc", "beta", "all"];
       if (!validTypes.includes(type as string)) {
-        return this.fail(
-          c,
+        return c.fail(
           "INVALID_VERSION_TYPE",
           `无效的版本类型: ${type}。支持的类型: ${validTypes.join(", ")}`,
           undefined,
@@ -92,7 +91,7 @@ export class VersionApiHandler extends BaseHandler {
 
       logger.debug(`获取到 ${versions.length} 个可用版本 (类型: ${type})`);
 
-      return this.success(c, {
+      return c.success({
         versions,
         type,
         total: versions.length,
@@ -123,7 +122,7 @@ export class VersionApiHandler extends BaseHandler {
 
       if (result.error) {
         // 如果有错误，但仍返回部分信息
-        return this.success(c, {
+        return c.success({
           currentVersion: result.currentVersion,
           latestVersion: result.latestVersion,
           hasUpdate: result.hasUpdate,
@@ -131,7 +130,7 @@ export class VersionApiHandler extends BaseHandler {
         });
       }
 
-      return this.success(c, {
+      return c.success({
         currentVersion: result.currentVersion,
         latestVersion: result.latestVersion,
         hasUpdate: result.hasUpdate,


### PR DESCRIPTION
- 为什么改：
  - BaseHandler 的 success() 和 fail() 方法仅是对 c.success() 和 c.fail() 的简单包装，没有增加任何额外价值
  - 代码库中存在两种响应方式并存：86% 直接使用 c.success()，14% 使用 this.success()
  - 增加了不必要的抽象层和调用复杂度（需要传递 c 参数）

- 改了什么：
  - 移除 BaseHandler.success() 方法（20 行代码）
  - 移除 BaseHandler.fail() 方法（12 行代码）
  - 更新 3 个 Handler 文件，将 22 处 this.success/fail() 调用改为直接使用 c.success/fail()
  - 保留 BaseHandler 中有实际价值的方法：getLogger()、handleError()、parseJsonBody()

- 影响范围：
  - apps/backend/handlers/base.handler.ts（移除 32 行冗余代码）
  - apps/backend/handlers/status.handler.ts（11 处调用更新）
  - apps/backend/handlers/update.handler.ts（3 处调用更新）
  - apps/backend/handlers/version.handler.ts（7 处调用更新）
  - 累计减少 46 行代码，提升代码一致性
  - API 响应格式和行为完全不变，向后兼容

- 验证方式：
  - 通过 TypeScript 类型检查（pnpm check:type）
  - 通过 Biome lint 检查（pnpm lint）
  - 所有现有测试用例保持通过
  - API 响应格式验证：c.success() 和 c.fail() 由 response-enhancer.middleware 提供，行为一致