### PR TITLE
refactor: 将 useToolPagination 重构为泛型 usePagination

### DIFF
--- a/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
+++ b/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
@@ -12,7 +12,7 @@ import {
 } from "@/components/ui/table";
 import { useServerSearch } from "@/hooks/useServerSearch";
 import { useServerSortPersistence } from "@/hooks/useServerSortPersistence";
-import { useToolPagination } from "@/hooks/useToolPagination";
+import { usePagination } from "@/hooks/useToolPagination";
 import { cn } from "@/lib/utils";
 import { useMcpServersWithStatus } from "@/stores/config";
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
@@ -144,11 +144,11 @@ export function McpServerTable({ className }: McpServerTableProps) {
   const { searchValue, setSearchValue, filteredServers, clearSearch } =
     useServerSearch(sortedServers);
 
-  // 使用分页 Hook（复用工具分页，泛型兼容）
-  const { currentPage, totalPages, paginatedTools, setPage } =
-    useToolPagination(filteredServers as unknown as any, 10);
+  // 使用分页 Hook
+  const { currentPage, totalPages, paginatedItems, setPage } =
+    usePagination<ServerRowData>(filteredServers, 10);
 
-  const paginatedServers = paginatedTools as unknown as ServerRowData[];
+  const paginatedServers = paginatedItems;
 
   // 手动刷新
   const handleRefresh = useCallback(async () => {

--- a/apps/frontend/src/hooks/useToolPagination.ts
+++ b/apps/frontend/src/hooks/useToolPagination.ts
@@ -1,15 +1,16 @@
 import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useCallback, useMemo, useState } from "react";
 
-interface UseToolPaginationResult {
+/** 分页结果接口 */
+interface UsePaginationResult<T> {
   /** 当前页码 */
   currentPage: number;
   /** 每页显示数量 */
   pageSize: number;
   /** 总页数 */
   totalPages: number;
-  /** 当前页的工具列表 */
-  paginatedTools: ToolRowData[];
+  /** 当前页的数据列表 */
+  paginatedItems: T[];
   /** 设置页码 */
   setPage: (page: number) => void;
   /** 设置每页显示数量 */
@@ -19,34 +20,34 @@ interface UseToolPaginationResult {
 }
 
 /**
- * 工具分页状态管理 Hook
+ * 分页状态管理 Hook
  * 提供客户端分页功能
  *
- * @param tools - 工具列表数据
+ * @param items - 数据列表
  * @param initialPageSize - 初始每页显示数量，默认为 10
  */
-export function useToolPagination(
-  tools: ToolRowData[],
+export function usePagination<T>(
+  items: T[],
   initialPageSize = 10
-): UseToolPaginationResult {
+): UsePaginationResult<T> {
   const [currentPage, setCurrentPage] = useState(1);
   const [pageSize, setPageSize] = useState(initialPageSize);
 
-  // 确保 tools 是有效数组
-  const safeTools = Array.isArray(tools) ? tools : [];
+  // 确保 items 是有效数组
+  const safeItems = Array.isArray(items) ? items : [];
 
   // 计算总页数
   const totalPages = useMemo(
-    () => Math.ceil(safeTools.length / pageSize) || 1,
-    [safeTools.length, pageSize]
+    () => Math.ceil(safeItems.length / pageSize) || 1,
+    [safeItems.length, pageSize]
   );
 
   // 计算当前页的数据
-  const paginatedTools = useMemo(() => {
+  const paginatedItems = useMemo(() => {
     const startIndex = (currentPage - 1) * pageSize;
     const endIndex = startIndex + pageSize;
-    return safeTools.slice(startIndex, endIndex);
-  }, [safeTools, currentPage, pageSize]);
+    return safeItems.slice(startIndex, endIndex);
+  }, [safeItems, currentPage, pageSize]);
 
   // 设置页码，带边界检查
   const setPage = useCallback(
@@ -71,9 +72,46 @@ export function useToolPagination(
     currentPage,
     pageSize,
     totalPages,
-    paginatedTools,
+    paginatedItems,
     setPage,
     setPageSize: handleSetPageSize,
     resetPage,
+  };
+}
+
+/** 工具分页结果接口（向后兼容） */
+interface UseToolPaginationResult {
+  /** 当前页码 */
+  currentPage: number;
+  /** 每页显示数量 */
+  pageSize: number;
+  /** 总页数 */
+  totalPages: number;
+  /** 当前页的工具列表 */
+  paginatedTools: ToolRowData[];
+  /** 设置页码 */
+  setPage: (page: number) => void;
+  /** 设置每页显示数量 */
+  setPageSize: (size: number) => void;
+  /** 重置到第一页 */
+  resetPage: () => void;
+}
+
+/**
+ * 工具分页状态管理 Hook
+ * 提供客户端分页功能
+ *
+ * @deprecated 使用 {@link usePagination} 代替
+ * @param tools - 工具列表数据
+ * @param initialPageSize - 初始每页显示数量，默认为 10
+ */
+export function useToolPagination(
+  tools: ToolRowData[],
+  initialPageSize = 10
+): UseToolPaginationResult {
+  const result = usePagination(tools, initialPageSize);
+  return {
+    ...result,
+    paginatedTools: result.paginatedItems,
   };
 }


### PR DESCRIPTION
- 新增泛型 usePagination<T> hook，支持任意数据类型的分页
- 保持 useToolPagination 作为向后兼容的包装器
- 移除 mcp-server-table.tsx 中的 as any 类型断言
- 提高类型安全性和代码复用性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>