### PR TITLE
fix: 在 Endpoint.reconnect() 中添加缺失的 await

### DIFF
--- a/packages/endpoint/src/endpoint.ts
+++ b/packages/endpoint/src/endpoint.ts
@@ -376,8 +376,8 @@ export class Endpoint {
   public async reconnect(): Promise<void> {
     console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
-    // 先断开连接
-    this.disconnect();
+    // 先断开连接（等待完全断开）
+    await this.disconnect();
 
     // 等待可配置的时间确保连接完全断开
     await new Promise((resolve) => setTimeout(resolve, this.reconnectDelay));


### PR DESCRIPTION
修复 reconnect() 方法调用 disconnect() 时缺少 await 导致的竞态条件。

- 在 this.disconnect() 前添加 await 关键字
- 确保 MCP 适配器清理完成后再开始重连
- 防止资源泄漏和状态不一致

修复 #1250

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>