### PR TITLE
fix: 移除 error-helper.ts 中的 any 类型以提升类型安全性

### DIFF
--- a/apps/backend/errors/error-helper.ts
+++ b/apps/backend/errors/error-helper.ts
@@ -27,6 +27,12 @@ export enum RecoveryStrategy {
 }
 
 /**
+ * 错误上下文基础类型
+ * 所有错误上下文都应使用此类型，而非 any
+ */
+export type ErrorContext = Record<string, unknown>;
+
+/**
  * MCP 错误接口
  */
 export interface MCPError {
@@ -38,7 +44,7 @@ export interface MCPError {
   recoverable: boolean;
   recoveryStrategy: RecoveryStrategy;
   originalError?: Error;
-  context?: Record<string, any>;
+  context?: ErrorContext;
 }
 
 /**
@@ -67,7 +73,7 @@ function getLogger(): Logger {
 export function categorizeError(
   error: Error,
   serviceName: string,
-  context?: Record<string, any>
+  context?: ErrorContext
 ): MCPError {
   const timestamp = new Date();
   const message = error.message.toLowerCase();


### PR DESCRIPTION
- 新增 ErrorContext 类型定义（Record<string, unknown>）
- 更新 MCPError.context 从 Record<string, any> 改为 ErrorContext
- 更新 categorizeError 函数的 context 参数从 Record<string, any> 改为 ErrorContext
- 与 mcp-errors.ts 中的 ErrorDetails.context 保持类型一致性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>