### PR TITLE
refactor: 统一 handlers 错误处理模式使用 BaseHandler.handleError()

### DIFF
--- a/apps/backend/handlers/__tests__/config.handler.test.ts
+++ b/apps/backend/handlers/__tests__/config.handler.test.ts
@@ -217,7 +217,7 @@ describe("ConfigApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIG_READ_ERROR",
-        "获取配置失败",
+        "String error",
         undefined,
         500
       );
@@ -254,7 +254,9 @@ describe("ConfigApiHandler", () => {
       expect(mockConfigManager.updateConfig).not.toHaveBeenCalled();
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIG_UPDATE_ERROR",
-        "配置必须是有效的对象"
+        "配置必须是有效的对象",
+        undefined,
+        500
       );
     });
 
@@ -269,7 +271,9 @@ describe("ConfigApiHandler", () => {
       expect(mockConfigManager.updateConfig).not.toHaveBeenCalled();
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIG_UPDATE_ERROR",
-        "配置必须是有效的对象"
+        "配置必须是有效的对象",
+        undefined,
+        500
       );
     });
 
@@ -285,7 +289,9 @@ describe("ConfigApiHandler", () => {
       expect(mockLogger.error).toHaveBeenCalledWith("配置更新失败:", error);
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIG_UPDATE_ERROR",
-        "Config update failed"
+        "Config update failed",
+        undefined,
+        500
       );
     });
 
@@ -298,7 +304,9 @@ describe("ConfigApiHandler", () => {
       expect(mockLogger.error).toHaveBeenCalledWith("配置更新失败:", jsonError);
       expect(mockContext.fail).toHaveBeenCalledWith(
         "CONFIG_UPDATE_ERROR",
-        "Invalid JSON"
+        "Invalid JSON",
+        undefined,
+        500
       );
     });
   });

--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -143,7 +143,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "SERVICE_STATUS_READ_ERROR",
-        "获取服务状态失败",
+        "String error",
         undefined,
         500
       );
@@ -254,7 +254,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "START_REQUEST_ERROR",
-        "处理启动请求失败",
+        "String error",
         undefined,
         500
       );
@@ -355,7 +355,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "STOP_REQUEST_ERROR",
-        "处理停止请求失败",
+        "String error",
         undefined,
         500
       );
@@ -409,7 +409,7 @@ describe("ServiceApiHandler", () => {
 
       expect(mockContext.fail).toHaveBeenCalledWith(
         "RESTART_REQUEST_ERROR",
-        "处理重启请求失败",
+        "String error",
         undefined,
         500
       );

--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -17,20 +17,13 @@ export class ConfigApiHandler extends BaseHandler {
    * GET /api/config
    */
   async getConfig(c: Context<AppContext>): Promise<Response> {
-    const logger = c.get("logger");
     try {
-      logger.debug("处理获取配置请求");
+      c.get("logger").debug("处理获取配置请求");
       const config = configManager.getConfig();
-      logger.debug("获取配置成功");
+      c.get("logger").debug("获取配置成功");
       return c.success(config);
     } catch (error) {
-      logger.error("获取配置失败:", error);
-      return c.fail(
-        "CONFIG_READ_ERROR",
-        error instanceof Error ? error.message : "获取配置失败",
-        undefined,
-        500
-      );
+      return this.handleError(c, error, "获取配置", "CONFIG_READ_ERROR");
     }
   }
 
@@ -69,11 +62,7 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").info("配置更新成功");
       return c.success(undefined, "配置更新成功");
     } catch (error) {
-      c.get("logger").error("配置更新失败:", error);
-      return c.fail(
-        "CONFIG_UPDATE_ERROR",
-        error instanceof Error ? error.message : "配置更新失败"
-      );
+      return this.handleError(c, error, "配置更新", "CONFIG_UPDATE_ERROR");
     }
   }
 
@@ -88,12 +77,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug("获取 MCP 端点成功");
       return c.success({ endpoint });
     } catch (error) {
-      c.get("logger").error("获取 MCP 端点失败:", error);
-      return c.fail(
-        "MCP_ENDPOINT_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 端点失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取 MCP 端点",
+        "MCP_ENDPOINT_READ_ERROR"
       );
     }
   }
@@ -109,12 +97,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug("获取 MCP 端点列表成功");
       return c.success({ endpoints });
     } catch (error) {
-      c.get("logger").error("获取 MCP 端点列表失败:", error);
-      return c.fail(
-        "MCP_ENDPOINTS_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 端点列表失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取 MCP 端点列表",
+        "MCP_ENDPOINTS_READ_ERROR"
       );
     }
   }
@@ -130,12 +117,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug("获取 MCP 服务配置成功");
       return c.success({ servers });
     } catch (error) {
-      c.get("logger").error("获取 MCP 服务配置失败:", error);
-      return c.fail(
-        "MCP_SERVERS_READ_ERROR",
-        error instanceof Error ? error.message : "获取 MCP 服务配置失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取 MCP 服务配置",
+        "MCP_SERVERS_READ_ERROR"
       );
     }
   }
