### PR TITLE
feat(ci): 增强 Claude workflow prompt 以支持自动 PR 创建

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -104,7 +104,7 @@ jobs:
           ANTHROPIC_DEFAULT_SONNET_MODEL: ${{ inputs.model || vars.ANTHROPIC_DEFAULT_SONNET_MODEL || vars.CLAUDE_DEFAULT_MODEL }}
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
-          prompt: ${{ github.event.comment.body || github.event.review.body || github.event.issue.body }}
+          prompt: "${{ github.event.comment.body || github.event.review.body || github.event.issue.body }} 我希望你完成任务之后判断一下是否需要提交PR，如果需要请提交PR"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
           claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"


### PR DESCRIPTION
## Summary

- 在 GitHub workflow 的 Claude prompt 中添加了任务完成后判断是否需要创建 PR 的指示
- 使 Claude 能够根据任务性质自主决定是否提交 Pull Request

## Test plan

- [ ] 验证 workflow 触发时 prompt 正确传递
- [ ] 测试 Claude 能否正确响应新的 prompt 指示

🤖 Generated with [Claude Code](https://claude.com/claude-code)