### PR TITLE
fix: 使用路径别名替换相对路径导入

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,8 +4,8 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import type { AppContext } from "../../types/hono.context.js";
 import type { RouteDefinition } from "../types.js";
 
 /**


### PR DESCRIPTION
将 apps/backend/routes/domains/endpoint.route.ts 中的相对路径导入
替换为项目路径别名 @/types/*，提高代码一致性和可维护性。

- 将 `../../types/hono.context.js` 替换为 `@/types/hono.context.js`

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>