### PR TITLE
refactor: 提取共享的 store 加载状态管理函数

### DIFF
--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -22,6 +22,7 @@ import type {
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { createLoadingActions } from "./utils";
 
 /**
  * 配置加载状态
@@ -139,25 +140,7 @@ export const useConfigStore = create<ConfigStore>()(
         );
       },
 
-      setLoading: (loading: Partial<ConfigLoadingState>) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, ...loading },
-          }),
-          false,
-          "setLoading"
-        );
-      },
-
-      setError: (error: Error | null) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, lastError: error },
-          }),
-          false,
-          "setError"
-        );
-      },
+      ...createLoadingActions<ConfigStore>(set),
 
       // ==================== 异步操作 ====================
 

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -16,6 +16,7 @@ import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { createLoadingActions } from "./utils";
 
 /**
  * 重启状态接口
@@ -283,25 +284,7 @@ export const useStatusStore = create<StatusStore>()(
         );
       },
 
-      setLoading: (loading: Partial<StatusLoadingState>) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, ...loading },
-          }),
-          false,
-          "setLoading"
-        );
-      },
-
-      setError: (error: Error | null) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, lastError: error },
-          }),
-          false,
-          "setError"
-        );
-      },
+      ...createLoadingActions<StatusStore>(set),
 
       // ==================== 异步操作 ====================
 

--- a/apps/frontend/src/stores/utils.ts
+++ b/apps/frontend/src/stores/utils.ts
@@ -1,0 +1,64 @@
+/**
+ * Zustand Store 共享工具函数
+ *
+ * 提供 Store 之间共享的通用功能，避免代码重复
+ */
+
+/**
+ * 基础加载状态接口
+ */
+export interface LoadingState {
+  isLoading: boolean;
+  lastUpdated: number | null;
+  lastError: Error | null;
+}
+
+/**
+ * 创建 setLoading 和 setError 方法的工厂函数
+ *
+ * @param set - Zustand 的 set 函数
+ * @returns 包含 setLoading 和 setError 方法的对象
+ *
+ * @example
+ * ```typescript
+ * const store = create<Store>()((set) => ({
+ *   loading: initialLoadingState,
+ *   ...createLoadingActions<Store>(set),
+ * }));
+ * ```
+ *
+ * @note 使用 any 类型以兼容 Zustand 的复杂 set 函数签名
+ */
+export function createLoadingActions<S extends { loading: LoadingState }>(
+  set: any
+) {
+  return {
+    /**
+     * 更新加载状态
+     * @param loading - 部分加载状态更新
+     */
+    setLoading: (loading: Partial<S["loading"]>) => {
+      set(
+        (state: S) => ({
+          loading: { ...state.loading, ...loading },
+        }),
+        false,
+        "setLoading"
+      );
+    },
+
+    /**
+     * 设置错误信息
+     * @param error - 错误对象，null 表示清除错误
+     */
+    setError: (error: Error | null) => {
+      set(
+        (state: S) => ({
+          loading: { ...state.loading, lastError: error },
+        }),
+        false,
+        "setError"
+      );
+    },
+  };
+}


### PR DESCRIPTION
- 创建 apps/frontend/src/stores/utils.ts 提供通用的加载状态管理
- 添加 createLoadingActions 工厂函数生成 setLoading 和 setError 方法
- 重构 config.ts 和 status.ts 使用共享工具，消除 36 行重复代码
- 符合 DRY 原则，简化未来维护工作

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>