### PR TITLE
fix: 统一 shared-types package.json 中的路径格式，添加 ./ 前缀

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -3,8 +3,8 @@
   "version": "1.9.7",
   "description": "小智项目的共享类型定义",
   "type": "module",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
- 将 main 字段从 "dist/index.js" 更新为 "./dist/index.js"
- 将 types 字段从 "dist/index.d.ts" 更新为 "./dist/index.d.ts"
- 现在与 exports 字段和其他包的配置保持一致

修复 #1132

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>