### PR TITLE
fix(ci): 使用 jq 替代 heredoc 避免 YAML 缩进问题

### DIFF
--- a/.github/workflows/auto-claude-comment.yml
+++ b/.github/workflows/auto-claude-comment.yml
@@ -59,18 +59,15 @@ jobs:
 
               # 使用 repository_dispatch 触发 claude.yml workflow
               # 这是 GitHub 官方支持的 workflow 间通信方式
-              gh api \
-                --method POST \
-                -H "Accept: application/vnd.github.v3+json" \
-                "/repos/${GITHUB_REPOSITORY}/dispatches" \
-                --input - << EOF
-              {
-                "event_type": "claude_issue_trigger",
-                "client_payload": {
-                  "issue_number": $issue_number
-                }
-              }
-              EOF
+              jq -n \
+                --arg event_type "claude_issue_trigger" \
+                --argjson issue_number "$issue_number" \
+                '{event_type: $event_type, client_payload: {issue_number: $issue_number}}' \
+              | gh api \
+                  --method POST \
+                  -H "Accept: application/vnd.github.v3+json" \
+                  "/repos/${GITHUB_REPOSITORY}/dispatches" \
+                  --input -
             else
               echo "issue #$issue_number 已有 @claude 评论，跳过"
             fi


### PR DESCRIPTION
## 问题描述

在 YAML 的 `run: |` 块中使用 heredoc 时，`EOF` 结束标记的缩进导致 bash 无法识别，产生语法错误。

## 解决方案

使用 `jq` 构造 JSON 对象，通过标准输入传递给 `gh api`，避免 heredoc 缩进问题。

## 测试计划

- [ ] 本地 bash 语法验证通过
- [ ] Workflow 运行测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)