### PR TITLE
fix: 修复 middlewares/index.ts 中的路径别名一致性

### DIFF
--- a/apps/backend/middlewares/index.ts
+++ b/apps/backend/middlewares/index.ts
@@ -20,4 +20,4 @@ export { endpointsMiddleware } from "./endpoints.middleware.js";
 export {
   getMCPServiceManager,
   requireMCPServiceManager,
-} from "../types/hono.context.js";
+} from "@/types/hono.context.js";


### PR DESCRIPTION
将相对路径导入 `../types/hono.context.js` 改为路径别名导入 `@/types/hono.context.js`，以保持与项目路径别名系统的一致性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>