### PR TITLE
fix: 处理 fetch 网络错误，避免未捕获的 Promise rejection

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -189,22 +189,31 @@ export class ApiClient {
       },
     };
 
-    const response = await fetch(url, { ...defaultOptions, ...options });
+    try {
+      const response = await fetch(url, { ...defaultOptions, ...options });
 
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
 
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+        try {
+          const errorData: ApiErrorResponse = await response.json();
+          errorMessage = errorData.error?.message || errorMessage;
+        } catch {
+          // 如果无法解析错误响应，使用默认错误消息
+        }
+
+        throw new Error(errorMessage);
       }
 
-      throw new Error(errorMessage);
+      return response.json();
+    } catch (error) {
+      // 处理网络错误或 fetch 抛出的其他异常
+      if (error instanceof TypeError) {
+        throw new Error(`网络请求失败: ${url} - ${error.message}`);
+      }
+      // 重新抛出其他错误（包括上面抛出的 HTTP 错误）
+      throw error;
     }
-
-    return response.json();
   }
 
   // ==================== 配置管理 API ====================


### PR DESCRIPTION
在 ApiClient.request 方法中添加 try-catch 块来捕获网络错误。

- 捕获 TypeError 类型的网络错误（如 DNS 解析失败、CORS 错误、服务器不可达等）
- 为网络错误提供清晰的错误消息，包含请求 URL
- 重新抛出其他类型的错误（如 HTTP 状态码错误）

修复 #1017

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>