### PR TITLE
fix: 为 NotificationService.registerClient 中的 ws.send 添加错误处理

### DIFF
--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -129,7 +129,16 @@ export class NotificationService {
         send: (data: string) => {
           if (ws.readyState === 1) {
             // WebSocket.OPEN
-            ws.send(data);
+            try {
+              ws.send(data);
+            } catch (error) {
+              this.logger.error(`发送消息给客户端 ${clientId} 失败:`, error);
+              this.eventBus.emitEvent("notification:error", {
+                error:
+                  error instanceof Error ? error : new Error(String(error)),
+                type: "client:send",
+              });
+            }
           }
         },
       };


### PR DESCRIPTION
在 NotificationService.registerClient() 方法的 send 函数中，
ws.send() 调用现在包含 try-catch 错误处理。当 WebSocket 发送失败时，
错误会被捕获并记录，同时通过事件总线发送错误事件。

修复了 #1031

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>