### PR TITLE
refactor: 提取公共的 ensureConfigExists 方法消除重复代码

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -104,6 +104,23 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   }
 
   /**
+   * 检查配置文件是否存在，如果不存在则显示提示并返回 false
+   */
+  private ensureConfigExists(spinner: ReturnType<typeof ora>): boolean {
+    const configManager = this.getService<any>("configManager");
+
+    if (!configManager.configExists()) {
+      spinner.fail("配置文件不存在");
+      console.log(
+        chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
+      );
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
    * 处理获取配置命令
    */
   private async handleGet(key: string): Promise<void> {
@@ -112,11 +129,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     try {
       const configManager = this.getService<any>("configManager");
 
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+      if (!this.ensureConfigExists(spinner)) {
         return;
       }
 
@@ -221,11 +234,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     try {
       const configManager = this.getService<any>("configManager");
 
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+      if (!this.ensureConfigExists(spinner)) {
         return;
       }
 


### PR DESCRIPTION
修复 #1201

将 handleGet 和 handleSet 方法中重复的配置文件存在性检查逻辑
提取为私有方法 ensureConfigExists，遵循 DRY 原则，提高代码可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>