### PR TITLE
fix: 在根 tsconfig.json 中添加 packages/mcp-core 的 project reference

### DIFF
--- a/packages/mcp-core/tsconfig.json
+++ b/packages/mcp-core/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "composite": false,
+    "composite": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -33,6 +33,7 @@
   "references": [
     { "path": "./apps/backend" },
     { "path": "./packages/config" },
+    { "path": "./packages/mcp-core" },
     { "path": "./packages/shared-types" },
     { "path": "./packages/cli" },
     { "path": "./packages/endpoint" },


### PR DESCRIPTION
修复根 tsconfig.json 缺少 packages/mcp-core 的 project reference 的问题。
同时将 mcp-core/tsconfig.json 中的 composite 设置为 true，以支持
TypeScript project references 功能。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>