### PR TITLE
fix: 修复 WebServer.stop 资源泄漏问题

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -876,7 +876,8 @@ export class WebServer {
 
         try {
           if (this.mcpServiceManager) {
-            await this.mcpServiceManager.stopAllServices();
+            // 使用 cleanup 方法确保完整清理所有资源，包括事件监听器和重试定时器
+            await this.mcpServiceManager.cleanup();
             this.mcpServiceManager = null;
             this.logger.debug("MCPServiceManager 已清理");
           }

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1846,6 +1846,9 @@ export class MCPServiceManager extends EventEmitter {
       "mcp:service:connection:failed",
       this.eventListeners.serviceConnectionFailed
     );
+
+    // 清理所有重试定时器，防止定时器泄漏
+    this.stopAllServiceRetries();
   }
 }
 


### PR DESCRIPTION
- WebServer.stop 现在调用 cleanup() 而非 stopAllServices()，确保事件监听器被正确移除
- MCPServiceManager.cleanup() 新增 stopAllServiceRetries() 调用，清理重试定时器和失败服务集合

修复问题 #1200

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>