### PR TITLE
fix: 将 timeout.ts 类型守卫函数的参数类型从 any 改为 unknown

### DIFF
--- a/apps/backend/types/timeout.ts
+++ b/apps/backend/types/timeout.ts
@@ -108,13 +108,23 @@ function getDefaultTimeoutMessage(taskId: string): string {
 /**
  * 验证是否为超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
+export function isTimeoutResponse(
+  response: unknown
+): response is TimeoutResponse {
   return !!(
     response &&
+    typeof response === "object" &&
+    response !== null &&
+    "status" in response &&
     response.status === "timeout" &&
+    "taskId" in response &&
     typeof response.taskId === "string" &&
+    "content" in response &&
     Array.isArray(response.content) &&
     response.content.length > 0 &&
+    typeof response.content[0] === "object" &&
+    response.content[0] !== null &&
+    "type" in response.content[0] &&
     response.content[0].type === "text"
   );
 }
@@ -122,10 +132,10 @@ export function isTimeoutResponse(response: any): response is TimeoutResponse {
 /**
  * 验证是否为超时错误
  */
-export function isTimeoutError(error: any): error is TimeoutError {
+export function isTimeoutError(error: unknown): error is TimeoutError {
   return !!(
     error &&
-    error.name === "TimeoutError" &&
-    error instanceof TimeoutError
+    error instanceof TimeoutError &&
+    error.name === "TimeoutError"
   );
 }


### PR DESCRIPTION
- isTimeoutResponse 函数使用 unknown 并添加完整的类型收窄检查
- isTimeoutError 函数使用 unknown 并优化检查顺序
- 提升类型安全性，符合 TypeScript 最佳实践

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>