### PR TITLE
refactor: 消除 ProcessManager 和 PlatformUtils 中的重复进程停止逻辑

### DIFF
--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -150,36 +150,11 @@ export class ProcessManagerImpl implements IProcessManager {
 
   /**
    * 优雅停止进程
+   * 委托给 PlatformUtils.killProcess 实现
    */
   async gracefulKillProcess(pid: number): Promise<void> {
     try {
-      // 尝试优雅停止
-      process.kill(pid, "SIGTERM");
-
-      // 等待进程停止
-      let attempts = 0;
-      const maxAttempts = 30; // 3秒超时
-
-      while (attempts < maxAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        try {
-          process.kill(pid, 0);
-          attempts++;
-        } catch {
-          // 进程已停止
-          return;
-        }
-      }
-
-      // 如果还在运行，强制停止
-      try {
-        process.kill(pid, 0);
-        process.kill(pid, "SIGKILL");
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      } catch {
-        // 进程已停止
-      }
+      await PlatformUtils.killProcess(pid, "SIGTERM");
     } catch (error) {
       throw new ProcessError(
         `无法停止进程: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/cli/src/services/__tests__/ProcessManager.test.ts
+++ b/packages/cli/src/services/__tests__/ProcessManager.test.ts
@@ -139,43 +139,23 @@ describe("ProcessManagerImpl", () => {
   });
 
   describe("gracefulKillProcess", () => {
-    let originalKill: typeof process.kill;
-
-    beforeEach(() => {
-      originalKill = process.kill;
-      process.kill = vi.fn();
-    });
-
-    afterEach(() => {
-      process.kill = originalKill;
-    });
-
-    it("should gracefully kill process", async () => {
-      let killCallCount = 0;
-      (process.kill as any).mockImplementation((pid: number, signal: any) => {
-        killCallCount++;
-        if (killCallCount > 1) {
-          throw new Error("ESRCH"); // Process stopped
-        }
-      });
+    it("应优雅停止进程", async () => {
+      mockPlatformUtils.killProcess.mockResolvedValue();
 
       await processManager.gracefulKillProcess(1234);
 
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGTERM");
+      expect(mockPlatformUtils.killProcess).toHaveBeenCalledWith(
+        1234,
+        "SIGTERM"
+      );
     });
 
-    it("should force kill if graceful kill fails", async () => {
-      (process.kill as any).mockImplementation((pid: number, signal: any) => {
-        if (signal === "SIGKILL") {
-          throw new Error("ESRCH"); // Process stopped
-        }
-        // Process still running for SIGTERM and signal 0
-      });
+    it("停止失败时应抛出 ProcessError", async () => {
+      mockPlatformUtils.killProcess.mockRejectedValue(new Error("Kill failed"));
 
-      await processManager.gracefulKillProcess(1234);
-
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGTERM");
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGKILL");
+      await expect(processManager.gracefulKillProcess(1234)).rejects.toThrow(
+        "无法停止进程"
+      );
     });
   });
 


### PR DESCRIPTION
将 ProcessManager.gracefulKillProcess 的实现委托给 PlatformUtils.killProcess，
消除了 28 行重复代码，符合 DRY 原则。

修改内容：
- ProcessManager.gracefulKillProcess 现在直接调用 PlatformUtils.killProcess
- 更新相关测试以验证调用行为而非实现细节

Fixes #1158

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>