### PR TITLE
fix: 修复 hono.context.ts 中使用相对路径导入类型的问题

### DIFF
--- a/apps/backend/types/hono.context.ts
+++ b/apps/backend/types/hono.context.ts
@@ -4,11 +4,12 @@
  */
 
 import type { Logger } from "@/Logger.js";
+import type { EndpointHandler } from "@/handlers/index.js";
 import type { MCPServiceManager } from "@/lib/mcp";
+import type { HandlerDependencies } from "@/routes/types.js";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
 import { Hono } from "hono";
-import type { EndpointHandler, HandlerDependencies } from "../routes/index.js";
 
 // 导出 API 响应类型供其他模块使用
 export type {


### PR DESCRIPTION
将 apps/backend/types/hono.context.ts 中的相对路径导入改为使用项目路径别名：
- EndpointHandler 从 @/handlers/index.js 导入
- HandlerDependencies 从 @/routes/types.js 导入

这符合项目的路径别名一致性原则，提高了代码的可维护性。

修复 #1161

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>