### PR TITLE
fix: 在 MCPServiceManager.cleanup() 中添加 cacheManager 清理调用

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1833,6 +1833,9 @@ export class MCPServiceManager extends EventEmitter {
   async cleanup(): Promise<void> {
     await this.stopAllServices();
 
+    // 清理缓存管理器的定时器，防止资源泄漏
+    this.cacheManager.cleanup();
+
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(
       "mcp:service:connected",


### PR DESCRIPTION
修复 MCPCacheManager 的定时器未在清理时停止的问题。

- 在 MCPServiceManager.cleanup() 方法中添加 this.cacheManager.cleanup() 调用
- 修复资源泄漏问题，确保定时器被正确清理

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>