### PR TITLE
fix: 修复 Dockerfile 版本更新脚本的路径问题

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM node:20
 # 定义 xiaozhi-client 版本号
 # 默认使用当前项目版本，可在构建时通过 --build-arg 覆盖
 # 例如: docker build --build-arg XIAOZHI_VERSION=1.6.0 .
-ARG XIAOZHI_VERSION=1.6.1
+ARG XIAOZHI_VERSION=1.9.7
 
 # 配置 npm 和 pnpm 使用国内镜像源
 # 设置 npm 注册表镜像

--- a/docker/scripts/update-version.js
+++ b/docker/scripts/update-version.js
@@ -11,7 +11,8 @@ import { fileURLToPath } from "node:url";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
-const projectRoot = join(__dirname, "..");
+const dockerDir = join(__dirname, "..");
+const projectRoot = join(__dirname, "../..");
 
 function updateDockerfileVersion() {
   try {
@@ -23,7 +24,7 @@ function updateDockerfileVersion() {
     console.log(`📦 当前项目版本: ${currentVersion}`);
 
     // 读取 Dockerfile
-    const dockerfilePath = join(projectRoot, "Dockerfile");
+    const dockerfilePath = join(dockerDir, "Dockerfile");
     const dockerfileContent = readFileSync(dockerfilePath, "utf8");
 
     // 使用正则表达式匹配并替换版本号


### PR DESCRIPTION
- 修复 docker/scripts/update-version.js 中项目根目录路径解析错误
- 将 projectRoot 正确指向项目根目录（而非 docker 目录）
- 添加 dockerDir 变量用于引用 docker 目录
- 更新 Dockerfile 中的 XIAOZHI_VERSION 从 1.6.1 到 1.9.7

修复 #1144

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>