### PR TITLE
fix(status): 将 status.service.ts 中的英文注释翻译为中文

### DIFF
--- a/apps/backend/services/status.service.ts
+++ b/apps/backend/services/status.service.ts
@@ -63,7 +63,7 @@ export class StatusService {
         this.clientInfo.lastHeartbeat = Date.now();
       }
 
-      // Reset heartbeat timeout when receiving client status
+      // 接收到客户端状态时重置心跳超时
       if (info.status === "connected") {
         this.resetHeartbeatTimeout();
       }
@@ -163,12 +163,12 @@ export class StatusService {
    * 重置心跳超时
    */
   private resetHeartbeatTimeout(): void {
-    // Clear existing timeout
+    // 清除现有的超时定时器
     if (this.heartbeatTimeout) {
       clearTimeout(this.heartbeatTimeout);
     }
 
-    // Set new timeout
+    // 设置新的超时定时器
     this.heartbeatTimeout = setTimeout(() => {
       this.logger.debug("客户端心跳超时，标记为断开连接");
       this.updateClientInfo({ status: "disconnected" }, "heartbeat-timeout");


### PR DESCRIPTION
修复了 apps/backend/services/status.service.ts 文件中违反本地化规范的英文注释：

- 第 66 行：将 "Reset heartbeat timeout when receiving client status" 翻译为中文
- 第 166 行：将 "Clear existing timeout" 翻译为中文
- 第 171 行：将 "Set new timeout" 翻译为中文

符合 CLAUDE.md 中关于代码注释必须使用中文的要求。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>