### PR TITLE
fix: 修复 WebServerLauncher.ts 中的 ESM 模块检测在 Windows 下的兼容性问题

### DIFF
--- a/apps/backend/WebServerLauncher.ts
+++ b/apps/backend/WebServerLauncher.ts
@@ -51,7 +51,9 @@ async function main() {
   }
 }
 
-// 检查是否为直接执行
-if (import.meta.url === `file://${process.argv[1]}`) {
+// 检查是否为直接执行（跨平台兼容）
+import { fileURLToPath } from "node:url";
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
   main();
 }


### PR DESCRIPTION
将 `import.meta.url === file://${process.argv[1]}` 替换为
`process.argv[1] === fileURLToPath(import.meta.url)`，使用 Node.js
推荐的跨平台路径转换方式，解决：
- Windows 路径分隔符问题（反斜杠 vs 正斜杠）
- Windows 盘符格式（C:）与 file:// URL 的不兼容
- 路径规范化和符号链接处理

Fixes #1090

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>