### PR TITLE
refactor(config): 统一路径别名规范，移除冗余的 @handlers/* 配置

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -1,8 +1,5 @@
 import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
-import { MCPServiceManager } from "@/lib/mcp";
-import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
-import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
 import {
   ConfigApiHandler,
   CozeHandler,
@@ -17,7 +14,10 @@ import {
   StatusApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
-} from "@handlers/index.js";
+} from "@/handlers/index.js";
+import { MCPServiceManager } from "@/lib/mcp";
+import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
+import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
 import type { ServerType } from "@hono/node-server";
 import { serve } from "@hono/node-server";
 import {

--- a/apps/backend/middlewares/endpoints.middleware.ts
+++ b/apps/backend/middlewares/endpoints.middleware.ts
@@ -3,7 +3,7 @@
  * 负责创建和管理 EndpointHandler 实例
  */
 
-import { EndpointHandler } from "@handlers/endpoint.handler.js";
+import { EndpointHandler } from "@/handlers/endpoint.handler.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { MiddlewareHandler } from "hono";

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -16,7 +16,7 @@ import type {
   StatusApiHandler,
   UpdateApiHandler,
   VersionApiHandler,
-} from "@handlers/index.js";
+} from "@/handlers/index.js";
 import type { Context, MiddlewareHandler } from "hono";
 
 /**

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -10,7 +10,7 @@
     "noImplicitAny": false,
     "types": ["vitest/globals"],
     "paths": {
-      "@handlers/*": ["./handlers/*"],
+      "@/*": ["./*"],
       "@middlewares/*": ["./middlewares/*"],
       "@services/*": ["./services/*"],
       "@errors/*": ["./errors/*"],


### PR DESCRIPTION
- 为什么改：简化路径别名配置体系，统一使用 `@/*` 前缀，减少维护成本。`@handlers/*` 别名与 `@/*` 功能重复，且 `@/*` 已配置为 `["./*"]` 可直接解析到 `./handlers/*`。
- 改了什么：
  1. `tsconfig.json`：移除 `"@handlers/*": ["./handlers/*"]` 配置
  2. `WebServer.ts`、`routes/types.ts`、`endpoints.middleware.ts`：将 `@handlers/*` 导入改为 `@/handlers/*`
  3. 同步修复导入语句排序以符合 Biome 规范
- 影响范围：
  - 仅影响后端模块（apps/backend）的导入路径
  - 路径解析逻辑不变，`@/handlers/*` 正确解析到 `./handlers/*`
  - 无破坏性变更，所有功能保持一致
- 验证方式：
  - ✅ `pnpm check:type` - TypeScript 类型检查通过
  - ✅ `pnpm lint` - Biome 代码规范检查通过
  - ✅ `pnpm test` - 所有测试用例通过（共 8 个项目测试套件）