### PR TITLE
refactor: 消除 apps/backend/lib/mcp/types.ts 与 packages/mcp-core/src/types.ts 的重复类型定义

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1695,6 +1695,8 @@ export class MCPServiceManager extends EventEmitter {
     return {
       isRunning: this.isRunning,
       serviceStatus,
+      // transportCount: 等同于服务数量，每个服务对应一个传输
+      transportCount: this.services.size,
       activeConnections: this.getActiveConnectionCount(),
       config: this.config,
       // 便捷访问属性

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -13,6 +13,7 @@ export type {
   // 配置相关
   MCPServiceConfig,
   ModelScopeSSEOptions,
+  InternalMCPServiceConfig,
   UnifiedServerConfig,
   // 状态相关
   MCPServiceStatus,
@@ -26,6 +27,7 @@ export type {
   ToolCallParams,
   ValidatedToolCallParams,
   ToolCallValidationOptions,
+  ToolStatusFilter,
   CustomMCPTool,
   JSONSchema,
   // 传输相关


### PR DESCRIPTION
通过从 @xiaozhi-client/mcp-core 导入重复的类型定义，消除了两个文件之间的重复代码。

主要更改：
- apps/backend/lib/mcp/types.ts: 从 mcp-core 重新导出公共类型，保留 backend 特有的类型
- packages/mcp-core/src/index.ts: 新增导出 InternalMCPServiceConfig 和 ToolStatusFilter
- apps/backend/lib/mcp/manager.ts: 修复 UnifiedServerStatus 缺少 transportCount 属性的问题

遵循 DRY 原则，减少维护成本，避免类型定义不一致的问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>