### PR TITLE
docs(ci): 移除 Claude Code 审查流程的 plan 权限模式

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -113,4 +113,4 @@ jobs:
           prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
-          claude_args: "--permission-mode plan --dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"
+          claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"


### PR DESCRIPTION
- 为什么改：移除 `--permission-mode plan` 参数，简化 Claude Code 工作流配置
- 改了什么：从 `.github/workflows/claude.yml` 的 `claude_args` 中移除 `--permission-mode plan` 参数
- 影响范围：仅影响 GitHub Actions 中 Claude Code 的审查流程行为，不影响核心功能
- 验证方式：可通过 GitHub Actions 工作流触发验证配置有效性