### PR TITLE
fix: 移除根 tsconfig.json 中与 monorepo 结构不一致的 rootDir 配置

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "allowJs": true,
     "checkJs": false,
     "outDir": "./dist",
-    "rootDir": "./apps/backend",
     "baseUrl": ".",
     "strict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
- 移除 "rootDir": "./apps/backend" 配置
- 让 TypeScript 根据 include 配置自动推断 rootDir
- 更符合项目的 monorepo 结构（apps/、packages/、mcps/）
- 修复了 #1164

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>