### PR TITLE
fix: 修复兼容层函数返回 any 类型降低类型安全问题

### DIFF
--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -20,7 +20,7 @@ import { useShallow } from "zustand/react/shallow";
 /**
  * 重启状态接口
  */
-interface RestartStatus {
+export interface RestartStatus {
   status: "restarting" | "completed" | "failed";
   error?: string;
   timestamp: number;

--- a/apps/frontend/src/stores/websocket-compat.ts
+++ b/apps/frontend/src/stores/websocket-compat.ts
@@ -9,7 +9,9 @@ import { ConnectionState } from "@services/websocket";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 import { useConfigStore } from "./config";
 import { useStatusStore } from "./status";
+import type { RestartStatus } from "./status";
 import { useWebSocketStore } from "./websocket";
+import type { PortChangeStatus } from "./websocket";
 
 /**
  * 向后兼容的配置选择器
@@ -86,7 +88,7 @@ export function useWebSocketConnected(): boolean {
  * 向后兼容的重启状态选择器
  * @deprecated 请使用 useRestartStatus() from "./status"
  */
-export function useWebSocketRestartStatus(): any {
+export function useWebSocketRestartStatus(): RestartStatus | null {
   console.warn(
     '[useWebSocketRestartStatus] 此选择器已废弃，请使用 useRestartStatus() from "./status"'
   );
@@ -108,7 +110,7 @@ export function useWebSocketWsUrl(): string {
  * 向后兼容的端口切换状态选择器
  * @deprecated 请使用 usePortChangeStatus() from "./websocket"
  */
-export function useWebSocketPortChangeStatus(): any {
+export function useWebSocketPortChangeStatus(): PortChangeStatus | undefined {
   console.warn(
     '[useWebSocketPortChangeStatus] 此选择器已废弃，请使用 usePortChangeStatus() from "./websocket"'
   );

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -20,7 +20,7 @@ import { useShallow } from "zustand/react/shallow";
 /**
  * 端口变更状态接口（保留用于端口切换功能）
  */
-interface PortChangeStatus {
+export interface PortChangeStatus {
   status:
     | "idle"
     | "checking"


### PR DESCRIPTION
修复 apps/frontend/src/stores/websocket-compat.ts 中兼容层函数的返回类型：
- useWebSocketRestartStatus() 返回类型从 any 改为 RestartStatus | null
- useWebSocketPortChangeStatus() 返回类型从 any 改为 PortChangeStatus | undefined

同时导出相关类型定义以供兼容层使用：
- 从 status.ts 导出 RestartStatus 接口
- 从 websocket.ts 导出 PortChangeStatus 接口

这些兼容层函数已标记为 @deprecated，但仍被旧代码使用。
修复类型可以提高类型安全性和 IDE 代码补全支持。

Fixes #1051

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>