### PR TITLE
feat(ci): 启用 plan 权限模式以增强代码审查安全性

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -113,4 +113,4 @@ jobs:
           prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
-          claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"
+          claude_args: "--permission-mode plan --dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"


### PR DESCRIPTION
- 为什么改：为了在 GitHub PR/MR 流程中提供更安全的代码审查环境，plan 模式限制 Claude Code 的操作范围，防止意外的代码修改
- 改了什么：在 Claude Code CLI 参数中新增 `--permission-mode plan` 选项，启用 plan 权限模式
- 影响范围：仅影响 GitHub Actions 工作流中的 Claude Code 行为，本地开发不受影响；plan 模式下需要用户明确授权才能执行文件修改操作
- 验证方式：在 GitHub PR 中触发 workflow，确认 Claude Code 以 plan 模式运行，无法直接修改代码