### PR TITLE
fix: 将 MCP 协议核心类型中的 any 替换为泛型参数以提升类型安全性

### DIFF
--- a/packages/shared-types/src/mcp/message.ts
+++ b/packages/shared-types/src/mcp/message.ts
@@ -5,19 +5,19 @@
 /**
  * MCP 消息接口
  */
-export interface MCPMessage {
+export interface MCPMessage<TParams = unknown> {
   jsonrpc: "2.0";
   method: string;
-  params?: any;
+  params?: TParams;
   id?: string | number;
 }
 
 /**
  * MCP 响应接口
  */
-export interface MCPResponse {
+export interface MCPResponse<TResult = unknown> {
   jsonrpc: "2.0";
-  result?: any;
+  result?: TResult;
   error?: MCPError;
   id: string | number | null;
 }
@@ -25,10 +25,10 @@ export interface MCPResponse {
 /**
  * MCP 错误接口
  */
-export interface MCPError {
+export interface MCPError<TData = unknown> {
   code: number;
   message: string;
-  data?: any;
+  data?: TData;
 }
 
 /**


### PR DESCRIPTION
- MCPMessage.params: any → TParams = unknown
- MCPResponse.result: any → TResult = unknown
- MCPError.data: any → TData = unknown

使用泛型参数替代 any 类型，在保持向后兼容性的同时提升类型安全性。
默认值为 unknown，调用者可以选择性地指定具体类型以获得更好的类型提示。

修复 #1134

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>