### PR TITLE
refactor: 移除 endpoint 和 mcp-core 中重复的 JSONSchema 类型定义

### DIFF
--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "ws": "^8.14.2",
     "@xiaozhi-client/mcp-core": "workspace:*",
-    "@xiaozhi-client/config": "workspace:*"
+    "@xiaozhi-client/config": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.24.0"

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -2,6 +2,9 @@
 // 1. 工具调用相关类型
 // =========================
 
+import type { JSONSchema } from "@xiaozhi-client/shared-types/mcp";
+import { ensureToolJSONSchema as ensureToolJSONSchemaUtil } from "@xiaozhi-client/shared-types/mcp";
+
 /**
  * 工具调用结果接口
  * 使用更宽松的类型定义以兼容不同来源的 ToolCallResult
@@ -64,51 +67,9 @@ export class ToolCallError extends Error {
 // 2. JSON Schema 类型
 // =========================
 
-/**
- * JSON Schema 类型定义
- * 兼容 MCP SDK 的 JSON Schema 格式
- */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>;
-
-/**
- * 确保对象符合 MCP Tool JSON Schema 格式
- * 返回类型兼容 MCP SDK 的 Tool 类型
- */
-export function ensureToolJSONSchema(schema: JSONSchema): {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  if (
-    typeof schema === "object" &&
-    schema !== null &&
-    "type" in schema &&
-    schema.type === "object"
-  ) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
-  }
-
-  // 如果不符合标准格式，返回默认的空对象 schema
-  return {
-    type: "object",
-    properties: {},
-    required: [],
-    additionalProperties: true,
-  };
-}
+// 重新导出 JSONSchema 类型和 ensureToolJSONSchema 工具函数
+export { JSONSchema };
+export const ensureToolJSONSchema = ensureToolJSONSchemaUtil;
 
 // =========================
 // 3. 工具信息类型

--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -9,5 +9,8 @@
     "declarationMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../shared-types" }
+  ]
 }

--- a/packages/endpoint/tsup.config.ts
+++ b/packages/endpoint/tsup.config.ts
@@ -35,6 +35,7 @@ export default defineConfig({
     // 工作区依赖
     "@xiaozhi-client/config",
     "@xiaozhi-client/mcp-core",
+    "@xiaozhi-client/shared-types",
   ],
   outExtension() {
     return { js: ".js" };

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -27,7 +27,8 @@
   },
   "dependencies": {
     "eventsource": "^4.0.0",
-    "ws": "^8.14.2"
+    "ws": "^8.14.2",
+    "@xiaozhi-client/shared-types": "workspace:*"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.24.0"

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -7,6 +7,11 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { JSONSchema } from "@xiaozhi-client/shared-types/mcp";
+import {
+  isValidToolJSONSchema,
+  ensureToolJSONSchema as ensureToolJSONSchemaUtil,
+} from "@xiaozhi-client/shared-types/mcp";
 
 // =========================
 // 1. 基础传输类型
@@ -182,58 +187,21 @@ export type { CompatibilityCallToolResult as ToolCallResult } from "@modelcontex
 
 /**
  * JSON Schema 类型定义
+ * 从 shared-types 包重新导出
  */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>;
+export type { JSONSchema };
 
 /**
  * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
+ * 从 shared-types 包重新导出
  */
-export function isValidToolJSONSchema(obj: unknown): obj is {
-  type: "object";
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "type" in obj &&
-    (obj as { type?: unknown }).type === "object"
-  );
-}
+export { isValidToolJSONSchema };
 
 /**
  * 确保对象符合 MCP Tool JSON Schema 格式
+ * 从 shared-types 包重新导出
  */
-export function ensureToolJSONSchema(schema: JSONSchema): {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  if (isValidToolJSONSchema(schema)) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
-  }
-
-  return {
-    type: "object",
-    properties: {} as Record<string, object>,
-    required: [],
-    additionalProperties: true,
-  };
-}
+export const ensureToolJSONSchema = ensureToolJSONSchemaUtil;
 
 /**
  * CustomMCP 工具类型定义

--- a/packages/mcp-core/tsconfig.json
+++ b/packages/mcp-core/tsconfig.json
@@ -12,7 +12,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
-    "composite": false,
+    "composite": true,
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
@@ -25,5 +25,8 @@
     "forceConsistentCasingInFileNames": true
   },
   "include": ["src/**/*"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts"],
+  "references": [
+    { "path": "../shared-types" }
+  ]
 }

