### PR TITLE
fix: 修复 shared-types toolApi.ts 中的 any 类型问题

### DIFF
--- a/packages/shared-types/src/api/toolApi.ts
+++ b/packages/shared-types/src/api/toolApi.ts
@@ -140,7 +140,7 @@ export interface ToolValidationErrorDetail {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: Record<string, unknown>;
   /** 建议的解决方案 */
   suggestions?: string[];
 }
@@ -150,7 +150,7 @@ export interface ToolValidationErrorDetail {
  */
 export interface AddToolResponse {
   /** 成功添加的工具 */
-  tool: any;
+  tool: ExtendedCustomMCPTool;
   /** 工具名称 */
   toolName: string;
   /** 工具类型 */


### PR DESCRIPTION
- AddToolResponse.tool 从 any 改为 ExtendedCustomMCPTool
- ToolValidationErrorDetail.details 从 any 改为 Record<string, unknown>

修复 #900

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>