### PR TITLE
fix: 修复 WebServer EventBus 监听器未清理导致的内存泄漏

### DIFF
--- a/apps/backend/__tests__/webserver/webserver.integration.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.integration.test.ts
@@ -55,6 +55,7 @@ vi.mock("../../Logger", () => {
 vi.mock("@/services/index.js", () => {
   const mockEventBus = {
     onEvent: vi.fn().mockReturnThis(),
+    offEvent: vi.fn().mockReturnThis(),
     emit: vi.fn(),
     emitEvent: vi.fn(),
     removeAllListeners: vi.fn(),
@@ -1727,6 +1728,9 @@ describe("WebServer 集成测试", () => {
     it("应该设置接入点状态变更监听器", async () => {
       webServer = new WebServer(currentPort);
 
+      // 必须先启动 WebServer，监听器才会注册
+      await webServer.start();
+
       // 验证事件总线 onEvent 方法被调用
       const { getEventBus } = await import("@/services/index.js");
       const mockEventBus = getEventBus();
@@ -1734,6 +1738,8 @@ describe("WebServer 集成测试", () => {
         "endpoint:status:changed",
         expect.any(Function)
       );
+
+      await webServer.stop();
     });
 
     it("应该在端点状态变更时广播事件", async () => {


### PR DESCRIPTION
问题描述：
- WebServer 类中多个 setup*Listener 方法通过 eventBus.onEvent() 注册了事件监听器
- 但在 stop() 方法中从未移除这些监听器，导致内存泄漏和重复执行问题

修复内容：
1. 添加 eventBusUnsubscribers 数组属性来存储取消函数
2. 修改 setupEndpointStatusListener() 和 setupMCPServerAddedListener() 方法
   - 将监听器提取为具名函数
   - 在注册监听器后保存取消函数
3. 将监听器设置从构造函数移到 start() 方法中
   - 支持同一实例的多次 start/stop
   - 确保每次启动时重新注册监听器
4. 在 stop() 方法开头添加监听器清理逻辑
   - 遍历所有取消函数并执行
   - 清空取消函数数组

测试更新：
1. 在集成测试的 EventBus mock 中添加 offEvent 方法
2. 在单元测试中添加 EventBus 监听器清理相关的测试用例
3. 修复集成测试中需要先启动 WebServer 才能验证监听器注册的问题

影响范围：
- apps/backend/WebServer.ts
- apps/backend/__tests__/webserver/webserver.integration.test.ts
- apps/backend/__tests__/webserver/webserver.unit.test.ts

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>