### PR TITLE
test(heartbeat): 修复测试断言日志级别不匹配问题

### DIFF
--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -473,7 +473,7 @@ describe("HeartbeatHandler", () => {
     it("should handle client connection", () => {
       heartbeatHandler.handleClientConnect(clientId);
 
-      expect(mockLogger.info).toHaveBeenCalledWith(
+      expect(mockLogger.debug).toHaveBeenCalledWith(
         `客户端连接建立: ${clientId}`
       );
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(


### PR DESCRIPTION
- 为什么改：测试用例 `should handle client connection` 失败，测试期望 `logger.info` 被调用，但源代码实际使用的是 `logger.debug`，导致断言失败
- 改了什么：将 `heartbeat.handler.test.ts:476` 的断言从 `expect(mockLogger.info)` 改为 `expect(mockLogger.debug)`
- 影响范围：仅影响测试代码，与同文件中 `handleClientDisconnect` 测试保持一致（第495行已正确使用 debug）
- 验证方式：44个测试用例全部通过，lint和类型检查无问题

源代码 `heartbeat.handler.ts:186` 中 `handleClientConnect` 方法使用 `this.logger.debug()` 记录客户端连接，而非 `info` 级别。修复后测试断言与实际实现保持一致。