### PR TITLE
fix(shared-types): 消除 ClientStatus 类型的重复定义

### DIFF
--- a/apps/backend/services/status.service.ts
+++ b/apps/backend/services/status.service.ts
@@ -4,14 +4,23 @@ import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 
 /**
- * 客户端信息接口
+ * 客户端状态信息
+ *
+ * 注意：此类型定义应与 @xiaozhi-client/shared-types 中的 ClientStatus 保持一致
+ * 这里为了后端独立运行而重复定义，避免对 shared-types 包的依赖
  */
-export interface ClientInfo {
+export interface ClientStatus {
   status: "connected" | "disconnected";
   mcpEndpoint: string;
   activeMCPServers: string[];
   lastHeartbeat?: number;
 }
+
+/**
+ * 为了向后兼容，保留 ClientInfo 作为 ClientStatus 的别名
+ * @deprecated 请直接使用 ClientStatus 类型
+ */
+export type ClientInfo = ClientStatus;
 
 /**
  * 重启状态接口
@@ -30,7 +39,7 @@ export interface RestartStatus {
 export class StatusService {
   private logger: Logger;
   private eventBus: EventBus;
-  private clientInfo: ClientInfo = {
+  private clientInfo: ClientStatus = {
     status: "disconnected",
     mcpEndpoint: "",
     activeMCPServers: [],
@@ -47,14 +56,14 @@ export class StatusService {
   /**
    * 获取客户端状态
    */
-  getClientStatus(): ClientInfo {
+  getClientStatus(): ClientStatus {
     return { ...this.clientInfo };
   }
 
   /**
    * 更新客户端信息
    */
-  updateClientInfo(info: Partial<ClientInfo>, source = "unknown"): void {
+  updateClientInfo(info: Partial<ClientStatus>, source = "unknown"): void {
     try {
       const oldStatus = { ...this.clientInfo };
       this.clientInfo = { ...this.clientInfo, ...info };
@@ -148,7 +157,7 @@ export class StatusService {
    * 获取完整状态信息
    */
   getFullStatus(): {
-    client: ClientInfo;
+    client: ClientStatus;
     restart?: RestartStatus;
     timestamp: number;
   } {

--- a/packages/shared-types/src/frontend/ui.ts
+++ b/packages/shared-types/src/frontend/ui.ts
@@ -31,11 +31,6 @@ export interface CozeUIState {
 }
 
 /**
- * 客户端状态
+ * 客户端状态（从 config/server 重新导出）
  */
-export interface ClientStatus {
-  status: "connected" | "disconnected";
-  mcpEndpoint: string;
-  activeMCPServers: string[];
-  lastHeartbeat?: number;
-}
+export type { ClientStatus } from "../config/server";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -189,6 +189,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../../packages/mcp-core
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@xiaozhi-client/version':
         specifier: workspace:*
         version: link:../../packages/version


### PR DESCRIPTION
- 修改 packages/shared-types/src/frontend/ui.ts：删除重复的 ClientStatus 接口定义，改为从 config/server.ts 导入
- 修改 apps/backend/services/status.service.ts：将 ClientInfo 接口重命名为 ClientStatus，保留 ClientInfo 作为别名以确保向后兼容
- 解决了 shared-types 包中违反 DRY 原则的类型重复问题

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>