### PR TITLE
fix: 将 FunctionToolData.context 类型从 any 改为 unknown

### DIFF
--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -173,7 +173,7 @@ export interface FunctionToolData {
   /** 函数描述 */
   description: string;
   /** 函数执行上下文 */
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   /** 超时时间 */
   timeout?: number;
   /** 可选的自定义名称 */


### PR DESCRIPTION
将 FunctionToolData 接口的 context 字段类型从 Record<string, any>
改为 Record<string, unknown>，提高类型安全性。

这符合 TypeScript 严格模式要求，使用 unknown 而非 any 可以在
不影响功能的情况下强制进行类型检查。

Fixes #1080

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>