### PR TITLE
fix: 修复 NetworkService.reconnectWebSocket 定时器未清理问题

### DIFF
--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -19,6 +19,7 @@ export class NetworkService {
   private apiClient: ApiClient;
   private webSocketManager: WebSocketManager;
   private initialized = false;
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
   constructor() {
     this.apiClient = apiClient;
@@ -46,6 +47,11 @@ export class NetworkService {
    * 销毁网络服务
    */
   destroy(): void {
+    // 清理重连定时器
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
     console.log("[NetworkService] 销毁网络服务");
     this.webSocketManager.disconnect();
     this.initialized = false;
@@ -254,9 +260,16 @@ export class NetworkService {
    * 重新连接 WebSocket
    */
   reconnectWebSocket(): void {
+    // 清除已有的重连定时器
+    if (this.reconnectTimer) {
+      clearTimeout(this.reconnectTimer);
+      this.reconnectTimer = null;
+    }
+
     this.webSocketManager.disconnect();
-    setTimeout(() => {
+    this.reconnectTimer = setTimeout(() => {
       this.webSocketManager.connect();
+      this.reconnectTimer = null;
     }, 1000);
   }
 


### PR DESCRIPTION
添加 reconnectTimer 属性以跟踪定时器引用，防止：
- 服务销毁时定时器未清理导致的资源泄漏
- 快速多次调用时创建多个定时器的竞态条件

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>