### PR TITLE
docs: 为 utils.ts 添加文件级 JSDoc 模块文档

### DIFF
--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -4,8 +4,6 @@
  * 提供 MCP 服务配置和工具调用的工具函数：
  * - 传输类型推断（基于 URL 或配置）
  * - 工具调用参数验证
- *
- * @module utils
  */
 
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";


### PR DESCRIPTION
根据项目文档规范，为 apps/backend/lib/mcp/utils.ts 添加文件级
JSDoc 模块文档注释，与 cache.ts 和 message.ts 的文档风格保持一致。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>