### PR TITLE
refactor(config): 简化后端路径别名配置

### DIFF
--- a/apps/backend/WebServer.cleanup.test.ts
+++ b/apps/backend/WebServer.cleanup.test.ts
@@ -45,7 +45,7 @@ vi.mock("./Logger", () => {
 });
 
 // Mock EventBus 服务
-vi.mock("@services/EventBus", () => {
+vi.mock("@/services/EventBus", () => {
   const mockEventBus = {
     onEvent: vi.fn(),
     emitEvent: vi.fn(),
@@ -68,13 +68,13 @@ const mockConfigServiceInstance = {
   updateMcpEndpoint: vi.fn(),
 };
 
-vi.mock("@services/ConfigService", () => {
+vi.mock("@/services/ConfigService", () => {
   return {
     ConfigService: vi.fn(() => mockConfigServiceInstance),
   };
 });
 
-vi.mock("@services/StatusService", () => {
+vi.mock("@/services/StatusService", () => {
   const mockStatusService = {
     getStatus: vi.fn(),
     updateClientInfo: vi.fn(),
@@ -85,7 +85,7 @@ vi.mock("@services/StatusService", () => {
   };
 });
 
-vi.mock("@services/NotificationService", () => {
+vi.mock("@/services/NotificationService", () => {
   const mockNotificationService = {
     addClient: vi.fn(),
     removeClient: vi.fn(),

--- a/apps/backend/WebServer.mcpServiceManager.test.ts
+++ b/apps/backend/WebServer.mcpServiceManager.test.ts
@@ -41,7 +41,7 @@ vi.mock("../Logger.js", () => ({
 }));
 
 // Mock EventBus
-vi.mock("@services/EventBus.js", () => ({
+vi.mock("@/services/EventBus.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     onEvent: vi.fn(),
     emitEvent: vi.fn(),

--- a/apps/backend/WebServer.test.ts
+++ b/apps/backend/WebServer.test.ts
@@ -52,7 +52,7 @@ vi.mock("./Logger", () => {
 
 // Mock @services/index.js
 // 注意：WebServer.ts 从 @services/index.js 导入多个模块，必须全部 Mock
-vi.mock("@services/index.js", () => {
+vi.mock("@/services/index.js", () => {
   const mockEventBus = {
     onEvent: vi.fn().mockReturnThis(),
     emit: vi.fn(),
@@ -114,7 +114,7 @@ const mockConfigServiceInstance = {
   updateMcpEndpoint: vi.fn().mockResolvedValue(undefined),
 };
 
-vi.mock("@services/ConfigService", () => {
+vi.mock("@/services/ConfigService", () => {
   return {
     ConfigService: vi.fn(() => mockConfigServiceInstance),
   };
@@ -937,7 +937,7 @@ describe("WebServer", () => {
       webServer = new WebServer(currentPort);
 
       // 验证事件总线被正确获取
-      const { getEventBus } = await import("@services/index.js");
+      const { getEventBus } = await import("@/services/index.js");
       expect(getEventBus).toHaveBeenCalled();
     });
   });
@@ -1728,7 +1728,7 @@ describe("WebServer", () => {
       webServer = new WebServer(currentPort);
 
       // 验证事件总线 onEvent 方法被调用
-      const { getEventBus } = await import("@services/index.js");
+      const { getEventBus } = await import("@/services/index.js");
       const mockEventBus = getEventBus();
       expect(mockEventBus.onEvent).toHaveBeenCalledWith(
         "endpoint:status:changed",
@@ -1741,7 +1741,7 @@ describe("WebServer", () => {
       await webServer.start();
 
       // 获取事件总线并触发事件
-      const { getEventBus } = await import("@services/index.js");
+      const { getEventBus } = await import("@/services/index.js");
       const mockEventBus = getEventBus() as any;
 
       // 模拟事件回调 - 使用 vi.mocked 来访问 mock 属性
@@ -1753,7 +1753,7 @@ describe("WebServer", () => {
 
       if (eventCallback) {
         // 从 @services/index.js 导入 NotificationService（与 mock 路径一致）
-        const { NotificationService } = await import("@services/index.js");
+        const { NotificationService } = await import("@/services/index.js");
         const mockNotificationService = vi.mocked(NotificationService);
         const mockInstance = mockNotificationService.mock.results[0]?.value;
 

--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -18,6 +18,13 @@ import {
 import { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
+import type { EventBus, EventBusEvents } from "@/services/index.js";
+import {
+  NotificationService,
+  StatusService,
+  destroyEventBus,
+  getEventBus,
+} from "@/services/index.js";
 import type { ServerType } from "@hono/node-server";
 import { serve } from "@hono/node-server";
 import {
@@ -35,13 +42,6 @@ import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
 import type { AppContext } from "@root/types/index.js";
 import { createApp } from "@root/types/index.js";
-import type { EventBus, EventBusEvents } from "@services/index.js";
-import {
-  NotificationService,
-  StatusService,
-  destroyEventBus,
-  getEventBus,
-} from "@services/index.js";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import type { MCPServerConfig } from "@xiaozhi-client/config";

--- a/apps/backend/handlers/__tests__/basic.test.ts
+++ b/apps/backend/handlers/__tests__/basic.test.ts
@@ -42,13 +42,13 @@ vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
-vi.mock("@services/EventBus.js", () => ({
+vi.mock("@/services/EventBus.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     emitEvent: vi.fn(),
   }),
 }));
 
-vi.mock("@services/StatusService.js", () => ({
+vi.mock("@/services/StatusService.js", () => ({
   StatusService: vi.fn().mockImplementation(() => ({
     updateRestartStatus: vi.fn(),
   })),
@@ -76,7 +76,7 @@ describe("Handlers Basic Tests", () => {
     const { StaticFileHandler } = await import("../static-file.handler.js");
     const { ServiceApiHandler } = await import("../service.handler.js");
     const { StatusApiHandler } = await import("../status.handler.js");
-    const { StatusService } = await import("@services/status.service.js");
+    const { StatusService } = await import("@/services/status.service.js");
 
     const mockStatusService = new StatusService();
 

--- a/apps/backend/handlers/__tests__/endpoint.handler.test.ts
+++ b/apps/backend/handlers/__tests__/endpoint.handler.test.ts
@@ -18,7 +18,7 @@ const mockEventBusInstance = {
 };
 
 // Mock EventBus 模块
-vi.mock("@services/EventBus.js", () => ({
+vi.mock("@/services/EventBus.js", () => ({
   getEventBus: vi.fn(() => mockEventBusInstance),
 }));
 

--- a/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
@@ -1,7 +1,7 @@
 import path from "node:path";
 import type { MCPServiceManager } from "@/lib/mcp";
+import type { EventBus } from "@/services/event-bus.service.js";
 import { MCPErrorCode } from "@errors/MCPErrors.js";
-import type { EventBus } from "@services/event-bus.service.js";
 import type { ConfigManager } from "@xiaozhi-client/config";
 import type { MCPServerConfig } from "@xiaozhi-client/config";
 import type { Context } from "hono";

--- a/apps/backend/handlers/__tests__/realtime-notification.handler.test.ts
+++ b/apps/backend/handlers/__tests__/realtime-notification.handler.test.ts
@@ -29,7 +29,7 @@ vi.mock("@xiaozhi-client/config", () => ({
   },
 }));
 
-vi.mock("@services/event-bus.service.js", () => ({
+vi.mock("@/services/event-bus.service.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     emitEvent: vi.fn(),
     onEvent: vi.fn(),
@@ -113,7 +113,7 @@ describe("RealtimeNotificationHandler", () => {
       emitEvent: vi.fn(),
       onEvent: vi.fn(),
     };
-    const { getEventBus } = await import("@services/event-bus.service.js");
+    const { getEventBus } = await import("@/services/event-bus.service.js");
     vi.mocked(getEventBus).mockReturnValue(mockEventBus);
 
     // Mock NotificationService

--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -1,4 +1,4 @@
-import type { StatusService } from "@services/status.service.js";
+import type { StatusService } from "@/services/status.service.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ServiceApiHandler } from "../service.handler.js";
 
@@ -16,7 +16,7 @@ vi.mock("node:child_process", () => ({
   spawn: vi.fn(),
 }));
 
-vi.mock("@services/event-bus.service.js", () => ({
+vi.mock("@/services/event-bus.service.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     emitEvent: vi.fn(),
   }),
@@ -83,7 +83,7 @@ describe("ServiceApiHandler", () => {
     mockEventBus = {
       emitEvent: vi.fn(),
     };
-    const { getEventBus } = await import("@services/event-bus.service.js");
+    const { getEventBus } = await import("@/services/event-bus.service.js");
     vi.mocked(getEventBus).mockReturnValue(mockEventBus);
 
     handler = new ServiceApiHandler(mockStatusService);

--- a/apps/backend/handlers/__tests__/status.handler.test.ts
+++ b/apps/backend/handlers/__tests__/status.handler.test.ts
@@ -1,4 +1,4 @@
-import type { StatusService } from "@services/status.service.js";
+import type { StatusService } from "@/services/status.service.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusApiHandler } from "../status.handler.js";
 

--- a/apps/backend/handlers/__tests__/update.handler.test.ts
+++ b/apps/backend/handlers/__tests__/update.handler.test.ts
@@ -7,7 +7,7 @@ import { UpdateApiHandler } from "../update.handler.js";
 // Mock dependencies
 vi.mock("@/lib/npm");
 vi.mock("../../Logger.js");
-vi.mock("@services/event-bus.service.js");
+vi.mock("@/services/event-bus.service.js");
 
 // Mock 类型定义
 interface MockNPMManager {
@@ -90,7 +90,7 @@ describe("UpdateApiHandler", () => {
       emitEvent: vi.fn(),
       onEvent: vi.fn(),
     };
-    const { getEventBus } = await import("@services/event-bus.service.js");
+    const { getEventBus } = await import("@/services/event-bus.service.js");
     vi.mocked(getEventBus).mockReturnValue(
       mockEventBus as unknown as ReturnType<typeof getEventBus>
     );

--- a/apps/backend/handlers/endpoint.handler.ts
+++ b/apps/backend/handlers/endpoint.handler.ts
@@ -1,8 +1,8 @@
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
 import type { ConfigManager } from "@xiaozhi-client/config";
 import type {
   ConnectionStatus,

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -1,8 +1,8 @@
+import type { NotificationService } from "@/services/notification.service.js";
+import type { StatusService } from "@/services/status.service.js";
 import { HEARTBEAT_MONITORING } from "@constants/index.js";
 import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
-import type { NotificationService } from "@services/notification.service.js";
-import type { StatusService } from "@services/status.service.js";
 import { configManager } from "@xiaozhi-client/config";
 
 /**

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -1,5 +1,6 @@
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { MCPService } from "@/lib/mcp";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "@root/Logger.js";
@@ -9,7 +10,6 @@ import {
   MCPError,
   MCPErrorCode,
 } from "@root/errors/MCPErrors.js";
-import { getEventBus } from "@services/event-bus.service.js";
 import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -1,9 +1,9 @@
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
+import type { NotificationService } from "@/services/notification.service.js";
+import type { StatusService } from "@/services/status.service.js";
 import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
-import type { NotificationService } from "@services/notification.service.js";
-import type { StatusService } from "@services/status.service.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -1,11 +1,11 @@
 import { spawn } from "node:child_process";
 import type { MCPServiceManager } from "@/lib/mcp";
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
+import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { logger } from "@root/Logger.js";
 import type { Logger } from "@root/Logger.js";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
-import type { StatusService } from "@services/status.service.js";
 import type { Context } from "hono";
 import { requireMCPServiceManager } from "../types/hono.context.js";
 

--- a/apps/backend/handlers/status.handler.ts
+++ b/apps/backend/handlers/status.handler.ts
@@ -1,5 +1,5 @@
+import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { StatusService } from "@services/status.service.js";
 import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 

--- a/apps/backend/handlers/update.handler.ts
+++ b/apps/backend/handlers/update.handler.ts
@@ -1,6 +1,6 @@
 import { NPMManager } from "@/lib/npm";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
-import { getEventBus } from "@services/event-bus.service.js";
 import type { Context } from "hono";
 import { z } from "zod";
 import { BaseHandler } from "./base.handler.js";

--- a/apps/backend/lib/mcp/__tests__/ToolSyncIntegration.test.ts
+++ b/apps/backend/lib/mcp/__tests__/ToolSyncIntegration.test.ts
@@ -235,7 +235,7 @@ vi.mock("@xiaozhi-client/config", async () => {
 });
 
 // Mock CustomMCPHandler
-vi.mock("@services/CustomMCPHandler.js", () => {
+vi.mock("@/services/CustomMCPHandler.js", () => {
   class MockCustomMCPHandler {
     initialize() {}
 
@@ -262,7 +262,7 @@ vi.mock("@services/CustomMCPHandler.js", () => {
 });
 
 // Mock MCPCacheManager
-vi.mock("@services/MCPCacheManager.js", () => {
+vi.mock("@/services/MCPCacheManager.js", () => {
   class MockMCPCacheManager {
     async writeCacheEntry() {}
     async readCacheEntry() {

--- a/apps/backend/lib/mcp/__tests__/custom.basic.test.ts
+++ b/apps/backend/lib/mcp/__tests__/custom.basic.test.ts
@@ -3,8 +3,8 @@
  * 专门测试 Coze 工作流功能
  */
 
+import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@root/services/event-bus.service.js";
-import type { EventBus } from "@services/event-bus.service.js";
 import type { CustomMCPTool } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { CustomMCPHandler } from "../custom.js";

--- a/apps/backend/lib/mcp/__tests__/log.test.ts
+++ b/apps/backend/lib/mcp/__tests__/log.test.ts
@@ -13,7 +13,7 @@ import {
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { PathUtils } from "@utils/path-utils.js";
+import { PathUtils } from "@/utils/path-utils.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   type ToolCallLogConfig,

--- a/apps/backend/lib/mcp/__tests__/mcp-service-manager-events.test.ts
+++ b/apps/backend/lib/mcp/__tests__/mcp-service-manager-events.test.ts
@@ -1,6 +1,6 @@
 import { MCPServiceManager } from "@/lib/mcp";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { getEventBus } from "@services/event-bus.service.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock dependencies

--- a/apps/backend/lib/mcp/log.ts
+++ b/apps/backend/lib/mcp/log.ts
@@ -5,7 +5,7 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
-import { PathUtils } from "@utils/path-utils.js";
+import { PathUtils } from "@/utils/path-utils.js";
 import pino from "pino";
 import type { Logger as PinoLogger } from "pino";
 

--- a/apps/backend/lib/npm/__tests__/manager.test.ts
+++ b/apps/backend/lib/npm/__tests__/manager.test.ts
@@ -8,7 +8,7 @@ vi.mock("../../../services/event-bus.service.js");
 
 import { NPMManager } from "@/lib/npm";
 // Import after mocking
-import type { EventBus } from "@services/event-bus.service.js";
+import type { EventBus } from "@/services/event-bus.service.js";
 
 /**
  * Mock EventBus 类型接口

--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -1,7 +1,7 @@
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
 import semver from "semver";
 
 const execAsync = promisify(exec);

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -1,8 +1,8 @@
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
+import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
 import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
-import type { ClientInfo, RestartStatus } from "@services/status.service.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 

--- a/apps/backend/services/status.service.ts
+++ b/apps/backend/services/status.service.ts
@@ -1,7 +1,7 @@
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { Logger } from "@root/Logger.js";
 import { logger } from "@root/Logger.js";
-import type { EventBus } from "@services/event-bus.service.js";
-import { getEventBus } from "@services/event-bus.service.js";
 
 /**
  * 客户端信息接口

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -12,16 +12,9 @@
     "paths": {
       "@/*": ["./*"],
       "@middlewares/*": ["./middlewares/*"],
-      "@services/*": ["./services/*"],
       "@errors/*": ["./errors/*"],
-      "@utils/*": ["./utils/*"],
-      "@core/*": ["./core/*"],
-      "@transports/*": ["./lib/mcp/transports/*"],
-      "@adapters/*": ["./adapters/*"],
-      "@managers/*": ["./managers/*"],
       "@types/*": ["./types/*"],
       "@root/*": ["./*"],
-      "@routes/*": ["./routes/*"],
       "@constants/*": ["./constants/*"]
     }
   },


### PR DESCRIPTION
- 为什么改：统一路径别名规范，移除冗余配置以降低维护成本。原 tsconfig.json 中存在大量与 `@/*` 功能重叠的路径别名（如 `@services/*`、`@utils/*`），增加了配置复杂度且容易造成混淆。

- 改了什么：
  1. **tsconfig.json 配置简化**：移除 7 个冗余路径别名（`@services/*`、`@utils/*`、`@core/*`、`@transports/*`、`@adapters/*`、`@managers/*`、`@routes/*`）
  2. **导入语句统一**：将 28 个文件中的路径别名替换为统一的 `@/*` 格式
     - `@services/*` → `@/services/*`（25 个文件）
     - `@utils/*` → `@/utils/*`（2 个文件）
  3. **导入顺序修复**：Biome linter 自动修复了 13 个文件的导入顺序问题

- 影响范围：
  - **代码模块**：apps/backend 下的 28 个文件（含测试文件）
  - **兼容性**：纯内部重构，无 API 变更，对外功能完全兼容
  - **配置**：tsconfig.json 路径映射从 13 项减少至 7 项

- 验证方式：
  - ✅ TypeScript 类型检查通过（pnpm check:type）
  - ✅ Biome linter 检查通过（pnpm lint）
  - ✅ 所有 555 个测试用例通过（pnpm test）