### PR TITLE
fix: 保存 serverShutdownTimer 引用以便在销毁时清理

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -129,6 +129,9 @@ export class WebServer {
   // 心跳监控
   private heartbeatMonitorInterval?: NodeJS.Timeout;
 
+  // 服务器关闭定时器
+  private serverShutdownTimer: ReturnType<typeof setTimeout> | undefined;
+
   // 路由系统
   private routeManager?: RouteManager;
 
@@ -912,7 +915,7 @@ export class WebServer {
             }
 
             // 设置超时，如果 2 秒内没有关闭则强制退出
-            setTimeout(() => {
+            this.serverShutdownTimer = setTimeout(() => {
               this.logger.info("Web 服务器已强制停止");
               doResolve();
             }, 2000);
@@ -926,10 +929,23 @@ export class WebServer {
   }
 
   /**
+   * 清理服务器关闭定时器
+   */
+  private clearShutdownTimer(): void {
+    if (this.serverShutdownTimer) {
+      clearTimeout(this.serverShutdownTimer);
+      this.serverShutdownTimer = undefined;
+    }
+  }
+
+  /**
    * 销毁 WebServer 实例，清理所有资源
    */
   public destroy(): void {
     this.logger.debug("销毁 WebServer 实例");
+
+    // 清理服务器关闭定时器
+    this.clearShutdownTimer();
 
     // 停止心跳监控
     if (this.heartbeatMonitorInterval) {


### PR DESCRIPTION
修复 WebServer.ts 中 setTimeout 未保存引用导致无法清理的问题。

- 添加 serverShutdownTimer 属性保存定时器引用
- 在 stop() 方法中保存 setTimeout 返回值
- 添加 clearShutdownTimer() 方法用于清理定时器
- 在 destroy() 方法中调用清理方法

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>