### PR TITLE
refactor: 移除 backend.d.ts 中重复的类型定义

### DIFF
--- a/packages/cli/src/types/backend.d.ts
+++ b/packages/cli/src/types/backend.d.ts
@@ -3,24 +3,6 @@
  * 使用 any 类型避免递归解析 backend 代码
  */
 
-declare module "@/lib/config/manager" {
-  export interface LocalMCPServerConfig {
-    command: string;
-    args: string[];
-    env?: Record<string, string>;
-  }
-
-  export interface MCPServerConfig {
-    type?: string;
-    url?: string;
-    command?: string;
-    args?: string[];
-    headers?: Record<string, string>;
-  }
-
-  export const configManager: any;
-}
-
 declare module "@/lib/config/manager.js" {
   export interface LocalMCPServerConfig {
     command: string;
@@ -37,10 +19,6 @@ declare module "@/lib/config/manager.js" {
   }
 
   export const configManager: any;
-}
-
-declare module "@/WebServer" {
-  export class WebServer {}
 }
 
 declare module "@/WebServer.js" {


### PR DESCRIPTION
- 移除不带 .js 扩展名的模块声明
- 保留带 .js 扩展名的声明（符合 ESM 模块系统规范）
- 修复 LocalMCPServerConfig 和 MCPServerConfig 的重复定义
- 修复 WebServer 类的重复定义
- 解决 jscpd 检测到的代码重复问题

Fixes #1012

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>