### PR TITLE
refactor(frontend): 移除 toolsApi.ts 中与 shared-types 重复的类型定义

### DIFF
--- a/apps/frontend/src/services/toolsApi.ts
+++ b/apps/frontend/src/services/toolsApi.ts
@@ -1,6 +1,9 @@
 /**
  * 工具管理 API 服务
  * 专门处理自定义工具的添加、删除和管理操作
+ *
+ * 注意：此服务使用旧的 Coze 工作流 API 格式以保持向后兼容性。
+ * 新代码应使用 @xiaozhi-client/shared-types 中定义的统一类型格式。
  */
 
 import type {
@@ -8,35 +11,6 @@ import type {
   WorkflowParameterConfig,
 } from "@xiaozhi-client/shared-types";
 import { apiClient } from "./api";
-
-/**
- * 添加工具请求参数
- */
-export interface AddToolRequest {
-  workflow: CozeWorkflow;
-  customName?: string;
-  customDescription?: string;
-  parameterConfig?: WorkflowParameterConfig;
-}
-
-/**
- * 添加工具响应
- */
-export interface AddToolResponse {
-  name: string;
-  description: string;
-  inputSchema: any;
-  handler: any;
-}
-
-/**
- * API错误类型
- */
-export interface ApiError {
-  code: string;
-  message: string;
-  details?: any;
-}
 
 /**
  * 工具管理服务类
@@ -53,7 +27,12 @@ export class ToolsApiService {
     customName?: string,
     customDescription?: string,
     parameterConfig?: WorkflowParameterConfig
-  ): Promise<AddToolResponse> {
+  ): Promise<{
+    name: string;
+    description: string;
+    inputSchema: unknown;
+    handler: unknown;
+  }> {
     // 请求参数验证
     this.validateAddToolRequest(
       workflow,


### PR DESCRIPTION
移除 apps/frontend/src/services/toolsApi.ts 中重复定义的类型：
- AddToolRequest: 未被外部使用的内部类型
- AddToolResponse: 未被外部使用的内部类型
- ApiError: 未被实际使用的类型定义

将 AddToolRequest 和 AddToolResponse 改为内联类型定义，
因为这些是 ToolsApiService 的内部实现细节，不需要导出。

同时将 `any` 类型替换为 `unknown` 以提高类型安全性。

修复 #1093

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>