### PR TITLE
fix: 将 endpointManager 中间件的 console.warn 替换为统一的 Logger 系统

### DIFF
--- a/apps/backend/middlewares/endpointManager.middleware.ts
+++ b/apps/backend/middlewares/endpointManager.middleware.ts
@@ -30,7 +30,7 @@ export const endpointManagerMiddleware = (): MiddlewareHandler<AppContext> => {
     } catch (error) {
       // 记录错误但不阻断请求
       if (error instanceof Error && error.message.includes("未初始化")) {
-        console.warn("小智连接管理器未初始化，使用 null 值:", error.message);
+        c.logger.warn("小智连接管理器未初始化，使用 null 值:", error.message);
         c.set("endpointManager", null);
       } else {
         throw error;


### PR DESCRIPTION
- 将 console.warn 替换为 c.logger.warn 以保持与其他中间件的一致性
- 参考 mcpServiceManager.middleware.ts 的实现

修复 #976

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>