### PR TITLE
refactor: 提取通用的 useSortPersistence hook 消除代码重复

### DIFF
--- a/apps/frontend/src/hooks/useServerSortPersistence.ts
+++ b/apps/frontend/src/hooks/useServerSortPersistence.ts
@@ -4,61 +4,17 @@ import type {
   ServerSortConfig,
   ServerSortField,
 } from "@/components/mcp-server/server-sort-selector";
-import { useEffect, useState } from "react";
-
-/** localStorage 存储键 */
-const STORAGE_KEY = "mcp-server-sort-config";
-
-/** 默认排序配置 */
-const DEFAULT_CONFIG: ServerSortConfig = {
-  field: "name",
-};
-
-/** 有效的排序字段列表 */
-const VALID_SORT_FIELDS: ServerSortField[] = [
-  "name",
-  "communicationType",
-  "toolCount",
-];
+import { useSortPersistence } from "./useSortPersistence";
 
 /**
  * 服务器排序配置持久化 Hook
  * 自动将用户选择的排序方式保存到 localStorage
  */
 export function useServerSortPersistence() {
-  const [sortConfig, setSortConfig] = useState<ServerSortConfig>(() => {
-    // 从 localStorage 读取保存的配置
-    if (typeof window !== "undefined") {
-      try {
-        const saved = localStorage.getItem(STORAGE_KEY);
-        if (saved) {
-          const parsed = JSON.parse(saved) as ServerSortConfig;
-          // 验证 field 是否有效
-          if (parsed && VALID_SORT_FIELDS.includes(parsed.field)) {
-            return parsed;
-          }
-          // 无效数据，使用默认配置
-          console.warn(
-            "[useServerSortPersistence] 无效的排序字段，使用默认配置"
-          );
-        }
-      } catch (error) {
-        console.warn("[useServerSortPersistence] 读取排序配置失败:", error);
-      }
-    }
-    return DEFAULT_CONFIG;
+  return useSortPersistence<ServerSortConfig, ServerSortField>({
+    storageKey: "mcp-server-sort-config",
+    defaultConfig: { field: "name" },
+    validFields: ["name", "communicationType", "toolCount"],
+    logPrefix: "useServerSortPersistence",
   });
-
-  // 当配置变化时，保存到 localStorage
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(sortConfig));
-      } catch (error) {
-        console.warn("[useServerSortPersistence] 保存排序配置失败:", error);
-      }
-    }
-  }, [sortConfig]);
-
-  return { sortConfig, setSortConfig };
 }

--- a/apps/frontend/src/hooks/useSortPersistence.ts
+++ b/apps/frontend/src/hooks/useSortPersistence.ts
@@ -1,0 +1,64 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+/**
+ * 排序持久化选项配置
+ */
+interface SortPersistenceOptions<T extends { field: F }, F extends string> {
+  /** localStorage 存储键 */
+  storageKey: string;
+  /** 默认排序配置 */
+  defaultConfig: T;
+  /** 有效的排序字段列表 */
+  validFields: F[];
+  /** 日志前缀 */
+  logPrefix: string;
+}
+
+/**
+ * 通用的排序配置持久化 Hook
+ * 自动将用户选择的排序方式保存到 localStorage
+ *
+ * @param options - 排序持久化配置选项
+ * @returns 包含 sortConfig 和 setSortConfig 的对象
+ */
+export function useSortPersistence<T extends { field: F }, F extends string>(
+  options: SortPersistenceOptions<T, F>
+) {
+  const { storageKey, defaultConfig, validFields, logPrefix } = options;
+
+  const [sortConfig, setSortConfig] = useState<T>(() => {
+    // 从 localStorage 读取保存的配置
+    if (typeof window !== "undefined") {
+      try {
+        const saved = localStorage.getItem(storageKey);
+        if (saved) {
+          const parsed = JSON.parse(saved) as T;
+          // 验证 field 是否有效
+          if (parsed && validFields.includes(parsed.field)) {
+            return parsed;
+          }
+          // 无效数据，使用默认配置
+          console.warn(`[${logPrefix}] 无效的排序字段，使用默认配置`);
+        }
+      } catch (error) {
+        console.warn(`[${logPrefix}] 读取排序配置失败:`, error);
+      }
+    }
+    return defaultConfig;
+  });
+
+  // 当配置变化时，保存到 localStorage
+  useEffect(() => {
+    if (typeof window !== "undefined") {
+      try {
+        localStorage.setItem(storageKey, JSON.stringify(sortConfig));
+      } catch (error) {
+        console.warn(`[${logPrefix}] 保存排序配置失败:`, error);
+      }
+    }
+  }, [sortConfig, storageKey, logPrefix]);
+
+  return { sortConfig, setSortConfig };
+}

