### PR TITLE
fix: 移除 mcp-errors.ts 中不合适的 shebang

### DIFF
--- a/apps/backend/errors/mcp-errors.ts
+++ b/apps/backend/errors/mcp-errors.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * MCP服务错误类型定义
  *


### PR DESCRIPTION
该文件是一个库文件，用于导出 MCP 错误类型定义，不是可执行入口点。
Shebang 应该只用于真正的可执行脚本。

修复 #1229

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>