### PR TITLE
refactor: 统一 EndpointHandler 使用 Context-based 依赖注入模式

### DIFF
--- a/apps/backend/middlewares/endpoints.middleware.ts
+++ b/apps/backend/middlewares/endpoints.middleware.ts
@@ -1,37 +1,26 @@
 /**
  * 小智端点处理器中间件
- * 负责创建和管理 EndpointHandler 实例
+ * 负责创建 EndpointHandler 实例并注入到 Context 中
+ * 使用 Context-based 依赖注入模式，Handler 从 Context 获取依赖
  */
 
 import { EndpointHandler } from "@/handlers/endpoint.handler.js";
-import { configManager } from "@xiaozhi-client/config";
-import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { MiddlewareHandler } from "hono";
 import type { AppContext } from "../types/hono.context.js";
 
 /**
  * 小智端点处理器中间件
  * 创建单例的 EndpointHandler 并注入到上下文中
+ * Handler 使用 Context-based 模式，从 Context 获取 EndpointManager 和 ConfigManager
  */
 export const endpointsMiddleware = (): MiddlewareHandler<AppContext> => {
-  // 使用闭包缓存 handler 实例和 manager
+  // 使用闭包缓存 handler 实例
   let endpointHandler: EndpointHandler | null = null;
-  let lastManager: EndpointManager | null | undefined = undefined;
 
   return async (c, next) => {
-    const endpointManager = c.get("endpointManager");
-
-    // 如果 manager 发生变化，则重建 handler
-    // 注意：使用引用相等检查（!==）确保使用最新的 manager 实例
-    // 即使 manager 内容相同，但对象引用不同时也会重建 handler
-    // 这是期望的行为，确保 handler 总是使用最新的连接管理
-    if (endpointManager !== lastManager) {
-      lastManager = endpointManager;
-      if (endpointManager) {
-        endpointHandler = new EndpointHandler(endpointManager, configManager);
-      } else {
-        endpointHandler = null;
-      }
+    // 懒创建 handler 实例（仅创建一次）
+    if (!endpointHandler) {
+      endpointHandler = new EndpointHandler();
     }
 
     // 将 handler 注入到上下文中

--- a/apps/backend/middlewares/index.ts
+++ b/apps/backend/middlewares/index.ts
@@ -20,4 +20,8 @@ export { endpointsMiddleware } from "./endpoints.middleware.js";
 export {
   getMCPServiceManager,
   requireMCPServiceManager,
+  getEndpointManager,
+  requireEndpointManager,
+  getConfigManager,
+  requireConfigManager,
 } from "../types/hono.context.js";

--- a/apps/backend/types/hono.context.ts
+++ b/apps/backend/types/hono.context.ts
@@ -5,6 +5,7 @@
 
 import type { Logger } from "@/Logger.js";
 import type { MCPServiceManager } from "@/lib/mcp";
+import type { ConfigManager } from "@xiaozhi-client/config";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
 import { Hono } from "hono";
@@ -126,4 +127,52 @@ export const requireMCPServiceManager = (
   }
 
   return serviceManager;
+};
+
+/**
+ * 从 Context 中获取 EndpointManager 的类型安全方法
+ */
+export const getEndpointManager = (
+  c: Context<AppContext>
+): EndpointManager | null => {
+  return c.get("endpointManager");
+};
+
+/**
+ * 要求必须存在 EndpointManager 的类型安全方法
+ */
+export const requireEndpointManager = (
+  c: Context<AppContext>
+): EndpointManager => {
+  const endpointManager = c.get("endpointManager");
+
+  if (!endpointManager) {
+    throw new Error(
+      "EndpointManager 未初始化，请检查 endpointManagerMiddleware 是否正确配置"
+    );
+  }
+
+  return endpointManager;
+};
+
+/**
+ * 从 Context 中获取 ConfigManager 的类型安全方法
+ * ConfigManager 通过单例模式提供，始终可用
+ */
+export const getConfigManager = (): ConfigManager => {
+  // 延迟导入避免循环依赖
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { configManager } = require("@xiaozhi-client/config");
+  return configManager;
+};
+
+/**
+ * 要求必须存在 ConfigManager 的类型安全方法
+ * ConfigManager 通过单例模式提供，始终可用
+ */
+export const requireConfigManager = (): ConfigManager => {
+  // 延迟导入避免循环依赖
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { configManager } = require("@xiaozhi-client/config");
+  return configManager;
 };


### PR DESCRIPTION
重构 EndpointHandler 从 Constructor-based 模式迁移到 Context-based 模式，
与项目现有的 MCPServiceManager 依赖注入模式保持一致。

主要变更：
- EndpointHandler 构造函数不再接受依赖参数
- 添加 getEndpointManager() 和 getConfigManager() 辅助方法从 Context 获取依赖
- 简化 endpointsMiddleware 中间件，移除构造函数参数传递逻辑
- 新增 requireEndpointManager 和 requireConfigManager 类型安全函数
- 更新相关测试用例

优势：
- 统一依赖注入模式，提升代码一致性
- 简化中间件职责，降低维护成本
- 更符合 Hono 框架最佳实践
- 便于测试和扩展

Fixes #977

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>