### PR TITLE
fix: 将 ServiceManager 中的 process.on 改为 process.once 防止内存泄漏

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -273,8 +273,8 @@ export class ServiceManagerImpl implements IServiceManager {
         process.exit(0);
       };
 
-      process.on("SIGINT", cleanup);
-      process.on("SIGTERM", cleanup);
+      process.once("SIGINT", cleanup);
+      process.once("SIGTERM", cleanup);
 
       await server.start();
     }


### PR DESCRIPTION
修复 #945

在 startMcpServerMode 和 startWebServerInForeground 方法中，
使用 process.once() 替代 process.on() 添加 SIGINT 和 SIGTERM
事件监听器，防止多次调用时累积监听器导致
MaxListenersExceededWarning。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>