### PR TITLE
refactor: 创建工具相关服务类，拆分 MCPToolHandler 职责

### DIFF
--- a/apps/backend/services/coze-workflow.service.ts
+++ b/apps/backend/services/coze-workflow.service.ts
@@ -1,0 +1,142 @@
+/**
+ * Coze 工作流服务
+ * 负责处理 Coze 工作流相关的逻辑，包括转换为工具配置、创建处理器等
+ */
+
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
+import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
+import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
+import type { ConfigManager } from "@xiaozhi-client/config";
+import { ToolNameService } from "./tool-name.service.js";
+import { ToolSchemaGenerator } from "./tool-schema-generator.service.js";
+import { ToolValidationService } from "./tool-validation.service.js";
+
+/**
+ * Coze 工作流服务
+ */
+export class CozeWorkflowService {
+  private logger: Logger;
+  private configManager: ConfigManager;
+  private toolNameService: ToolNameService;
+  private schemaGenerator: ToolSchemaGenerator;
+  private validationService: ToolValidationService;
+
+  constructor(configManager: ConfigManager) {
+    this.logger = logger;
+    this.configManager = configManager;
+    this.toolNameService = new ToolNameService(configManager);
+    this.schemaGenerator = new ToolSchemaGenerator();
+    this.validationService = new ToolValidationService();
+  }
+
+  /**
+   * 将扣子工作流转换为自定义 MCP 工具
+   * @param workflow 工作流数据
+   * @param customName 自定义名称
+   * @param customDescription 自定义描述
+   * @param parameterConfig 参数配置
+   * @returns 自定义 MCP 工具配置
+   */
+  convertWorkflowToTool(
+    workflow: CozeWorkflow,
+    customName?: string,
+    customDescription?: string,
+    parameterConfig?: WorkflowParameterConfig
+  ): CustomMCPTool {
+    // 验证工作流数据完整性
+    this.validationService.validateWorkflowData(workflow);
+
+    // 生成工具名称（处理冲突）
+    const baseName =
+      customName || this.toolNameService.sanitizeToolName(workflow.workflow_name);
+    const toolName = this.toolNameService.resolveToolNameConflict(baseName);
+
+    // 生成工具描述
+    const description = this.toolNameService.generateToolDescription(
+      workflow,
+      customDescription
+    );
+
+    // 生成输入参数结构
+    const inputSchema = this.schemaGenerator.generateInputSchema(
+      workflow,
+      parameterConfig
+    );
+
+    // 配置 HTTP 处理器
+    const handler = this.createHttpHandler(workflow);
+
+    // 创建工具配置
+    const tool: CustomMCPTool = {
+      name: toolName,
+      description,
+      inputSchema,
+      handler,
+    };
+
+    // 验证生成的工具配置
+    this.validationService.validateGeneratedTool(tool);
+
+    return tool;
+  }
+
+  /**
+   * 创建 HTTP 处理器配置
+   * @param workflow 工作流数据
+   * @returns HTTP 处理器配置
+   */
+  private createHttpHandler(workflow: CozeWorkflow): ProxyHandlerConfig {
+    // 验证扣子API配置
+    this.validateCozeApiConfig();
+
+    return {
+      type: "proxy",
+      platform: "coze",
+      config: {
+        workflow_id: workflow.workflow_id,
+      },
+    };
+  }
+
+  /**
+   * 验证扣子 API 配置
+   * @throws {MCPError} 当配置无效时
+   * @private
+   */
+  private validateCozeApiConfig(): void {
+    // 检查是否配置了扣子token
+    const cozeConfig = this.configManager.getCozePlatformConfig();
+    if (!cozeConfig || !cozeConfig.token) {
+      throw MCPError.configError(
+        MCPErrorCode.INVALID_CONFIG,
+        "未配置扣子API Token，请先在配置中设置 platforms.coze.token"
+      );
+    }
+  }
+
+  /**
+   * 获取工具名称服务实例
+   * 用于外部直接访问工具名称相关功能
+   */
+  getToolNameService(): ToolNameService {
+    return this.toolNameService;
+  }
+
+  /**
+   * 获取 Schema 生成器实例
+   * 用于外部直接访问 Schema 生成功能
+   */
+  getSchemaGenerator(): ToolSchemaGenerator {
+    return this.schemaGenerator;
+  }
+
+  /**
+   * 获取验证服务实例
+   * 用于外部直接访问验证功能
+   */
+  getValidationService(): ToolValidationService {
+    return this.validationService;
+  }
+}

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -1,6 +1,12 @@
 export * from "./status.service.js";
 export * from "./notification.service.js";
 export * from "./event-bus.service.js";
+export * from "./tool-validation.service.js";
+export * from "./tool-name.service.js";
+export * from "./tool-schema-generator.service.js";
+export * from "./coze-workflow.service.js";
+export * from "./tool-precheck.service.js";
+export * from "./tool-error-handler.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";

