### PR TITLE
fix: 修复 event-bus.service.ts 中的 any 类型问题

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -87,7 +87,14 @@ describe("EventBus", () => {
     });
 
     it("should emit status:updated event successfully", () => {
-      const eventData = { status: { connected: true }, source: "test" };
+      const eventData = {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "test-endpoint",
+          activeMCPServers: ["server1"],
+        },
+        source: "test",
+      };
       const listener = vi.fn();
 
       eventBus.onEvent("status:updated", listener);
@@ -486,7 +493,14 @@ describe("EventBus", () => {
 
       eventBus.emitEvent("config:updated", eventData);
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "test-endpoint",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       const stats = eventBus.getEventStats();
 
@@ -537,7 +551,14 @@ describe("EventBus", () => {
     it("should clear all event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "test-endpoint",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       let stats = eventBus.getEventStats();
       expect(Object.keys(stats)).toHaveLength(2);
@@ -562,7 +583,14 @@ describe("EventBus", () => {
         type: "customMCP",
         timestamp: new Date(),
       });
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "test-endpoint",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       const status = eventBus.getStatus();
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -2,6 +2,35 @@ import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
+import type {
+  ClientInfo,
+  RestartStatus,
+} from "@/services/status.service.js";
+import type { NotificationData } from "@/services/notification.service.js";
+
+// 重新导出常用类型，方便使用
+export type { ClientInfo, RestartStatus } from "@/services/status.service.js";
+export type { NotificationData } from "@/services/notification.service.js";
+
+/**
+ * WebSocket 消息数据类型
+ */
+export interface WebSocketMessageData {
+  [key: string]: unknown;
+}
+
+/**
+ * MCP 服务器添加结果类型
+ */
+export interface MCPServerAddResult {
+  name: string;
+  success: boolean;
+  error?: string;
+  config?: MCPServerConfig;
+  tools?: string[];
+  status?: string;
+}
 
 /**
  * 事件类型定义
@@ -17,7 +46,7 @@ export interface EventBusEvents {
   "config:error": { error: Error; operation: string };
 
   // 状态相关事件
-  "status:updated": { status: any; source: string };
+  "status:updated": { status: ClientInfo; source: string };
   "status:error": { error: Error; operation: string };
 
   // 接入点状态变更事件
@@ -88,10 +117,18 @@ export interface EventBusEvents {
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };
   "websocket:client:disconnected": { clientId: string; timestamp: number };
-  "websocket:message:received": { type: string; data: any; clientId: string };
+  "websocket:message:received": {
+    type: string;
+    data: WebSocketMessageData;
+    clientId: string;
+  };
 
   // 通知相关事件
-  "notification:broadcast": { type: string; data: any; target?: string };
+  "notification:broadcast": {
+    type: string;
+    data: NotificationData;
+    target?: string;
+  };
   "notification:error": { error: Error; type: string };
 
   // MCP服务相关事件
@@ -112,7 +149,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };
@@ -146,7 +183,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {
@@ -203,7 +240,7 @@ export interface EventBusEvents {
     timestamp: number;
   };
   "large-data-test": {
-    data: any;
+    data: Record<string, unknown>;
     timestamp: number;
   };
   "destroy-test": {
@@ -223,7 +260,7 @@ export interface EventBusEvents {
     timestamp: number;
   };
   "performance-test": {
-    data: any;
+    data: Record<string, unknown>;
     timestamp: number;
   };
   "test:performance": {


### PR DESCRIPTION
- 替换 status: any 为 status: ClientInfo
- 替换 data: any 为 data: WebSocketMessageData
- 替换 data: any 为 data: NotificationData
- 替换 config: any 为 config: MCPServerConfig
- 替换 results: any[] 为 results: MCPServerAddResult[]
- 定义 WebSocketMessageData 和 MCPServerAddResult 接口
- 添加常用类型的重新导出以便使用
- 更新测试文件以使用正确的 ClientInfo 类型

修复 #1020

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>