### PR TITLE
refactor(config): 移除 backend 中冗余的 workspace 包 paths 配置

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,6 +13,7 @@
     "@xiaozhi-client/config": "workspace:*",
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
+    "@xiaozhi-client/version": "workspace:*",
     "ajv": "^8.17.1",
     "chalk": "^5.6.0",
     "comment-json": "^4.2.5",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -10,13 +10,6 @@
     "noImplicitAny": false,
     "types": ["vitest/globals"],
     "paths": {
-      "@xiaozhi-client/config": ["../../packages/config/dist"],
-      "@xiaozhi-client/config/*": ["../../packages/config/dist/*"],
-      "@xiaozhi-client/shared-types": ["../../packages/shared-types/dist"],
-      "@xiaozhi-client/endpoint": ["../../packages/endpoint/dist"],
-      "@xiaozhi-client/endpoint/*": ["../../packages/endpoint/dist/*"],
-      "@xiaozhi-client/version": ["../../packages/version/dist"],
-      "@xiaozhi-client/version/*": ["../../packages/version/dist/*"],
       "@handlers/*": ["./handlers/*"],
       "@middlewares/*": ["./middlewares/*"],
       "@services/*": ["./services/*"],

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -50,14 +50,6 @@ export default defineConfig({
   },
   resolve: {
     alias: {
-      "@xiaozhi-client/config": resolve(
-        __dirname,
-        "../../packages/config/dist"
-      ),
-      "@xiaozhi-client/config/": resolve(
-        __dirname,
-        "../../packages/config/dist/"
-      ),
       "@": __dirname,
       "@handlers": resolve(__dirname, "handlers"),
       "@services": resolve(__dirname, "services"),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -188,6 +188,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../../packages/mcp-core
+      '@xiaozhi-client/version':
+        specifier: workspace:*
+        version: link:../../packages/version
       ajv:
         specifier: ^8.17.1
         version: 8.17.1


### PR DESCRIPTION
- 为什么改：根目录 tsconfig.json 已简化，apps/backend 中的 @xiaozhi-client/* paths 配置冗余，pnpm workspace 的自动链接机制已能正确处理包解析
- 改了什么：
  1. apps/backend/package.json：添加缺失的 "@xiaozhi-client/version": "workspace:*" 依赖声明
  2. apps/backend/tsconfig.json：移除所有 @xiaozhi-client/config、@xiaozhi-client/endpoint、@xiaozhi-client/version、@xiaozhi-client/shared-types 的 paths 配置
  3. apps/backend/vitest.config.ts：移除 @xiaozhi-client/config 的 alias 配置
- 影响范围：apps/backend 模块的模块解析方式，从显式 TypeScript paths 映射改为依赖 pnpm workspace 的自动链接，对外部行为无影响
- 验证方式：pnpm install、pnpm check:type（全部通过）、pnpm test（555 个测试通过）、pnpm build（全部成功）