### PR TITLE
fix: 移除 packages/config 中冗余的 json5 依赖

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,8 +26,7 @@
   },
   "dependencies": {
     "comment-json": "^4.2.5",
-    "dayjs": "^1.11.13",
-    "json5": "^2.2.3"
+    "dayjs": "^1.11.13"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,9 +546,6 @@ importers:
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
-      json5:
-        specifier: ^2.2.3
-        version: 2.2.3
     devDependencies:
       '@types/node':
         specifier: ^24.3.0


### PR DESCRIPTION
代码中实际使用的是 comment-json 包来实现 JSON5/JSONC 注释保留功能，
json5 依赖声明但从未被导入或使用。

移除此冗余依赖可以：
- 减小包体积和依赖解析时间
- 避免维护者混淆
- 提高代码可维护性

Fixes #904

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>