### PR TITLE
fix: 统一 TypeScript 编译目标为 ES2020 以确保跨包类型兼容性

### DIFF
--- a/packages/mcp-core/tsconfig.json
+++ b/packages/mcp-core/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2020"],
     "moduleResolution": "bundler",
     "resolveJsonModule": true,
     "allowJs": false,

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2022",
+    "target": "ES2020",
     "module": "ESNext",
-    "lib": ["ES2022"],
+    "lib": ["ES2020"],
     "outDir": "./dist",
     "rootDir": "src",
     "declaration": true,


### PR DESCRIPTION
- 将 packages/mcp-core/tsconfig.json 的 target 从 ES2022 改为 ES2020
- 将 packages/shared-types/tsconfig.json 的 target 从 ES2022 改为 ES2020
- 统一 lib 配置为 ES2020 以匹配 target
- 与 apps/frontend 的 ES2020 目标保持一致

修复 #964

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>