### PR TITLE
fix: 将 packages/mcp-core/tsconfig.json 的 composite 设置为 true

### DIFF
--- a/packages/mcp-core/tsconfig.json
+++ b/packages/mcp-core/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "composite": false,
+    "composite": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,


### PR DESCRIPTION
修复 mcp-core 包的 TypeScript 项目引用配置，与其他独立包（如 shared-types）保持一致。composite: true 是 TypeScript 项目引用功能的必要条件。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>