### PR TITLE
fix: 为 spawn 进程添加 error 事件监听器防止错误静默忽略

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -101,6 +101,13 @@ export class ServiceApiHandler {
             XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
           },
         });
+
+        // 监听 error 事件，处理 spawn 失败的情况
+        child.on("error", (error) => {
+          this.logger.error(`启动 xiaozhi 进程失败: ${error.message}`);
+          throw error;
+        });
+
         child.unref();
         this.logger.info("MCP 服务启动命令已发送");
         return;
@@ -117,6 +124,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 监听 error 事件，处理 spawn 失败的情况
+      child.on("error", (error) => {
+        this.logger.error(`重启 xiaozhi 进程失败: ${error.message}`);
+        throw error;
       });
 
       child.unref();
@@ -144,6 +157,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 监听 error 事件，处理 spawn 失败的情况
+      child.on("error", (error) => {
+        this.logger.error(`停止 xiaozhi 进程失败: ${error.message}`);
+        throw error;
       });
 
       child.unref();
@@ -178,6 +197,12 @@ export class ServiceApiHandler {
           ...process.env,
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
+      });
+
+      // 监听 error 事件，处理 spawn 失败的情况
+      child.on("error", (error) => {
+        this.logger.error(`启动 xiaozhi 进程失败: ${error.message}`);
+        throw error;
       });
 
       child.unref();

--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -54,6 +54,22 @@ export class NPMManager {
     ]);
 
     return new Promise((resolve, reject) => {
+      // 监听 error 事件，处理 spawn 失败的情况
+      npmProcess.on("error", (error) => {
+        const errorMessage = `无法启动 npm 进程: ${error.message}`;
+        console.log(errorMessage);
+
+        this.eventBus.emitEvent("npm:install:failed", {
+          version,
+          installId,
+          error: errorMessage,
+          duration: Date.now() - startTime,
+          timestamp: Date.now(),
+        });
+
+        reject(new Error(errorMessage));
+      });
+
       npmProcess.stdout.on("data", (data) => {
         const message = data.toString();
 


### PR DESCRIPTION
在 NPMManager 和 ServiceApiHandler 中为所有 spawn 调用添加 error 事件监听器：
- NPMManager.installVersion: 添加 error 监听器，当 npm 进程启动失败时 reject Promise 并发射失败事件
- ServiceApiHandler.executeRestart: 为 start 和 restart spawn 添加错误处理
- ServiceApiHandler.stopService: 为 stop spawn 添加错误处理
- ServiceApiHandler.startService: 为 start spawn 添加错误处理

这修复了当命令不存在或权限不足时导致 Promise 永久 pending 或错误静默忽略的问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>