### PR TITLE
fix: 提取连接参数默认值到常量文件消除重复定义

### DIFF
--- a/apps/frontend/src/components/system-setting-dialog.tsx
+++ b/apps/frontend/src/components/system-setting-dialog.tsx
@@ -24,6 +24,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { DEFAULT_CONNECTION_PARAMS } from "@/constants/connection";
 import { useWebSocketActions } from "@/providers/WebSocketProvider";
 import { useConfig } from "@/stores/config";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -79,9 +80,15 @@ export function SystemSettingDialog() {
         apiKey: config?.modelscope?.apiKey || "",
       },
       connection: {
-        heartbeatInterval: config?.connection?.heartbeatInterval || 30000,
-        heartbeatTimeout: config?.connection?.heartbeatTimeout || 10000,
-        reconnectInterval: config?.connection?.reconnectInterval || 5000,
+        heartbeatInterval:
+          config?.connection?.heartbeatInterval ??
+          DEFAULT_CONNECTION_PARAMS.HEARTBEAT_INTERVAL,
+        heartbeatTimeout:
+          config?.connection?.heartbeatTimeout ??
+          DEFAULT_CONNECTION_PARAMS.HEARTBEAT_TIMEOUT,
+        reconnectInterval:
+          config?.connection?.reconnectInterval ??
+          DEFAULT_CONNECTION_PARAMS.RECONNECT_INTERVAL,
       },
     },
   });
@@ -93,9 +100,15 @@ export function SystemSettingDialog() {
         apiKey: config?.modelscope?.apiKey || "",
       },
       connection: {
-        heartbeatInterval: config?.connection?.heartbeatInterval || 30000,
-        heartbeatTimeout: config?.connection?.heartbeatTimeout || 10000,
-        reconnectInterval: config?.connection?.reconnectInterval || 5000,
+        heartbeatInterval:
+          config?.connection?.heartbeatInterval ??
+          DEFAULT_CONNECTION_PARAMS.HEARTBEAT_INTERVAL,
+        heartbeatTimeout:
+          config?.connection?.heartbeatTimeout ??
+          DEFAULT_CONNECTION_PARAMS.HEARTBEAT_TIMEOUT,
+        reconnectInterval:
+          config?.connection?.reconnectInterval ??
+          DEFAULT_CONNECTION_PARAMS.RECONNECT_INTERVAL,
       },
     });
   }, [config, form]);

--- a/apps/frontend/src/constants/connection.ts
+++ b/apps/frontend/src/constants/connection.ts
@@ -1,0 +1,17 @@
+/**
+ * 连接参数常量
+ *
+ * 定义 WebSocket 连接相关的默认常量值，确保整个应用使用一致的默认值。
+ */
+
+/**
+ * 连接参数默认值
+ */
+export const DEFAULT_CONNECTION_PARAMS = {
+  /** 心跳间隔（毫秒） */
+  HEARTBEAT_INTERVAL: 30000,
+  /** 心跳超时（毫秒） */
+  HEARTBEAT_TIMEOUT: 10000,
+  /** 重连间隔（毫秒） */
+  RECONNECT_INTERVAL: 5000,
+} as const;

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -7,6 +7,7 @@
  * - 支持多个 store 订阅 WebSocket 事件
  */
 
+import { DEFAULT_CONNECTION_PARAMS } from "@/constants/connection";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 
 /**
@@ -246,9 +247,12 @@ export class WebSocketManager {
   private constructor(config: WebSocketManagerConfig = {}) {
     this.url = config.url || this.getDefaultWebSocketUrl();
     this.maxReconnectAttempts = config.maxReconnectAttempts || 5;
-    this.reconnectInterval = config.reconnectInterval || 3000;
-    this.heartbeatInterval = config.heartbeatInterval || 30000; // 30秒
-    this.heartbeatTimeout = config.heartbeatTimeout || 35000; // 35秒
+    this.reconnectInterval =
+      config.reconnectInterval ?? DEFAULT_CONNECTION_PARAMS.RECONNECT_INTERVAL;
+    this.heartbeatInterval =
+      config.heartbeatInterval ?? DEFAULT_CONNECTION_PARAMS.HEARTBEAT_INTERVAL;
+    this.heartbeatTimeout =
+      config.heartbeatTimeout ?? DEFAULT_CONNECTION_PARAMS.HEARTBEAT_TIMEOUT;
   }
 
   /**


### PR DESCRIPTION
创建统一的连接参数默认值常量文件，解决以下问题：
- system-setting-dialog.tsx 中两处重复定义默认值
- websocket.ts 中的默认值与其他位置不一致

变更：
- 新增 apps/frontend/src/constants/connection.ts 定义默认值常量
- 更新 system-setting-dialog.tsx 使用常量替代硬编码值
- 更新 websocket.ts 使用统一常量，修正不一致的默认值

相关 Issue: #1167

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>