### PR TITLE
fix: 在 check:type 脚本中添加 --parallel=false 以消除 MaxListenersExceededWarning

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "test:coverage": "nx run-many -t test:coverage --parallel=false",
     "lint": "nx run-many -t lint",
     "lint:fix": "nx run-many -t lint:fix",
-    "check:type": "nx run-many -t type-check --exclude=docs",
+    "check:type": "nx run-many -t type-check --exclude=docs --parallel=false",
     "check:all": "pnpm run lint && pnpm run check:type && pnpm run check:spell && pnpm run check:cpd",
     "check:spell": "cspell .",
     "check:cpd": "jscpd apps/ packages/",


### PR DESCRIPTION
修复 #1095

- 在 package.json 的 check:type 脚本中添加 --parallel=false 标志
- 与 build 和 test 脚本保持一致的行为
- 消除 Node.js MaxListenersExceededWarning 警告

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>