### PR TITLE
fix: 使用路径别名替换相对路径导入错误类型

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -51,7 +51,7 @@ import type { Hono } from "hono";
 import { WebSocketServer } from "ws";
 
 import { HTTP_SERVER_CONFIG } from "@/constants/index.js";
-import { MCPServiceManagerNotInitializedError } from "./errors/mcp-errors.middleware.js";
+import { MCPServiceManagerNotInitializedError } from "@/errors/mcp-errors.middleware.js";
 // 路由系统导入
 import {
   type HandlerDependencies,

--- a/apps/backend/middlewares/mcpServiceManager.middleware.ts
+++ b/apps/backend/middlewares/mcpServiceManager.middleware.ts
@@ -4,12 +4,12 @@
  * 提供统一的依赖注入模式，从 WebServer 获取实例而非 Singleton
  */
 
-import type { Context, Next } from "hono";
 import {
   MCPServiceManagerNotInitializedError,
   WebServerNotAvailableError,
-} from "../errors/mcp-errors.middleware.js";
-import type { AppContextVariables } from "../types/hono.context.js";
+} from "@/errors/mcp-errors.middleware.js";
+import type { AppContextVariables } from "@/types/hono.context.js";
+import type { Context, Next } from "hono";
 
 /**
  * MCP Service Manager 中间件


### PR DESCRIPTION
- WebServer.ts: 使用 @/errors/mcp-errors.middleware.js 替换相对路径
- mcpServiceManager.middleware.ts: 使用路径别名并修复导入顺序

这确保了代码与项目路径别名一致性原则保持一致，提高了代码可维护性。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>