### PR TITLE
refactor: 重构 ConfigManager 以符合单一职责原则

### DIFF
--- a/packages/config/src/event-manager.ts
+++ b/packages/config/src/event-manager.ts
@@ -1,0 +1,86 @@
+/**
+ * 配置事件管理器
+ * 负责管理配置变更事件的订阅和通知
+ */
+
+/**
+ * 事件回调函数类型
+ */
+export type EventCallback = (data: unknown) => void;
+
+/**
+ * 配置事件管理器
+ * 提供事件的订阅、取消订阅和发射功能
+ */
+export class ConfigEventManager {
+  private eventCallbacks: Map<string, Array<EventCallback>> = new Map();
+
+  /**
+   * 注册事件监听器
+   * @param eventName 事件名称
+   * @param callback 事件回调函数
+   */
+  public on(eventName: string, callback: EventCallback): void {
+    if (!this.eventCallbacks.has(eventName)) {
+      this.eventCallbacks.set(eventName, []);
+    }
+    this.eventCallbacks.get(eventName)?.push(callback);
+  }
+
+  /**
+   * 取消事件监听器
+   * @param eventName 事件名称
+   * @param callback 要取消的事件回调函数
+   */
+  public off(eventName: string, callback: EventCallback): void {
+    const callbacks = this.eventCallbacks.get(eventName);
+    if (callbacks) {
+      const index = callbacks.indexOf(callback);
+      if (index !== -1) {
+        callbacks.splice(index, 1);
+      }
+    }
+  }
+
+  /**
+   * 发射事件
+   * @param eventName 事件名称
+   * @param data 事件数据
+   */
+  public emit(eventName: string, data: unknown): void {
+    const callbacks = this.eventCallbacks.get(eventName);
+    if (callbacks) {
+      for (const callback of callbacks) {
+        try {
+          callback(data);
+        } catch (error) {
+          console.error(`事件回调执行失败 [${eventName}]:`, error);
+        }
+      }
+    }
+  }
+
+  /**
+   * 移除所有指定事件的监听器
+   * @param eventName 事件名称
+   */
+  public removeAllListeners(eventName: string): void {
+    this.eventCallbacks.delete(eventName);
+  }
+
+  /**
+   * 清空所有事件监听器
+   */
+  public clear(): void {
+    this.eventCallbacks.clear();
+  }
+
+  /**
+   * 获取指定事件的监听器数量
+   * @param eventName 事件名称
+   */
+  public listenerCount(eventName: string): number {
+    const callbacks = this.eventCallbacks.get(eventName);
+    return callbacks ? callbacks.length : 0;
+  }
+}

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -2,3 +2,7 @@ export * from "./manager.js";
 export * from "./adapter.js";
 export * from "./resolver.js";
 export * from "./initializer.js";
+export * from "./types.js";
+export * from "./event-manager.js";
+export * from "./stats-manager.js";
+export * from "./validator.js";

