### PR TITLE
perf: 使用 structuredClone 替代 JSON.parse(JSON.stringify()) 进行深拷贝

### DIFF
--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -494,8 +494,9 @@ export class ConfigManager {
   public getConfig(): Readonly<AppConfig> {
     this.config = this.loadConfig();
 
-    // 返回深度只读副本
-    return JSON.parse(JSON.stringify(this.config));
+    // 使用 structuredClone API 进行深拷贝（性能优于 JSON.parse(JSON.stringify())）
+    // structuredClone 是原生 API，支持更多类型（如 Date、RegExp、Map、Set 等）
+    return structuredClone(this.config) as Readonly<AppConfig>;
   }
 
   /**


### PR DESCRIPTION
修复 packages/config/src/manager.ts 中 getConfig() 方法的性能问题。

### 变更内容
- 将 `JSON.parse(JSON.stringify(this.config))` 替换为 `structuredClone(this.config)`

### 性能优势
- structuredClone 是原生 API，性能优于 JSON 序列化/反序列化
- 支持更多类型（如 Date、RegExp、Map、Set 等）
- 无需外部依赖

### 兼容性
- 项目要求 Node.js 18+，structuredClone 在此版本可用

### 相关问题
- 修复 #1272

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>