### PR TITLE
fix: 使用统一的 Logger 系统替换 console.warn

### DIFF
--- a/apps/backend/utils/toolSorters.ts
+++ b/apps/backend/utils/toolSorters.ts
@@ -3,6 +3,7 @@
  * 提供可扩展的排序策略，支持多种排序方式
  */
 
+import { logger } from "@/Logger.js";
 import type { EnhancedToolInfo } from "@/lib/mcp";
 
 export type ToolSortField = "name" | "enabled" | "usageCount" | "lastUsedTime";
@@ -95,7 +96,7 @@ export function sortTools(
 ): EnhancedToolInfo[] {
   const sorter = toolSorters[config.field];
   if (!sorter) {
-    console.warn(`[sortTools] 未知的排序字段: ${config.field}`);
+    logger.warn(`[sortTools] 未知的排序字段: ${config.field}`);
     return tools;
   }
 


### PR DESCRIPTION
- 在 apps/backend/utils/toolSorters.ts 中导入 logger
- 将 console.warn 替换为 logger.warn 以保持代码规范一致性
- 修复 Issue #1106

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>