### PR TITLE
fix: 在 ServiceManager 中为 spawn 进程添加 error 事件监听器

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -248,6 +248,13 @@ export class ServiceManagerImpl implements IServiceManager {
         }
       );
 
+      // 监听 error 事件，处理子进程启动失败的情况
+      child.on("error", (err) => {
+        consola.error(`启动 MCP Server 失败: ${err.message}`);
+        this.processManager.cleanupPidFile();
+        process.exit(1);
+      });
+
       // 保存 PID 信息
       this.processManager.savePidInfo(child.pid || 0, "daemon");
 
@@ -302,6 +309,13 @@ export class ServiceManagerImpl implements IServiceManager {
         XIAOZHI_CONFIG_DIR: PathUtils.getConfigDir(),
         XIAOZHI_DAEMON: "true",
       },
+    });
+
+    // 监听 error 事件，处理子进程启动失败的情况
+    child.on("error", (err) => {
+      consola.error(`启动 WebServer 失败: ${err.message}`);
+      this.processManager.cleanupPidFile();
+      process.exit(1);
     });
 
     // 保存 PID 信息

--- a/packages/cli/src/services/__tests__/DaemonMode.integration.test.ts
+++ b/packages/cli/src/services/__tests__/DaemonMode.integration.test.ts
@@ -112,6 +112,7 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 12345,
         unref: vi.fn(),
+        on: vi.fn(),
         stdout: null,
         stderr: null,
       };
@@ -160,6 +161,7 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 12346,
         unref: vi.fn(),
+        on: vi.fn(),
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -200,6 +202,7 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 54321,
         unref: vi.fn(),
+        on: vi.fn(),
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -288,6 +291,7 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 99999,
         unref: vi.fn(),
+        on: vi.fn(),
         stdout: { pipe: vi.fn() },
         stderr: { pipe: vi.fn() },
       };

--- a/packages/cli/src/services/__tests__/ServiceManager.test.ts
+++ b/packages/cli/src/services/__tests__/ServiceManager.test.ts
@@ -338,6 +338,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -388,6 +389,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -424,6 +426,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 5678,
           unref: vi.fn(),
+          on: vi.fn(),
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -508,6 +511,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: undefined,
           unref: vi.fn(),
+          on: vi.fn(),
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -536,6 +540,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
         };
         mockSpawn.mockReturnValue(mockChild as any);
 


### PR DESCRIPTION
修复了在 detached 模式下启动子进程时缺少 error 事件监听器的问题。

### 问题描述
- 当 spawn 启动子进程失败时（如 node 命令不存在、权限不足等），
  由于缺少 error 事件监听器，错误会被静默忽略
- 父进程无法知道子进程启动失败
- PID 文件可能包含无效的 PID
- 用户会收到"服务已启动"的错误消息

### 修复内容
- 在 startMcpServerMode 方法中添加 error 事件监听器
- 在 startWebServerInDaemon 方法中添加 error 事件监听器
- 错误发生时输出错误信息、清理 PID 文件并退出进程
- 同步更新相关测试用例的 mock 对象，添加 on 方法

### 影响范围
- packages/cli/src/services/ServiceManager.ts
- packages/cli/src/services/__tests__/DaemonMode.integration.test.ts
- packages/cli/src/services/__tests__/ServiceManager.test.ts

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>