### PR TITLE
fix: 统一路由 handler 包装函数使用 createHandler 模式

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,64 +4,18 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
-import type { Context } from "hono";
-import type { AppContext } from "../../types/hono.context.js";
 import type { RouteDefinition } from "../types.js";
+import { createHandler } from "../types.js";
 
 /**
- * 端点处理器方法名类型
+ * 端点处理器包装器
+ * 使用 createHandler 工厂函数统一处理依赖注入
+ * 当 endpointHandler 未初始化时返回中文错误信息
  */
-type EndpointHandlerMethod =
-  | "getEndpointStatus"
-  | "connectEndpoint"
-  | "disconnectEndpoint"
-  | "addEndpoint"
-  | "removeEndpoint";
-
-/**
- * 统一的错误响应函数
- */
-const createErrorResponse = (code: string, message: string) => {
-  return {
-    error: {
-      code,
-      message,
-    },
-  };
-};
-
-/**
- * 端点处理器包装函数
- * 从中间件获取 endpointHandler 并调用相应方法
- */
-const withEndpointHandler = async (
-  c: Context<AppContext>,
-  handlerName: EndpointHandlerMethod
-): Promise<Response> => {
-  // 从中间件获取 endpointHandler
-  const endpointHandler = c.get("endpointHandler");
-
-  if (!endpointHandler) {
-    const errorResponse = createErrorResponse(
-      "ENDPOINT_HANDLER_NOT_AVAILABLE",
-      "端点处理器尚未初始化，请稍后再试"
-    );
-    return c.json(errorResponse, 503);
-  }
-
-  // 调用对应的处理方法
-  try {
-    // 使用类型安全的方式调用方法
-    return await endpointHandler[handlerName](c);
-  } catch (error) {
-    console.error(`端点处理器错误 [${handlerName}]:`, error);
-    const errorResponse = createErrorResponse(
-      "ENDPOINT_HANDLER_ERROR",
-      error instanceof Error ? error.message : "端点处理失败"
-    );
-    return c.json(errorResponse, 500);
-  }
-};
+const h = createHandler("endpointHandler", {
+  errorCode: "ENDPOINT_HANDLER_NOT_AVAILABLE",
+  errorMessage: "端点处理器尚未初始化，请稍后再试",
+});
 
 /**
  * 端点管理路由定义（扁平化版本）
@@ -70,30 +24,26 @@ export const endpointRoutes: RouteDefinition[] = [
   {
     method: "POST",
     path: "/api/endpoint/status",
-    handler: (c: Context<AppContext>) =>
-      withEndpointHandler(c, "getEndpointStatus"),
+    handler: h((handler, c) => handler.getEndpointStatus(c)),
   },
   {
     method: "POST",
     path: "/api/endpoint/connect",
-    handler: (c: Context<AppContext>) =>
-      withEndpointHandler(c, "connectEndpoint"),
+    handler: h((handler, c) => handler.connectEndpoint(c)),
   },
   {
     method: "POST",
     path: "/api/endpoint/disconnect",
-    handler: (c: Context<AppContext>) =>
-      withEndpointHandler(c, "disconnectEndpoint"),
+    handler: h((handler, c) => handler.disconnectEndpoint(c)),
   },
   {
     method: "POST",
     path: "/api/endpoint/add",
-    handler: (c: Context<AppContext>) => withEndpointHandler(c, "addEndpoint"),
+    handler: h((handler, c) => handler.addEndpoint(c)),
   },
   {
     method: "POST",
     path: "/api/endpoint/remove",
-    handler: (c: Context<AppContext>) =>
-      withEndpointHandler(c, "removeEndpoint"),
+    handler: h((handler, c) => handler.removeEndpoint(c)),
   },
 ];


### PR DESCRIPTION
- 移除 mcpserver.route.ts 中的 withMCPServerHandler 自定义包装函数
- 移除 endpoint.route.ts 中的 withEndpointHandler 自定义包装函数
- 增强 createHandler 工厂函数支持可选依赖配置
- 为可选依赖提供中文错误信息
- 统一路由系统架构，提高代码一致性和可维护性

修复 #1061

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>