### PR TITLE
fix: 改进 Validation.ts 中的类型安全性，移除 any 类型

### DIFF
--- a/packages/cli/src/utils/Validation.ts
+++ b/packages/cli/src/utils/Validation.ts
@@ -37,7 +37,10 @@ export class Validation {
   /**
    * 验证必填字段
    */
-  static validateRequired(value: any, fieldName: string): void {
+  static validateRequired(
+    value: string | number | boolean | object | null | undefined,
+    fieldName: string
+  ): void {
     if (value === undefined || value === null || value === "") {
       throw ValidationError.requiredField(fieldName);
     }
@@ -169,7 +172,7 @@ export class Validation {
   /**
    * 验证 JSON 格式
    */
-  static validateJson(jsonString: string, fieldName = "json"): any {
+  static validateJson(jsonString: string, fieldName = "json"): unknown {
     try {
       return JSON.parse(jsonString);
     } catch (error) {
@@ -206,8 +209,8 @@ export class Validation {
   /**
    * 验证数组长度
    */
-  static validateArrayLength(
-    array: any[],
+  static validateArrayLength<T>(
+    array: T[],
     fieldName: string,
     options: { min?: number; max?: number } = {}
   ): void {
@@ -230,7 +233,7 @@ export class Validation {
    * 验证对象属性
    */
   static validateObjectProperties(
-    obj: Record<string, any>,
+    obj: Record<string, unknown>,
     requiredProps: string[],
     fieldName = "object"
   ): void {


### PR DESCRIPTION
- validateRequired: 使用联合类型替代 any
- validateJson: 返回 unknown 类型，要求调用者进行类型断言
- validateArrayLength: 使用泛型 <T> 替代 any[]
- validateObjectProperties: 使用 Record<string, unknown> 替代 Record<string, any>

修复 #1072

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>