### PR TITLE
refactor: 提取共享的 MCP 服务常量和工具格式化函数

### DIFF
--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -26,6 +26,8 @@ import type {
   MCPServerConfig,
   WorkflowParameter,
 } from "@xiaozhi-client/shared-types";
+import { formatToolInfo } from "@/utils/toolFormatter";
+import type { FormattedToolInfo } from "@/utils/toolFormatter";
 import { CoffeeIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -36,20 +38,8 @@ import { RemoveMcpServerButton } from "./remove-mcp-server-button";
 import { RestartButton } from "./restart-button";
 import { ToolDebugDialog } from "./tool-debug-dialog";
 
-// 服务名称常量
-const UNKNOWN_SERVICE_NAME = "未知服务";
-const CUSTOM_SERVICE_NAME = "自定义服务";
-
 // 工具类型别名
-type ToolWithServerInfo = {
-  name: string;
-  serverName: string;
-  toolName: string;
-  enable: boolean;
-  description?: string;
-  usageCount?: number;
-  lastUsedTime?: string;
-  inputSchema?: JSONSchema;
+type ToolWithServerInfo = FormattedToolInfo & {
   handler?: {
     type: string;
     platform: string;
@@ -81,45 +71,8 @@ export function McpServerList({
 
   // 格式化工具信息的辅助函数
   const formatTool = useCallback(
-    (tool: CustomMCPToolWithStats, enable: boolean) => {
-      const { serviceName, toolName } = (() => {
-        // 安全检查：确保 handler 存在
-        if (!tool || !tool.handler) {
-          return {
-            serviceName: UNKNOWN_SERVICE_NAME,
-            toolName: tool?.name || UNKNOWN_SERVICE_NAME,
-          };
-        }
-
-        if (tool.handler.type === "mcp") {
-          return {
-            serviceName:
-              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
-            toolName: tool.handler.config?.toolName || tool.name,
-          };
-        }
-        if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
-          return {
-            serviceName: "customMCP",
-            toolName: tool.name,
-          };
-        }
-        return {
-          serviceName: CUSTOM_SERVICE_NAME,
-          toolName: tool.name,
-        };
-      })();
-
-      return {
-        serverName: serviceName,
-        toolName,
-        enable,
-        name: tool.name,
-        description: tool.description,
-        usageCount: tool.usageCount,
-        lastUsedTime: tool.lastUsedTime,
-        inputSchema: tool.inputSchema,
-      };
+    (tool: CustomMCPToolWithStats, enable: boolean): ToolWithServerInfo => {
+      return formatToolInfo(tool, enable);
     },
     []
   );

--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -29,6 +29,8 @@ import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
 import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import { formatToolInfo } from "@/utils/toolFormatter";
+import type { FormattedToolInfo } from "@/utils/toolFormatter";
 import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -36,16 +38,11 @@ import { ToolPagination } from "./tool-pagination";
 import { ToolSearchInput } from "./tool-search-input";
 import { ToolSortSelector } from "./tool-sort-selector";
 
-// 服务名称常量
-const UNKNOWN_SERVICE_NAME = "未知服务";
-const CUSTOM_SERVICE_NAME = "自定义服务";
-
-export interface ToolRowData {
-  name: string;
-  serverName: string;
-  toolName: string;
-  description: string;
-  enabled: boolean;
+export interface ToolRowData
+  extends Pick<
+    FormattedToolInfo,
+    "name" | "serverName" | "toolName" | "description" | "enabled"
+  > {
   usageCount: number;
   lastUsedTime: string;
   inputSchema: any;
@@ -116,42 +113,16 @@ export function McpToolTable({
   // 格式化工具信息的辅助函数
   const formatTool = useCallback(
     (tool: CustomMCPToolWithStats, enabled: boolean): ToolRowData => {
-      const { serviceName, toolName } = (() => {
-        if (!tool || !tool.handler) {
-          return {
-            serviceName: UNKNOWN_SERVICE_NAME,
-            toolName: tool?.name || UNKNOWN_SERVICE_NAME,
-          };
-        }
-
-        if (tool.handler.type === "mcp") {
-          return {
-            serviceName:
-              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
-            toolName: tool.handler.config?.toolName || tool.name,
-          };
-        }
-        if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
-          return {
-            serviceName: "customMCP",
-            toolName: tool.name,
-          };
-        }
-        return {
-          serviceName: CUSTOM_SERVICE_NAME,
-          toolName: tool.name,
-        };
-      })();
-
+      const formatted = formatToolInfo(tool, enabled);
       return {
-        name: tool.name,
-        serverName: serviceName,
-        toolName,
-        description: tool.description || "",
+        name: formatted.name,
+        serverName: formatted.serverName,
+        toolName: formatted.toolName,
+        description: formatted.description || "",
         enabled,
-        usageCount: tool.usageCount || 0,
-        lastUsedTime: tool.lastUsedTime || "",
-        inputSchema: tool.inputSchema,
+        usageCount: formatted.usageCount || 0,
+        lastUsedTime: formatted.lastUsedTime || "",
+        inputSchema: formatted.inputSchema,
       };
     },
     []

--- a/apps/frontend/src/constants/mcp.ts
+++ b/apps/frontend/src/constants/mcp.ts
@@ -1,0 +1,13 @@
+/**
+ * MCP 服务相关常量
+ */
+
+/**
+ * MCP 服务名称常量
+ */
+export const MCP_SERVICE_NAMES = {
+  /** 未知服务名称 */
+  UNKNOWN: "未知服务",
+  /** 自定义服务名称 */
+  CUSTOM: "自定义服务",
+} as const;

--- a/apps/frontend/src/utils/toolFormatter.ts
+++ b/apps/frontend/src/utils/toolFormatter.ts
@@ -1,0 +1,91 @@
+import { MCP_SERVICE_NAMES } from "@/constants/mcp";
+import type { CustomMCPToolWithStats, JSONSchema } from "@xiaozhi-client/shared-types";
+
+/**
+ * 格式化后的工具信息
+ */
+export interface FormattedToolInfo {
+  /** 工具名称（内部标识符） */
+  name: string;
+  /** 服务名称 */
+  serverName: string;
+  /** 工具显示名称 */
+  toolName: string;
+  /** 工具描述 */
+  description?: string;
+  /** 使用次数 */
+  usageCount?: number;
+  /** 最后使用时间 */
+  lastUsedTime?: string;
+  /** 输入模式 */
+  inputSchema?: JSONSchema;
+  /** 是否启用（已弃用，使用 enabled） */
+  enable?: boolean;
+  /** 是否启用 */
+  enabled?: boolean;
+}
+
+/**
+ * 从工具对象中提取服务名称和工具名称
+ * @param tool - 工具对象
+ * @returns 服务名称和工具名称
+ */
+function extractServiceAndToolName(
+  tool: CustomMCPToolWithStats
+): { serviceName: string; toolName: string } {
+  // 安全检查：确保 handler 存在
+  if (!tool || !tool.handler) {
+    return {
+      serviceName: MCP_SERVICE_NAMES.UNKNOWN,
+      toolName: tool?.name || MCP_SERVICE_NAMES.UNKNOWN,
+    };
+  }
+
+  // MCP 类型工具
+  if (tool.handler.type === "mcp") {
+    return {
+      serviceName:
+        tool.handler.config?.serviceName || MCP_SERVICE_NAMES.UNKNOWN,
+      toolName: tool.handler.config?.toolName || tool.name,
+    };
+  }
+
+  // Coze 代理类型工具
+  if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
+    return {
+      serviceName: "customMCP",
+      toolName: tool.name,
+    };
+  }
+
+  // 默认自定义服务
+  return {
+    serviceName: MCP_SERVICE_NAMES.CUSTOM,
+    toolName: tool.name,
+  };
+}
+
+/**
+ * 格式化工具信息
+ * @param tool - 原始工具对象
+ * @param enabled - 是否启用
+ * @returns 格式化后的工具信息
+ */
+export function formatToolInfo(
+  tool: CustomMCPToolWithStats,
+  enabled: boolean
+): FormattedToolInfo {
+  const { serviceName, toolName } = extractServiceAndToolName(tool);
+
+  return {
+    name: tool.name,
+    serverName: serviceName,
+    toolName,
+    enable: enabled,
+    enabled,
+    description: tool.description,
+    usageCount: tool.usageCount,
+    lastUsedTime: tool.lastUsedTime,
+    inputSchema: tool.inputSchema,
+  };
+}


### PR DESCRIPTION
修复 #1235

将 mcp-server-list.tsx 和 mcp-tool-table.tsx 中重复的代码提取为共享模块：

- 新增 src/constants/mcp.ts：定义 MCP_SERVICE_NAMES 常量
- 新增 src/utils/toolFormatter.ts：提供 formatToolInfo 函数和 FormattedToolInfo 类型
- 更新两个组件使用共享的常量和函数

此改动遵循 DRY 原则，提高代码可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>