### PR TITLE
fix: 将 toolSorters.ts 中的 console.warn 替换为统一的 Logger 系统

### DIFF
--- a/apps/backend/utils/toolSorters.ts
+++ b/apps/backend/utils/toolSorters.ts
@@ -3,6 +3,7 @@
  * 提供可扩展的排序策略，支持多种排序方式
  */
 
+import { logger } from "@/Logger.js";
 import type { EnhancedToolInfo } from "@/lib/mcp";
 
 export type ToolSortField = "name" | "enabled" | "usageCount" | "lastUsedTime";
@@ -95,7 +96,7 @@ export function sortTools(
 ): EnhancedToolInfo[] {
   const sorter = toolSorters[config.field];
   if (!sorter) {
-    console.warn(`[sortTools] 未知的排序字段: ${config.field}`);
+    logger.warn(`[sortTools] 未知的排序字段: ${config.field}`);
     return tools;
   }
 


### PR DESCRIPTION
- 添加 logger 导入
- 将 console.warn 替换为 logger.warn
- 修复导入顺序以符合 Biome 规范

修复 #895

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>