### PR TITLE
fix: 在 tool-call-logs-dialog 中添加 HTTP 状态码检查

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -68,6 +68,11 @@ export function ToolCallLogsDialog() {
       try {
         await new Promise((resolve) => setTimeout(resolve, 1000));
         const response = await fetch(`/api/tool-calls/logs?limit=${limit}`);
+
+        if (!response.ok) {
+          throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+        }
+
         const data: ApiResponse<ToolCallLogsResponse> = await response.json();
 
         if (data.success && data.data) {
@@ -77,7 +82,7 @@ export function ToolCallLogsDialog() {
           setError(data.error?.message || "获取日志失败");
         }
       } catch (err) {
-        setError("网络请求失败");
+        setError(err instanceof Error ? err.message : "网络请求失败");
         console.error("Failed to fetch tool call logs:", err);
       } finally {
         if (isRefresh) {

--- a/apps/frontend/src/test/ToolCallLogsDialog.test.tsx
+++ b/apps/frontend/src/test/ToolCallLogsDialog.test.tsx
@@ -50,6 +50,7 @@ describe("ToolCallLogsDialog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (fetch as any).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue(mockSuccessResponse),
     });
   });
@@ -96,6 +97,7 @@ describe("ToolCallLogsDialog", () => {
           setTimeout(
             () =>
               resolve({
+                ok: true,
                 json: vi.fn().mockResolvedValue(mockSuccessResponse),
               }),
             100
@@ -158,6 +160,7 @@ describe("ToolCallLogsDialog", () => {
     };
 
     (fetch as any).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue(mockErrorResponse),
     });
 
@@ -186,6 +189,7 @@ describe("ToolCallLogsDialog", () => {
     };
 
     (fetch as any).mockResolvedValue({
+      ok: true,
       json: vi.fn().mockResolvedValue(mockEmptyResponse),
     });
 
@@ -284,5 +288,27 @@ describe("ToolCallLogsDialog", () => {
     // 这个测试需要更复杂的mock设置，包括定时器控制
     // 在实际使用中，重试功能是正常的
     expect(true).toBe(true);
+  });
+
+  it("应该正确处理 HTTP 错误状态码", async () => {
+    // 模拟 500 服务器错误
+    (fetch as any).mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: "Internal Server Error",
+    });
+
+    render(<ToolCallLogsDialog />);
+
+    const triggerButton = screen.getByRole("button", { name: /调用日志/ });
+    fireEvent.click(triggerButton);
+
+    await waitFor(
+      () => {
+        expect(screen.getByText("加载失败")).toBeInTheDocument();
+        expect(screen.getByText("HTTP 500: Internal Server Error")).toBeInTheDocument();
+      },
+      { timeout: 3000 }
+    );
   });
 });


### PR DESCRIPTION
修复 Issue #1056

在 fetchLogs 函数中添加 response.ok 检查，确保当后端返回错误状态码（如 404、500、503）时能够正确处理错误响应，而不是将错误响应误当作成功处理。

更改内容：
- 添加 response.ok 状态码检查
- 改进错误消息显示，使用 err instanceof Error 判断
- 更新相关测试用例，在 fetch mock 中添加 ok 属性
- 添加 HTTP 错误状态码处理的测试用例

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>