### PR TITLE
fix: 修复 service.handler.ts 中环境变量泄露的安全漏洞

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -10,6 +10,32 @@ import type { Context } from "hono";
 import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
+ * 允许传递给子进程的环境变量白名单
+ * 仅包含必要的、非敏感的环境变量，避免泄露敏感信息
+ */
+const ALLOWED_ENV_VARS = [
+  "PATH", // 系统路径，必需
+  "NODE_ENV", // Node.js 运行环境
+  "XIAOZHI_CONFIG_DIR", // 小智配置目录
+] as const;
+
+/**
+ * 创建安全的环境变量对象
+ * 仅包含白名单中定义的环境变量
+ */
+function createSafeEnv(): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = {};
+
+  for (const key of ALLOWED_ENV_VARS) {
+    if (process.env[key] !== undefined) {
+      env[key] = process.env[key];
+    }
+  }
+
+  return env;
+}
+
+/**
  * 服务 API 处理器
  */
 export class ServiceApiHandler {
@@ -97,7 +123,7 @@ export class ServiceApiHandler {
           detached: true,
           stdio: "ignore",
           env: {
-            ...process.env,
+            ...createSafeEnv(),
             XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
           },
         });
@@ -114,7 +140,7 @@ export class ServiceApiHandler {
         detached: true,
         stdio: "ignore",
         env: {
-          ...process.env,
+          ...createSafeEnv(),
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
       });
@@ -141,7 +167,7 @@ export class ServiceApiHandler {
         detached: true,
         stdio: "ignore",
         env: {
-          ...process.env,
+          ...createSafeEnv(),
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
       });
@@ -175,7 +201,7 @@ export class ServiceApiHandler {
         detached: true,
         stdio: "ignore",
         env: {
-          ...process.env,
+          ...createSafeEnv(),
           XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
         },
       });


### PR DESCRIPTION
使用白名单机制替代 ...process.env，仅传递必要的、非敏感的环境
变量给子进程，防止敏感信息（如 API 密钥、密码、令牌等）泄露。

- 添加 ALLOWED_ENV_VARS 白名单常量（PATH、NODE_ENV、XIAOZHI_CONFIG_DIR）
- 创建 createSafeEnv() 辅助函数，仅返回白名单环境变量
- 更新所有 spawn 调用以使用安全的环境变量
- 更新测试用例以验证新的安全行为

修复 #1004

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>