### PR TITLE
fix: 修复 useWebSocketConnection hook 中的类型安全问题

### DIFF
--- a/apps/frontend/src/hooks/useWebSocketConnection.ts
+++ b/apps/frontend/src/hooks/useWebSocketConnection.ts
@@ -5,6 +5,7 @@
  * 返回连接状态、错误信息、连接控制方法
  */
 
+import type { WebSocketMessage } from "@services/websocket";
 import { ConnectionState, webSocketManager } from "@services/websocket";
 import {
   useWebSocketActions,
@@ -60,7 +61,7 @@ export function useWebSocketConnection() {
   }, [reconnect]);
 
   const sendMessage = useCallback(
-    (message: any) => {
+    (message: WebSocketMessage) => {
       try {
         return send(message);
       } catch (error) {


### PR DESCRIPTION
将 sendMessage 方法的参数类型从 any 改为 WebSocketMessage，
提升代码的类型安全性和 IDE 支持。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>