### PR TITLE
refactor(handlers): 重构 Logger 访问方式从 c.get("logger") 到 c.logger

### DIFF
--- a/apps/backend/handlers/__tests__/config.handler.test.ts
+++ b/apps/backend/handlers/__tests__/config.handler.test.ts
@@ -157,12 +157,7 @@ describe("ConfigApiHandler", () => {
       req: {
         json: vi.fn(),
       },
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === "logger") {
-          return mockLogger;
-        }
-        return undefined;
-      }),
+      logger: mockLogger,
     };
 
     configApiHandler = new ConfigApiHandler();

--- a/apps/backend/handlers/__tests__/static-file.handler.test.ts
+++ b/apps/backend/handlers/__tests__/static-file.handler.test.ts
@@ -75,12 +75,7 @@ describe("StaticFileHandler", () => {
       req: {
         url: "http://localhost:3000/",
       },
-      get: vi.fn().mockImplementation((key: string) => {
-        if (key === "logger") {
-          return mockLogger;
-        }
-        return undefined;
-      }),
+      logger: mockLogger,
       text: vi.fn().mockImplementation((text, status, headers) => ({
         status,
         text,

--- a/apps/backend/handlers/__tests__/update.handler.test.ts
+++ b/apps/backend/handlers/__tests__/update.handler.test.ts
@@ -33,12 +33,7 @@ describe("UpdateApiHandler", () => {
   let mockEventBus: MockEventBus;
 
   const createMockContext = (overrides = {}) => ({
-    get: vi.fn((key: string) => {
-      if (key === "logger") {
-        return mockLogger;
-      }
-      return undefined;
-    }),
+    logger: mockLogger,
     req: {
       json: vi.fn(),
     },

--- a/apps/backend/handlers/base.handler.ts
+++ b/apps/backend/handlers/base.handler.ts
@@ -1,27 +1,11 @@
-import type { Logger } from "@root/Logger.js";
 import type { Context } from "hono";
 
 /**
  * 抽象 API Handler 基类
- * 提供统一的 Logger 获取方法和便捷的辅助方法
+ * 提供便捷的辅助方法
+ * logger 通过 c.logger 直接访问
  */
 export abstract class BaseHandler {
-  /**
-   * 从 context 获取 logger 实例
-   * @param c - Hono context
-   * @returns Logger 实例
-   * @throws Error 如果 logger 未在 context 中设置
-   */
-  protected getLogger(c: Context): Logger {
-    const logger = c.get("logger");
-    if (!logger) {
-      throw new Error(
-        "Logger not found in context. Ensure loggerMiddleware is registered."
-      );
-    }
-    return logger as Logger;
-  }
-
   /**
    * 统一错误处理方法
    * 记录错误日志并返回格式化的错误响应
@@ -41,14 +25,13 @@ export abstract class BaseHandler {
     defaultMessage = "操作失败",
     statusCode = 500
   ): Response {
-    const logger = this.getLogger(c);
     const errorMessage = error instanceof Error ? error.message : String(error);
     const errorCode =
       error instanceof Error && "code" in error
         ? String((error as { code: unknown }).code)
         : defaultCode;
 
-    logger.error(`${operation}失败:`, error);
+    c.logger.error(`${operation}失败:`, error);
 
     return c.fail(
       errorCode,

--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -16,7 +16,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config
    */
   async getConfig(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取配置请求");
       const config = configManager.getConfig();
@@ -38,7 +38,7 @@ export class ConfigApiHandler extends BaseHandler {
    * PUT /api/config
    */
   async updateConfig(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理更新配置请求");
       const newConfig: AppConfig = await c.req.json();
@@ -82,7 +82,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/mcp-endpoint
    */
   async getMcpEndpoint(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取 MCP 端点请求");
       const endpoint = configManager.getMcpEndpoint();
@@ -104,7 +104,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/mcp-endpoints
    */
   async getMcpEndpoints(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取 MCP 端点列表请求");
       const endpoints = configManager.getMcpEndpoints();
@@ -126,7 +126,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/mcp-servers
    */
   async getMcpServers(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取 MCP 服务配置请求");
       const servers = configManager.getMcpServers();
@@ -148,7 +148,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/connection
    */
   async getConnectionConfig(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取连接配置请求");
       const connection = configManager.getConnectionConfig();
@@ -170,7 +170,7 @@ export class ConfigApiHandler extends BaseHandler {
    * POST /api/config/reload
    */
   async reloadConfig(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理重新加载配置请求");
       configManager.reloadConfig();
@@ -193,7 +193,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/path
    */
   async getConfigPath(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取配置文件路径请求");
       const path = configManager.getConfigPath();
@@ -215,7 +215,7 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config/exists
    */
   async checkConfigExists(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理检查配置是否存在请求");
       const exists = configManager.configExists();

--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -76,7 +76,7 @@ export class CozeHandler extends BaseHandler {
    * GET /api/coze/workspaces
    */
   async getWorkspaces(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理获取工作空间列表请求");
 
@@ -143,7 +143,7 @@ export class CozeHandler extends BaseHandler {
    * GET /api/coze/workflows?workspace_id=xxx&page_num=1&page_size=20
    */
   async getWorkflows(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理获取工作流列表请求");
 
@@ -288,7 +288,7 @@ export class CozeHandler extends BaseHandler {
    * POST /api/coze/cache/clear
    */
   async clearCache(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理清除扣子 API 缓存请求");
 
@@ -348,7 +348,7 @@ export class CozeHandler extends BaseHandler {
    * GET /api/coze/cache/stats
    */
   async getCacheStats(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理获取缓存统计信息请求");
 

--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -120,7 +120,7 @@ export class MCPToolLogHandler extends BaseHandler {
    * 获取工具调用日志
    */
   async getToolCallLogs(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       const validation = this.parseAndValidateQueryParams(c);
 

--- a/apps/backend/handlers/static-file.handler.ts
+++ b/apps/backend/handlers/static-file.handler.ts
@@ -88,7 +88,7 @@ export class StaticFileHandler extends BaseHandler {
    * GET /*
    */
   async handleStaticFile(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     const pathname = new URL(c.req.url).pathname;
 
     try {

--- a/apps/backend/handlers/status.handler.ts
+++ b/apps/backend/handlers/status.handler.ts
@@ -18,7 +18,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status
    */
   async getStatus(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取状态请求");
       const status = this.statusService.getFullStatus();
@@ -34,7 +34,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status/client
    */
   async getClientStatus(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取客户端状态请求");
       const clientStatus = this.statusService.getClientStatus();
@@ -55,7 +55,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status/restart
    */
   async getRestartStatus(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取重启状态请求");
       const restartStatus = this.statusService.getRestartStatus();
@@ -76,7 +76,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status/connected
    */
   async checkClientConnected(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理检查客户端连接请求");
       const connected = this.statusService.isClientConnected();
@@ -97,7 +97,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status/heartbeat
    */
   async getLastHeartbeat(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取最后心跳时间请求");
       const lastHeartbeat = this.statusService.getLastHeartbeat();
@@ -118,7 +118,7 @@ export class StatusApiHandler extends BaseHandler {
    * GET /api/status/mcp-servers
    */
   async getActiveMCPServers(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取活跃 MCP 服务器请求");
       const servers = this.statusService.getActiveMCPServers();
@@ -139,7 +139,7 @@ export class StatusApiHandler extends BaseHandler {
    * PUT /api/status/client
    */
   async updateClientStatus(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理更新客户端状态请求");
       const statusUpdate = await this.parseJsonBody<Record<string, unknown>>(
@@ -178,7 +178,7 @@ export class StatusApiHandler extends BaseHandler {
    * PUT /api/status/mcp-servers
    */
   async setActiveMCPServers(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理设置活跃 MCP 服务器请求");
       const { servers } = await this.parseJsonBody<{ servers: string[] }>(
@@ -217,7 +217,7 @@ export class StatusApiHandler extends BaseHandler {
    * POST /api/status/reset
    */
   async resetStatus(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.info("处理重置状态请求");
       this.statusService.reset();

--- a/apps/backend/handlers/update.handler.ts
+++ b/apps/backend/handlers/update.handler.ts
@@ -28,7 +28,7 @@ export class UpdateApiHandler extends BaseHandler {
    * Body: { version: string }
    */
   async performUpdate(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       const body = await this.parseJsonBody<{ version: string }>(
         c,

--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -12,7 +12,7 @@ export class VersionApiHandler extends BaseHandler {
    * GET /api/version
    */
   async getVersion(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取版本信息请求");
 
@@ -32,7 +32,7 @@ export class VersionApiHandler extends BaseHandler {
    * GET /api/version/simple
    */
   async getVersionSimple(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取版本号请求");
 
@@ -50,7 +50,7 @@ export class VersionApiHandler extends BaseHandler {
    * POST /api/version/cache/clear
    */
   async clearVersionCache(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理清除版本缓存请求");
 
@@ -68,7 +68,7 @@ export class VersionApiHandler extends BaseHandler {
    * GET /api/version/available?type=stable|rc|beta|all
    */
   async getAvailableVersions(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理获取可用版本列表请求");
 
@@ -111,7 +111,7 @@ export class VersionApiHandler extends BaseHandler {
    * GET /api/version/latest
    */
   async checkLatestVersion(c: Context): Promise<Response> {
-    const logger = this.getLogger(c);
+    const logger = c.logger;
     try {
       logger.debug("处理检查最新版本请求");
 

--- a/apps/backend/middlewares/error.middleware.ts
+++ b/apps/backend/middlewares/error.middleware.ts
@@ -1,5 +1,3 @@
-import { logger } from "@root/Logger.js";
-import type { Logger } from "@root/Logger.js";
 import type { Context } from "hono";
 
 // 统一错误响应格式
@@ -54,19 +52,8 @@ export const createSuccessResponse = <T>(
  * 错误处理中间件
  */
 export const errorHandlerMiddleware = (err: Error, c: Context) => {
-  // 尝试从 context 获取 logger，如果失败则使用全局 logger
-  let loggerInstance: Logger;
-  try {
-    const contextLogger = c.get("logger");
-    if (contextLogger) {
-      loggerInstance = contextLogger as Logger;
-    } else {
-      loggerInstance = logger;
-    }
-  } catch {
-    // 如果无法从 context 获取，使用全局 logger
-    loggerInstance = logger;
-  }
+  // 使用 Context 上的 logger 属性
+  c.logger.error("HTTP request error:", err);
 
   // 在开发环境中打印详细错误信息
   if (process.env.NODE_ENV === "development") {
@@ -78,7 +65,6 @@ export const errorHandlerMiddleware = (err: Error, c: Context) => {
     });
   }
 
-  loggerInstance.error("HTTP request error:", err);
   return c.fail(
     "INTERNAL_SERVER_ERROR",
     "服务器内部错误",

--- a/apps/backend/middlewares/logger.middleware.ts
+++ b/apps/backend/middlewares/logger.middleware.ts
@@ -1,11 +1,22 @@
 import { logger } from "@root/Logger.js";
+import type { Logger } from "@root/Logger.js";
 import type { Context, Next } from "hono";
 
 /**
+ * 扩展 Hono Context 接口
+ * 添加 logger 属性，允许直接通过 c.logger 访问
+ */
+declare module "hono" {
+  interface Context {
+    logger: Logger;
+  }
+}
+
+/**
  * Logger 中间件 - 将 logger 实例挂载到 Hono context
- * 使所有请求处理器可以通过 context 访问 logger
+ * 使所有请求处理器可以通过 c.logger 直接访问 logger
  */
 export const loggerMiddleware = async (c: Context, next: Next) => {
-  c.set("logger", logger);
+  c.logger = logger;
   await next();
 };

--- a/apps/backend/types/hono.context.ts
+++ b/apps/backend/types/hono.context.ts
@@ -4,7 +4,6 @@
  */
 
 import type { MCPServiceManager } from "@/lib/mcp";
-import type { Logger } from "@root/Logger.js";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -47,12 +46,6 @@ export interface IWebServer {
  * 定义了项目中所有通过中间件注入的变量
  */
 export type AppContextVariables = {
-  /**
-   * 日志记录器实例
-   * 由 loggerMiddleware 注入
-   */
-  logger?: Logger;
-
   /**
    * MCP 服务管理器实例
    * 由 mcpServiceManagerMiddleware 注入
@@ -100,13 +93,6 @@ export type AppContext = {
  */
 export const createApp = (): Hono<AppContext> => {
   return new Hono<AppContext>();
-};
-
-/**
- * 从 Context 中获取日志记录器的类型安全方法
- */
-export const getLogger = (c: Context<AppContext>): Logger | undefined => {
-  return c.get("logger");
 };
 
 /**


### PR DESCRIPTION
- **为什么改**：当前项目通过 BaseHandler.getLogger(c) 方法内部使用 c.get("logger") 获取 logger，类似于 response-enhancer 的 c.success、c.fail 风格，可以通过 TypeScript 接口扩展简化为 c.logger 直接访问，提升代码一致性和可读性
- **改了什么**：
  - 在 logger.middleware.ts 中添加 TypeScript 接口扩展（declare module "hono"），直接在 Context 上添加 logger 属性
  - 移除 BaseHandler.getLogger() 方法，将 handleError 中的 this.getLogger(c) 改为 c.logger
  - 更新所有 Handler 文件（config、version、status、coze、update、mcp-tool-log、static-file）中的 this.getLogger(c) 为 c.logger
  - 从 AppContextVariables 类型中移除 logger 定义，移除 getLogger 辅助函数
  - 同步修复相关中间件（mcpServiceManager.middleware、error.middleware）和测试文件
- **影响范围**：仅限内部重构，所有 API 接口和行为保持不变，完全向后兼容。共修改 16 个文件，新增 75 行，删除 131 行，净减少 56 行代码
- **验证方式**：
  - 所有类型检查通过（pnpm check:type）
  - 所有 linting 检查通过（pnpm lint）
  - 936 个单元测试全部通过（49 个测试文件）
  - 手动验证 API 请求日志记录功能正常