### PR TITLE
fix: 修复 InternalMCPManagerAdapter 中的内存泄漏问题

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      off: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);


### PR DESCRIPTION
- 添加私有字段保存事件监听器引用 (connectedHandler, errorHandler)
- 在 cleanup() 方法中移除事件监听器以防止内存泄漏
- 更新测试 mock 以支持 off() 方法

修复 #1152

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>