### PR TITLE
fix: 在 EndpointManager.cleanup() 中添加 removeAllListeners 防止内存泄漏

### DIFF
--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -482,6 +482,9 @@ export class EndpointManager extends EventEmitter {
     }
     this.mcpEventListeners = [];
 
+    // 清理所有事件监听器（防止内存泄漏）
+    this.removeAllListeners();
+
     await this.clearEndpoints();
 
     console.debug("[EndpointManager] 资源清理完成");


### PR DESCRIPTION
在 EndpointManager 的 cleanup() 方法中添加 this.removeAllListeners()
调用，以确保在清理资源时移除所有事件监听器，防止内存泄漏。

修复问题 #1184

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>