### PR TITLE
fix: 修改 endpoint.route.ts 使用路径别名导入

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,8 +4,8 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import type { AppContext } from "../../types/hono.context.js";
 import type { RouteDefinition } from "../types.js";
 
 /**


### PR DESCRIPTION
- 将相对路径 `../../types/hono.context.js` 改为路径别名 `@/types/hono.context.js`
- 与项目中其他 handlers 保持导入风格一致
- 修复 issue #921

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>