### PR TITLE
fix(ci): 使用 repository_dispatch 实现 workflow 间通信

### DIFF
--- a/.github/workflows/auto-claude-comment.yml
+++ b/.github/workflows/auto-claude-comment.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   issues: write
+  contents: write  # 需要 contents 权限来触发 repository_dispatch
 
 jobs:
   auto-comment:
@@ -39,7 +40,7 @@ jobs:
           retry_on: error
           command: pnpm install
 
-      - name: 检查并添加 Claude 评论
+      - name: 检查并触发 Claude 处理
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -48,12 +49,22 @@ jobs:
 
           # 遍历每个 issue
           echo "$issues" | jq -r '.[].number' | while read -r issue_number; do
-            # 检查是否已有 @claude 评论
+            # 检查是否已有 @claude 评论（避免重复触发）
             has_claude=$(gh issue view "$issue_number" --json comments -q '.comments[].body' | grep -c "@claude" || true)
 
             if [ "$has_claude" -eq 0 ]; then
-              echo "为 issue #$issue_number 添加 @claude 评论"
+              echo "为 issue #$issue_number 添加 @claude 评论并触发 Claude workflow"
+              # 添加评论（作为记录）
               gh issue comment "$issue_number" --body "@claude"
+
+              # 使用 repository_dispatch 触发 claude.yml workflow
+              # 这是 GitHub 官方支持的 workflow 间通信方式
+              gh api \
+                --method POST \
+                -H "Accept: application/vnd.github.v3+json" \
+                "/repos/${GITHUB_REPOSITORY}/dispatches" \
+                -f event_type="claude_issue_trigger" \
+                -f client_payload="{\"issue_number\":$issue_number}"
             else
               echo "issue #$issue_number 已有 @claude 评论，跳过"
             fi

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -9,6 +9,14 @@ on:
     types: [opened, assigned]
   pull_request_review:
     types: [submitted]
+  workflow_dispatch:
+    inputs:
+      issue_number:
+        description: "Issue 编号"
+        required: true
+        type: string
+  repository_dispatch:
+    types: [claude_issue_trigger]
 
 jobs:
   claude:
@@ -16,7 +24,9 @@ jobs:
       (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review_comment' && contains(github.event.comment.body, '@claude')) ||
       (github.event_name == 'pull_request_review' && contains(github.event.review.body, '@claude')) ||
-      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude')))
+      (github.event_name == 'issues' && (contains(github.event.issue.body, '@claude') || contains(github.event.issue.title, '@claude'))) ||
+      github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'repository_dispatch'
     runs-on: ubuntu-latest
     permissions:
       contents: write
@@ -113,9 +123,17 @@ jobs:
         id: parse
         if: |
           success() &&
-          (github.event_name == 'issues' || github.event_name == 'issue_comment')
+          (github.event_name == 'issues' ||
+           github.event_name == 'issue_comment' ||
+           github.event_name == 'workflow_dispatch' ||
+           github.event_name == 'repository_dispatch')
         env:
-          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          ISSUE_NUMBER: >-
+            ${{
+              github.event_name == 'workflow_dispatch' && inputs.issue_number ||
+              github.event_name == 'repository_dispatch' && github.event.client_payload.issue_number ||
+              github.event.issue.number
+            }}
           GH_TOKEN: ${{ github.token }}
         run: |
           sleep 10


### PR DESCRIPTION
## 概述

修复 `auto-claude-comment.yml` 无法触发 `claude.yml` 的问题。

## 问题

由于 GitHub Actions 的安全限制，使用 `GITHUB_TOKEN` 创建的评论不会触发其他 workflows（防止无限循环）。

## 解决方案

使用 GitHub 官方支持的 `repository_dispatch` 事件实现 workflow 间通信：

- `auto-claude-comment.yml` 扫描开放的 issue，通过 `repository_dispatch` 触发 `claude.yml`
- `claude.yml` 添加 `workflow_dispatch` 和 `repository_dispatch` 触发器
- 更新 `ISSUE_NUMBER` 获取逻辑，支持从多种触发方式获取 issue 编号

## 工作流程

```
auto-claude-comment.yml
    ↓ 扫描开放的 issue
    ↓ 发送 repository_dispatch (携带 issue_number)
claude.yml
    ↓ 运行 Claude Code
    ↓ 创建 PR
```

## 优势

- ✅ 避免代码重复（所有处理逻辑集中在 `claude.yml`）
- ✅ 使用 GitHub 官方支持的 workflow 间通信方式
- ✅ 可通过 API 直接触发 `repository_dispatch`

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)