### PR TITLE
chore(ci): 集成智谱AI MCP服务到Claude Code工作流

### DIFF
--- a/.cspell/words.txt
+++ b/.cspell/words.txt
@@ -103,3 +103,5 @@ Xiaozhi
 XIAOZHI
 XVCJ
 xzcli
+ZHIPU
+zread

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -30,6 +30,46 @@ jobs:
         with:
           fetch-depth: 1
 
+      - name: Create MCP Config
+        env:
+          ZHIPU_API_KEY: ${{ secrets.ZHIPU_API_KEY }}
+        run: |
+          cat > /tmp/mcp-config.json << EOF
+          {
+            "mcpServers": {
+              "zai-mcp-server": {
+                "type": "stdio",
+                "command": "npx",
+                "args": ["-y", "@z_ai/mcp-server"],
+                "env": {
+                  "Z_AI_MODE": "ZHIPU",
+                  "Z_AI_API_KEY": "$ZHIPU_API_KEY"
+                }
+              },
+              "web-search-prime": {
+                "type": "http",
+                "url": "https://open.bigmodel.cn/api/mcp/web_search_prime/mcp",
+                "headers": {
+                  "Authorization": "Bearer $ZHIPU_API_KEY"
+                }
+              },
+              "web-reader": {
+                "type": "http",
+                "url": "https://open.bigmodel.cn/api/mcp/web_reader/mcp",
+                "headers": {
+                  "Authorization": "Bearer $ZHIPU_API_KEY"
+                }
+              },
+              "zread": {
+                "type": "http",
+                "url": "https://open.bigmodel.cn/api/mcp/zread/mcp",
+                "headers": {
+                  "Authorization": "Bearer $ZHIPU_API_KEY"
+                }
+              }
+            }
+          }
+          EOF
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -42,3 +82,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
+          claude_args: "--mcp-config /tmp/mcp-config.json"


### PR DESCRIPTION
- 为什么改：为Claude Code增加智谱AI相关MCP服务支持，包括图像分析、网页搜索、网页读取和GitHub仓库读取能力
- 改了什么：
  - 在CI工作流中新增MCP配置生成步骤，配置4个智谱MCP服务（zai-mcp-server、web-search-prime、web-reader、zread）
  - 将智谱API密钥通过GitHub Secrets注入到MCP配置中
  - 在Claude Code Action中添加--mcp-config参数指向生成的配置文件
  - 更新.cspell/words.txt，添加ZHIPU和zread拼写检查词汇
- 影响范围：仅影响GitHub Actions工作流，不改变应用代码逻辑。需要确保仓库设置了ZHIPU_API_KEY密钥
- 验证方式：触发CI工作流验证MCP服务配置正确加载，Claude Code可以正常使用智谱MCP服务