### PR TITLE
fix: shared-types 添加 target 字段以确保构建配置一致性

### DIFF
--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     utils: "src/utils/index.ts",
   },
   format: ["esm"],
+  target: "node18",
   outDir: "../../dist/shared-types",
   dts: {
     compilerOptions: {


### PR DESCRIPTION
- 在 packages/shared-types/tsup.config.ts 中添加 target: "node18"
- 统一所有包的编译目标，避免跨包类型兼容性问题
- 修复 Issue #1136

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>