### PR TITLE
fix: 修复 websocket-compat.ts 中废弃函数的 any 类型问题

### DIFF
--- a/apps/frontend/src/stores/websocket-compat.ts
+++ b/apps/frontend/src/stores/websocket-compat.ts
@@ -83,10 +83,37 @@ export function useWebSocketConnected(): boolean {
 }
 
 /**
+ * 重启状态接口
+ */
+interface RestartStatus {
+  status: "restarting" | "completed" | "failed";
+  error?: string;
+  timestamp: number;
+}
+
+/**
+ * 端口变更状态接口
+ */
+interface PortChangeStatus {
+  status:
+    | "idle"
+    | "checking"
+    | "polling"
+    | "connecting"
+    | "completed"
+    | "failed";
+  targetPort?: number;
+  currentAttempt?: number;
+  maxAttempts?: number;
+  error?: string;
+  timestamp: number;
+}
+
+/**
  * 向后兼容的重启状态选择器
  * @deprecated 请使用 useRestartStatus() from "./status"
  */
-export function useWebSocketRestartStatus(): any {
+export function useWebSocketRestartStatus(): RestartStatus | null {
   console.warn(
     '[useWebSocketRestartStatus] 此选择器已废弃，请使用 useRestartStatus() from "./status"'
   );
@@ -108,7 +135,7 @@ export function useWebSocketWsUrl(): string {
  * 向后兼容的端口切换状态选择器
  * @deprecated 请使用 usePortChangeStatus() from "./websocket"
  */
-export function useWebSocketPortChangeStatus(): any {
+export function useWebSocketPortChangeStatus(): PortChangeStatus | undefined {
   console.warn(
     '[useWebSocketPortChangeStatus] 此选择器已废弃，请使用 usePortChangeStatus() from "./websocket"'
   );


### PR DESCRIPTION
- useWebSocketRestartStatus 返回类型从 any 改为 RestartStatus | null
- useWebSocketPortChangeStatus 返回类型从 any 改为 PortChangeStatus | undefined
- 添加本地类型定义以保持兼容性层独立性

关闭 #1264

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>