### PR TITLE
refactor: 移除 ProcessManager.gracefulKillProcess 与 PlatformUtils.killProcess 的重复代码

### DIFF
--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -153,33 +153,7 @@ export class ProcessManagerImpl implements IProcessManager {
    */
   async gracefulKillProcess(pid: number): Promise<void> {
     try {
-      // 尝试优雅停止
-      process.kill(pid, "SIGTERM");
-
-      // 等待进程停止
-      let attempts = 0;
-      const maxAttempts = 30; // 3秒超时
-
-      while (attempts < maxAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        try {
-          process.kill(pid, 0);
-          attempts++;
-        } catch {
-          // 进程已停止
-          return;
-        }
-      }
-
-      // 如果还在运行，强制停止
-      try {
-        process.kill(pid, 0);
-        process.kill(pid, "SIGKILL");
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      } catch {
-        // 进程已停止
-      }
+      await PlatformUtils.killProcess(pid, "SIGTERM");
     } catch (error) {
       throw new ProcessError(
         `无法停止进程: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
将 ProcessManager.gracefulKillProcess 方法简化为直接调用 PlatformUtils.killProcess，
消除了 28 行重复的进程终止逻辑。

- 代码从 35 行减少到 9 行
- 完全复用 PlatformUtils 的实现
- 保持 ProcessManager 的错误处理封装
- 所有测试通过

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>