### PR TITLE
feat(ci): 跳过Claude Code权限检查以支持MCP服务

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,6 +70,7 @@ jobs:
             }
           }
           EOF
+
       - name: Run Claude Code
         id: claude
         uses: anthropics/claude-code-action@v1
@@ -82,4 +83,4 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
-          claude_args: "--mcp-config /tmp/mcp-config.json"
+          claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"


### PR DESCRIPTION
- 为什么改：Claude Code在CI环境中需要使用MCP服务，但默认的权限检查会导致MCP配置无法正常加载
- 改了什么：在`.github/workflows/claude.yml`中为`claude_args`添加`--dangerously-skip-permissions`参数
- 影响范围：仅影响GitHub Actions中的Claude Code执行环境，不改变生产环境行为
- 验证方式：CI工作流成功加载MCP配置并使用相关工具