@@ -151,12 +137,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug("获取连接配置成功");
       return c.success({ connection });
     } catch (error) {
-      c.get("logger").error("获取连接配置失败:", error);
-      return c.fail(
-        "CONNECTION_CONFIG_READ_ERROR",
-        error instanceof Error ? error.message : "获取连接配置失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取连接配置",
+        "CONNECTION_CONFIG_READ_ERROR"
       );
     }
   }
@@ -173,13 +158,7 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").info("重新加载配置成功");
       return c.success(config, "配置重新加载成功");
     } catch (error) {
-      c.get("logger").error("重新加载配置失败:", error);
-      return c.fail(
-        "CONFIG_RELOAD_ERROR",
-        error instanceof Error ? error.message : "重新加载配置失败",
-        undefined,
-        500
-      );
+      return this.handleError(c, error, "重新加载配置", "CONFIG_RELOAD_ERROR");
     }
   }
 
@@ -194,12 +173,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug("获取配置文件路径成功");
       return c.success({ path });
     } catch (error) {
-      c.get("logger").error("获取配置文件路径失败:", error);
-      return c.fail(
-        "CONFIG_PATH_READ_ERROR",
-        error instanceof Error ? error.message : "获取配置文件路径失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取配置文件路径",
+        "CONFIG_PATH_READ_ERROR"
       );
     }
   }
@@ -215,12 +193,11 @@ export class ConfigApiHandler extends BaseHandler {
       c.get("logger").debug(`配置存在检查结果: ${exists}`);
       return c.success({ exists });
     } catch (error) {
-      c.get("logger").error("检查配置是否存在失败:", error);
-      return c.fail(
-        "CONFIG_EXISTS_CHECK_ERROR",
-        error instanceof Error ? error.message : "检查配置是否存在失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "检查配置是否存在",
+        "CONFIG_EXISTS_CHECK_ERROR"
       );
     }
   }

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -8,16 +8,18 @@ import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
 import { requireMCPServiceManager } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
 
 /**
  * 服务 API 处理器
  */
-export class ServiceApiHandler {
+export class ServiceApiHandler extends BaseHandler {
   private logger: Logger;
   private statusService: StatusService;
   private eventBus: EventBus;
 
   constructor(statusService: StatusService) {
+    super();
     this.logger = logger;
     this.statusService = statusService;
     this.eventBus = getEventBus();
@@ -65,12 +67,11 @@ export class ServiceApiHandler {
 
       return c.success(null, "重启请求已接收");
     } catch (error) {
-      c.get("logger").error("处理重启请求失败:", error);
-      return c.fail(
-        "RESTART_REQUEST_ERROR",
-        error instanceof Error ? error.message : "处理重启请求失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "处理重启请求",
+        "RESTART_REQUEST_ERROR"
       );
     }
   }
@@ -151,13 +152,7 @@ export class ServiceApiHandler {
 
       return c.success(null, "停止请求已接收");
     } catch (error) {
-      c.get("logger").error("处理停止请求失败:", error);
-      return c.fail(
-        "STOP_REQUEST_ERROR",
-        error instanceof Error ? error.message : "处理停止请求失败",
-        undefined,
-        500
-      );
+      return this.handleError(c, error, "处理停止请求", "STOP_REQUEST_ERROR");
     }
   }
 
@@ -185,13 +180,7 @@ export class ServiceApiHandler {
 
       return c.success(null, "启动请求已接收");
     } catch (error) {
-      c.get("logger").error("处理启动请求失败:", error);
-      return c.fail(
-        "START_REQUEST_ERROR",
-        error instanceof Error ? error.message : "处理启动请求失败",
-        undefined,
-        500
-      );
+      return this.handleError(c, error, "处理启动请求", "START_REQUEST_ERROR");
     }
   }
 
@@ -209,12 +198,11 @@ export class ServiceApiHandler {
       c.get("logger").debug("获取服务状态成功");
       return c.success(status);
     } catch (error) {
-      c.get("logger").error("获取服务状态失败:", error);
-      return c.fail(
-        "SERVICE_STATUS_READ_ERROR",
-        error instanceof Error ? error.message : "获取服务状态失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取服务状态",
+        "SERVICE_STATUS_READ_ERROR"
       );
     }
   }
@@ -239,12 +227,11 @@ export class ServiceApiHandler {
       c.get("logger").debug("获取服务健康状态成功");
       return c.success(health);
     } catch (error) {
-      c.get("logger").error("获取服务健康状态失败:", error);
-      return c.fail(
-        "SERVICE_HEALTH_READ_ERROR",
-        error instanceof Error ? error.message : "获取服务健康状态失败",
-        undefined,
-        500
+      return this.handleError(
+        c,
+        error,
+        "获取服务健康状态",
+        "SERVICE_HEALTH_READ_ERROR"
       );
     }
   }


### PR DESCRIPTION
修复问题 #1032: Handlers 错误处理模式不一致违反架构统一性原则

主要变更:
- ConfigApiHandler: 所有 9 个方法现在统一使用 BaseHandler.handleError()
- ServiceApiHandler: 继承 BaseHandler 并使用 handleError() 处理所有 5 个 API 方法的错误
- 更新相关测试断言以匹配新的错误处理行为

收益:
- 消除重复的错误处理代码
- 统一错误处理模式,提高代码一致性
- 便于未来维护和扩展

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>