### PR TITLE
refactor(backend): 调整日志级别以优化日志输出

### DIFF
--- a/apps/backend/handlers/__tests__/config.handler.test.ts
+++ b/apps/backend/handlers/__tests__/config.handler.test.ts
@@ -187,7 +187,7 @@ describe("ConfigApiHandler", () => {
 
       expect(mockConfigManager.getConfig).toHaveBeenCalledTimes(1);
       expect(mockLogger.debug).toHaveBeenCalledWith("处理获取配置请求");
-      expect(mockLogger.info).toHaveBeenCalledWith("获取配置成功");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取配置成功");
       expect(mockContext.success).toHaveBeenCalledWith(mockConfig);
     });
 

--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -416,7 +416,7 @@ describe("HeartbeatHandler", () => {
 
       heartbeatHandler.stopHeartbeatMonitoring(mockIntervalId);
 
-      expect(mockLogger.info).toHaveBeenCalledWith("停止心跳监控");
+      expect(mockLogger.debug).toHaveBeenCalledWith("停止心跳监控");
       expect(clearIntervalSpy).toHaveBeenCalledWith(mockIntervalId);
     });
   });
@@ -492,7 +492,7 @@ describe("HeartbeatHandler", () => {
     it("should handle client disconnection", () => {
       heartbeatHandler.handleClientDisconnect(clientId);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `客户端连接断开: ${clientId}`
       );
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
@@ -697,7 +697,7 @@ describe("HeartbeatHandler", () => {
 
       // Stop monitoring
       heartbeatHandler.stopHeartbeatMonitoring(intervalId);
-      expect(mockLogger.info).toHaveBeenCalledWith("停止心跳监控");
+      expect(mockLogger.debug).toHaveBeenCalledWith("停止心跳监控");
     });
 
     it("should handle mixed success and error scenarios", async () => {

--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -17,13 +17,14 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config
    */
   async getConfig(c: Context<AppContext>): Promise<Response> {
+    const logger = c.get("logger");
     try {
-      c.get("logger").debug("处理获取配置请求");
+      logger.debug("处理获取配置请求");
       const config = configManager.getConfig();
-      c.get("logger").info("获取配置成功");
+      logger.debug("获取配置成功");
       return c.success(config);
     } catch (error) {
-      c.get("logger").error("获取配置失败:", error);
+      logger.error("获取配置失败:", error);
       return c.fail(
         "CONFIG_READ_ERROR",
         error instanceof Error ? error.message : "获取配置失败",

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -156,7 +156,7 @@ export class HeartbeatHandler {
    * 停止心跳监控
    */
   stopHeartbeatMonitoring(intervalId: NodeJS.Timeout): void {
-    this.logger.info("停止心跳监控");
+    this.logger.debug("停止心跳监控");
     clearInterval(intervalId);
   }
 
@@ -199,7 +199,7 @@ export class HeartbeatHandler {
    * 处理客户端连接断开
    */
   handleClientDisconnect(clientId: string): void {
-    this.logger.info(`客户端连接断开: ${clientId}`);
+    this.logger.debug(`客户端连接断开: ${clientId}`);
 
     // 更新状态为断开连接
     this.statusService.updateClientInfo(

--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -162,7 +162,7 @@ describe("NotificationService", () => {
     it("should register client successfully", () => {
       notificationService.registerClient("test-client-123", mockWebSocket);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         "WebSocket 客户端已注册: test-client-123"
       );
       expect(mockLogger.debug).toHaveBeenCalledWith("当前客户端数量: 1");
@@ -187,7 +187,7 @@ describe("NotificationService", () => {
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         expect.stringContaining('"type":"testMessage"')
       );
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         "发送 1 条排队消息给客户端 test-client-123"
       );
     });
@@ -241,7 +241,7 @@ describe("NotificationService", () => {
       // Then unregister it
       notificationService.unregisterClient("test-client-123");
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         "WebSocket 客户端已注销: test-client-123"
       );
       expect(mockLogger.debug).toHaveBeenCalledWith("剩余客户端数量: 0");
@@ -258,7 +258,7 @@ describe("NotificationService", () => {
       notificationService.unregisterClient("non-existent-client");
 
       // Should not throw error or log anything for non-existent client
-      expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(
         expect.stringContaining("WebSocket 客户端已注销")
       );
     });
@@ -794,7 +794,7 @@ describe("NotificationService", () => {
 
       notificationService.cleanupDisconnectedClients();
 
-      expect(mockLogger.info).toHaveBeenCalledWith("清理了 1 个断开的客户端");
+      expect(mockLogger.debug).toHaveBeenCalledWith("清理了 1 个断开的客户端");
 
       const stats = notificationService.getClientStats();
       expect(stats.totalClients).toBe(1);
@@ -809,7 +809,7 @@ describe("NotificationService", () => {
 
       notificationService.cleanupDisconnectedClients();
 
-      expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(
         expect.stringContaining("清理了")
       );
 
@@ -820,7 +820,7 @@ describe("NotificationService", () => {
     it("should handle cleanup with no clients", () => {
       notificationService.cleanupDisconnectedClients();
 
-      expect(mockLogger.info).not.toHaveBeenCalledWith(
+      expect(mockLogger.debug).not.toHaveBeenCalledWith(
         expect.stringContaining("清理了")
       );
     });
@@ -845,7 +845,7 @@ describe("NotificationService", () => {
 
       notificationService.cleanupDisconnectedClients();
 
-      expect(mockLogger.info).toHaveBeenCalledWith("清理了 2 个断开的客户端");
+      expect(mockLogger.debug).toHaveBeenCalledWith("清理了 2 个断开的客户端");
 
       const stats = notificationService.getClientStats();
       expect(stats.totalClients).toBe(1);
@@ -862,7 +862,7 @@ describe("NotificationService", () => {
 
       notificationService.destroy();
 
-      expect(mockLogger.info).toHaveBeenCalledWith("销毁通知服务");
+      expect(mockLogger.debug).toHaveBeenCalledWith("销毁通知服务");
 
       const stats = notificationService.getClientStats();
       expect(stats.totalClients).toBe(0);
@@ -872,7 +872,7 @@ describe("NotificationService", () => {
     it("should handle destroy with no clients", () => {
       notificationService.destroy();
 
-      expect(mockLogger.info).toHaveBeenCalledWith("销毁通知服务");
+      expect(mockLogger.debug).toHaveBeenCalledWith("销毁通知服务");
 
       const stats = notificationService.getClientStats();
       expect(stats.totalClients).toBe(0);
@@ -895,7 +895,7 @@ describe("NotificationService", () => {
 
       // Should send both queued messages
       expect(mockWebSocket.send).toHaveBeenCalledTimes(2);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         "发送 2 条排队消息给客户端 test-client"
       );
 
@@ -913,7 +913,7 @@ describe("NotificationService", () => {
 
       // Should only send the new message
       expect(newMockWebSocket.send).toHaveBeenCalledTimes(1);
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         "发送 1 条排队消息给客户端 test-client"
       );
     });

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -115,7 +115,7 @@ export class NotificationService {
       };
 
       this.clients.set(clientId, client);
-      this.logger.info(`WebSocket 客户端已注册: ${clientId}`);
+      this.logger.debug(`WebSocket 客户端已注册: ${clientId}`);
       this.logger.debug(`当前客户端数量: ${this.clients.size}`);
 
       // 发送排队的消息
@@ -143,7 +143,7 @@ export class NotificationService {
       if (this.clients.has(clientId)) {
         this.clients.delete(clientId);
         this.messageQueue.delete(clientId);
-        this.logger.info(`WebSocket 客户端已注销: ${clientId}`);
+        this.logger.debug(`WebSocket 客户端已注销: ${clientId}`);
         this.logger.debug(`剩余客户端数量: ${this.clients.size}`);
 
         // 发射客户端断开事件
@@ -254,7 +254,7 @@ export class NotificationService {
       return;
     }
 
-    this.logger.info(`发送 ${queue.length} 条排队消息给客户端 ${clientId}`);
+    this.logger.debug(`发送 ${queue.length} 条排队消息给客户端 ${clientId}`);
 
     for (const message of queue) {
       this.sendMessageToClient(client, message, clientId);
@@ -337,7 +337,7 @@ export class NotificationService {
     }
 
     if (disconnectedClients.length > 0) {
-      this.logger.info(`清理了 ${disconnectedClients.length} 个断开的客户端`);
+      this.logger.debug(`清理了 ${disconnectedClients.length} 个断开的客户端`);
     }
   }
 
@@ -345,7 +345,7 @@ export class NotificationService {
    * 销毁通知服务
    */
   destroy(): void {
-    this.logger.info("销毁通知服务");
+    this.logger.debug("销毁通知服务");
     this.clients.clear();
     this.messageQueue.clear();
   }


### PR DESCRIPTION
- 为什么改：降低信息类日志的输出频率，避免日志过于冗长，优化日志可读性
- 改了什么：
  - 将 5 个 handler 和 service 中的 info 级别日志降级为 debug 级别
  - 涉及文件：config.handler.ts、heartbeat.handler.ts、notification.service.ts
  - 前端移除 RestartButton 组件的 iconMode 属性，简化组件接口
  - 前端移除 ServerStatusCard 中的 AddMcpServerButton 组件
  - 前端移除 SystemStatusCard 中的 RestartButton 组件
  - 前端 AddMcpServerButton 组件改为全宽按钮，显示文字标签
- 影响范围：
  - 后端：仅影响日志输出级别，不影响业务逻辑
  - 前端：简化UI布局，移除部分按钮，提升界面简洁性
  - 测试：同步更新相关测试用例的日志级别断言
- 验证方式：运行后端和前端测试用例确保通过，检查日志输出符合预期