### PR TITLE
fix: 修复 ServiceApiHandler 中重启定时器资源泄漏问题

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -943,6 +943,9 @@ export class WebServer {
     this.statusService.destroy();
     this.notificationService.destroy();
 
+    // 清理处理器的定时器资源
+    this.serviceApiHandler.cleanup();
+
     // 销毁事件总线
     destroyEventBus();
 


### PR DESCRIPTION
在 restartService 方法中添加了定时器跟踪和清理机制：

- 添加 restartTimeouts Set 用于跟踪所有活跃的重启定时器
- 修改嵌套 setTimeout 实现，在定时器执行后自动从集合中移除
- 添加 cleanup 方法用于清除所有待处理的定时器
- 在 WebServer.destroy() 中调用 cleanup 确保资源正确释放

新增 6 个单元测试验证定时器清理逻辑：
- cleanup 应该清除所有待处理的定时器
- cleanup 后新的重启请求应该正常工作
- cleanup 应该可以安全地多次调用
- 在定时器触发前调用 cleanup 应该阻止状态更新
- 定时器执行完成后应该自动从集合中移除
- 重启失败时定时器也应该被清理

修复 #893

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>