### PR TITLE
fix(frontend): 修复 WebSocket 默认端口逻辑错误

### DIFF
--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -298,9 +298,9 @@ export class WebSocketManager {
     // 根据当前页面 URL 构建 WebSocket URL
     const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
     const hostname = window.location.hostname;
-    // FIXME: 这里需要通过开发模式显式处理，否则用户如果设置5173端口，会导致强制变成9999端口
-    const port = window.location.port === "5173" ? 9999 : window.location.port;
-    return `${protocol}//${hostname}${port ? `:${port}` : ""}`;
+    // 固定使用后端端口 9999，与当前页面端口无关
+    const port = 9999;
+    return `${protocol}//${hostname}:${port}`;
   }
 
   /**


### PR DESCRIPTION
- 为什么改：原有逻辑导致非 5173 端口访问前端时，WebSocket 连接到错误的端口。例如访问 http://localhost:5174/dashboard 时，wsUrl 会错误地使用 ws://localhost:5174，而应该始终连接后端的 9999 端口
- 改了什么：移除端口条件判断逻辑，将 `getDefaultWebSocketUrl()` 方法中的端口计算从 `window.location.port === "5173" ? 9999 : window.location.port` 改为固定值 `9999`
- 影响范围：仅影响 WebSocket 默认 URL 生成逻辑，前端应用使用任何端口访问时都能正确连接到后端 9999 端口
- 验证方式：通过 `pnpm check:type`、`pnpm lint`、`pnpm test`，前端 533 个测试全部通过