### PR TITLE
fix: 使用 CommandArguments 和 CommandOptions 替换 any 类型

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -7,6 +7,10 @@ import chalk from "chalk";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
+import type {
+  CommandArguments,
+  CommandOptions,
+} from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
 
 /**
@@ -27,14 +31,14 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           defaultValue: "json",
         },
       ],
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleInit(options);
       },
     },
     {
       name: "get",
       description: "查看配置值",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         this.validateArgs(args, 1);
         await this.handleGet(args[0]);
       },
@@ -42,7 +46,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     {
       name: "set",
       description: "设置配置值",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         this.validateArgs(args, 2);
         await this.handleSet(args[0], args[1]);
       },
@@ -56,14 +60,17 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   /**
    * 主命令执行（显示帮助）
    */
-  async execute(args: any[], options: any): Promise<void> {
+  override async execute(
+    args: CommandArguments,
+    options: CommandOptions
+  ): Promise<void> {
     console.log("配置管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
    * 处理初始化命令
    */
-  private async handleInit(options: any): Promise<void> {
+  private async handleInit(options: CommandOptions): Promise<void> {
     const spinner = ora("初始化配置...").start();
 
     try {

--- a/packages/cli/src/commands/EndpointCommandHandler.ts
+++ b/packages/cli/src/commands/EndpointCommandHandler.ts
@@ -6,6 +6,10 @@ import chalk from "chalk";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
+import type {
+  CommandArguments,
+  CommandOptions,
+} from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
 
 /**
@@ -19,14 +23,14 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     {
       name: "list",
       description: "列出所有 MCP 端点",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleList();
       },
     },
     {
       name: "add",
       description: "添加新的 MCP 端点",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         this.validateArgs(args, 1);
         await this.handleAdd(args[0]);
       },
@@ -34,7 +38,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     {
       name: "remove",
       description: "移除指定的 MCP 端点",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         this.validateArgs(args, 1);
         await this.handleRemove(args[0]);
       },
@@ -42,7 +46,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     {
       name: "set",
       description: "设置 MCP 端点（可以是单个或多个）",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         this.validateArgs(args, 1);
         await this.handleSet(args);
       },
@@ -56,7 +60,10 @@ export class EndpointCommandHandler extends BaseCommandHandler {
   /**
    * 主命令执行（显示帮助）
    */
-  async execute(args: any[], options: any): Promise<void> {
+  override async execute(
+    args: CommandArguments,
+    options: CommandOptions
+  ): Promise<void> {
     console.log("MCP 端点管理命令。使用 --help 查看可用的子命令。");
   }
 

--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -7,6 +7,10 @@ import chalk from "chalk";
 import ora from "ora";
 import type { CommandOption } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
+import type {
+  CommandArguments,
+  CommandOptions,
+} from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
 
 /**
@@ -30,7 +34,10 @@ export class ProjectCommandHandler extends BaseCommandHandler {
   /**
    * 执行创建项目命令
    */
-  async execute(args: any[], options: any): Promise<void> {
+  override async execute(
+    args: CommandArguments,
+    options: CommandOptions
+  ): Promise<void> {
     this.validateArgs(args, 1);
     const projectName = args[0];
 
@@ -42,7 +49,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
    */
   protected async handleCreate(
     projectName: string,
-    options: any
+    options: CommandOptions
   ): Promise<void> {
     const spinner = ora("初始化项目...").start();
 

--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -5,6 +5,10 @@
 import consola from "consola";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
+import type {
+  CommandArguments,
+  CommandOptions,
+} from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
 
 /**
@@ -26,21 +30,21 @@ export class ServiceCommandHandler extends BaseCommandHandler {
           description: "以 stdio 模式运行 MCP Server (用于 Cursor 等客户端)",
         },
       ],
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleStart(options);
       },
     },
     {
       name: "stop",
       description: "停止服务",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleStop();
       },
     },
     {
       name: "status",
       description: "检查服务状态",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleStatus();
       },
     },
@@ -48,14 +52,14 @@ export class ServiceCommandHandler extends BaseCommandHandler {
       name: "restart",
       description: "重启服务",
       options: [{ flags: "-d, --daemon", description: "在后台运行服务" }],
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleRestart(options);
       },
     },
     {
       name: "attach",
       description: "连接到后台服务查看日志",
-      execute: async (args: any[], options: any) => {
+      execute: async (args: CommandArguments, options: CommandOptions) => {
         await this.handleAttach();
       },
     },
@@ -68,14 +72,17 @@ export class ServiceCommandHandler extends BaseCommandHandler {
   /**
    * 主命令执行（显示帮助）
    */
-  async execute(args: any[], options: any): Promise<void> {
+  override async execute(
+    args: CommandArguments,
+    options: CommandOptions
+  ): Promise<void> {
     console.log("服务管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
    * 处理启动命令
    */
-  private async handleStart(options: any): Promise<void> {
+  private async handleStart(options: CommandOptions): Promise<void> {
     try {
       // 处理--debug参数
       if (options.debug) {
@@ -138,7 +145,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
   /**
    * 处理重启命令
    */
-  private async handleRestart(options: any): Promise<void> {
+  private async handleRestart(options: CommandOptions): Promise<void> {
     try {
       const serviceManager = this.getService<any>("serviceManager");
       await serviceManager.restart({


### PR DESCRIPTION
- 在所有命令处理器中导入并使用 CommandArguments 和 CommandOptions 类型
- 替换 ConfigCommandHandler、ServiceCommandHandler、EndpointCommandHandler、ProjectCommandHandler 中的 any 类型
- 为 execute 方法添加 override 修饰符以提高代码清晰度
- 确保类型安全并遵循项目类型规范

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>