--- a/packages/mcp-core/tsup.config.ts
+++ b/packages/mcp-core/tsup.config.ts
@@ -41,6 +41,8 @@ export default defineConfig({
     "node:net",
     // 外部依赖（peer dependencies）
     "@modelcontextprotocol/sdk",
+    // 工作区依赖
+    "@xiaozhi-client/shared-types",
   ],
   outExtension() {
     return { js: ".js" };

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -11,24 +11,24 @@
       "import": "./dist/index.js"
     },
     "./mcp": {
-      "types": "./dist/mcp/index.d.ts",
-      "import": "./dist/mcp/index.js"
+      "types": "./dist/mcp.d.ts",
+      "import": "./dist/mcp.js"
     },
     "./coze": {
-      "types": "./dist/coze/index.d.ts",
-      "import": "./dist/coze/index.js"
+      "types": "./dist/coze.d.ts",
+      "import": "./dist/coze.js"
     },
     "./api": {
-      "types": "./dist/api/index.d.ts",
-      "import": "./dist/api/index.js"
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.js"
     },
     "./config": {
-      "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js"
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js"
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.js"
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js"
     }
   },
   "files": [

--- a/packages/shared-types/src/mcp/index.ts
+++ b/packages/shared-types/src/mcp/index.ts
@@ -60,6 +60,6 @@ export type {
 } from "./tool-definition";
 
 // JSON Schema 类型
-export type { JSONSchema } from "./schema";
+export type { JSONSchema, StrictJSONSchema } from "./schema";
 
-export { isJSONSchema } from "./schema";
+export { isJSONSchema, isValidToolJSONSchema, ensureToolJSONSchema } from "./schema";

--- a/packages/shared-types/src/mcp/schema.ts
+++ b/packages/shared-types/src/mcp/schema.ts
@@ -4,15 +4,30 @@
  */
 
 /**
- * JSON Schema 类型
- * 带类型守卫的严格 JSON Schema 类型定义
+ * JSON Schema 类型定义
+ * 兼容 MCP SDK 的 JSON Schema 格式
+ * 这是一个宽松的类型定义，允许任何 JSON Schema 格式
  */
-export interface JSONSchema {
+export type JSONSchema =
+  | (Record<string, unknown> & {
+      type: "object";
+      properties?: Record<string, unknown>;
+      required?: string[];
+      additionalProperties?: boolean;
+    })
+  | Record<string, unknown>;
+
+/**
+ * 严格的 JSON Schema 接口
+ * 带类型守卫的严格 JSON Schema 类型定义
+ * @deprecated 使用 JSONSchema 类型代替，此接口保留用于向后兼容
+ */
+export interface StrictJSONSchema {
   type?: string | string[];
-  properties?: Record<string, JSONSchema>;
+  properties?: Record<string, StrictJSONSchema>;
   required?: string[];
-  items?: JSONSchema;
-  additionalProperties?: boolean | JSONSchema;
+  items?: StrictJSONSchema;
+  additionalProperties?: boolean | StrictJSONSchema;
   description?: string;
   enum?: unknown[];
   const?: unknown;
@@ -21,11 +36,57 @@ export interface JSONSchema {
 
 /**
  * 检查值是否为有效的 JSON Schema
+ * @deprecated 此函数向后兼容，建议使用 isValidToolJSONSchema
  */
-export function isJSONSchema(value: unknown): value is JSONSchema {
+export function isJSONSchema(value: unknown): value is StrictJSONSchema {
   if (typeof value !== "object" || value === null) {
     return false;
   }
   // 基本的结构检查
   return true;
+}
+
+/**
+ * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
+ */
+export function isValidToolJSONSchema(obj: unknown): obj is {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+} {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    (obj as { type?: unknown }).type === "object"
+  );
+}
+
+/**
+ * 确保对象符合 MCP Tool JSON Schema 格式
+ * 返回类型兼容 MCP SDK 的 Tool 类型
+ */
+export function ensureToolJSONSchema(schema: JSONSchema): {
+  type: "object";
+  properties?: Record<string, object>;
+  required?: string[];
+  additionalProperties?: boolean;
+} {
+  if (isValidToolJSONSchema(schema)) {
+    return schema as {
+      type: "object";
+      properties?: Record<string, object>;
+      required?: string[];
+      additionalProperties?: boolean;
+    };
+  }
+
+  // 如果不符合标准格式，返回默认的空对象 schema
+  return {
+    type: "object",
+    properties: {},
+    required: [],
+    additionalProperties: true,
+  };
 }

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     utils: "src/utils/index.ts",
   },
   format: ["esm"],
-  outDir: "../../dist/shared-types",
+  outDir: "./dist",
   dts: {
     compilerOptions: {
       composite: false

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -573,6 +573,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../mcp-core
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       ws:
         specifier: ^8.14.2
         version: 8.19.0
@@ -601,6 +604,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: '>=1.26.0'
         version: 1.26.0(zod@4.3.6)
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       eventsource:
         specifier: ^4.0.0
         version: 4.1.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -36,6 +36,7 @@
     { "path": "./packages/shared-types" },
     { "path": "./packages/cli" },
     { "path": "./packages/endpoint" },
+    { "path": "./packages/mcp-core" },
     { "path": "./packages/version" },
     { "path": "./mcps/calculator-mcp" },
     { "path": "./mcps/datetime-mcp" }


### PR DESCRIPTION
将 JSONSchema 类型定义及相关函数迁移到 shared-types 包，
遵循 DRY 原则，避免代码重复。

主要更改：
- 在 shared-types/src/mcp/schema.ts 中添加统一的 JSONSchema 类型定义
- 添加 isValidToolJSONSchema 和 ensureToolJSONSchema 工具函数
- 更新 endpoint 和 mcp-core 包从 shared-types 导入 JSONSchema
- 修复 shared-types 的构建配置和 package.json exports
- 添加必要的依赖和 TypeScript project references

修复 Issue #1242

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>