### PR TITLE
refactor(backend): 统一 scripts 配置，支持独立调试

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -4,7 +4,15 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "check:type": "tsc --noEmit"
+    "build": "cross-env NODE_ENV=${NODE_ENV:-production} tsup --config apps/backend/tsup.config.ts",
+    "test": "vitest run --coverage.enabled=false",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "lint": "biome check apps/backend",
+    "lint:fix": "biome check --write apps/backend",
+    "format": "biome format --write apps/backend",
+    "check:type": "tsc --noEmit",
+    "dev": "cross-env NODE_ENV=development tsup --config apps/backend/tsup.config.ts --watch"
   },
   "dependencies": {
     "@coze/api": "^1.3.9",

--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -7,7 +7,8 @@
     "build": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cross-env NODE_ENV=${NODE_ENV:-production} tsup --config apps/backend/tsup.config.ts",
+        "command": "pnpm run build",
+        "cwd": "apps/backend",
         "env": {
           "PWD": "{workspaceRoot}"
         }
@@ -18,7 +19,7 @@
     "test": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "vitest run --coverage.enabled=false",
+        "command": "pnpm run test",
         "cwd": "apps/backend"
       },
       "outputs": ["{workspaceRoot}/coverage"]
@@ -26,14 +27,14 @@
     "test:watch": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "vitest",
+        "command": "pnpm run test:watch",
         "cwd": "apps/backend"
       }
     },
     "test:coverage": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "vitest run --coverage",
+        "command": "pnpm run test:coverage",
         "cwd": "apps/backend"
       },
       "outputs": ["{workspaceRoot}/coverage"]
@@ -41,25 +42,28 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check apps/backend"
+        "command": "pnpm run lint",
+        "cwd": "apps/backend"
       }
     },
     "lint:fix": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check --write apps/backend"
+        "command": "pnpm run lint:fix",
+        "cwd": "apps/backend"
       }
     },
     "format": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome format --write apps/backend"
+        "command": "pnpm run format",
+        "cwd": "apps/backend"
       }
     },
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm check:type",
+        "command": "pnpm run check:type",
         "cwd": "apps/backend"
       },
       "dependsOn": ["config:build", "endpoint:build", "version:build"]
@@ -67,7 +71,8 @@
     "dev": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "cross-env NODE_ENV=development tsup --config apps/backend/tsup.config.ts --watch",
+        "command": "pnpm run dev",
+        "cwd": "apps/backend",
         "env": {
           "PWD": "{workspaceRoot}"
         }


### PR DESCRIPTION
- 为什么改：当前 project.json 中命令分散配置，开发者无法在 apps/backend 目录下直接使用 pnpm 命令进行调试，需要统一管理
- 改了什么：
  - apps/backend/package.json：新增 build、test、test:watch、test:coverage、lint、lint:fix、format、dev 等 9 个 scripts
  - apps/backend/project.json：所有 target 的 command 改为使用 `pnpm run <script-name>` 引用 package.json 中的 scripts，并统一添加 `cwd: "apps/backend"` 确保正确工作目录
- 影响范围：
  - 不影响现有 CI/CD 流程和 nx 命令调用
  - 开发者现在可以在 apps/backend 目录下直接运行 `pnpm run test`、`pnpm run lint` 等命令进行独立调试
- 验证方式：
  - 在 apps/backend 目录下执行 `pnpm run test` 验证测试可运行
  - 在根目录执行 `npx nx run backend:test` 验证 nx 命令仍然正常工作