### PR TITLE
fix: 修复 DIContainer 类型安全问题

### DIFF
--- a/packages/cli/src/Container.ts
+++ b/packages/cli/src/Container.ts
@@ -2,10 +2,12 @@
  * 依赖注入容器
  */
 
+import type { ConfigManager } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import { VersionUtils } from "@xiaozhi-client/version";
 import { ErrorHandler } from "./errors/ErrorHandlers";
 import type { IDIContainer } from "./interfaces/Config";
+import type { ProcessManagerImpl } from "./services/ProcessManager";
 import { FileUtils } from "./utils/FileUtils";
 import { FormatUtils } from "./utils/FormatUtils";
 import { PathUtils } from "./utils/PathUtils";
@@ -16,9 +18,9 @@ import { Validation } from "./utils/Validation";
  * 依赖注入容器实现
  */
 export class DIContainer implements IDIContainer {
-  private instances = new Map<string, any>();
-  private factories = new Map<string, () => any>();
-  private asyncFactories = new Map<string, () => Promise<any>>();
+  private instances = new Map<string, unknown>();
+  private factories = new Map<string, () => unknown>();
+  private asyncFactories = new Map<string, () => Promise<unknown>>();
   private singletons = new Set<string>();
 
   /**
@@ -146,14 +148,16 @@ export class DIContainer implements IDIContainer {
 
     container.registerSingleton("daemonManager", () => {
       const DaemonManagerModule = require("./services/DaemonManager.js");
-      const processManager = container.get("processManager") as any;
+      const processManager =
+        container.get<ProcessManagerImpl>("processManager");
       return new DaemonManagerModule.DaemonManagerImpl(processManager);
     });
 
     container.registerSingleton("serviceManager", () => {
       const ServiceManagerModule = require("./services/ServiceManager.js");
-      const processManager = container.get("processManager") as any;
-      const configManager = container.get("configManager") as any;
+      const processManager =
+        container.get<ProcessManagerImpl>("processManager");
+      const configManager = container.get<ConfigManager>("configManager");
       return new ServiceManagerModule.ServiceManagerImpl(
         processManager,
         configManager

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,6 +2,7 @@
  * 命令注册器
  */
 
+import type { VersionUtils } from "@xiaozhi-client/version";
 import type { Command } from "commander";
 import { ErrorHandler } from "../errors/ErrorHandlers";
 import type {
@@ -146,7 +147,8 @@ export class CommandRegistry implements ICommandRegistry {
    * 注册版本命令
    */
   private registerVersionCommand(program: Command): void {
-    const versionUtils = this.container.get("versionUtils") as any;
+    const versionUtils =
+      this.container.get<typeof VersionUtils>("versionUtils");
 
     program.version(versionUtils.getVersion(), "-v, --version", "显示版本信息");
 

--- a/packages/cli/src/interfaces/Config.ts
+++ b/packages/cli/src/interfaces/Config.ts
@@ -6,12 +6,20 @@
  * 依赖注入容器接口
  */
 export interface IDIContainer {
-  /** 注册服务 */
-  register<T>(key: string, factory: () => T): void;
+  /** 注册服务工厂 */
+  register<T>(key: string, factory: () => T, singleton?: boolean): void;
+  /** 注册单例服务 */
+  registerSingleton<T>(key: string, factory: () => T): void;
+  /** 注册实例 */
+  registerInstance<T>(key: string, instance: T): void;
   /** 获取服务实例 */
   get<T>(key: string): T;
   /** 检查服务是否已注册 */
   has(key: string): boolean;
+  /** 清除所有注册的服务 */
+  clear(): void;
+  /** 获取所有已注册的服务键 */
+  getRegisteredKeys(): string[];
 }
 
 /**


### PR DESCRIPTION
- 完善 IDIContainer 接口定义，添加 registerSingleton、registerInstance、clear 和 getRegisteredKeys 方法
- 将内部存储类型从 any 改为 unknown，提升类型安全性
- 在 usage sites 使用泛型类型参数替代 as any 断言
- 添加必要的类型导入（ConfigManager、ProcessManagerImpl、VersionUtils）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>