### PR TITLE
refactor(config): 移除 tsconfig 中冗余的路径别名配置

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -20,8 +20,6 @@
       "@adapters/*": ["./adapters/*"],
       "@managers/*": ["./managers/*"],
       "@types/*": ["./types/*"],
-      "@/types/*": ["./types/*"],
-      "@/lib/*": ["./lib/*"],
       "@root/*": ["./*"],
       "@routes/*": ["./routes/*"],
       "@constants/*": ["./constants/*"]


### PR DESCRIPTION
- 为什么改：路径别名系统中存在重复配置，`@/types/*` 和 `@/lib/*` 与 `@types/*` 和 `@/lib/*` 功能重复，造成配置冗余
- 改了什么：从 `apps/backend/tsconfig.json` 的 paths 配置中移除 `@/types/*` 和 `@/lib/*` 两个别名
- 影响范围：仅影响配置文件，保留的 `@types/*` 和 `@/lib/*` 别名继续提供相同功能，无破坏性变更
- 验证方式：运行 `pnpm check:type` 验证类型检查正常，确保项目构建无误