### PR TITLE
fix: 将 PAGINATION_CONSTANTS 移至 shared-types 以消除 DRY 违规

### DIFF
--- a/apps/backend/constants/api.constants.ts
+++ b/apps/backend/constants/api.constants.ts
@@ -4,10 +4,6 @@
 
 /**
  * 分页相关常量
+ * 从 @xiaozhi-client/shared-types 重新导出
  */
-export const PAGINATION_CONSTANTS = {
-  /** 默认每页记录数 */
-  DEFAULT_LIMIT: 50,
-  /** 最大每页记录数 */
-  MAX_LIMIT: 200,
-} as const;
+export { PAGINATION_CONSTANTS } from "@xiaozhi-client/shared-types";

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,6 +13,7 @@
     "@xiaozhi-client/config": "workspace:*",
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*",
     "@xiaozhi-client/version": "workspace:*",
     "ajv": "^8.17.1",
     "chalk": "^5.6.0",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -10,9 +10,13 @@
     "noImplicitAny": false,
     "types": ["vitest/globals"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@xiaozhi-client/shared-types": ["../../packages/shared-types/src"]
     }
   },
+  "references": [
+    { "path": "../../packages/shared-types" }
+  ],
   "include": ["./**/*.ts"],
   "exclude": [
     "node_modules",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@xiaozhi-client/config": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*",
     "chalk": "^5.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",

--- a/packages/cli/src/Constants.ts
+++ b/packages/cli/src/Constants.ts
@@ -84,13 +84,9 @@ export const TIMEOUT_CONSTANTS = {
 
 /**
  * 分页相关常量
+ * 从 @xiaozhi-client/shared-types 重新导出
  */
-export const PAGINATION_CONSTANTS = {
-  /** 默认每页记录数 */
-  DEFAULT_LIMIT: 50,
-  /** 最大每页记录数 */
-  MAX_LIMIT: 200,
-} as const;
+export { PAGINATION_CONSTANTS } from "@xiaozhi-client/shared-types";
 
 /**
  * 重试常量

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,8 +3,8 @@
   "version": "1.9.7",
   "description": "小智项目的共享类型定义",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "../../dist/shared-types/index.js",
+  "types": "../../dist/shared-types/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -33,3 +33,6 @@ export type {
 
 // 重新导出 ConnectionConfig 以避免命名冲突，使用默认的 app.ts 中的定义
 export type { ConnectionConfig } from "./app";
+
+// 分页相关常量
+export { PAGINATION_CONSTANTS } from "./pagination.constants.js";

--- a/packages/shared-types/src/config/pagination.constants.ts
+++ b/packages/shared-types/src/config/pagination.constants.ts
@@ -1,0 +1,9 @@
+/**
+ * 分页相关常量
+ */
+export const PAGINATION_CONSTANTS = {
+  /** 默认每页记录数 */
+  DEFAULT_LIMIT: 50,
+  /** 最大每页记录数 */
+  MAX_LIMIT: 200,
+} as const;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -51,3 +51,6 @@ export * from "./frontend";
 
 // 工具类型
 export { TimeoutError } from "./utils";
+
+// 分页相关常量
+export { PAGINATION_CONSTANTS } from "./config/pagination.constants.js";

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],
-    "outDir": "./dist",
+    "outDir": "../../dist/shared-types",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../../packages/mcp-core
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@xiaozhi-client/version':
         specifier: workspace:*
         version: link:../../packages/version
@@ -515,6 +518,9 @@ importers:
       '@xiaozhi-client/config':
         specifier: workspace:*
         version: link:../config
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       chalk:
         specifier: ^5.6.0
         version: 5.6.2


### PR DESCRIPTION
- 在 packages/shared-types/src/config/pagination.constants.ts 中创建统一的分页常量定义
- 更新 apps/backend/constants/api.constants.ts 为 re-export
- 更新 packages/cli/src/Constants.ts 为 re-export
- 为 backend 和 CLI 添加 @xiaozhi-client/shared-types 依赖
- 修复 shared-types tsconfig.json 的输出目录配置
- 修复 shared-types package.json 的 main/types 路径配置
- 更新 backend tsconfig.json 添加 shared-types 项目引用

Fixes #1060

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>