### PR TITLE
fix: 添加 Vite emptyOutDir 配置以解决 outDir 警告

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -44,6 +44,8 @@ export default defineConfig({
   },
   build: {
     outDir: "../../dist/frontend",
+    emptyOutDir: true,
+    allowEmptyOutDir: true,
     sourcemap: true,
     // 代码分割优化配置
     rollupOptions: {


### PR DESCRIPTION
- 添加 emptyOutDir: true 显式启用清空操作
- 添加 allowEmptyOutDir: true 允许清空项目根目录外的目录
- 修复构建时的 "outDir is not inside project root" 警告

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>