### PR TITLE
fix: 在 shouldCleanupCache 中使用 DEFAULT_CONFIG.CLEANUP_INTERVAL 常量

### DIFF
--- a/apps/backend/types/mcp.ts
+++ b/apps/backend/types/mcp.ts
@@ -239,7 +239,7 @@ export function shouldCleanupCache(cache: EnhancedToolResultCache): boolean {
   const cachedTime = new Date(cache.timestamp).getTime();
 
   // 已消费且超过清理时间（1分钟）
-  if (cache.consumed && now - cachedTime > 60000) {
+  if (cache.consumed && now - cachedTime > DEFAULT_CONFIG.CLEANUP_INTERVAL) {
     return true;
   }
 


### PR DESCRIPTION
修复 #1251 - 将硬编码的 60000ms 替换为已定义的常量，遵循 DRY 原则

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>