### PR TITLE
fix: 统一开发依赖版本以确保构建一致性

### DIFF
--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -51,7 +51,7 @@
     "react-hook-form": "^7.62.0",
     "react-router-dom": "^7.8.2",
     "recharts": "2.15.4",
-    "semver": "^7.7.3",
+    "semver": "^7.7.2",
     "sonner": "^2.0.5",
     "tailwind-merge": "^3.3.1",
     "tailwindcss-animate": "^1.0.7",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -41,8 +41,8 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/ws": "^8.5.0",
-    "tsup": "^8.3.5",
-    "tsx": "^4.19.2",
+    "tsup": "^8.5.0",
+    "tsx": "^4.20.5",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5"
   },

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -35,7 +35,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/ws": "^8.5.0",
-    "tsup": "^8.3.5",
+    "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5"
   },

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -41,7 +41,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "tsup": "^8.3.5",
+    "tsup": "^8.5.0",
     "typescript": "^5.7.2"
   },
   "publishConfig": {

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -29,7 +29,7 @@
     "@types/node": "^24.3.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5",
-    "tsup": "^8.3.5"
+    "tsup": "^8.5.0"
   },
   "nx": {
     "targets": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -350,7 +350,7 @@ importers:
         specifier: 2.15.4
         version: 2.15.4(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       semver:
-        specifier: ^7.7.3
+        specifier: ^7.7.2
         version: 7.7.3
       sonner:
         specifier: ^2.0.5
@@ -582,10 +582,10 @@ importers:
         specifier: ^8.5.0
         version: 8.18.1
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       tsx:
-        specifier: ^4.19.2
+        specifier: ^4.20.5
         version: 4.21.0
       typescript:
         specifier: ^5.9.2
@@ -613,7 +613,7 @@ importers:
         specifier: ^8.5.0
         version: 8.18.1
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2
@@ -628,7 +628,7 @@ importers:
         specifier: ^24.3.0
         version: 24.10.9
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.7.2
@@ -640,7 +640,7 @@ importers:
         specifier: ^24.3.0
         version: 24.10.9
       tsup:
-        specifier: ^8.3.5
+        specifier: ^8.5.0
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2


### PR DESCRIPTION
- 统一 tsup 版本从 ^8.3.5 到 ^8.5.0（4个包）
- 统一 tsx 版本从 ^4.19.2 到 ^4.20.5
- 统一 semver 版本从 ^7.7.3 到 ^7.7.2
- 更新 pnpm-lock.yaml

修复 #1138

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>