--- a/apps/frontend/src/hooks/useToolSortPersistence.ts
+++ b/apps/frontend/src/hooks/useToolSortPersistence.ts
@@ -2,58 +2,17 @@
 
 import type { ToolSortConfig } from "@/components/mcp-tool/tool-sort-selector";
 import type { ToolSortField } from "@/components/mcp-tool/tool-sort-selector";
-import { useEffect, useState } from "react";
-
-const STORAGE_KEY = "mcp-tool-sort-config";
-
-const DEFAULT_CONFIG: ToolSortConfig = {
-  field: "name",
-};
-
-// 有效的排序字段列表
-const VALID_SORT_FIELDS: ToolSortField[] = [
-  "name",
-  "enabled",
-  "usageCount",
-  "lastUsedTime",
-];
+import { useSortPersistence } from "./useSortPersistence";
 
 /**
  * 排序配置持久化 Hook
  * 自动将用户选择的排序方式保存到 localStorage
  */
 export function useToolSortPersistence() {
-  const [sortConfig, setSortConfig] = useState<ToolSortConfig>(() => {
-    // 从 localStorage 读取保存的配置
-    if (typeof window !== "undefined") {
-      try {
-        const saved = localStorage.getItem(STORAGE_KEY);
-        if (saved) {
-          const parsed = JSON.parse(saved) as ToolSortConfig;
-          // 验证 field 是否有效
-          if (parsed && VALID_SORT_FIELDS.includes(parsed.field)) {
-            return parsed;
-          }
-          // 无效数据，使用默认配置
-          console.warn("[useToolSortPersistence] 无效的排序字段，使用默认配置");
-        }
-      } catch (error) {
-        console.warn("[useToolSortPersistence] 读取排序配置失败:", error);
-      }
-    }
-    return DEFAULT_CONFIG;
+  return useSortPersistence<ToolSortConfig, ToolSortField>({
+    storageKey: "mcp-tool-sort-config",
+    defaultConfig: { field: "name" },
+    validFields: ["name", "enabled", "usageCount", "lastUsedTime"],
+    logPrefix: "useToolSortPersistence",
   });
-
-  // 当配置变化时，保存到 localStorage
-  useEffect(() => {
-    if (typeof window !== "undefined") {
-      try {
-        localStorage.setItem(STORAGE_KEY, JSON.stringify(sortConfig));
-      } catch (error) {
-        console.warn("[useToolSortPersistence] 保存排序配置失败:", error);
-      }
-    }
-  }, [sortConfig]);
-
-  return { sortConfig, setSortConfig };
 }


### PR DESCRIPTION
将 useServerSortPersistence 和 useToolSortPersistence 两个 hook 中的重复逻辑提取为通用的 useSortPersistence hook，遵循 DRY 原则。

主要变更:
- 新增 apps/frontend/src/hooks/useSortPersistence.ts: 通用排序持久化 hook
- 重构 useServerSortPersistence.ts: 使用通用 hook 实现
- 重构 useToolSortPersistence.ts: 使用通用 hook 实现

优点:
- 消除代码重复，逻辑集中管理
- 便于维护和扩展
- 保持 API 向后兼容

Fixes #1022

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>