### PR TITLE
fix(frontend): cleanup copy timeout on unmount

### DIFF
--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -9,7 +9,7 @@ import type { VersionInfo } from "@/services/api";
 import { apiClient } from "@/services/api";
 import { Button } from "@ui/button";
 import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";
 
 interface VersionDisplayProps {
@@ -31,6 +31,7 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
   const [checkingUpdate, setCheckingUpdate] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -48,6 +49,14 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
     };
 
     fetchVersion();
+  }, []);
+
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
   }, []);
 
   useEffect(() => {
@@ -81,7 +90,10 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
       try {
         await navigator.clipboard.writeText(versionInfo.version);
         setCopied(true);
-        setTimeout(() => setCopied(false), 2000);
+        if (copiedTimerRef.current) {
+          clearTimeout(copiedTimerRef.current);
+        }
+        copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
       } catch (err) {
         console.error("复制版本号失败:", err);
       }


### PR DESCRIPTION
Closes #859

- Store `setTimeout` handles in a ref and clear on unmount.
- Clear any previous timer before creating a new one.

Verified:
- `pnpm nx run frontend:lint`
- `pnpm nx run frontend:type-check`
