### PR TITLE
fix: 修复 service.handler.ts 中导入不一致问题

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -6,8 +6,8 @@ import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
+import { requireMCPServiceManager } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
  * 服务 API 处理器


### PR DESCRIPTION
将 requireMCPServiceManager 的导入方式从相对路径改为路径别名，
与同文件中 AppContext 的导入方式保持一致，符合项目路径别名系统规范。

修复前：
- import type { AppContext } from "@/types/hono.context.js";
- import { requireMCPServiceManager } from "../types/hono.context.js";

修复后：
- import type { AppContext } from "@/types/hono.context.js";
- import { requireMCPServiceManager } from "@/types/hono.context.js";

Fixes #1001

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>