### PR TITLE
fix: 配置 Git 认证以修复 GitHub Actions 中的 git push 失败问题

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -81,6 +81,14 @@ jobs:
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
 
+      - name: 配置 Git 认证
+        env:
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+        run: |
+          # 配置 Git 使用 token 认证
+          git config --global credential.helper store
+          echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
+
       - name: 解析版本号参数
         id: parse-version
         run: |


### PR DESCRIPTION
## 问题

在 `.github/workflows/npm-publish.yml` 中，虽然设置了 `GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}`，但执行 `pnpm release --version $TARGET_VERSION` 时，`git push` 操作仍然失败。

## 根本原因

Git push 操作不会自动使用 `GITHUB_TOKEN` 环境变量。Git 需要通过 credential helper 或在 remote URL 中嵌入 token 来获取认证。

## 解决方案

在"配置 Git 用户"步骤之后添加了新步骤来配置 Git 认证：
- 配置 `credential.helper store`
- 将 `x-access-token` 写入 `~/.git-credentials` 文件

## 测试计划

- [ ] 使用 `dry_run=true` 模式测试工作流
- [ ] 验证 git push 操作成功执行
- [ ] 确认没有认证错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)