### PR TITLE
fix: 修复 routes 和 handlers 目录中的路径别名一致性问题

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -6,8 +6,8 @@ import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
+import { requireMCPServiceManager } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
  * 服务 API 处理器

--- a/apps/backend/routes/RouteManager.ts
+++ b/apps/backend/routes/RouteManager.ts
@@ -3,8 +3,8 @@
  * 提供直接、高效的路由注册和管理功能
  */
 
+import type { AppContext } from "@/types/hono.context.js";
 import type { Context, Hono, Next } from "hono";
-import type { AppContext } from "../types/hono.context.js";
 import {
   type RouteDefinition,
   type RouteRegistry,

--- a/apps/backend/routes/index.ts
+++ b/apps/backend/routes/index.ts
@@ -15,7 +15,7 @@ export * from "./domains/index.js";
 
 // 重新导出 Hono 相关类型以方便使用
 export type { Context } from "hono";
-export type { AppContext } from "../types/hono.context.js";
+export type { AppContext } from "@/types/hono.context.js";
 
 // 重新导出处理器类型
 export type { EndpointHandler } from "../handlers/index.js";


### PR DESCRIPTION
将 `../types/hono.context.js` 相对路径导入替换为 `@/types/hono.context.js` 路径别名，
以保持与项目其他部分的一致性。

修复的文件：
- apps/backend/routes/RouteManager.ts
- apps/backend/routes/index.ts
- apps/backend/handlers/service.handler.ts

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>