### PR TITLE
feat(ci): 直接在 Claude workflow 中创建 PR

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -108,26 +108,37 @@ jobs:
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           show_full_output: ${{ vars.CLAUDE_FULL_OUTPUT || 'false' }}
           claude_args: "--dangerously-skip-permissions --mcp-config /tmp/mcp-config.json"
-      - name: Trigger Create PR Workflow
+
+      - name: 创建PR
+        id: parse
         if: |
           success() &&
           (github.event_name == 'issues' || github.event_name == 'issue_comment')
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          GH_TOKEN: ${{ github.token }}
         run: |
-          # 获取 issue number
-          if [ "${{ github.event_name }}" = "issues" ]; then
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            ISSUE_NUMBER="${{ github.event.issue.number }}"
-          fi
-
-          echo "🚀 触发 Create PR workflow for issue #$ISSUE_NUMBER"
-
-          # 等待几秒确保 Claude 的更改已经推送
           sleep 10
+          output=$(npx tsx scripts/parse-claude-reply.ts --issue "$ISSUE_NUMBER" 2>&1)
+          echo "$output"
+          result=$(echo "$output" | sed -n '/^{/,/^}/p')
+          echo "$result"
 
-          gh workflow run create-pr.yml \
-            -f issue_number="$ISSUE_NUMBER"
+          # 提取各个字段
+          branch_name=$(echo "$result" | jq -r .branchName)
+          pr_title=$(echo "$result" | jq -r .title)
+          pr_body=$(echo "$result" | jq -r .body)
 
-          echo "✅ Create PR workflow 已触发"
+          # 输出到 GITHUB_OUTPUT（使用 heredoc 处理多行）
+          echo "branch_name=$branch_name" >> $GITHUB_OUTPUT
+          echo "pr_title=$pr_title" >> $GITHUB_OUTPUT
+
+          # 使用 heredoc 处理多行 body
+          echo "pr_body<<EOF" >> $GITHUB_OUTPUT
+          echo "$pr_body" >> $GITHUB_OUTPUT
+          echo "EOF" >> $GITHUB_OUTPUT
+          gh pr create \
+            --base main \
+            --head "$branch_name" \
+            --title "$pr_title" \
+            --body "$pr_body" \


### PR DESCRIPTION
## 概述

- 移除对 `create-pr.yml` 工作流的依赖
- 使用 `parse-claude-reply.ts` 脚本解析 Issue 并提取 PR 信息
- 直接在同一 workflow 中创建 PR，简化流程
- 修复 `GH_TOKEN` 环境变量使用 (`${{ github.token }}`)
- 移除冗余的条件判断逻辑

## 改动说明

### 重构 PR 创建流程

**之前**：Claude workflow → 触发 create-pr.yml workflow → 创建 PR

**现在**：Claude workflow → 直接解析并创建 PR

### 具体变更

- 使用 `parse-claude-reply.ts` 脚本解析 Claude 回复
- 提取分支名、标题和描述信息
- 直接调用 `gh pr create` 创建 PR
- 移除冗余的 `issues` vs `issue_comment` 条件判断（两者都能获取 `issue.number`）
- 使用正确的 `github.token` 而非 `secrets.GITHUB_TOKEN`

## 测试计划

- [ ] 验证 workflow 可以正确解析 Issue
- [ ] 确认 PR 能够成功创建
- [ ] 检查 PR 标题和描述格式正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)