### PR TITLE
fix(ci): 使用 PAT_TOKEN 替代 github.token

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -134,7 +134,7 @@ jobs:
               github.event_name == 'repository_dispatch' && github.event.client_payload.issue_number ||
               github.event.issue.number
             }}
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
         run: |
           sleep 10
           output=$(npx tsx scripts/parse-claude-reply.ts --issue "$ISSUE_NUMBER" 2>&1)


### PR DESCRIPTION
## 概要

- 将 GitHub Actions 工作流中的 `GH_TOKEN` 从 `github.token` 更改为 `secrets.PAT_TOKEN`
- 确保工作流具有足够的权限执行创建 PR 等操作

## 变更说明

修改 `.github/workflows/claude.yml` 中的环境变量 `GH_TOKEN`，使用个人访问令牌（PAT_TOKEN）替代默认的 `github.token`。这样可以确保工作流在处理 Issue 评论和创建 PR 时具有足够的权限。

## 测试计划

- [ ] 验证工作流能正常运行
- [ ] 验证能够成功创建 PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)