### PR TITLE
fix(release): 确保 nx-release-publish 在发布前执行构建

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -33,7 +33,7 @@
       "cache": false
     },
     "nx-release-publish": {
-      "dependsOn": ["^nx-release-publish"],
+      "dependsOn": ["^nx-release-publish", "build"],
       "inputs": ["default", "^production"]
     }
   },


### PR DESCRIPTION
## 问题描述

用户安装 `xiaozhi-client@1.10.8-beta.7` 后运行 `xiaozhi -v` 报错：
```
Error [ERR_MODULE_NOT_FOUND]: Cannot find module
.../xiaozhi-client/node_modules/@xiaozhi-client/config/dist/index.js
```

## 根本原因

1.10.8-beta.7 的 npm 包缺少构建产物（dist/index.js 等文件）。
这是因为迁移到 Nx Release 发布流程后，`nx-release-publish` 目标没有依赖 `build` 目标。

## 解决方案

在 `nx.json` 的 `targetDefaults.nx-release-publish.dependsOn` 中添加 `"build"` 依赖，确保发布前先执行构建。

## 变更内容

- `nx.json`: 为 `nx-release-publish` 添加 `build` 依赖

## 测试计划

- [ ] 本地运行 `pnpm release:dry --version 1.10.8-beta.8` 预演发布流程
- [ ] 确认构建产物包含在 npm 包中

🤖 Generated with [Claude Code](https://claude.com/claude-code)