### PR TITLE
fix: 为 spawn 进程添加 error 事件监听器以避免静默失败

### DIFF
--- a/apps/backend/__tests__/webserver/webserver.integration.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.integration.test.ts
@@ -273,6 +273,7 @@ vi.mock("node:child_process", () => ({
   exec: vi.fn(),
   spawn: vi.fn(() => ({
     unref: vi.fn(),
+    on: vi.fn(),
   })),
 }));
 

--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -75,6 +75,7 @@ describe("ServiceApiHandler", () => {
     // Mock spawn
     mockSpawn = vi.fn().mockReturnValue({
       unref: vi.fn(),
+      on: vi.fn(),
     });
     const { spawn } = await import("node:child_process");
     vi.mocked(spawn).mockImplementation(mockSpawn);
@@ -541,7 +542,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "START_REQUEST_ERROR",
-        "Cannot read properties of null (reading 'unref')",
+        "Cannot read properties of null (reading 'on')",
         undefined,
         500
       );
@@ -554,7 +555,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "START_REQUEST_ERROR",
-        "child.unref is not a function",
+        "child.on is not a function",
         undefined,
         500
       );
@@ -562,6 +563,7 @@ describe("ServiceApiHandler", () => {
 
     it("should handle unref method throwing error", async () => {
       mockSpawn.mockReturnValue({
+        on: vi.fn(),
         unref: vi.fn().mockImplementation(() => {
           throw new Error("Unref failed");
         }),

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -101,6 +101,12 @@ export class ServiceApiHandler {
             XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
           },
         });
+
+        child.on("error", (error) => {
+          this.logger.error("启动 xiaozhi 进程失败:", error);
+          throw new Error(`启动 xiaozhi 进程失败: ${error.message}`);
+        });
+
         child.unref();
         this.logger.info("MCP 服务启动命令已发送");
         return;
@@ -117,6 +123,11 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      child.on("error", (error) => {
+        this.logger.error("重启 xiaozhi 进程失败:", error);
+        throw new Error(`重启 xiaozhi 进程失败: ${error.message}`);
       });
 
       child.unref();
@@ -144,6 +155,11 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      child.on("error", (error) => {
+        this.logger.error("停止 xiaozhi 进程失败:", error);
+        throw new Error(`停止 xiaozhi 进程失败: ${error.message}`);
       });
 
       child.unref();
@@ -178,6 +194,11 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      child.on("error", (error) => {
+        this.logger.error("启动 xiaozhi 进程失败:", error);
+        throw new Error(`启动 xiaozhi 进程失败: ${error.message}`);
       });
 
       child.unref();


### PR DESCRIPTION
为 service.handler.ts 中的所有 spawn 调用添加 error 事件监听器，
确保当 xiaozhi 命令不存在或执行失败时能够正确报告错误。

- 修复 executeRestart 方法中的两个 spawn 调用
- 额外修复 stopService 和 startService 方法中的 spawn 调用
- 更新相关测试用例以匹配新的错误处理行为

修复 #944

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>