--- a/packages/config/src/stats-manager.ts
+++ b/packages/config/src/stats-manager.ts
@@ -1,0 +1,187 @@
+/**
+ * 配置统计管理器
+ * 负责工具使用统计的收集和更新
+ */
+
+import type { CustomMCPTool, MCPToolConfig } from "./types.js";
+import type { AppConfig } from "./types.js";
+
+/**
+ * 工具使用统计信息
+ */
+export interface ToolUsageStats {
+  usageCount?: number;
+  lastUsedTime?: string;
+}
+
+/**
+ * 配置统计管理器
+ * 负责管理工具使用统计的更新和查询
+ */
+export class ConfigStatsManager {
+  private statsUpdateLocks: Map<string, Promise<void>> = new Map();
+  private statsUpdateLockTimeouts: Map<string, NodeJS.Timeout> = new Map();
+  private readonly STATS_UPDATE_TIMEOUT = 5000; // 5秒超时
+
+  /**
+   * 更新 MCP 服务工具统计信息
+   * @param config 配置对象（会被修改）
+   * @param serverName 服务名称
+   * @param toolName 工具名称
+   * @param callTime 调用时间（ISO 8601 格式）
+   * @param incrementUsageCount 是否增加使用计数
+   */
+  public updateMCPServerToolStats(
+    config: AppConfig,
+    serverName: string,
+    toolName: string,
+    callTime: string,
+    incrementUsageCount = true
+  ): void {
+    // 确保 mcpServerConfig 存在
+    if (!config.mcpServerConfig) {
+      config.mcpServerConfig = {};
+    }
+
+    // 确保服务配置存在
+    if (!config.mcpServerConfig[serverName]) {
+      config.mcpServerConfig[serverName] = { tools: {} };
+    }
+
+    // 确保工具配置存在
+    if (!config.mcpServerConfig[serverName].tools[toolName]) {
+      config.mcpServerConfig[serverName].tools[toolName] = {
+        enable: true, // 默认启用
+      };
+    }
+
+    const toolConfig = config.mcpServerConfig[serverName].tools[toolName];
+    const currentUsageCount = toolConfig.usageCount || 0;
+    const currentLastUsedTime = toolConfig.lastUsedTime;
+
+    // 根据参数决定是否更新使用次数
+    if (incrementUsageCount) {
+      toolConfig.usageCount = currentUsageCount + 1;
+    }
+
+    // 时间校验：只有新时间晚于现有时间才更新 lastUsedTime
+    if (
+      !currentLastUsedTime ||
+      new Date(callTime) > new Date(currentLastUsedTime)
+    ) {
+      // 使用 dayjs 格式化时间为更易读的格式
+      toolConfig.lastUsedTime = callTime;
+    }
+  }
+
+  /**
+   * 更新 CustomMCP 工具统计信息
+   * @param tools CustomMCP 工具数组（会被修改）
+   * @param toolName 工具名称
+   * @param callTime 调用时间（ISO 8601 格式）
+   * @param incrementUsageCount 是否增加使用计数
+   */
+  public updateCustomMCPToolStats(
+    tools: CustomMCPTool[],
+    toolName: string,
+    callTime: string,
+    incrementUsageCount = true
+  ): void {
+    const toolIndex = tools.findIndex((tool) => tool.name === toolName);
+
+    if (toolIndex === -1) {
+      // 如果 customMCP 中没有对应的工具，跳过更新
+      return;
+    }
+
+    const tool = tools[toolIndex];
+
+    // 确保 stats 对象存在
+    if (!tool.stats) {
+      tool.stats = {};
+    }
+
+    const currentUsageCount = tool.stats.usageCount || 0;
+    const currentLastUsedTime = tool.stats.lastUsedTime;
+
+    // 根据参数决定是否更新使用次数
+    if (incrementUsageCount) {
+      tool.stats.usageCount = currentUsageCount + 1;
+    }
+
+    // 时间校验：只有新时间晚于现有时间才更新 lastUsedTime
+    if (
+      !currentLastUsedTime ||
+      new Date(callTime) > new Date(currentLastUsedTime)
+    ) {
+      tool.stats.lastUsedTime = callTime;
+    }
+  }
+
+  /**
+   * 获取统计更新锁（确保同一工具的统计更新串行执行）
+   * @param toolKey 工具键
+   */
+  public async acquireStatsUpdateLock(toolKey: string): Promise<boolean> {
+    if (this.statsUpdateLocks.has(toolKey)) {
+      console.log("工具统计更新正在进行中，跳过本次更新", { toolKey });
+      return false;
+    }
+
+    const updatePromise = new Promise<void>((resolve) => {
+      // 锁定逻辑在调用者中实现
+    });
+
+    this.statsUpdateLocks.set(toolKey, updatePromise);
+
+    // 设置超时自动释放锁
+    const timeout = setTimeout(() => {
+      this.releaseStatsUpdateLock(toolKey);
+    }, this.STATS_UPDATE_TIMEOUT);
+
+    this.statsUpdateLockTimeouts.set(toolKey, timeout);
+
+    return true;
+  }
+
+  /**
+   * 释放统计更新锁
+   * @param toolKey 工具键
+   */
+  public releaseStatsUpdateLock(toolKey: string): void {
+    this.statsUpdateLocks.delete(toolKey);
+
+    const timeout = this.statsUpdateLockTimeouts.get(toolKey);
+    if (timeout) {
+      clearTimeout(timeout);
+      this.statsUpdateLockTimeouts.delete(toolKey);
+    }
+
+    console.log("已释放工具的统计更新锁", { toolKey });
+  }
+
+  /**
+   * 清理所有统计更新锁（用于异常恢复）
+   */
+  public clearAllStatsUpdateLocks(): void {
+    const lockCount = this.statsUpdateLocks.size;
+    this.statsUpdateLocks.clear();
+
+    // 清理所有超时定时器
+    for (const timeout of this.statsUpdateLockTimeouts.values()) {
+      clearTimeout(timeout);
+    }
+    this.statsUpdateLockTimeouts.clear();
+
+    if (lockCount > 0) {
+      console.log("已清理统计更新锁", { count: lockCount });
+    }
+  }
+
+  /**
+   * 获取统计更新锁状态（用于调试和监控）
+   */
+  public getStatsUpdateLocks(): string[] {
+    return Array.from(this.statsUpdateLocks.keys());
+  }
+}