--- a/apps/backend/services/tool-error-handler.service.ts
+++ b/apps/backend/services/tool-error-handler.service.ts
@@ -1,0 +1,320 @@
+/**
+ * 工具错误处理服务
+ * 负责统一的错误处理和格式化
+ */
+
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+
+/**
+ * 错误响应接口
+ */
+interface ErrorResponse {
+  code: string;
+  message: string;
+  status: number;
+}
+
+/**
+ * 工具错误处理服务
+ */
+export class ToolErrorHandler {
+  private logger: Logger;
+
+  constructor() {
+    this.logger = logger;
+  }
+
+  /**
+   * 处理添加工具时的错误
+   * @param error 错误对象
+   * @returns 格式化的错误响应
+   */
+  handleAddToolError(error: unknown): ErrorResponse {
+    const errorMessage =
+      error instanceof Error ? error.message : "添加自定义工具失败";
+
+    // 工具类型错误 (400)
+    if (
+      errorMessage.includes("工具类型") ||
+      errorMessage.includes("TOOL_TYPE")
+    ) {
+      return {
+        code: "INVALID_TOOL_TYPE",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 缺少必需字段错误 (400)
+    if (
+      errorMessage.includes("必需字段") ||
+      errorMessage.includes("MISSING_REQUIRED_FIELD")
+    ) {
+      return {
+        code: "MISSING_REQUIRED_FIELD",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 工具或服务不存在错误 (404)
+    if (
+      errorMessage.includes("不存在") ||
+      errorMessage.includes("NOT_FOUND") ||
+      errorMessage.includes("未找到")
+    ) {
+      return {
+        code: "SERVICE_OR_TOOL_NOT_FOUND",
+        message: errorMessage,
+        status: 404,
+      };
+    }
+
+    // 服务未初始化错误 (503)
+    if (
+      errorMessage.includes("未初始化") ||
+      errorMessage.includes("SERVICE_NOT_INITIALIZED")
+    ) {
+      return {
+        code: "SERVICE_NOT_INITIALIZED",
+        message: errorMessage,
+        status: 503,
+      };
+    }
+
+    // 工具名称冲突错误 (409)
+    if (
+      errorMessage.includes("已存在") ||
+      errorMessage.includes("冲突") ||
+      errorMessage.includes("TOOL_NAME_CONFLICT")
+    ) {
+      return {
+        code: "TOOL_NAME_CONFLICT",
+        message: `${errorMessage}。建议：1) 使用自定义名称；2) 删除现有同名工具后重试`,
+        status: 409,
+      };
+    }
+
+    // 数据验证错误 (400)
+    if (this.isValidationError(errorMessage)) {
+      return {
+        code: "VALIDATION_ERROR",
+        message: this.formatValidationError(errorMessage),
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (
+      errorMessage.includes("配置") ||
+      errorMessage.includes("token") ||
+      errorMessage.includes("API") ||
+      errorMessage.includes("CONFIGURATION_ERROR")
+    ) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查：1) 相关配置是否正确；2) 网络连接是否正常；3) 配置文件权限是否正确`,
+        status: 422,
+      };
+    }
+
+    // 资源限制错误 (429)
+    if (
+      errorMessage.includes("资源限制") ||
+      errorMessage.includes("RESOURCE_LIMIT_EXCEEDED")
+    ) {
+      return {
+        code: "RESOURCE_LIMIT_EXCEEDED",
+        message: errorMessage,
+        status: 429,
+      };
+    }
+
+    // 未实现功能错误 (501)
+    if (
+      errorMessage.includes("未实现") ||
+      errorMessage.includes("NOT_IMPLEMENTED")
+    ) {
+      return {
+        code: "TOOL_TYPE_NOT_IMPLEMENTED",
+        message: errorMessage,
+        status: 501,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "ADD_CUSTOM_TOOL_ERROR",
+      message: `添加工具失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 处理删除工具时的错误
+   * @param error 错误对象
+   * @returns 格式化的错误响应
+   */
+  handleRemoveToolError(error: unknown): ErrorResponse {
+    const errorMessage =
+      error instanceof Error ? error.message : "删除自定义工具失败";
+
+    // 工具不存在错误 (404)
+    if (errorMessage.includes("不存在") || errorMessage.includes("未找到")) {
+      return {
+        code: "TOOL_NOT_FOUND",
+        message: `${errorMessage}。请检查工具名称是否正确，或刷新页面查看最新的工具列表`,
+        status: 404,
+      };
+    }
+
+    // 参数错误 (400)
+    if (errorMessage.includes("不能为空") || errorMessage.includes("无效")) {
+      return {
+        code: "INVALID_REQUEST",
+        message: `${errorMessage}。请提供有效的工具名称`,
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (errorMessage.includes("配置") || errorMessage.includes("权限")) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查配置文件权限和格式是否正确`,
+        status: 422,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "REMOVE_CUSTOM_TOOL_ERROR",
+      message: `删除工具失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 处理更新工具时的错误
+   * @param error 错误对象
+   * @returns 格式化的错误响应
+   */
+  handleUpdateToolError(error: unknown): ErrorResponse {
+    const errorMessage =
+      error instanceof Error ? error.message : "更新自定义工具配置失败";
+
+    // 工具不存在错误 (404)
+    if (errorMessage.includes("不存在") || errorMessage.includes("未找到")) {
+      return {
+        code: "TOOL_NOT_FOUND",
+        message: `${errorMessage}。请检查工具名称是否正确`,
+        status: 404,
+      };
+    }
+
+    // 工具类型错误 (400)
+    if (
+      errorMessage.includes("工具类型") ||
+      errorMessage.includes("INVALID_TOOL_TYPE")
+    ) {
+      return {
+        code: "INVALID_TOOL_TYPE",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 参数错误 (400)
+    if (errorMessage.includes("不能为空") || errorMessage.includes("无效")) {
+      return {
+        code: "INVALID_REQUEST",
+        message: `${errorMessage}。请提供有效的工具配置数据`,
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (errorMessage.includes("配置") || errorMessage.includes("权限")) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查配置文件权限和格式是否正确`,
+        status: 422,
+      };
+    }
+
+    // 未实现功能错误 (501)
+    if (
+      errorMessage.includes("未实现") ||
+      errorMessage.includes("NOT_IMPLEMENTED")
+    ) {
+      return {
+        code: "TOOL_TYPE_NOT_IMPLEMENTED",
+        message: errorMessage,
+        status: 501,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "UPDATE_CUSTOM_TOOL_ERROR",
+      message: `更新工具配置失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 判断是否为数据验证错误
+   * @param errorMessage 错误消息
+   * @returns 是否为验证错误
+   */
+  isValidationError(errorMessage: string): boolean {
+    const validationKeywords = [
+      "不能为空",
+      "必须是",
+      "格式无效",
+      "过长",
+      "过短",
+      "验证失败",
+      "无效",
+      "不符合",
+      "超过",
+      "少于",
+      "敏感词",
+      "时间",
+      "URL",
+    ];
+
+    return validationKeywords.some((keyword) => errorMessage.includes(keyword));
+  }
+
+  /**
+   * 格式化验证错误信息
+   * @param errorMessage 错误消息
+   * @returns 格式化后的错误消息
+   */
+  formatValidationError(errorMessage: string): string {
+    // 为常见的验证错误提供更友好的提示
+    const errorMappings: Record<string, string> = {
+      工作流ID不能为空: "请提供有效的工作流ID",
+      工作流名称不能为空: "请提供有效的工作流名称",
+      应用ID不能为空: "请提供有效的应用ID",
+      工作流ID格式无效: "工作流ID应为数字格式，请检查工作流配置",
+      应用ID格式无效: "应用ID只能包含字母、数字、下划线和连字符",
+      工作流名称过长: "工作流名称不能超过100个字符，请缩短名称",
+      工作流描述过长: "工作流描述不能超过500个字符，请缩短描述",
+      图标URL格式无效: "请提供有效的图标URL地址",
+      更新时间不能早于创建时间: "工作流的时间信息有误，请检查工作流数据",
+      敏感词: "工作流名称包含敏感词汇，请修改后重试",
+    };
+
+    // 查找匹配的错误映射
+    for (const [key, value] of Object.entries(errorMappings)) {
+      if (errorMessage.includes(key)) {
+        return value;
+      }
+    }
+
+    return errorMessage;
+  }
+}

--- a/apps/backend/services/tool-name.service.ts
+++ b/apps/backend/services/tool-name.service.ts
@@ -1,0 +1,186 @@
+/**
+ * 工具名称服务
+ * 负责工具名称相关的操作，包括规范化、冲突解决、中文转英文等
+ */
+
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
+import type { CozeWorkflow } from "@/types/coze.js";
+import type { ConfigManager } from "@xiaozhi-client/config";
+
+/**
+ * 工具名称服务
+ */
+export class ToolNameService {
+  private logger: Logger;
+  private configManager: ConfigManager;
+
+  constructor(configManager: ConfigManager) {
+    this.logger = logger;
+    this.configManager = configManager;
+  }
+
+  /**
+   * 规范化工具名称
+   * @param name 原始名称
+   * @returns 规范化后的工具名称
+   */
+  sanitizeToolName(name: string): string {
+    if (!name || typeof name !== "string") {
+      return "coze_workflow_unnamed";
+    }
+
+    // 去除首尾空格
+    let sanitized = name.trim();
+
+    if (!sanitized) {
+      return "coze_workflow_empty";
+    }
+
+    // 将中文转换为拼音或英文描述（简化处理）
+    sanitized = this.convertChineseToEnglish(sanitized);
+
+    // 移除特殊字符，只保留字母、数字和下划线
+    sanitized = sanitized.replace(/[^a-zA-Z0-9_]/g, "_");
+
+    // 移除连续的下划线
+    sanitized = sanitized.replace(/_+/g, "_");
+
+    // 移除开头和结尾的下划线
+    sanitized = sanitized.replace(/^_+|_+$/g, "");
+
+    // 确保以字母开头
+    if (!/^[a-zA-Z]/.test(sanitized)) {
+      sanitized = `coze_workflow_${sanitized}`;
+    }
+
+    // 限制长度（保留足够空间给数字后缀）
+    if (sanitized.length > 45) {
+      sanitized = sanitized.substring(0, 45);
+    }
+
+    // 确保不为空
+    if (!sanitized) {
+      sanitized = "coze_workflow_tool";
+    }
+
+    return sanitized;
+  }
+
+  /**
+   * 解决工具名称冲突
+   * @param baseName 基础名称
+   * @returns 唯一的工具名称
+   */
+  resolveToolNameConflict(baseName: string): string {
+    const existingTools = this.configManager.getCustomMCPTools();
+    const existingNames = new Set(existingTools.map((tool) => tool.name));
+
+    let finalName = baseName;
+    let counter = 1;
+
+    // 如果名称已存在，添加数字后缀
+    while (existingNames.has(finalName)) {
+      finalName = `${baseName}_${counter}`;
+      counter++;
+
+      // 防止无限循环
+      if (counter > 999) {
+        throw MCPError.operationError(
+          MCPErrorCode.OPERATION_FAILED,
+          `无法为工具生成唯一名称，基础名称: ${baseName}`
+        );
+      }
+    }
+
+    return finalName;
+  }
+
+  /**
+   * 生成工具描述
+   * @param workflow 工作流数据
+   * @param customDescription 自定义描述
+   * @returns 工具描述
+   */
+  generateToolDescription(
+    workflow: CozeWorkflow,
+    customDescription?: string
+  ): string {
+    if (customDescription) {
+      return customDescription;
+    }
+
+    if (workflow.description?.trim()) {
+      return workflow.description.trim();
+    }
+
+    // 生成默认描述
+    return `扣子工作流工具: ${workflow.workflow_name}`;
+  }
+
+  /**
+   * 简单的中文到英文转换
+   * 注意：这是一个简化版本，只处理常见词汇
+   * 生产环境建议使用专业的拼音转换库
+   * @param text 中文文本
+   * @returns 转换后的英文文本
+   */
+  private convertChineseToEnglish(text: string): string {
+    // 常见中文词汇的映射
+    const chineseToEnglishMap: Record<string, string> = {
+      工作流: "workflow",
+      测试: "test",
+      数据: "data",
+      处理: "process",
+      分析: "analysis",
+      生成: "generate",
+      查询: "query",
+      搜索: "search",
+      转换: "convert",
+      计算: "calculate",
+      统计: "statistics",
+      报告: "report",
+      文档: "document",
+      图片: "image",
+      视频: "video",
+      音频: "audio",
+      文本: "text",
+      翻译: "translate",
+      识别: "recognize",
+      检测: "detect",
+      监控: "monitor",
+      管理: "manage",
+      配置: "config",
+      设置: "setting",
+      用户: "user",
+      系统: "system",
+      服务: "service",
+      接口: "api",
+      数据库: "database",
+      网络: "network",
+      安全: "security",
+      备份: "backup",
+      恢复: "restore",
+      同步: "sync",
+      导入: "import",
+      导出: "export",
+      上传: "upload",
+      下载: "download",
+    };
+
+    let result = text;
+
+    // 替换常见中文词汇
+    for (const [chinese, english] of Object.entries(chineseToEnglishMap)) {
+      result = result.replace(new RegExp(chinese, "g"), english);
+    }
+
+    // 如果还有中文字符，用拼音前缀替代
+    if (/[\u4e00-\u9fa5]/.test(result)) {
+      result = `chinese_${result}`;
+    }
+
+    return result;
+  }
+}

--- a/apps/backend/services/tool-precheck.service.ts
+++ b/apps/backend/services/tool-precheck.service.ts
@@ -1,0 +1,281 @@
+/**
+ * 工具预检查服务
+ * 负责工具操作前的预检查逻辑
+ */
+
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import type { ConfigManager } from "@xiaozhi-client/config";
+
+/**
+ * 预检查结果接口
+ */
+interface PreCheckResult {
+  code: string;
+  message: string;
+  status: number;
+}
+
+/**
+ * 工具预检查服务
+ */
+export class ToolPreCheckService {
+  private logger: Logger;
+  private configManager: ConfigManager;
+  private readonly MAX_TOOLS = 100; // 最大工具数量限制
+  private readonly MAX_CONFIG_SIZE = 1024 * 1024; // 1MB配置大小限制
+
+  constructor(configManager: ConfigManager) {
+    this.logger = logger;
+    this.configManager = configManager;
+  }
+
+  /**
+   * 执行边界条件预检查
+   * @param workflow 工作流数据
+   * @param customName 自定义名称
+   * @param customDescription 自定义描述
+   * @returns 预检查结果，如果检查通过返回 null
+   */
+  performPreChecks(
+    workflow: unknown,
+    customName?: string,
+    customDescription?: string
+  ): PreCheckResult | null {
+    // 检查基础参数
+    const basicCheckResult = this.checkBasicParameters(
+      workflow,
+      customName,
+      customDescription
+    );
+    if (basicCheckResult) return basicCheckResult;
+
+    // 检查系统状态
+    const systemCheckResult = this.checkSystemStatus();
+    if (systemCheckResult) return systemCheckResult;
+
+    // 检查资源限制
+    const resourceCheckResult = this.checkResourceLimits();
+    if (resourceCheckResult) return resourceCheckResult;
+
+    return null; // 所有检查通过
+  }
+
+  /**
+   * 检查基础参数
+   * @param workflow 工作流数据
+   * @param customName 自定义名称
+   * @param customDescription 自定义描述
+   * @returns 预检查结果，如果检查通过返回 null
+   * @private
+   */
+  private checkBasicParameters(
+    workflow: unknown,
+    customName?: string,
+    customDescription?: string
+  ): PreCheckResult | null {
+    // 检查workflow参数
+    if (!workflow) {
+      return {
+        code: "INVALID_REQUEST",
+        message: "请求体中缺少 workflow 参数",
+        status: 400,
+      };
+    }
+
+    if (typeof workflow !== "object") {
+      return {
+        code: "INVALID_REQUEST",
+        message: "workflow 参数必须是对象类型",
+        status: 400,
+      };
+    }
+
+    // 类型守卫：确保 workflow 不是数组
+    if (!Array.isArray(workflow)) {
+      const workflowObj = workflow as Record<string, unknown>;
+
+      // 检查必需字段
+      if (
+        !workflowObj.workflow_id ||
+        typeof workflowObj.workflow_id !== "string" ||
+        !workflowObj.workflow_id.trim()
+      ) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "workflow_id 不能为空且必须是非空字符串",
+          status: 400,
+        };
+      }
+
+      if (
+        !workflowObj.workflow_name ||
+        typeof workflowObj.workflow_name !== "string" ||
+        !workflowObj.workflow_name.trim()
+      ) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "workflow_name 不能为空且必须是非空字符串",
+          status: 400,
+        };
+      }
+    }
+
+    // 检查自定义参数
+    if (customName !== undefined) {
+      if (typeof customName !== "string") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 必须是字符串类型",
+          status: 400,
+        };
+      }
+
+      if (customName.trim() === "") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 不能为空字符串",
+          status: 400,
+        };
+      }
+
+      if (customName.length > 50) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 长度不能超过50个字符",
+          status: 400,
+        };
+      }
+    }
+
+    if (customDescription !== undefined) {
+      if (typeof customDescription !== "string") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customDescription 必须是字符串类型",
+          status: 400,
+        };
+      }
+
+      if (customDescription.length > 200) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customDescription 长度不能超过200个字符",
+          status: 400,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * 检查系统状态
+   * @returns 预检查结果，如果检查通过返回 null
+   * @private
+   */
+  private checkSystemStatus(): PreCheckResult | null {
+    // 检查扣子API配置
+    try {
+      const cozeConfig = this.configManager.getCozePlatformConfig();
+      if (!cozeConfig || !cozeConfig.token) {
+        return {
+          code: "CONFIGURATION_ERROR",
+          message:
+            "未配置扣子API Token。请在系统设置中配置 platforms.coze.token",
+          status: 422,
+        };
+      }
+
+      // 检查token格式
+      if (
+        typeof cozeConfig.token !== "string" ||
+        cozeConfig.token.trim() === ""
+      ) {
+        return {
+          code: "CONFIGURATION_ERROR",
+          message: "扣子API Token格式无效。请检查配置中的 platforms.coze.token",
+          status: 422,
+        };
+      }
+    } catch (error) {
+      return {
+        code: "SYSTEM_ERROR",
+        message: "系统配置检查失败，请稍后重试",
+        status: 500,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * 检查资源限制
+   * @returns 预检查结果，如果检查通过返回 null
+   * @private
+   */
+  private checkResourceLimits(): PreCheckResult | null {
+    try {
+      // 检查现有工具数量限制
+      const existingTools = this.configManager.getCustomMCPTools();
+
+      if (existingTools.length >= this.MAX_TOOLS) {
+        return {
+          code: "RESOURCE_LIMIT_EXCEEDED",
+          message: `已达到最大工具数量限制 (${this.MAX_TOOLS})。请删除一些不需要的工具后重试`,
+          status: 429,
+        };
+      }
+
+      // 检查配置文件大小（简单估算）
+      const configSizeEstimate = JSON.stringify(existingTools).length;
+
+      if (configSizeEstimate > this.MAX_CONFIG_SIZE) {
+        return {
+          code: "PAYLOAD_TOO_LARGE",
+          message: "配置文件过大。请删除一些不需要的工具以释放空间",
+          status: 413,
+        };
+      }
+    } catch (error) {
+      // 资源检查失败不应阻止操作，只记录警告
+      this.logger.warn("资源限制检查失败:", error);
+    }
+
+    return null;
+  }
+
+  /**
+   * 验证工具标识符
+   * @param serverName 服务名称
+   * @param toolName 工具名称
+   * @throws {MCPError} 当标识符无效时
+   */
+  validateToolIdentifier(serverName: string, toolName: string): void {
+    if (
+      !serverName ||
+      typeof serverName !== "string" ||
+      serverName.trim() === ""
+    ) {
+      throw new Error("服务名称不能为空");
+    }
+
+    if (!toolName || typeof toolName !== "string" || toolName.trim() === "") {
+      throw new Error("工具名称不能为空");
+    }
+
+    // 验证服务名称格式
+    if (!/^[a-zA-Z0-9_-]+$/.test(serverName)) {
+      throw new Error(
+        "服务名称格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+
+    // 验证工具名称格式
+    if (!/^[a-zA-Z0-9_-]+$/.test(toolName)) {
+      throw new Error(
+        "工具名称格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+  }
+}

--- a/apps/backend/services/tool-schema-generator.service.ts
+++ b/apps/backend/services/tool-schema-generator.service.ts
@@ -1,0 +1,71 @@
+/**
+ * 工具 Schema 生成服务
+ * 负责生成工具的输入参数结构（JSON Schema）
+ */
+
+import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
+import type { JSONSchema } from "@/types/toolApi.js";
+
+/**
+ * 工具 Schema 生成服务
+ */
+export class ToolSchemaGenerator {
+  /**
+   * 生成输入参数结构
+   * @param workflow 工作流数据
+   * @param parameterConfig 参数配置
+   * @returns JSON Schema 格式的输入参数结构
+   */
+  generateInputSchema(
+    workflow: CozeWorkflow,
+    parameterConfig?: WorkflowParameterConfig
+  ): JSONSchema {
+    // 如果提供了参数配置，使用参数配置生成schema
+    if (parameterConfig && parameterConfig.parameters.length > 0) {
+      return this.generateInputSchemaFromConfig(parameterConfig);
+    }
+
+    // 否则使用默认的基础参数结构
+    const baseSchema: JSONSchema = {
+      type: "object",
+      properties: {
+        input: {
+          type: "string",
+          description: "输入内容",
+        },
+      },
+      required: ["input"],
+      additionalProperties: false,
+    };
+
+    return baseSchema;
+  }
+
+  /**
+   * 根据参数配置生成输入参数结构
+   * @param parameterConfig 参数配置
+   * @returns JSON Schema 格式的输入参数结构
+   */
+  generateInputSchemaFromConfig(parameterConfig: WorkflowParameterConfig): JSONSchema {
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+
+    for (const param of parameterConfig.parameters) {
+      properties[param.fieldName] = {
+        type: param.type,
+        description: param.description,
+      };
+
+      if (param.required) {
+        required.push(param.fieldName);
+      }
+    }
+
+    return {
+      type: "object",
+      properties,
+      required: required.length > 0 ? required : undefined,
+      additionalProperties: false,
+    };
+  }
+}

--- a/apps/backend/services/tool-validation.service.ts
+++ b/apps/backend/services/tool-validation.service.ts
@@ -1,0 +1,717 @@
+/**
+ * 工具验证服务
+ * 集中处理工具相关的验证逻辑，包括工作流验证、工具结构验证等
+ */
+
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
+import type { MCPServiceManager } from "@/lib/mcp";
+import type { CozeWorkflow } from "@/types/coze.js";
+import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
+import type { JSONSchema } from "@/types/toolApi.js";
+import Ajv from "ajv";
+
+/**
+ * 认证配置接口
+ */
+interface AuthConfig {
+  type: string;
+  token?: string;
+}
+
+/**
+ * 工具验证服务
+ * 负责验证工具相关的各种数据和配置
+ */
+export class ToolValidationService {
+  private logger: Logger;
+  private ajv: Ajv;
+
+  constructor() {
+    this.logger = logger;
+    this.ajv = new Ajv({ allErrors: true, verbose: true });
+  }
+
+  /**
+   * 验证服务和工具是否存在
+   * @param serviceManager MCP 服务管理器
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @throws {MCPError} 当服务或工具不存在时
+   */
+  async validateServiceAndTool(
+    serviceManager: MCPServiceManager,
+    serviceName: string,
+    toolName: string
+  ): Promise<void> {
+    // 特殊处理 customMCP 服务
+    if (serviceName === "customMCP") {
+      this.validateCustomMCPTool(serviceManager, toolName);
+      return;
+    }
+
+    // 标准服务的验证逻辑（预留，如果需要的话）
+    throw MCPError.validationError(
+      MCPErrorCode.TOOL_NOT_FOUND,
+      `服务 "${serviceName}" 暂不支持直接调用`
+    );
+  }
+
+  /**
+   * 验证 customMCP 工具是否存在
+   * @param serviceManager MCP 服务管理器
+   * @param toolName 工具名称
+   * @throws {MCPError} 当工具不存在时
+   * @private
+   */
+  private validateCustomMCPTool(
+    serviceManager: MCPServiceManager,
+    toolName: string
+  ): void {
+    if (!serviceManager.hasCustomMCPTool(toolName)) {
+      const availableTools = serviceManager
+        .getCustomMCPTools()
+        .map((tool) => tool.name);
+
+      if (availableTools.length === 0) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_NOT_FOUND,
+          `customMCP 工具 '${toolName}' 不存在。当前没有配置任何 customMCP 工具。请检查 xiaozhi.config.json 中的 customMCP 配置。`
+        );
+      }
+
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_NOT_FOUND,
+        `customMCP 工具 '${toolName}' 不存在。可用的 customMCP 工具: ${availableTools.join(", ")}。请使用 'xiaozhi mcp list' 查看所有可用工具。`
+      );
+    }
+
+    // 验证 customMCP 工具配置是否有效
+    try {
+      const customTools = serviceManager.getCustomMCPTools();
+      const targetTool = customTools.find((tool) => tool.name === toolName);
+
+      if (targetTool && !targetTool.description) {
+        this.logger.warn(`customMCP 工具 '${toolName}' 缺少描述信息`);
+      }
+
+      if (targetTool && !targetTool.inputSchema) {
+        this.logger.warn(`customMCP 工具 '${toolName}' 缺少输入参数定义`);
+      }
+    } catch (error) {
+      this.logger.error(
+        `验证 customMCP 工具 '${toolName}' 配置时出错:`,
+        error
+      );
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        `customMCP 工具 '${toolName}' 配置验证失败。请检查配置文件中的工具定义。`
+      );
+    }
+  }
+
+  /**
+   * 验证 customMCP 工具的参数
+   * @param serviceManager MCP 服务管理器
+   * @param toolName 工具名称
+   * @param args 工具参数
+   * @throws {MCPError} 当参数验证失败时
+   */
+  async validateCustomMCPArguments(
+    serviceManager: MCPServiceManager,
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<void> {
+    try {
+      // 获取工具的 inputSchema
+      const customTools = serviceManager.getCustomMCPTools();
+      const targetTool = customTools.find((tool) => tool.name === toolName);
+
+      if (!targetTool) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_NOT_FOUND,
+          `customMCP 工具 '${toolName}' 不存在`
+        );
+      }
+
+      // 如果工具没有定义 inputSchema，跳过验证
+      if (!targetTool.inputSchema) {
+        this.logger.warn(
+          `customMCP 工具 '${toolName}' 没有定义 inputSchema，跳过参数验证`
+        );
+        return;
+      }
+
+      // 使用 AJV 验证参数
+      const validate = this.ajv.compile(targetTool.inputSchema);
+      const valid = validate(args);
+
+      if (!valid) {
+        // 构建详细的错误信息
+        const errors = validate.errors || [];
+        const errorMessages = errors.map((error) => {
+          const path = error.instancePath || error.schemaPath || "";
+          const message = error.message || "未知错误";
+
+          if (error.keyword === "required") {
+            const missingProperty = error.params?.missingProperty || "未知字段";
+            return `缺少必需参数: ${missingProperty}`;
+          }
+
+          if (error.keyword === "type") {
+            const expectedType = error.params?.type || "未知类型";
+            return `参数 ${path} 类型错误，期望: ${expectedType}`;
+          }
+
+          if (error.keyword === "enum") {
+            const allowedValues = error.params?.allowedValues || [];
+            return `参数 ${path} 值无效，允许的值: ${allowedValues.join(", ")}`;
+          }
+
+          return `参数 ${path} ${message}`;
+        });
+
+        const errorMessage = `参数验证失败: ${errorMessages.join("; ")}`;
+        this.logger.error(
+          `customMCP 工具 '${toolName}' 参数验证失败:`,
+          errorMessage
+        );
+
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          errorMessage
+        );
+      }
+
+      this.logger.debug(`customMCP 工具 '${toolName}' 参数验证通过`);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("参数验证失败")) {
+        throw error;
+      }
+
+      this.logger.error(`验证 customMCP 工具 '${toolName}' 参数时出错:`, error);
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        `参数验证过程中发生错误: ${error instanceof Error ? error.message : "未知错误"}`
+      );
+    }
+  }
+
+  /**
+   * 验证工作流数据完整性
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当验证失败时
+   */
+  validateWorkflowData(workflow: CozeWorkflow): void {
+    if (!workflow) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流数据不能为空"
+      );
+    }
+
+    // 验证必需字段
+    this.validateRequiredFields(workflow);
+
+    // 验证字段格式
+    this.validateFieldFormats(workflow);
+
+    // 验证字段长度
+    this.validateFieldLengths(workflow);
+
+    // 验证业务逻辑
+    this.validateBusinessLogic(workflow);
+  }
+
+  /**
+   * 验证工作流更新数据完整性
+   * 用于更新场景，只验证关键字段
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当验证失败时
+   */
+  validateWorkflowUpdateData(workflow: Partial<CozeWorkflow>): void {
+    if (!workflow) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流数据不能为空"
+      );
+    }
+
+    // 对于更新操作，我们采用更灵活的验证策略
+    // 因为这可能是参数配置更新，而不是工作流本身更新
+
+    // 如果提供了 workflow_id，验证其格式
+    if (workflow.workflow_id) {
+      if (
+        typeof workflow.workflow_id !== "string" ||
+        workflow.workflow_id.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流ID必须是非空字符串"
+        );
+      }
+
+      // 验证工作流ID格式（数字字符串）
+      if (!/^\d+$/.test(workflow.workflow_id)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流ID格式无效，应为数字字符串"
+        );
+      }
+    }
+
+    // 如果存在 workflow_name，验证其格式
+    if (workflow.workflow_name) {
+      if (
+        typeof workflow.workflow_name !== "string" ||
+        workflow.workflow_name.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流名称必须是非空字符串"
+        );
+      }
+
+      // 验证工作流名称长度
+      if (workflow.workflow_name.length > 100) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流名称过长，不能超过100个字符"
+        );
+      }
+    }
+
+    // 如果存在 app_id，验证其格式
+    if (workflow.app_id) {
+      if (
+        typeof workflow.app_id !== "string" ||
+        workflow.app_id.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID必须是非空字符串"
+        );
+      }
+
+      // 验证应用ID格式
+      if (!/^[a-zA-Z0-9_-]+$/.test(workflow.app_id)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID格式无效，只能包含字母、数字、下划线和连字符"
+        );
+      }
+
+      // 验证应用ID长度
+      if (workflow.app_id.length > 50) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID过长，不能超过50个字符"
+        );
+      }
+    }
+
+    // 对于参数配置更新，workflow_id 可能不是必需的
+    // 因为实际的工作流ID已经存储在工具配置中
+    // 我们主要验证存在字段的格式，而不是强制要求所有字段都存在
+  }
+
+  /**
+   * 验证必需字段
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当缺少必需字段时
+   * @private
+   */
+  private validateRequiredFields(workflow: CozeWorkflow): void {
+    const requiredFields = [
+      { field: "workflow_id", name: "工作流ID" },
+      { field: "workflow_name", name: "工作流名称" },
+      { field: "app_id", name: "应用ID" },
+    ];
+
+    for (const { field, name } of requiredFields) {
+      const value = workflow[field as keyof CozeWorkflow];
+      if (!value || typeof value !== "string" || value.trim() === "") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `${name}不能为空且必须是非空字符串`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证字段格式
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当字段格式无效时
+   * @private
+   */
+  private validateFieldFormats(workflow: CozeWorkflow): void {
+    // 验证工作流ID格式（数字字符串）
+    if (!/^\d+$/.test(workflow.workflow_id)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流ID格式无效，应为数字字符串"
+      );
+    }
+
+    // 验证应用ID格式
+    if (!/^[a-zA-Z0-9_-]+$/.test(workflow.app_id)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "应用ID格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+
+    // 验证图标URL格式（如果存在）
+    if (workflow.icon_url?.trim()) {
+      try {
+        new URL(workflow.icon_url);
+      } catch {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "图标URL格式无效"
+        );
+      }
+    }
+
+    // 验证时间戳格式
+    if (
+      workflow.created_at &&
+      (!Number.isInteger(workflow.created_at) || workflow.created_at <= 0)
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "创建时间格式无效，应为正整数时间戳"
+      );
+    }
+
+    if (
+      workflow.updated_at &&
+      (!Number.isInteger(workflow.updated_at) || workflow.updated_at <= 0)
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "更新时间格式无效，应为正整数时间戳"
+      );
+    }
+  }
+
+  /**
+   * 验证字段长度
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当字段长度超出限制时
+   * @private
+   */
+  private validateFieldLengths(workflow: CozeWorkflow): void {
+    const lengthLimits = [
+      { field: "workflow_name", name: "工作流名称", max: 100 },
+      { field: "description", name: "工作流描述", max: 500 },
+      { field: "app_id", name: "应用ID", max: 50 },
+    ];
+
+    for (const { field, name, max } of lengthLimits) {
+      const value = workflow[field as keyof CozeWorkflow] as string;
+      if (value && value.length > max) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `${name}过长，不能超过${max}个字符`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证业务逻辑
+   * @param workflow 工作流数据
+   * @throws {MCPError} 当业务逻辑验证失败时
+   * @private
+   */
+  private validateBusinessLogic(workflow: CozeWorkflow): void {
+    // 验证创建者信息
+    if (workflow.creator) {
+      if (!workflow.creator.id || typeof workflow.creator.id !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "创建者ID不能为空且必须是字符串"
+        );
+      }
+      if (!workflow.creator.name || typeof workflow.creator.name !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "创建者名称不能为空且必须是字符串"
+        );
+      }
+    }
+
+    // 验证时间逻辑
+    if (
+      workflow.created_at &&
+      workflow.updated_at &&
+      workflow.updated_at < workflow.created_at
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "更新时间不能早于创建时间"
+      );
+    }
+
+    // 验证工作流名称不能包含敏感词
+    const sensitiveWords = [
+      "admin",
+      "root",
+      "system",
+      "config",
+      "password",
+      "token",
+    ];
+    const lowerName = workflow.workflow_name.toLowerCase();
+    for (const word of sensitiveWords) {
+      if (lowerName.includes(word)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `工作流名称不能包含敏感词: ${word}`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证生成的工具配置
+   * @param tool 工具配置
+   * @param validateWithConfigManager 是否使用 configManager 验证
+   * @throws {MCPError} 当验证失败时
+   */
+  validateGeneratedTool(
+    tool: CustomMCPTool,
+    validateWithConfigManager = false
+  ): void {
+    // 基础结构验证
+    this.validateToolStructure(tool);
+
+    // JSON Schema验证
+    this.validateJsonSchema(tool.inputSchema);
+
+    // HTTP处理器验证
+    if (tool.handler) {
+      this.validateProxyHandler(tool.handler as ProxyHandlerConfig);
+    }
+  }
+
+  /**
+   * 验证工具基础结构
+   * @param tool 工具配置
+   * @throws {MCPError} 当结构无效时
+   */
+  validateToolStructure(tool: CustomMCPTool): void {
+    if (!tool || typeof tool !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具配置必须是有效对象"
+      );
+    }
+
+    // 验证必需字段
+    const requiredFields = ["name", "description", "inputSchema", "handler"];
+    for (const field of requiredFields) {
+      if (!(field in tool) || tool[field as keyof CustomMCPTool] == null) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `工具配置缺少必需字段: ${field}`
+        );
+      }
+    }
+
+    // 验证字段类型
+    if (typeof tool.name !== "string" || tool.name.trim() === "") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具名称必须是非空字符串"
+      );
+    }
+
+    if (
+      typeof tool.description !== "string" ||
+      tool.description.trim() === ""
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具描述必须是非空字符串"
+      );
+    }
+
+    if (typeof tool.inputSchema !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须是对象"
+      );
+    }
+
+    if (typeof tool.handler !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "处理器配置必须是对象"
+      );
+    }
+  }
+
+  /**
+   * 验证代理处理器配置
+   * @param handler 处理器配置
+   * @throws {MCPError} 当配置无效时
+   */
+  validateProxyHandler(handler: ProxyHandlerConfig): void {
+    if (!handler || typeof handler !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "HTTP处理器配置不能为空"
+      );
+    }
+
+    // 验证处理器类型
+    if (handler.type !== "proxy") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "处理器类型必须是'proxy'"
+      );
+    }
+
+    if (handler.platform === "coze") {
+      if (!handler.config.workflow_id) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Coze处理器必须包含有效的workflow_id"
+        );
+      }
+    } else {
+      throw MCPError.configError(
+        MCPErrorCode.INVALID_CONFIG,
+        "不支持的工作流平台"
+      );
+    }
+  }
+
+  /**
+   * 验证认证配置
+   * @param auth 认证配置
+   * @throws {MCPError} 当配置无效时
+   */
+  validateAuthConfig(auth: AuthConfig): void {
+    if (!auth || typeof auth !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "认证配置必须是对象"
+      );
+    }
+
+    if (!auth.type || typeof auth.type !== "string") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "认证类型不能为空"
+      );
+    }
+
+    const validAuthTypes = ["bearer", "basic", "api_key"];
+    if (!validAuthTypes.includes(auth.type)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        `认证类型必须是以下之一: ${validAuthTypes.join(", ")}`
+      );
+    }
+
+    // 验证token格式
+    if (auth.type === "bearer") {
+      if (!auth.token || typeof auth.token !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Bearer认证必须包含有效的token"
+        );
+      }
+
+      // 验证token格式（应该是环境变量引用或实际token）
+      if (
+        !auth.token.startsWith("${") &&
+        !auth.token.match(/^[a-zA-Z0-9_-]+$/)
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Bearer token格式无效"
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证请求体模板
+   * @param bodyTemplate 请求体模板
+   * @throws {MCPError} 当模板无效时
+   */
+  validateBodyTemplate(bodyTemplate: string): void {
+    if (typeof bodyTemplate !== "string") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "请求体模板必须是字符串"
+      );
+    }
+
+    try {
+      JSON.parse(bodyTemplate);
+    } catch {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "请求体模板必须是有效的JSON格式"
+      );
+    }
+
+    // 验证模板变量格式
+    const templateVars = bodyTemplate.match(/\{\{[^}]+\}\}/g);
+    if (templateVars) {
+      for (const templateVar of templateVars) {
+        const varName = templateVar.slice(2, -2).trim();
+        if (!varName || !/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(varName)) {
+          throw MCPError.validationError(
+            MCPErrorCode.TOOL_VALIDATION_FAILED,
+            `模板变量格式无效: ${templateVar}`
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * 验证 JSON Schema 格式
+   * @param schema JSON Schema
+   * @throws {MCPError} 当格式无效时
+   */
+  validateJsonSchema(schema: JSONSchema): void {
+    if (!schema || typeof schema !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须是有效的对象"
+      );
+    }
+
+    if (!schema.type || schema.type !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构的type必须是'object'"
+      );
+    }
+
+    if (!schema.properties || typeof schema.properties !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须包含properties字段"
+      );
+    }
+
+    // 验证required字段
+    if (schema.required && !Array.isArray(schema.required)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构的required字段必须是数组"
+      );
+    }
+  }
+}


### PR DESCRIPTION
为解决 MCPToolHandler 文件过大（2733行，57个方法）违反单一职责原则的问题，
创建以下6个服务类：

- ToolValidationService: 集中的验证逻辑（工作流验证、工具结构验证等）
- ToolNameService: 工具名称相关操作（规范化、冲突解决、中文转英文）
- ToolSchemaGenerator: Schema 生成（输入参数结构生成）
- CozeWorkflowService: Coze 工作流处理（转换为工具配置）
- ToolPreCheckService: 预检查逻辑（基础参数、系统状态、资源限制）
- ToolErrorHandler: 统一错误处理（添加、删除、更新工具错误）

重构收益：
- 职责分离更清晰
- 代码可维护性提高
- 便于单元测试
- 为后续重构奠定基础

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>