### PR TITLE
fix(npm): 添加 spawn 进程 error 事件监听器

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -54,6 +54,23 @@ export class NPMManager {
     ]);
 
     return new Promise((resolve, reject) => {
+      // 监听进程启动失败事件
+      npmProcess.on("error", (error) => {
+        const errorMessage = `进程启动失败: ${error.message}`;
+        console.log(errorMessage, { error });
+
+        // 发射安装失败事件
+        this.eventBus.emitEvent("npm:install:failed", {
+          version,
+          installId,
+          error: errorMessage,
+          duration: Date.now() - startTime,
+          timestamp: Date.now(),
+        });
+
+        reject(error);
+      });
+
       npmProcess.stdout.on("data", (data) => {
         const message = data.toString();
 


### PR DESCRIPTION
修复 NPMManager.installVersion 方法中 spawn 进程未监听 error 事件的问题。

当进程启动失败（如 npm 命令不存在、权限不足等）时，现在会：
- 正确触发 error 事件监听器
- 发射 npm:install:failed 事件
- 记录错误日志
- 拒绝 Promise 而非永久挂起

修复问题 #1252

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>