--- a/packages/config/src/types.ts
+++ b/packages/config/src/types.ts
@@ -1,0 +1,211 @@
+/**
+ * 配置类型定义
+ * 统一导出所有配置相关的类型定义
+ */
+
+// 本地 MCP 服务配置
+export interface LocalMCPServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+// SSE MCP 服务配置
+export interface SSEMCPServerConfig {
+  type: "sse";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+// HTTP MCP 服务配置
+export interface HTTPMCPServerConfig {
+  type?: "http" | "streamable-http"; // 可选，默认就是 http
+  url: string;
+  headers?: Record<string, string>;
+}
+
+// 向后兼容的别名
+/** @deprecated 使用 HTTPMCPServerConfig 代替 */
+export type StreamableHTTPMCPServerConfig = HTTPMCPServerConfig;
+
+// 统一的 MCP 服务配置
+export type MCPServerConfig =
+  | LocalMCPServerConfig
+  | SSEMCPServerConfig
+  | HTTPMCPServerConfig;
+
+export interface MCPToolConfig {
+  description?: string;
+  enable: boolean;
+  usageCount?: number; // 工具使用次数
+  lastUsedTime?: string; // 最后使用时间（ISO 8601 格式）
+}
+
+export interface MCPServerToolsConfig {
+  tools: Record<string, MCPToolConfig>;
+}
+
+export interface ConnectionConfig {
+  heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
+  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000
+  reconnectInterval?: number; // 重连间隔（毫秒），默认5000
+}
+
+export interface ModelScopeConfig {
+  apiKey?: string; // ModelScope API 密钥
+}
+
+export interface WebUIConfig {
+  port?: number; // Web UI 端口号，默认 9999
+  autoRestart?: boolean; // 是否在配置更新后自动重启服务，默认 true
+}
+
+// 工具调用日志配置接口
+export interface ToolCallLogConfig {
+  maxRecords?: number; // 最大记录条数，默认 100
+  logFilePath?: string; // 自定义日志文件路径（可选）
+}
+
+// CustomMCP 相关接口定义
+
+// 代理处理器配置
+export interface ProxyHandlerConfig {
+  type: "proxy";
+  platform: "coze" | "openai" | "anthropic" | "custom";
+  config: {
+    // Coze 平台配置
+    workflow_id?: string;
+    bot_id?: string;
+    api_key?: string;
+    base_url?: string;
+    // 通用配置
+    timeout?: number;
+    retry_count?: number;
+    retry_delay?: number;
+    headers?: Record<string, string>;
+    params?: Record<string, unknown>;
+  };
+}
+
+// HTTP 处理器配置
+export interface HttpHandlerConfig {
+  type: "http";
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry_count?: number;
+  retry_delay?: number;
+  auth?: {
+    type: "bearer" | "basic" | "api_key";
+    token?: string;
+    username?: string;
+    password?: string;
+    api_key?: string;
+    api_key_header?: string;
+  };
+  body_template?: string; // 支持模板变量替换
+  response_mapping?: {
+    success_path?: string; // JSONPath 表达式
+    error_path?: string;
+    data_path?: string;
+  };
+}
+
+// 函数处理器配置
+export interface FunctionHandlerConfig {
+  type: "function";
+  module: string; // 模块路径
+  function: string; // 函数名
+  timeout?: number;
+  context?: Record<string, unknown>; // 函数执行上下文
+}
+
+// 脚本处理器配置
+export interface ScriptHandlerConfig {
+  type: "script";
+  script: string; // 脚本内容或文件路径
+  interpreter?: "node" | "python" | "bash";
+  timeout?: number;
+  env?: Record<string, string>; // 环境变量
+}
+
+// 链式处理器配置
+export interface ChainHandlerConfig {
+  type: "chain";
+  tools: string[]; // 要链式调用的工具名称
+  mode: "sequential" | "parallel"; // 执行模式
+  error_handling: "stop" | "continue" | "retry"; // 错误处理策略
+}
+
+// MCP 处理器配置（用于同步的工具）
+export interface MCPHandlerConfig {
+  type: "mcp";
+  config: {
+    serviceName: string;
+    toolName: string;
+  };
+}
+
+export type HandlerConfig =
+  | ProxyHandlerConfig
+  | HttpHandlerConfig
+  | FunctionHandlerConfig
+  | ScriptHandlerConfig
+  | ChainHandlerConfig
+  | MCPHandlerConfig;
+
+// CustomMCP 工具接口
+// TODO: 注意：此定义应与 @xiaozhi-client/shared-types 中的 CustomMCPToolConfig 保持一致
+// 未来将迁移到从 shared-types 导入
+export interface CustomMCPTool {
+  // 确保必填字段
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: HandlerConfig;
+
+  // 使用统计信息（可选）
+  stats?: {
+    usageCount?: number; // 工具使用次数
+    lastUsedTime?: string; // 最后使用时间（ISO 8601格式）
+  };
+}
+
+// CustomMCP 配置接口
+export interface CustomMCPConfig {
+  tools: CustomMCPTool[];
+}
+
+// Web 服务器实例接口（用于配置更新通知）
+export interface WebServerInstance {
+  broadcastConfigUpdate(config: AppConfig): void;
+}
+
+export interface PlatformsConfig {
+  [platformName: string]: PlatformConfig;
+}
+
+export interface PlatformConfig {
+  token?: string;
+}
+
+/**
+ * 扣子平台配置接口
+ */
+export interface CozePlatformConfig extends PlatformConfig {
+  /** 扣子 API Token */
+  token: string;
+}
+
+export interface AppConfig {
+  mcpEndpoint: string | string[];
+  mcpServers: Record<string, MCPServerConfig>;
+  mcpServerConfig?: Record<string, MCPServerToolsConfig>;
+  customMCP?: CustomMCPConfig; // 新增 customMCP 配置支持
+  connection?: ConnectionConfig; // 连接配置（可选，用于向后兼容）
+  modelscope?: ModelScopeConfig; // ModelScope 配置（可选）
+  webUI?: WebUIConfig; // Web UI 配置（可选）
+  platforms?: PlatformsConfig; // 平台配置（可选）
+  toolCallLog?: ToolCallLogConfig; // 工具调用日志配置（可选）
+}

--- a/packages/config/src/validator.ts
+++ b/packages/config/src/validator.ts
@@ -1,0 +1,394 @@
+/**
+ * 配置验证器
+ * 负责配置数据的验证和解析
+ */
+
+import type {
+  AppConfig,
+  CustomMCPTool,
+  HandlerConfig,
+  ChainHandlerConfig,
+  HttpHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  ScriptHandlerConfig,
+  FunctionHandlerConfig,
+} from "./types.js";
+import { ConfigValidationError } from "./adapter.js";
+
+/**
+ * 配置验证器
+ * 提供配置数据的验证功能
+ */
+export class ConfigValidator {
+  /**
+   * 验证配置文件结构
+   * @param config 配置对象
+   * @throws {ConfigValidationError} 配置验证失败时抛出
+   */
+  public validateConfig(config: unknown): asserts config is AppConfig {
+    if (!config || typeof config !== "object") {
+      throw new ConfigValidationError("配置文件格式错误：根对象无效");
+    }
+
+    const configObj = config as Record<string, unknown>;
+
+    if (
+      configObj.mcpEndpoint === undefined ||
+      configObj.mcpEndpoint === null
+    ) {
+      throw new ConfigValidationError(
+        "配置文件格式错误：mcpEndpoint 字段无效"
+      );
+    }
+
+    // 验证 mcpEndpoint 类型（字符串或字符串数组）
+    if (typeof configObj.mcpEndpoint === "string") {
+      // 空字符串是允许的
+    } else if (Array.isArray(configObj.mcpEndpoint)) {
+      for (const endpoint of configObj.mcpEndpoint) {
+        if (typeof endpoint !== "string" || endpoint.trim() === "") {
+          throw new ConfigValidationError(
+            "配置文件格式错误：mcpEndpoint 数组中的每个元素必须是非空字符串"
+          );
+        }
+      }
+    } else {
+      throw new ConfigValidationError(
+        "配置文件格式错误：mcpEndpoint 必须是字符串或字符串数组"
+      );
+    }
+
+    if (!configObj.mcpServers || typeof configObj.mcpServers !== "object") {
+      throw new ConfigValidationError(
+        "配置文件格式错误：mcpServers 字段无效"
+      );
+    }
+
+    // 验证每个 MCP 服务配置
+    for (const [serverName, serverConfig] of Object.entries(
+      configObj.mcpServers as Record<string, unknown>
+    )) {
+      if (!serverConfig || typeof serverConfig !== "object") {
+        throw new ConfigValidationError(
+          `配置文件格式错误：mcpServers.${serverName} 无效`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证 customMCP 工具配置
+   * @param tools 工具数组
+   * @returns 是否验证通过
+   */
+  public validateCustomMCPTools(tools: CustomMCPTool[]): boolean {
+    if (!Array.isArray(tools)) {
+      return false;
+    }
+
+    for (const tool of tools) {
+      // 检查必需字段
+      if (!tool.name || typeof tool.name !== "string") {
+        console.warn("CustomMCP 工具缺少有效的 name 字段", { tool });
+        return false;
+      }
+
+      if (!tool.description || typeof tool.description !== "string") {
+        console.warn("CustomMCP 工具缺少有效的 description 字段", {
+          toolName: tool.name,
+        });
+        return false;
+      }
+
+      if (!tool.inputSchema || typeof tool.inputSchema !== "object") {
+        console.warn("CustomMCP 工具缺少有效的 inputSchema 字段", {
+          toolName: tool.name,
+        });
+        return false;
+      }
+
+      if (!tool.handler || typeof tool.handler !== "object") {
+        console.warn("CustomMCP 工具缺少有效的 handler 字段", {
+          toolName: tool.name,
+        });
+        return false;
+      }
+
+      // 检查 handler 类型
+      if (
+        !["proxy", "function", "http", "script", "chain", "mcp"].includes(
+          tool.handler.type
+        )
+      ) {
+        console.warn("CustomMCP 工具的 handler.type 类型无效", {
+          toolName: tool.name,
+          type: tool.handler.type,
+        });
+        return false;
+      }
+
+      // 根据处理器类型进行特定验证
+      if (!this.validateHandlerConfig(tool.name, tool.handler)) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateHandlerConfig(
+    toolName: string,
+    handler: HandlerConfig
+  ): boolean {
+    switch (handler.type) {
+      case "proxy":
+        return this.validateProxyHandler(toolName, handler);
+      case "http":
+        return this.validateHttpHandler(toolName, handler);
+      case "function":
+        return this.validateFunctionHandler(toolName, handler);
+      case "script":
+        return this.validateScriptHandler(toolName, handler);
+      case "chain":
+        return this.validateChainHandler(toolName, handler);
+      case "mcp":
+        return this.validateMCPHandler(toolName, handler);
+      default:
+        console.warn("CustomMCP 工具使用了未知的处理器类型", {
+          toolName,
+          handlerType: (handler as HandlerConfig).type,
+        });
+        return false;
+    }
+  }
+
+  /**
+   * 验证代理处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateProxyHandler(
+    toolName: string,
+    handler: ProxyHandlerConfig
+  ): boolean {
+    if (!handler.platform) {
+      console.warn("CustomMCP 工具的 proxy 处理器缺少 platform 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    if (!["coze", "openai", "anthropic", "custom"].includes(handler.platform)) {
+      console.warn("CustomMCP 工具的 proxy 处理器使用了不支持的平台", {
+        toolName,
+        platform: handler.platform,
+      });
+      return false;
+    }
+
+    if (!handler.config || typeof handler.config !== "object") {
+      console.warn("CustomMCP 工具的 proxy 处理器缺少 config 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    // Coze 平台特定验证
+    if (handler.platform === "coze") {
+      if (!handler.config.workflow_id && !handler.config.bot_id) {
+        console.warn(
+          "CustomMCP 工具的 Coze 处理器必须提供 workflow_id 或 bot_id",
+          { toolName }
+        );
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证 HTTP 处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateHttpHandler(
+    toolName: string,
+    handler: HttpHandlerConfig
+  ): boolean {
+    if (!handler.url || typeof handler.url !== "string") {
+      console.warn("CustomMCP 工具的 http 处理器缺少有效的 url 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    try {
+      new URL(handler.url);
+    } catch {
+      console.warn("CustomMCP 工具的 http 处理器 url 格式无效", {
+        toolName,
+        url: handler.url,
+      });
+      return false;
+    }
+
+    if (
+      handler.method &&
+      !["GET", "POST", "PUT", "DELETE", "PATCH"].includes(handler.method)
+    ) {
+      console.warn("CustomMCP 工具的 http 处理器使用了不支持的 HTTP 方法", {
+        toolName,
+        method: handler.method,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证函数处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateFunctionHandler(
+    toolName: string,
+    handler: FunctionHandlerConfig
+  ): boolean {
+    if (!handler.module || typeof handler.module !== "string") {
+      console.warn("CustomMCP 工具的 function 处理器缺少有效的 module 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    if (!handler.function || typeof handler.function !== "string") {
+      console.warn("CustomMCP 工具的 function 处理器缺少有效的 function 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证脚本处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateScriptHandler(
+    toolName: string,
+    handler: ScriptHandlerConfig
+  ): boolean {
+    if (!handler.script || typeof handler.script !== "string") {
+      console.warn("CustomMCP 工具的 script 处理器缺少有效的 script 字段", {
+        toolName,
+      });
+      return false;
+    }
+
+    if (
+      handler.interpreter &&
+      !["node", "python", "bash"].includes(handler.interpreter)
+    ) {
+      console.warn("CustomMCP 工具的 script 处理器使用了不支持的解释器", {
+        toolName,
+        interpreter: handler.interpreter,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证链式处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateChainHandler(
+    toolName: string,
+    handler: ChainHandlerConfig
+  ): boolean {
+    if (
+      !handler.tools ||
+      !Array.isArray(handler.tools) ||
+      handler.tools.length === 0
+    ) {
+      console.warn("CustomMCP 工具的 chain 处理器缺少有效的 tools 数组", {
+        toolName,
+      });
+      return false;
+    }
+
+    if (!["sequential", "parallel"].includes(handler.mode)) {
+      console.warn("CustomMCP 工具的 chain 处理器使用了不支持的执行模式", {
+        toolName,
+        mode: handler.mode,
+      });
+      return false;
+    }
+
+    if (!["stop", "continue", "retry"].includes(handler.error_handling)) {
+      console.warn("CustomMCP 工具的 chain 处理器使用了不支持的错误处理策略", {
+        toolName,
+        errorHandling: handler.error_handling,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 验证 MCP 处理器配置
+   * @param toolName 工具名称
+   * @param handler 处理器配置
+   * @returns 是否验证通过
+   */
+  private validateMCPHandler(
+    toolName: string,
+    handler: MCPHandlerConfig
+  ): boolean {
+    if (!handler.config || typeof handler.config !== "object") {
+      console.warn("CustomMCP 工具的 mcp 处理器缺少 config 字段", { toolName });
+      return false;
+    }
+
+    if (
+      !handler.config.serviceName ||
+      typeof handler.config.serviceName !== "string"
+    ) {
+      console.warn("CustomMCP 工具的 mcp 处理器缺少有效的 serviceName", {
+        toolName,
+      });
+      return false;
+    }
+
+    if (
+      !handler.config.toolName ||
+      typeof handler.config.toolName !== "string"
+    ) {
+      console.warn("CustomMCP 工具的 mcp 处理器缺少有效的 toolName", {
+        toolName,
+      });
+      return false;
+    }
+
+    return true;
+  }
+}


### PR DESCRIPTION
将 ConfigManager 拆分为多个专职管理器：
- 创建 ConfigEventManager 处理事件订阅和通知
- 创建 ConfigStatsManager 处理工具使用统计
- 创建 ConfigValidator 处理配置验证
- 创建 types.ts 统一管理类型定义
- 重构 ConfigManager 使用组合模式调用各管理器

主要改进：
1. 代码行数从 2257 行减少到约 1600 行
2. 每个类职责明确，便于维护和测试
3. 事件管理器可被其他模块复用
4. 保持向后兼容性，所有原有 API 仍然可用

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>