### PR TITLE
fix: 将 formatUtils 中 formatJson 和 formatError 的 any 类型改为 unknown

### DIFF
--- a/apps/frontend/src/utils/formatUtils.ts
+++ b/apps/frontend/src/utils/formatUtils.ts
@@ -53,7 +53,7 @@ export const generateStableKey = (
  * @param data 要格式化的数据
  * @returns 格式化后的JSON字符串
  */
-export const formatJson = (data: any): string | null => {
+export const formatJson = (data: unknown): string | null => {
   if (!data) return null;
   try {
     return JSON.stringify(data, null, 2);
@@ -63,11 +63,11 @@ export const formatJson = (data: any): string | null => {
 };
 
 /**
- * 重新抛出错误的工具函数
+ * 格式化错误对象为字符串
  * @param error 错误对象
  * @returns 错误字符串
  */
-export const formatError = (error: any): string => {
+export const formatError = (error: unknown): string => {
   if (typeof error === "string") return error;
   if (error instanceof Error) return error.message;
   return String(error);


### PR DESCRIPTION
- formatJson: data 参数从 any 改为 unknown
- formatError: error 参数从 any 改为 unknown
- 更新 formatError 的 JSDoc 注释使其更准确

使用 unknown 类型强制在使用前进行类型检查，符合 TypeScript 最佳实践，
提高了类型安全性。

修复 #1207

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>