### PR TITLE
fix: 使用 JSONSchema 类型替换 extractParametersFromSchema 中的 any 类型

### DIFF
--- a/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
+++ b/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
@@ -27,6 +27,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
   CozeWorkflow,
+  JSONSchema,
   WorkflowParameter,
 } from "@xiaozhi-client/shared-types";
 import { Plus, Trash2 } from "lucide-react";
@@ -91,7 +92,7 @@ export interface WorkflowParameterConfigDialogProps {
 /**
  * 从 inputSchema 提取现有参数配置
  */
-function extractParametersFromSchema(inputSchema: any): FormData["parameters"] {
+function extractParametersFromSchema(inputSchema: JSONSchema): FormData["parameters"] {
   if (!inputSchema || !inputSchema.properties) {
     return [];
   }
@@ -100,7 +101,7 @@ function extractParametersFromSchema(inputSchema: any): FormData["parameters"] {
   const required = inputSchema.required || [];
 
   return Object.entries(properties).map(
-    ([fieldName, schema]: [string, any]) => {
+    ([fieldName, schema]: [string, JSONSchema]) => {
       let type: "string" | "number" | "boolean" = "string";
 
       if (schema.type === "integer" || schema.type === "number") {


### PR DESCRIPTION
修复 #1053

- 导入 JSONSchema 类型从 @xiaozhi-client/shared-types
- 更新 extractParametersFromSchema 函数参数类型从 any 到 JSONSchema
- 更新 Object.entries 回调中的 schema 类型从 any 到 JSONSchema
- 提升代码类型安全性，符合项目类型安全规范

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>