### PR TITLE
fix: 将 WebSocket 服务中的 any 类型替换为 unknown 提升类型安全性

### DIFF
--- a/apps/frontend/src/services/__tests__/websocket.test.ts
+++ b/apps/frontend/src/services/__tests__/websocket.test.ts
@@ -55,7 +55,7 @@ class MockWebSocket {
     }
   }
 
-  mockMessage(data: any): void {
+  mockMessage(data: unknown): void {
     if (this.onmessage) {
       this.onmessage({ data: JSON.stringify(data) } as MessageEvent);
     }

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -14,7 +14,7 @@ import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
  */
 interface WebSocketMessage {
   type: string;
-  data?: any;
+  data?: unknown;
   timestamp?: number;
   error?: {
     code: string;
@@ -120,7 +120,7 @@ interface EventBusEvents {
 /**
  * 事件监听器类型
  */
-type EventListener<T = any> = (data: T) => void;
+type EventListener<T = unknown> = (data: T) => void;
 
 /**
  * WebSocket 连接状态
@@ -147,7 +147,8 @@ interface WebSocketManagerConfig {
  * 事件总线类 - 支持多个订阅者
  */
 class EventBus {
-  private listeners: Map<string, Set<EventListener>> = new Map();
+  private listeners: Map<keyof EventBusEvents, Set<EventListener<unknown>>> =
+    new Map();
 
   /**
    * 订阅事件
@@ -159,7 +160,7 @@ class EventBus {
     if (!this.listeners.has(event)) {
       this.listeners.set(event, new Set());
     }
-    this.listeners.get(event)!.add(listener);
+    this.listeners.get(event)!.add(listener as EventListener<unknown>);
 
     // 返回取消订阅函数
     return () => {
@@ -176,7 +177,7 @@ class EventBus {
   ): void {
     const eventListeners = this.listeners.get(event);
     if (eventListeners) {
-      eventListeners.delete(listener);
+      eventListeners.delete(listener as EventListener<unknown>);
       if (eventListeners.size === 0) {
         this.listeners.delete(event);
       }
@@ -408,7 +409,7 @@ export class WebSocketManager {
   /**
    * 发送消息
    */
-  send(message: any): boolean {
+  send(message: unknown): boolean {
     if (!this.isConnected()) {
       console.warn("[WebSocket] 连接未建立，无法发送消息");
       return false;
@@ -500,50 +501,71 @@ export class WebSocketManager {
         case "configUpdate":
         case "config":
           if (message.data) {
-            this.eventBus.emit("data:configUpdate", message.data);
+            this.eventBus.emit("data:configUpdate", message.data as AppConfig);
           }
           break;
 
         case "statusUpdate":
         case "status":
           if (message.data) {
-            this.eventBus.emit("data:statusUpdate", message.data);
+            this.eventBus.emit(
+              "data:statusUpdate",
+              message.data as ClientStatus
+            );
           }
           break;
 
         case "restartStatus":
           if (message.data) {
-            this.eventBus.emit("data:restartStatus", message.data);
+            this.eventBus.emit(
+              "data:restartStatus",
+              message.data as RestartStatus
+            );
           }
           break;
 
         case "endpoint_status_changed":
           if (message.data) {
-            this.eventBus.emit("data:endpointStatusChanged", message.data);
+            this.eventBus.emit(
+              "data:endpointStatusChanged",
+              message.data as EndpointStatusChangedEvent
+            );
           }
           break;
 
         case "npm:install:started":
           if (message.data) {
-            this.eventBus.emit("data:npmInstallStarted", message.data);
+            this.eventBus.emit(
+              "data:npmInstallStarted",
+              message.data as NPMInstallStartedEvent
+            );
           }
           break;
 
         case "npm:install:log":
           if (message.data) {
-            this.eventBus.emit("data:npmInstallLog", message.data);
+            this.eventBus.emit(
+              "data:npmInstallLog",
+              message.data as NPMInstallLogEvent
+            );
           }
           break;
 
         case "npm:install:completed":
           if (message.data) {
-            this.eventBus.emit("data:npmInstallCompleted", message.data);
+            this.eventBus.emit(
+              "data:npmInstallCompleted",
+              message.data as NPMInstallCompletedEvent
+            );
           }
           break;
 
         case "npm:install:failed":
           if (message.data) {
-            this.eventBus.emit("data:npmInstallFailed", message.data);
+            this.eventBus.emit(
+              "data:npmInstallFailed",
+              message.data as NPMInstallFailedEvent
+            );
           }
           break;
 


### PR DESCRIPTION
- 将 WebSocketMessage.data 的 any 类型替换为 unknown
- 将 EventListener<T = any> 的默认类型替换为 unknown
- 将 send 方法的 any 参数替换为 unknown
- 更新相关测试文件的类型定义

这些修改遵循 TypeScript 最佳实践，使用 unknown 类型提供更好的
类型安全性，同时保持代码的灵活性。使用 unknown 需要在使用前
进行类型检查或断言，比 any 更安全。

Fixes #887

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>