### PR TITLE
fix: 统一 shared-types 包的 TypeScript 版本至 ^5.9.2

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -42,7 +42,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "tsup": "^8.3.5",
-    "typescript": "^5.7.2"
+    "typescript": "^5.9.2"
   },
   "publishConfig": {
     "access": "public"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -631,7 +631,7 @@ importers:
         specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
-        specifier: ^5.7.2
+        specifier: ^5.9.2
         version: 5.9.3
 
   packages/version:


### PR DESCRIPTION
将 packages/shared-types/package.json 中的 TypeScript 版本从 ^5.7.2 升级至 ^5.9.2，
与项目中其他包保持一致，确保跨包类型检查和构建产物的兼容性。

修复 #1113

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>