### PR TITLE
fix: 统一 Node.js 版本要求为 20+

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -227,7 +227,7 @@ xiaozhi-client 是一个务实的开源 MCP 客户端：
 ### 构建过程
 
 - 使用 tsup 进行打包
-- 输出 Node.js 18+ 的 ESM 格式
+- 输出 Node.js 20+ 的 ESM 格式
 - 包含源映射和 TypeScript 声明文件
 - 将模板和配置文件复制到 dist 目录
 

--- a/package.json
+++ b/package.json
@@ -8,6 +8,9 @@
   },
   "author": "shenjingnan <sjn.code@gmail.com>",
   "license": "MIT",
+  "engines": {
+    "node": ">=20.0.0"
+  },
   "keywords": [
     "xiaozhi",
     "mcp",

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -42,7 +42,7 @@ packages/cli/
 
 - **入口点**：`src/index.ts` → `../../dist/cli/index.js`
 - **格式**：ESM (ES Modules)
-- **目标**：Node.js 18+
+- **目标**：Node.js 20+
 - **打包工具**：tsup (esbuild)
 
 ## 外部依赖

--- a/packages/mcp-core/examples/README.md
+++ b/packages/mcp-core/examples/README.md
@@ -4,7 +4,7 @@
 
 ## 前置要求
 
-- Node.js 18+
+- Node.js 20+
 - pnpm 或 npm
 
 ## 安装依赖


### PR DESCRIPTION
- 在 package.json 中添加 engines 字段指定 Node.js >= 20.0.0
- 更新 CLAUDE.md 中的构建目标版本声明
- 更新 packages/cli/README.md 中的 Node.js 版本要求
- 更新 packages/mcp-core/examples/README.md 中的前置条件

修复 #1058

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>