### PR TITLE
fix: RouteManager 使用统一的 Logger 系统替代 console

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -559,9 +559,8 @@ export class WebServer {
    * 设置路由系统
    */
   private setupRouteSystem(): void {
-    // 初始化路由管理器
-    // 注意：RouteManager 不再需要依赖参数，因为依赖通过中间件动态注入
-    this.routeManager = new RouteManager();
+    // 初始化路由管理器，注入 Logger 实例
+    this.routeManager = new RouteManager(this.logger);
   }
 
   /**


### PR DESCRIPTION
- 将 RouteManager 改为通过构造函数注入 Logger 实例
- 替换所有 console.log 为 this.logger.info
- 替换所有 console.warn 为 this.logger.warn
- 替换所有 console.error 为 this.logger.error
- 更新 WebServer 以在创建 RouteManager 时注入 Logger
- 修复 import 顺序以符合 Biome linting 规则

修复 #984

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>