### PR TITLE
fix: 统一 RestartStatus 类型定义，解决 DRY 原则违反问题

### DIFF
--- a/apps/backend/services/status.service.ts
+++ b/apps/backend/services/status.service.ts
@@ -5,6 +5,7 @@ import { getEventBus } from "@/services/event-bus.service.js";
 
 /**
  * 客户端信息接口
+ * 与 shared-types 中的 ClientStatus 保持一致
  */
 export interface ClientInfo {
   status: "connected" | "disconnected";
@@ -15,12 +16,18 @@ export interface ClientInfo {
 
 /**
  * 重启状态接口
+ * 与 shared-types 中的 RestartStatus 保持一致
  */
 export interface RestartStatus {
+  /** 重启状态 */
   status: "restarting" | "completed" | "failed";
+  /** 错误信息 */
   error?: string;
+  /** 时间戳 */
   timestamp: number;
+  /** 服务名称（可选） */
   serviceName?: string;
+  /** 重试次数（可选） */
   attempt?: number;
 }
 

--- a/apps/frontend/src/components/restart-button.test.tsx
+++ b/apps/frontend/src/components/restart-button.test.tsx
@@ -1,6 +1,7 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
-import { RestartButton, type RestartStatus } from "./restart-button";
+import { RestartButton } from "./restart-button";
+import type { RestartStatus } from "@xiaozhi-client/shared-types";
 
 // Mock status store
 const mockRestartService = vi.fn();

--- a/apps/frontend/src/components/restart-button.tsx
+++ b/apps/frontend/src/components/restart-button.tsx
@@ -1,16 +1,8 @@
 import { Button } from "@/components/ui/button";
 import { useRestartPollingStatus, useStatusStore } from "@/stores/status";
+import type { RestartStatus } from "@xiaozhi-client/shared-types";
 import clsx from "clsx";
 import { LoaderCircleIcon, PowerIcon } from "lucide-react";
-
-/**
- * 重启状态接口
- */
-export interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-}
 
 /**
  * RestartButton 组件属性接口

--- a/apps/frontend/src/hooks/useNetworkService.ts
+++ b/apps/frontend/src/hooks/useNetworkService.ts
@@ -4,11 +4,10 @@
  */
 
 import { ConnectionState, networkService } from "@services/index";
-import type { RestartStatus } from "@services/websocket";
 import { useConfigStore } from "@stores/config";
 import { useStatusStore } from "@stores/status";
 import { useWebSocketActions } from "@stores/websocket";
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import type { AppConfig, ClientStatus, RestartStatus } from "@xiaozhi-client/shared-types";
 import { useCallback, useEffect, useRef } from "react";
 
 /**

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import type {
   MCPServerConfig,
   MCPServerListResponse,
   MCPServerStatus,
+  RestartStatus,
 } from "@xiaozhi-client/shared-types";
 
 /**
@@ -70,15 +71,6 @@ interface VersionInfo {
   version: string;
   description: string;
   author: string;
-}
-
-/**
- * 重启状态接口
- */
-interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
 }
 
 /**
@@ -1159,7 +1151,6 @@ export type {
   ApiErrorResponse,
   ServiceStatus,
   ServiceHealth,
-  RestartStatus,
   FullStatus,
   VersionInfo,
   EndpointStatusResponse,

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -7,7 +7,7 @@
  * - 支持多个 store 订阅 WebSocket 事件
  */
 
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import type { AppConfig, ClientStatus, RestartStatus } from "@xiaozhi-client/shared-types";
 
 /**
  * WebSocket 消息类型
@@ -21,15 +21,6 @@ interface WebSocketMessage {
     message: string;
     timestamp?: number;
   };
-}
-
-/**
- * 重启状态接口
- */
-interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
 }
 
 /**
@@ -704,7 +695,6 @@ export const webSocketManager = WebSocketManager.getInstance();
 export { ConnectionState };
 export type {
   WebSocketMessage,
-  RestartStatus,
   WebSocketManagerConfig,
   EventBusEvents,
   EventListener,

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -12,19 +12,10 @@
 
 import { apiClient } from "@services/api";
 import { webSocketManager } from "@services/websocket";
-import type { ClientStatus } from "@xiaozhi-client/shared-types";
+import type { ClientStatus, RestartStatus } from "@xiaozhi-client/shared-types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-
-/**
- * 重启状态接口
- */
-interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-}
 
 /**
  * 服务状态接口

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -26,6 +26,7 @@ export type {
 
 // 服务器配置相关类型
 export type {
+  ClientStatus,
   ClientStatus as ConfigClientStatus,
   ServerInfo,
   RestartStatus,

--- a/packages/shared-types/src/config/server.ts
+++ b/packages/shared-types/src/config/server.ts
@@ -36,12 +36,14 @@ export interface ServerInfo {
  * 重启状态
  */
 export interface RestartStatus {
-  /** 是否正在重启 */
-  restarting: boolean;
-  /** 重启时间 */
-  restartTime?: string;
-  /** 重启原因 */
-  reason?: string;
-  /** 预计完成时间 */
-  estimatedCompletion?: string;
+  /** 重启状态 */
+  status: "restarting" | "completed" | "failed";
+  /** 错误信息 */
+  error?: string;
+  /** 时间戳 */
+  timestamp: number;
+  /** 服务名称（可选） */
+  serviceName?: string;
+  /** 重试次数（可选） */
+  attempt?: number;
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -44,6 +44,9 @@ export type {
   MCPServerConfig,
   SSEMCPServerConfig,
   StreamableHTTPMCPServerConfig,
+  ClientStatus,
+  ServerInfo,
+  RestartStatus,
 } from "./config";
 
 // 前端相关类型


### PR DESCRIPTION
- 更新 shared-types 中的 RestartStatus 定义，使用完整的状态机模型
  (status: "restarting" | "completed" | "failed", error?, timestamp, serviceName?, attempt?)
- 移除前端文件中的重复定义，统一从 shared-types 导入
  - apps/frontend/src/services/api.ts
  - apps/frontend/src/services/websocket.ts
  - apps/frontend/src/stores/status.ts
  - apps/frontend/src/components/restart-button.tsx
- 后端保持本地定义以确保与后端逻辑完全兼容，添加注释说明与 shared-types 保持一致
- 添加 ClientStatus 和 ServerInfo 到 shared-types 主导出
- 更新相关测试文件的导入语句

修复 #1036

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>