### PR TITLE
fix: 移除 apps/backend/lib/mcp/manager.ts 中不必要的 shebang

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1,5 +1,3 @@
-#!/usr/bin/env node
-
 /**
  * MCP 服务管理器
  * 使用 MCPService 实例管理多个 MCP 服务


### PR DESCRIPTION
该文件是核心 MCP 服务管理器类（MCPServiceManager），不是可执行入口点。
项目的可执行入口点配置在 package.json 中为 dist/cli/index.js。

移除 shebang 可以:
- 避免误导性：shebang 暗示文件可以直接执行，但实际上不能
- 保持一致性：与项目中其他非入口点库文件的惯例一致
- 改善维护性：防止维护者误以为该文件是独立的可执行脚本

Fixes #1270

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>