### PR TITLE
perf: 将 cache.ts 的 atomicWrite 方法改为真正的异步操作

### DIFF
--- a/apps/backend/lib/mcp/cache.ts
+++ b/apps/backend/lib/mcp/cache.ts
@@ -5,13 +5,8 @@
  */
 
 import { createHash } from "node:crypto";
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  renameSync,
-  writeFileSync,
-} from "node:fs";
+import { existsSync, mkdirSync, readFileSync } from "node:fs";
+import { rename, writeFile } from "node:fs/promises";
 import { dirname, resolve } from "node:path";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
@@ -247,15 +242,15 @@ export class MCPCacheManager {
   private async atomicWrite(filePath: string, data: string): Promise<void> {
     const tempPath = `${filePath}.tmp`;
     try {
-      // 写入临时文件
-      writeFileSync(tempPath, data, "utf8");
-      // 原子性重命名
-      renameSync(tempPath, filePath);
+      // 使用异步写入临时文件
+      await writeFile(tempPath, data, "utf8");
+      // 使用异步原子性重命名
+      await rename(tempPath, filePath);
     } catch (error) {
       // 清理临时文件
       try {
         if (existsSync(tempPath)) {
-          writeFileSync(tempPath, "", "utf8"); // 清空后删除
+          await writeFile(tempPath, "", "utf8"); // 清空后删除
         }
       } catch {
         // 忽略清理错误


### PR DESCRIPTION
修复 #1082

- 将 writeFileSync 改为异步的 writeFile (from fs/promises)
- 将 renameSync 改为异步的 rename (from fs/promises)
- 修复了虽然方法声明为 async 但内部完全使用同步操作的问题
- 当缓存文件较大时不再阻塞事件循环，提升并发性能

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>