### PR TITLE
fix: 修复 tool-call-logs-dialog.tsx 中 CopyButton 组件的资源泄漏风险

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -43,7 +43,7 @@ import {
   RotateCwIcon,
   XCircle,
 } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export function ToolCallLogsDialog() {
   const [open, setOpen] = useState(false);
@@ -324,20 +324,35 @@ function CopyButton({
   className = "",
 }: CopyButtonProps) {
   const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   const handleCopy = async () => {
     try {
       await navigator.clipboard.writeText(copyContent);
       setCopied(true);
 
-      // 3秒后自动恢复状态
-      setTimeout(() => {
+      // 清除之前的定时器
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+
+      // 保存定时器引用，3秒后自动恢复状态
+      copiedTimerRef.current = setTimeout(() => {
         setCopied(false);
       }, 3000);
     } catch (error) {
       console.error("复制失败:", error);
     }
   };
+
+  // 组件卸载时清理定时器
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
 
   return (
     <Button


### PR DESCRIPTION
- 使用 useRef 保存 setTimeout 定时器引用
- 在创建新定时器前清除旧定时器
- 添加 useEffect 清理函数确保组件卸载时清除定时器
- 修复潜在的内存泄漏问题

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>