### PR TITLE
fix: 修复 WebServer.stop() 方法中未清理 StatusService 心跳超时定时器的问题

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -892,6 +892,9 @@ export class WebServer {
           this.heartbeatMonitorInterval = undefined;
         }
 
+        // 清理状态服务中的心跳超时定时器
+        this.statusService.clearHeartbeatTimeout();
+
         // 强制断开所有 WebSocket 客户端连接
         if (this.wss) {
           for (const client of this.wss.clients) {


### PR DESCRIPTION
在 WebServer.stop() 方法中添加对 statusService.clearHeartbeatTimeout() 的调用，
以确保在服务器停止时正确清理 StatusService 中的 heartbeatTimeout 定时器，
防止资源泄漏。

问题:
- StatusService 中的 heartbeatTimeout 定时器在 WebServer.stop() 时未被清理
- 只有在 WebServer.destroy() 方法中才调用 statusService.destroy() 来清理
- 如果用户只调用 stop() 而不调用 destroy()，定时器会保持活动状态

影响:
- 资源泄漏：未清理的定时器不会被垃圾回收
- 潜在的错误行为：超时回调可能在连接关闭后仍被触发
- 内存累积：在高连接创建/销毁场景下会累积未清理的定时器

修复:
- 在 stop() 方法的心跳监控停止逻辑后添加 clearHeartbeatTimeout() 调用
- 确保所有定时器资源在服务器停止时被正确清理

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>