### PR TITLE
style(ci): 规范 Claude workflow YAML 引号格式

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -41,8 +41,8 @@ jobs:
       - name: 设置 Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 'lts/iron'
-          cache: 'pnpm'
+          node-version: "lts/iron"
+          cache: "pnpm"
 
       - name: 安装依赖
         uses: nick-invision/retry@v3
@@ -108,3 +108,36 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
           claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"
+
+      - name: Get Claude branch name
+        run: |
+          echo "Claude created branch: ${{ steps.claude.outputs.branch }}"
+          echo "Pull Request URL: ${{ steps.claude.outputs.pull_request_url }}"
+          echo "Pull Request Number: ${{ steps.claude.outputs.pull_request_number }}"
+
+      # # 仅在 issue 触发时创建 PR（不在 PR 评论触发时创建）
+      # - name: 创建 Pull Request
+      #   if: github.event_name == 'issues' || github.event_name == 'issue_comment'
+      #   uses: peter-evans/create-pull-request@v5
+      #   with:
+      #     token: ${{ secrets.GITHUB_TOKEN }}
+      #     # 生成分支名：claude/fix-{issue-number}
+      #     branch: claude/fix-${{ github.event.issue.number }}
+      #     base: ${{ github.event.repository.default_branch }}
+      #     # 生成 PR 标题：fix: #{issue-number} {issue-title}
+      #     title: fix: #${{ github.event.issue.number }} ${{ github.event.issue.title }}
+      #     # 生成 PR 描述，引用原 issue
+      #     body: |
+      #       ## 说明
+      #       此 PR 由 Claude Code 自动创建，用于修复 issue #${{ github.event.issue.number }}
+
+      #       ## 原始 Issue
+      #       #${{ github.event.issue.number }}
+
+      #       ---
+      #       🤖 由 [Claude Code](https://claude.com/claude-code) 自动生成
+      #     labels: |
+      #       automated-pr
+      #       claude-generated
+      #     # 设为草稿，需要人工审核后再发布
+      #     draft: true


### PR DESCRIPTION
## 改动内容

- 将 `node-version` 和 `cache` 的单引号改为双引号，符合 YAML 规范
- 添加 Claude 输出信息调试步骤（branch、pull_request_url、pull_request_number）
- 添加注释化的 PR 自动创建步骤作为参考（暂不启用）

## 改动原因

- YAML 规范建议使用双引号
- 调试步骤有助于了解 Claude Code 的输出
- 保留 PR 自动创建步骤作为未来实现参考

## 测试计划

- [ ] Review YAML 语法正确性
- [ ] 验证 workflow 配置合规

---

🤖 由 [Claude Code](https://claude.com/claude-code) 自动生成