### PR TITLE
fix: 修复 TemplateManager 接口使用 any 类型的问题

### DIFF
--- a/packages/cli/src/interfaces/Service.ts
+++ b/packages/cli/src/interfaces/Service.ts
@@ -81,19 +81,41 @@ export interface DaemonManager {
 }
 
 /**
+ * 模板信息接口
+ */
+export interface TemplateInfo {
+  name: string;
+  path: string;
+  description?: string;
+  version?: string;
+  author?: string;
+  files: string[];
+}
+
+/**
+ * 模板创建选项
+ */
+export interface TemplateCreateOptions {
+  templateName?: string;
+  targetPath: string;
+  projectName: string;
+  variables?: Record<string, string>;
+}
+
+/**
  * 模板管理器接口
  */
 export interface TemplateManager {
   /** 获取可用模板列表 */
-  getAvailableTemplates(): Promise<any[]>;
+  getAvailableTemplates(): Promise<TemplateInfo[]>;
   /** 复制模板到目标目录 */
   copyTemplate(templateName: string, targetPath: string): Promise<void>;
   /** 验证模板是否存在 */
   validateTemplate(templateName: string): Promise<boolean>;
   /** 获取模板信息 */
-  getTemplateInfo(templateName: string): Promise<any | null>;
+  getTemplateInfo(templateName: string): Promise<TemplateInfo | null>;
   /** 创建项目 */
-  createProject(options: any): Promise<void>;
+  createProject(options: TemplateCreateOptions): Promise<void>;
   /** 清除模板缓存 */
   clearCache(): void;
 }

--- a/packages/cli/src/services/TemplateManager.ts
+++ b/packages/cli/src/services/TemplateManager.ts
@@ -5,32 +5,17 @@
 import fs from "node:fs";
 import path from "node:path";
 import { FileError, ValidationError } from "../errors/index";
-import type { TemplateManager as ITemplateManager } from "../interfaces/Service";
+import type {
+  TemplateManager as ITemplateManager,
+  TemplateCreateOptions,
+  TemplateInfo,
+} from "../interfaces/Service";
 import { FileUtils } from "../utils/FileUtils";
 import { PathUtils } from "../utils/PathUtils";
 import { Validation } from "../utils/Validation";
 
-/**
- * 模板信息接口
- */
-export interface TemplateInfo {
-  name: string;
-  path: string;
-  description?: string;
-  version?: string;
-  author?: string;
-  files: string[];
-}
-
-/**
- * 模板创建选项
- */
-export interface TemplateCreateOptions {
-  templateName?: string;
-  targetPath: string;
-  projectName: string;
-  variables?: Record<string, string>;
-}
+// 重新导出类型以保持向后兼容
+export type { TemplateInfo, TemplateCreateOptions };
 
 /**
  * 模板管理器实现


### PR DESCRIPTION
将 TemplateManager 接口中的 any 类型替换为具体的类型定义：
- 将 TemplateInfo 和 TemplateCreateOptions 类型定义移至 Service.ts
- 更新 TemplateManager.ts 从接口文件导入类型
- 保持向后兼容，重新导出类型定义

修复 #1029

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>