### PR TITLE
fix: 将 shared-types MCP 协议类型中的 any 替换为 unknown

### DIFF
--- a/packages/shared-types/src/mcp/message.ts
+++ b/packages/shared-types/src/mcp/message.ts
@@ -8,7 +8,7 @@
 export interface MCPMessage {
   jsonrpc: "2.0";
   method: string;
-  params?: any;
+  params?: unknown;
   id?: string | number;
 }
 
@@ -17,7 +17,7 @@ export interface MCPMessage {
  */
 export interface MCPResponse {
   jsonrpc: "2.0";
-  result?: any;
+  result?: unknown;
   error?: MCPError;
   id: string | number | null;
 }
@@ -28,7 +28,7 @@ export interface MCPResponse {
 export interface MCPError {
   code: number;
   message: string;
-  data?: any;
+  data?: unknown;
 }
 
 /**


### PR DESCRIPTION
修复 #1160

将 packages/shared-types/src/mcp/message.ts 中的 any 类型替换为 unknown：
- MCPMessage.params?: unknown
- MCPResponse.result?: unknown
- MCPError.data?: unknown

这提高了类型安全性，同时保持与现有代码的兼容性（现有代码已使用类型断言）。

验证：
- 类型检查通过（所有 10 个项目）
- 所有测试通过（555 个测试用例）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>