### PR TITLE
docs: 添加 handlers 模块的文件级 JSDoc 注释

### DIFF
--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -1,3 +1,22 @@
+/**
+ * API Handlers 统一导出模块
+ *
+ * 导出所有 API 处理器，包括：
+ * - ConfigApiHandler: 配置管理
+ * - CozeHandler: 扣子工作流
+ * - HeartbeatHandler: 心跳检测
+ * - EndpointHandler: 端点管理
+ * - MCPRouteHandler: MCP 协议路由
+ * - MCPHandler: MCP 服务管理
+ * - RealtimeNotificationHandler: 实时通知
+ * - ServiceApiHandler: 服务管理
+ * - StaticFileHandler: 静态文件服务
+ * - StatusApiHandler: 状态查询
+ * - MCPToolHandler: MCP 工具调用
+ * - MCPToolLogHandler: 工具调用日志
+ * - UpdateApiHandler: 版本更新
+ * - VersionApiHandler: 版本信息
+ */
 export * from "./config.handler.js";
 export { CozeHandler } from "./coze.handler.js";
 export * from "./heartbeat.handler.js";


### PR DESCRIPTION
为 apps/backend/handlers/index.ts 添加文件级 JSDoc 注释，
说明该模块的用途和导出的所有 API 处理器。

修复 #1011

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>