### PR TITLE
fix: 将 any 类型替换为 JSONSchema 类型

### DIFF
--- a/apps/frontend/src/lib/schema-utils.ts
+++ b/apps/frontend/src/lib/schema-utils.ts
@@ -1,9 +1,10 @@
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
 import { z } from "zod";
 
 /**
  * 根据 JSON Schema 动态生成 Zod schema
  */
-export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
+export function createZodSchemaFromJsonSchema(jsonSchema: JSONSchema): z.ZodTypeAny {
   if (!jsonSchema || typeof jsonSchema !== "object") {
     return z.any();
   }
@@ -14,13 +15,13 @@ export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
         return z.enum(jsonSchema.enum as [string, ...string[]]);
       }
       let stringSchema = z.string();
-      if (jsonSchema.minLength) {
+      if (typeof jsonSchema.minLength === "number") {
         stringSchema = stringSchema.min(jsonSchema.minLength);
       }
-      if (jsonSchema.maxLength) {
+      if (typeof jsonSchema.maxLength === "number") {
         stringSchema = stringSchema.max(jsonSchema.maxLength);
       }
-      if (jsonSchema.pattern) {
+      if (typeof jsonSchema.pattern === "string") {
         stringSchema = stringSchema.regex(new RegExp(jsonSchema.pattern));
       }
       return stringSchema;
@@ -92,7 +93,7 @@ export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
 /**
  * 获取字段的默认值
  */
-export function getDefaultValueForSchema(schema: any): any {
+export function getDefaultValueForSchema(schema: JSONSchema): unknown {
   if (!schema) return undefined;
 
   switch (schema.type) {
@@ -128,7 +129,7 @@ export function getDefaultValueForSchema(schema: any): any {
 /**
  * 根据 JSON Schema 生成默认值对象
  */
-export function createDefaultValues(jsonSchema: any): Record<string, any> {
+export function createDefaultValues(jsonSchema: JSONSchema): Record<string, unknown> {
   if (!jsonSchema || !jsonSchema.properties) return {};
 
   const defaults: Record<string, any> = {};


### PR DESCRIPTION
修复了 schema-utils.ts 和 tool-debug-dialog.tsx 中使用 any 类型表示 JSON Schema 的问题，改用已定义的 JSONSchema 类型。

主要变更：
- schema-utils.ts:
  - createZodSchemaFromJsonSchema 参数改为 JSONSchema
  - getDefaultValueForSchema 参数和返回值改为 JSONSchema 和 unknown
  - createDefaultValues 参数和返回值改为 JSONSchema 和 Record<string, unknown>
  - 添加类型检查以确保 minLength、maxLength、pattern 为正确的类型

- tool-debug-dialog.tsx:
  - ArrayFieldProps、ObjectFieldProps、FormRendererProps 中的 schema 参数改为 JSONSchema
  - ToolDebugDialogProps 中的 inputSchema 改为 JSONSchema
  - renderFormField 函数参数改为 JSONSchema
  - result 状态类型改为 unknown
  - formatResult 参数类型改为 unknown
  - 修复了可能的 undefined 问题
  - 保留 form 参数的 any 类型，因为动态表单类型在编译时无法确定

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>