### PR TITLE
fix: 为 service.handler.ts 中的 spawn 进程添加 error 事件监听器

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -101,6 +101,13 @@ export class ServiceApiHandler {
             XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
           },
         });
+
+        // 添加 error 事件监听器，捕获 spawn 失败
+        child.on("error", (error) => {
+          this.logger.error("启动 xiaozhi 进程失败:", error);
+          throw new Error(`无法启动 xiaozhi 进程: ${error.message}`);
+        });
+
         child.unref();
         this.logger.info("MCP 服务启动命令已发送");
         return;
@@ -117,6 +124,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 添加 error 事件监听器，捕获 spawn 失败
+      child.on("error", (error) => {
+        this.logger.error("重启 xiaozhi 进程失败:", error);
+        throw new Error(`无法重启 xiaozhi 进程: ${error.message}`);
       });
 
       child.unref();
@@ -144,6 +157,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 添加 error 事件监听器，捕获 spawn 失败
+      child.on("error", (error) => {
+        c.get("logger").error("停止 xiaozhi 进程失败:", error);
+        throw new Error(`无法停止 xiaozhi 进程: ${error.message}`);
       });
 
       child.unref();
@@ -178,6 +197,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 添加 error 事件监听器，捕获 spawn 失败
+      child.on("error", (error) => {
+        c.get("logger").error("启动 xiaozhi 进程失败:", error);
+        throw new Error(`无法启动 xiaozhi 进程: ${error.message}`);
       });
 
       child.unref();


### PR DESCRIPTION
修复 apps/backend/handlers/service.handler.ts 中多个 spawn 调用缺少 error 事件监听器的问题。当 spawn 操作失败时（例如命令不存在、权限不足等），现在会正确记录错误并抛出异常，而不是静默忽略。

### 修复位置
- executeRestart 方法中的 start spawn (约第 96 行)
- executeRestart 方法中的 restart spawn (约第 113 行)
- stopService 方法中的 spawn (约第 140 行)
- startService 方法中的 spawn (约第 174 行)

### 变更内容
为所有 spawn 调用添加了 child.on('error') 监听器，参考 packages/cli/src/services/DaemonManager.ts 中的正确实现。

### 影响
- 当 xiaozhi 命令不存在或 spawn 失败时，用户现在会收到明确的错误提示
- 错误会被记录到日志中，便于调试
- 避免错误静默忽略导致的用户体验问题

Fixes #925

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>