### PR TITLE
fix: 修复 shared-types 包配置中 main 和 types 字段路径格式

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,8 +3,8 @@
   "version": "1.9.7",
   "description": "小智项目的共享类型定义",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
将 main 和 types 字段添加 ./ 前缀以符合项目规范和 npm 最佳实践。

修改内容：
- main: "dist/index.js" → "./dist/index.js"
- types: "dist/index.d.ts" → "./dist/index.d.ts"

参考 issue: #1109

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>