### PR TITLE
fix: 更新 axios 依赖至 >=1.13.5 以修复 CVE-2026-25639

### DIFF
--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
       "form-data": "^4.0.4",
       "braces": ">=3.0.3",
       "micromatch": ">=4.0.8",
-      "axios": ">=1.12.0",
+      "axios": ">=1.13.5",
       "@conventional-changelog/git-client": ">=2.0.0",
       "hono@>=1.1.0 <4.10.3": ">=4.10.3",
       "js-yaml@<4.1.1": ">=4.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   form-data: ^4.0.4
   braces: '>=3.0.3'
   micromatch: '>=4.0.8'
-  axios: '>=1.12.0'
+  axios: '>=1.13.5'
   '@conventional-changelog/git-client': '>=2.0.0'
   hono@>=1.1.0 <4.10.3: '>=4.10.3'
   js-yaml@<4.1.1: '>=4.1.1'
@@ -27,7 +27,7 @@ importers:
     dependencies:
       '@coze/api':
         specifier: ^1.3.9
-        version: 1.3.9(axios@1.13.4)
+        version: 1.3.9(axios@1.13.5)
       '@hono/node-server':
         specifier: ^1.17.1
         version: 1.19.9(hono@4.11.7)
@@ -175,7 +175,7 @@ importers:
     dependencies:
       '@coze/api':
         specifier: ^1.3.9
-        version: 1.3.9(axios@1.13.4)
+        version: 1.3.9(axios@1.13.5)
       '@hono/node-server':
         specifier: ^1.17.1
         version: 1.19.9(hono@4.11.7)
@@ -1311,7 +1311,7 @@ packages:
   '@coze/api@1.3.9':
     resolution: {integrity: sha512-wDotCNH66yqEOQP1oDM7ujm9LKCg2ONfriODBSC4trjdrQfuUIaq21riuYnsKWgjKALz1jSNpjbQqJ5psOXFYQ==}
     peerDependencies:
-      axios: '>=1.12.0'
+      axios: '>=1.13.5'
 
   '@cspell/cspell-bundled-dicts@9.6.2':
     resolution: {integrity: sha512-s5u/3nhQUftKibPIbRLLAf4M5JG1NykqkPCxS0STMmri0hzVMZbAOCyHjdLoOCqPUn0xZzLA8fgeYg3b7QuHpg==}
@@ -3819,8 +3819,8 @@ packages:
     peerDependencies:
       postcss: ^8.1.0
 
-  axios@1.13.4:
-    resolution: {integrity: sha512-1wVkUaAO6WyaYtCkcYCOx12ZgpGf9Zif+qXa4n+oYzK558YryKqiL6UWwd5DqiH3VRW0GYhTZQ/vlgJrCoNQlg==}
+  axios@1.13.5:
+    resolution: {integrity: sha512-cz4ur7Vb0xS4/KUN0tPWe44eqxrIu31me+fbang3ijiNscE129POzipJJA6zniq2C/Z6sJCjMimjS8Lc/GAs8Q==}
 
   babel-plugin-const-enum@1.2.0:
     resolution: {integrity: sha512-o1m/6iyyFnp9MRsK1dHF3bneqyf3AlM2q3A/YbgQr2pCat6B6XJVDv2TXqzfY2RYUi4mak6WAksSBPlyYGx9dg==}
@@ -7408,7 +7408,7 @@ snapshots:
       '@agora-js/report': 4.23.2-1
       '@agora-js/shared': 4.23.2-1
       agora-rte-extension: 1.2.4
-      axios: 1.13.4
+      axios: 1.13.5
       webrtc-adapter: 8.2.0
     transitivePeerDependencies:
       - debug
@@ -7416,13 +7416,13 @@ snapshots:
   '@agora-js/report@4.23.2-1':
     dependencies:
       '@agora-js/shared': 4.23.2-1
-      axios: 1.13.4
+      axios: 1.13.5
     transitivePeerDependencies:
       - debug
 
   '@agora-js/shared@4.23.2-1':
     dependencies:
-      axios: 1.13.4
+      axios: 1.13.5
       ua-parser-js: 0.7.41
     transitivePeerDependencies:
       - debug
@@ -8226,12 +8226,12 @@ snapshots:
   '@colors/colors@1.5.0':
     optional: true
 
-  '@coze/api@1.3.9(axios@1.13.4)':
+  '@coze/api@1.3.9(axios@1.13.5)':
     dependencies:
       agora-extension-ai-denoiser: 1.1.0(agora-rtc-sdk-ng@4.23.2-1)
       agora-rtc-sdk-ng: 4.23.2-1
       agora-rte-extension: 1.2.4
-      axios: 1.13.4
+      axios: 1.13.5
       jsonwebtoken: 9.0.3
       node-fetch: 2.7.0
       opus-encdec: 0.1.1
@@ -10547,7 +10547,7 @@ snapshots:
       '@agora-js/report': 4.23.2-1
       '@agora-js/shared': 4.23.2-1
       agora-rte-extension: 1.2.4
-      axios: 1.13.4
+      axios: 1.13.5
       formdata-polyfill: 4.0.10
       pako: 2.1.0
       ua-parser-js: 0.7.41
@@ -10636,7 +10636,7 @@ snapshots:
       postcss: 8.5.6
       postcss-value-parser: 4.2.0
 
-  axios@1.13.4:
+  axios@1.13.5:
     dependencies:
       follow-redirects: 1.15.11
       form-data: 4.0.5
@@ -13203,7 +13203,7 @@ snapshots:
       '@yarnpkg/lockfile': 1.1.0
       '@yarnpkg/parsers': 3.0.2
       '@zkochan/js-yaml': 0.0.7
-      axios: 1.13.4
+      axios: 1.13.5
       chalk: 4.1.2
       cli-cursor: 3.1.0
       cli-spinners: 2.6.1


### PR DESCRIPTION
通过 pnpm override 强制使用 axios >= 1.13.5，修复拒绝服务漏洞 (GHSA-43fc-jf86-j433)。

- 更新 package.json 中的 axios override 从 >=1.12.0 到 >=1.13.5
- 修复 CVE-2026-25639 安全漏洞

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>