### PR TITLE
fix: 统一所有包的 tsup 版本至 ^8.5.0

### DIFF
--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -41,7 +41,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/ws": "^8.5.0",
-    "tsup": "^8.3.5",
+    "tsup": "^8.5.0",
     "tsx": "^4.19.2",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5"

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/ws": "^8.5.0",
-    "tsup": "^8.3.5",
+    "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5"
   },

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "tsup": "^8.3.5",
+    "tsup": "^8.5.0",
     "typescript": "^5.7.2"
   },
   "publishConfig": {

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5",
-    "tsup": "^8.3.5"
+    "tsup": "^8.5.0"
   },
   "nx": {
     "targets": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -582,7 +582,7 @@ importers:
         specifier: ^8.5.0
         version: 8.18.1
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
         specifier: ^4.19.2
@@ -613,7 +613,7 @@ importers:
         specifier: ^8.5.0
         version: 8.18.1
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2
@@ -628,7 +628,7 @@ importers:
         specifier: ^24.3.0
         version: 24.10.9
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.2
@@ -640,7 +640,7 @@ importers:
         specifier: ^24.3.0
         version: 24.10.9
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2


### PR DESCRIPTION
将 packages/version、packages/shared-types、packages/endpoint 和
packages/mcp-core 中的 tsup 版本从 ^8.3.5 升级至 ^8.5.0，
确保与根目录的 tsup 版本保持一致，避免构建行为差异。

修复 #1137

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>