### PR TITLE
fix: 修复 install-log-dialog useEffect 缺少依赖数组导致的性能问题

### DIFF
--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -66,6 +66,7 @@ export function InstallLogDialog({
   }, [isOpen, version, startInstall, clearStatus]);
 
   // 自动滚动到最新日志
+  // biome-ignore lint/correctness/useExhaustiveDependencies: 需要在日志变化时触发滚动
   useEffect(() => {
     const timer = setTimeout(() => {
       if (logContainerRef.current) {
@@ -74,7 +75,7 @@ export function InstallLogDialog({
       }
     }, 100);
     return () => clearTimeout(timer);
-  });
+  }, [installStatus.logs]);
 
   // 计算进度条进度
   const getProgressValue = () => {


### PR DESCRIPTION
为 useEffect 添加 installStatus.logs 依赖数组，避免每次渲染都创建新定时器。
添加 Biome 抑制注释，因为该依赖在 effect body 中未直接引用但实际需要。

Fixes #1269

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>