### PR TITLE
fix: 升级 calculator-mcp 和 datetime-mcp 包中的 tsup 版本至 ^8.3.5

### DIFF
--- a/mcps/calculator-mcp/package.json
+++ b/mcps/calculator-mcp/package.json
@@ -32,7 +32,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.0",
-    "tsup": "^8.0.0",
+    "tsup": "^8.3.5",
     "typescript": "^5.3.0"
   }
 }

--- a/mcps/datetime-mcp/package.json
+++ b/mcps/datetime-mcp/package.json
@@ -31,7 +31,7 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^1.5.0",
-    "tsup": "^8.0.0",
+    "tsup": "^8.3.5",
     "typescript": "^5.3.0"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -487,7 +487,7 @@ importers:
         specifier: ^1.5.0
         version: 1.9.4
       tsup:
-        specifier: ^8.0.0
+        specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.0
@@ -506,7 +506,7 @@ importers:
         specifier: ^1.5.0
         version: 1.9.4
       tsup:
-        specifier: ^8.0.0
+        specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.3.0


### PR DESCRIPTION
- 将 calculator-mcp/package.json 中的 tsup 从 ^8.0.0 升级到 ^8.3.5
- 将 datetime-mcp/package.json 中的 tsup 从 ^8.0.0 升级到 ^8.3.5
- 保持与项目中其他包的 tsup 版本一致

Fixes #1247

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>