### PR TITLE
refactor(handlers): 优化 MCPServiceManager 访问方式为直接属性访问

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -89,7 +89,7 @@ export class MCPToolHandler {
       );
 
       // 从 Context 中获取 MCPServiceManager 实例
-      const serviceManager = c.get("mcpServiceManager");
+      const serviceManager = c.mcpServiceManager;
       if (!serviceManager) {
         return c.fail(
           "SERVICE_NOT_INITIALIZED",
@@ -261,7 +261,7 @@ export class MCPToolHandler {
         (c.req.query("status") as "enabled" | "disabled" | "all") || "all";
 
       // 从 Context 中获取 MCPServiceManager 实例
-      const serviceManager = c.get("mcpServiceManager");
+      const serviceManager = c.mcpServiceManager;
       if (!serviceManager) {
         return c.fail(
           "SERVICE_NOT_INITIALIZED",
@@ -597,7 +597,7 @@ export class MCPToolHandler {
     }
 
     // 从 Context 中获取 MCPServiceManager 实例
-    const serviceManager = c.get("mcpServiceManager");
+    const serviceManager = c.mcpServiceManager;
     if (!serviceManager) {
       return c.fail(
         "SERVICE_NOT_INITIALIZED",

--- a/apps/backend/handlers/mcp.handler.ts
+++ b/apps/backend/handlers/mcp.handler.ts
@@ -66,7 +66,7 @@ export class MCPRouteHandler {
    */
   private getMCPServiceManager(c: Context): MCPServiceManager {
     // 首先尝试从 Context 获取
-    const serviceManager = c.get("mcpServiceManager");
+    const serviceManager = c.mcpServiceManager;
     if (serviceManager) {
       return serviceManager;
     }

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -6,7 +6,6 @@ import type { EventBus } from "@services/EventBus.js";
 import { getEventBus } from "@services/EventBus.js";
 import type { StatusService } from "@services/StatusService.js";
 import type { Context } from "hono";
-import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
  * 服务 API 处理器
@@ -43,7 +42,15 @@ export class ServiceApiHandler {
       this.statusService.updateRestartStatus("restarting");
 
       // 从 Context 获取 MCP 服务管理器
-      const mcpServiceManager = requireMCPServiceManager(c);
+      const mcpServiceManager = c.mcpServiceManager;
+      if (!mcpServiceManager) {
+        return c.fail(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化",
+          undefined,
+          503
+        );
+      }
 
       // 异步执行重启，不阻塞响应
       setTimeout(async () => {
@@ -202,7 +209,16 @@ export class ServiceApiHandler {
     try {
       this.logger.debug("处理获取服务状态请求");
 
-      const mcpServiceManager = requireMCPServiceManager(c);
+      const mcpServiceManager = c.mcpServiceManager;
+      if (!mcpServiceManager) {
+        return c.fail(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化",
+          undefined,
+          503
+        );
+      }
+
       const status = mcpServiceManager.getStatus();
 
       this.logger.debug("获取服务状态成功");

--- a/apps/backend/types/hono.context.ts
+++ b/apps/backend/types/hono.context.ts
@@ -97,6 +97,8 @@ export const createApp = (): Hono<AppContext> => {
 
 /**
  * 从 Context 中获取 MCPServiceManager 的类型安全方法
+ * @deprecated 使用 c.mcpServiceManager 直接访问
+ * 保留此函数以保持向后兼容
  */
 export const getMCPServiceManager = (
   c: Context<AppContext>
@@ -106,6 +108,8 @@ export const getMCPServiceManager = (
 
 /**
  * 要求必须存在 MCPServiceManager 的类型安全方法
+ * @deprecated 使用 c.mcpServiceManager 直接访问
+ * 保留此函数以保持向后兼容
  */
 export const requireMCPServiceManager = (
   c: Context<AppContext>


### PR DESCRIPTION
- 为什么改：当前使用 `c.get("mcpServiceManager")` 访问方式存在字符串拼写错误风险、类型推断不完善、与项目现有中间件模式不一致的问题。参考
`response-enhancer.middleware.ts` 的实现模式，统一使用 TypeScript 模块扩展进行属性注入。
- 改了什么：
  - 在 `mcpServiceManager.middleware.ts` 中添加 TypeScript 模块扩展 (`declare module "hono"`)，为 `Context` 接口添加 `mcpServiceManager` 属性
  - 将中间件中的 `c.set("mcpServiceManager", serviceManager)` 改为直接属性赋值 `c.mcpServiceManager = serviceManager`
  - 更新 4 个 Handler 文件中的访问方式：
    - `service.handler.ts`: 2 处（restartService、getServiceStatus）
    - `mcp-tool.handler.ts`: 3 处（callTool、listTools、handleAddMCPTool）
    - `mcp.handler.ts`: 1 处（getMCPServiceManager 私有方法）
  - 为 `hono.context.ts` 中的辅助函数添加 `@deprecated` 标记，保持向后兼容
- 影响范围：
  - 所有依赖 `mcpServiceManagerMiddleware` 的 Handler 代码
  - 保留了旧辅助函数以确保向后兼容，不影响外部依赖
  - API 接口行为完全不变，仅优化内部访问方式
- 验证方式：
  - TypeScript 类型检查通过 (`pnpm check:type`)
  - Biome Lint 检查通过 (`pnpm lint`)
  - 新访问方式与现有 `c.logger`、`c.success`、`c.fail` 等属性访问模式保持一致

- 使用 TypeScript 模块扩展 (`declare module "hono"`) 在编译时扩展 Hono Context 类型
- 属性访问提供更好的类型推断，无需泛型参数
- 编译时即可发现拼写错误，而非运行时报错
- 与项目现有的 `response-enhancer.middleware.ts` 实现模式保持一致