### PR TITLE
fix: 将 CozeApiError.response 类型从 any 改为 CozeApiErrorResponse

### DIFF
--- a/apps/backend/types/coze.ts
+++ b/apps/backend/types/coze.ts
@@ -130,6 +130,20 @@ export interface CozeWorkflowsParams {
 }
 
 /**
+ * 扣子 API 错误响应结构
+ */
+export interface CozeApiErrorResponse {
+  /** 错误代码 */
+  code?: number;
+  /** 错误消息 */
+  msg?: string;
+  /** 请求ID */
+  logid?: string;
+  /** 其他未知字段 */
+  [key: string]: unknown;
+}
+
+/**
  * 扣子 API 错误响应
  */
 export interface CozeApiError extends Error {
@@ -138,7 +152,7 @@ export interface CozeApiError extends Error {
   /** HTTP 状态码 */
   statusCode?: number;
   /** 原始响应数据 */
-  response?: any;
+  response?: CozeApiErrorResponse;
 }
 
 /**

--- a/packages/shared-types/src/api/errors.ts
+++ b/packages/shared-types/src/api/errors.ts
@@ -66,6 +66,20 @@ export interface ToolValidationError {
 }
 
 /**
+ * 扣子 API 错误响应结构
+ */
+export interface CozeApiErrorResponse {
+  /** 错误代码 */
+  code?: number;
+  /** 错误消息 */
+  msg?: string;
+  /** 请求ID */
+  logid?: string;
+  /** 其他未知字段 */
+  [key: string]: unknown;
+}
+
+/**
  * 扣子 API 错误响应
  */
 export interface CozeApiError extends Error {
@@ -74,5 +88,5 @@ export interface CozeApiError extends Error {
   /** HTTP 状态码 */
   statusCode?: number;
   /** 原始响应数据 */
-  response?: any;
+  response?: CozeApiErrorResponse;
 }

--- a/packages/shared-types/src/api/index.ts
+++ b/packages/shared-types/src/api/index.ts
@@ -34,6 +34,7 @@ export {
 export type {
   ApiError,
   ToolValidationError as ApiValidationToolValidationError,
+  CozeApiErrorResponse,
   CozeApiError as ApiCozeApiError,
 } from "./errors";
 

--- a/packages/shared-types/src/coze/api.ts
+++ b/packages/shared-types/src/coze/api.ts
@@ -37,6 +37,20 @@ export interface CozeWorkflowsResponse
   extends CozeApiResponse<CozeWorkflowsData> {}
 
 /**
+ * 扣子 API 错误响应结构
+ */
+export interface CozeApiErrorResponse {
+  /** 错误代码 */
+  code?: number;
+  /** 错误消息 */
+  msg?: string;
+  /** 请求ID */
+  logid?: string;
+  /** 其他未知字段 */
+  [key: string]: unknown;
+}
+
+/**
  * 扣子 API 错误响应
  */
 export interface CozeApiError extends Error {
@@ -45,7 +59,7 @@ export interface CozeApiError extends Error {
   /** HTTP 状态码 */
   statusCode?: number;
   /** 原始响应数据 */
-  response?: any;
+  response?: CozeApiErrorResponse;
 }
 
 /**

--- a/packages/shared-types/src/coze/index.ts
+++ b/packages/shared-types/src/coze/index.ts
@@ -11,6 +11,7 @@ export type {
   CozeApiResponse,
   CozeWorkspacesResponse,
   CozeWorkflowsResponse,
+  CozeApiErrorResponse,
   CozeApiError,
   CacheItem,
   CozeWorkflowsData,


### PR DESCRIPTION
- 新增 CozeApiErrorResponse 接口定义错误响应结构
- 更新 apps/backend/types/coze.ts 中的 CozeApiError
- 更新 packages/shared-types/src/coze/api.ts 中的 CozeApiError
- 更新 packages/shared-types/src/api/errors.ts 中的 CozeApiError
- 从相关索引文件导出 CozeApiErrorResponse 类型
- 提升类型安全性，提供准确的类型提示

修复 #1076

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>