### PR TITLE
fix(ci): 移除 Context7 MCP 服务器配置

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -60,12 +60,6 @@ jobs:
           cat > /tmp/mcp-config.json << EOF
           {
             "mcpServers": {
-              "context7": {
-                "url": "https://mcp.context7.com/mcp",
-                "headers": {
-                  "CONTEXT7_API_KEY": "$CONTEXT7_API_KEY"
-                }
-              },
               "zai-mcp-server": {
                 "type": "stdio",
                 "command": "npx",


### PR DESCRIPTION
- 为什么改：Context7 服务不再需要作为 MCP 服务器配置
- 改了什么：从 Claude Code 工作流配置中移除 context7 MCP 服务器定义（包括 URL 和 API_KEY 配置）
- 影响范围：仅影响 CI 环境中的 Claude Code MCP 服务器配置，不影响核心功能
- 验证方式：检查 CI 工作流配置文件，确认 Context7 配置已完全移除