### PR TITLE
refactor: 移除 packages/cli/vitest.config.ts 中未使用的路径别名配置

### DIFF
--- a/packages/cli/src/commands/__tests__/service-commands.integration.test.ts
+++ b/packages/cli/src/commands/__tests__/service-commands.integration.test.ts
@@ -10,10 +10,6 @@ const mockServiceManager = {
   attach: vi.fn(),
 };
 
-vi.mock("@services/ServiceManager.js", () => ({
-  ServiceManager: vi.fn().mockImplementation(() => mockServiceManager),
-}));
-
 // Mock ProcessManager
 const mockProcessManager = {
   isServiceRunning: vi.fn(),
@@ -23,27 +19,15 @@ const mockProcessManager = {
   stopService: vi.fn(),
 };
 
-vi.mock("@services/ProcessManager.js", () => ({
-  ProcessManager: vi.fn().mockImplementation(() => mockProcessManager),
-}));
-
 // Mock DaemonManager
 const mockDaemonManager = {
   attachToLogs: vi.fn(),
 };
 
-vi.mock("@services/DaemonManager.js", () => ({
-  DaemonManager: vi.fn().mockImplementation(() => mockDaemonManager),
-}));
-
 // Mock ErrorHandler
 const mockErrorHandler = {
   handle: vi.fn(),
 };
-
-vi.mock("@utils/ErrorHandler.js", () => ({
-  ErrorHandler: mockErrorHandler,
-}));
 
 describe("服务命令集成测试", () => {
   let serviceCommandHandler: ServiceCommandHandler;

--- a/packages/cli/src/services/__tests__/ServiceManager.test.ts
+++ b/packages/cli/src/services/__tests__/ServiceManager.test.ts
@@ -35,11 +35,6 @@ const mockWebServerInstance = {
   stop: vi.fn().mockResolvedValue(undefined),
 };
 
-const mockMCPServerInstance = {
-  start: vi.fn().mockResolvedValue(undefined),
-  stop: vi.fn().mockResolvedValue(undefined),
-};
-
 vi.mock("@/WebServer.js", () => ({
   WebServer: vi.fn().mockImplementation(() => mockWebServerInstance),
 }));
@@ -56,10 +51,6 @@ vi.mock("node:child_process", () => ({
   exec: vi.fn().mockImplementation((cmd: string, callback: any) => {
     callback(null, { stdout: "", stderr: "" });
   }),
-}));
-
-vi.mock("@services/MCPServer.js", () => ({
-  MCPServer: vi.fn().mockImplementation(() => mockMCPServerInstance),
 }));
 
 // Mock PathUtils
@@ -170,8 +161,6 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
     // 重置 mock 实例
     mockWebServerInstance.start.mockClear();
     mockWebServerInstance.stop.mockClear();
-    mockMCPServerInstance.start.mockClear();
-    mockMCPServerInstance.stop.mockClear();
 
     // 设置默认 mock 返回值
     mockConfigManager.configExists.mockReturnValue(true);

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -52,38 +52,10 @@ export default defineConfig({
   resolve: {
     alias: {
       // Backend 路径别名（从 packages/cli 向上到项目根目录）
-      "@handlers": resolve(__dirname, "../../apps/backend/handlers"),
-      "@handlers/*": resolve(__dirname, "../../apps/backend/handlers/*"),
-      "@services": resolve(__dirname, "../../apps/backend/services"),
-      "@services/*": resolve(__dirname, "../../apps/backend/services/*"),
-      "@errors": resolve(__dirname, "../../apps/backend/errors"),
-      "@errors/*": resolve(__dirname, "../../apps/backend/errors/*"),
-      "@utils": resolve(__dirname, "../../apps/backend/utils"),
-      "@utils/*": resolve(__dirname, "../../apps/backend/utils/*"),
-      "@core": resolve(__dirname, "../../apps/backend/core"),
-      "@core/*": resolve(__dirname, "../../apps/backend/core/*"),
-      "@transports": resolve(
-        __dirname,
-        "../../apps/backend/lib/mcp/transports"
-      ),
-      "@transports/*": resolve(
-        __dirname,
-        "../../apps/backend/lib/mcp/transports/*"
-      ),
-      "@adapters": resolve(__dirname, "../../apps/backend/adapters"),
-      "@adapters/*": resolve(__dirname, "../../apps/backend/adapters/*"),
-      "@managers": resolve(__dirname, "../../apps/backend/managers"),
-      "@managers/*": resolve(__dirname, "../../apps/backend/managers/*"),
-      "@types": resolve(__dirname, "../../apps/backend/types"),
-      "@types/*": resolve(__dirname, "../../apps/backend/types/*"),
       "@/lib": resolve(__dirname, "../../apps/backend/lib"),
       "@/lib/*": resolve(__dirname, "../../apps/backend/lib/*"),
       "@": resolve(__dirname, "../../apps/backend"),
       "@/*": resolve(__dirname, "../../apps/backend/*"),
-      "@routes": resolve(__dirname, "../../apps/backend/routes"),
-      "@routes/*": resolve(__dirname, "../../apps/backend/routes/*"),
-      "@constants": resolve(__dirname, "../../apps/backend/constants"),
-      "@constants/*": resolve(__dirname, "../../apps/backend/constants/*"),
     },
   },
 });


### PR DESCRIPTION
移除了 11 个在代码中完全未使用的路径别名配置，简化配置并消除维护负担。

变更内容：
- vitest.config.ts: 移除 @handlers/*, @services/*, @errors/*, @utils/*, @core/*, @transports/*, @adapters/*, @managers/*, @types/*, @routes/*, @constants/* 别名
- service-commands.integration.test.ts: 移除无效的 vi.mock() 调用
- ServiceManager.test.ts: 移除无效的 vi.mock("@services/MCPServer.js") 和未使用的 mockMCPServerInstance 引用

这些别名仅在测试文件的 vi.mock() 中使用，但源代码使用的是相对导入或 @/lib/* 别名，
导致这些 mocks 完全无效。测试通过 DI 容器的 get() 方法注入 mocks，而非模块拦截。

保留的别名与实际代码使用保持一致：@/lib, @/lib/*, @, @/*

验证：
- 15 个测试文件通过 (491 个测试)
- 类型检查通过
- 未引入新的测试失败

Fixes #1194

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>