### PR TITLE
fix: 统一 inputSchema 类型定义，移除 as any 类型断言

### DIFF
--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,7 +4,7 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
-import { MCPManager } from "@xiaozhi-client/mcp-core";
+import { MCPManager, type JSONSchema } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
@@ -105,7 +105,7 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        inputSchema: mcpTool.inputSchema,
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,

--- a/packages/mcp-core/src/manager.ts
+++ b/packages/mcp-core/src/manager.ts
@@ -5,7 +5,7 @@
 
 import { EventEmitter } from "node:events";
 import { MCPConnection } from "./connection.js";
-import type { MCPServiceConfig, ToolCallResult } from "./types.js";
+import type { MCPServiceConfig, ToolCallResult, JSONSchema } from "./types.js";
 import { MCPTransportType } from "./types.js";
 
 /**
@@ -214,13 +214,13 @@ export class MCPManager extends EventEmitter {
     name: string;
     serverName: string;
     description: string;
-    inputSchema: unknown;
+    inputSchema: JSONSchema;
   }> {
     const allTools: Array<{
       name: string;
       serverName: string;
       description: string;
-      inputSchema: unknown;
+      inputSchema: JSONSchema;
     }> = [];
 
     for (const [serverName, connection] of this.connections) {


### PR DESCRIPTION
- 修改 MCPManager.listTools() 返回类型从 unknown 改为 JSONSchema
- 从 @xiaozhi-client/mcp-core 导入 JSONSchema 类型
- 移除 internal-mcp-manager.ts 中的 as any 类型断言
- 确保跨包类型安全性

修复 #906

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>