### PR TITLE
perf: 优化 FileUtils.listDirectory 递归性能

### DIFF
--- a/packages/cli/src/utils/FileUtils.ts
+++ b/packages/cli/src/utils/FileUtils.ts
@@ -234,7 +234,7 @@ export class FileUtils {
       }
 
       const items = fs.readdirSync(dirPath);
-      let result: string[] = [];
+      const result: string[] = [];
 
       for (const item of items) {
         // 跳过隐藏文件（除非明确要求包含）
@@ -248,7 +248,7 @@ export class FileUtils {
         // 递归处理子目录
         if (options.recursive && fs.statSync(itemPath).isDirectory()) {
           const subItems = FileUtils.listDirectory(itemPath, options);
-          result = result.concat(subItems);
+          result.push(...subItems);
         }
       }
 


### PR DESCRIPTION
将递归中的数组合并从 concat 改为 push + 展开运算符，避免在深层嵌套目录结构下创建临时数组，提升性能。

- 使用 result.push(...subItems) 替代 result.concat(subItems)
- 将 let result 改为 const result（因为不再重新赋值）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>