### PR TITLE
fix: 修复 routes/domains 目录下路径别名一致性问题

### DIFF
--- a/apps/backend/routes/domains/config.route.ts
+++ b/apps/backend/routes/domains/config.route.ts
@@ -1,5 +1,5 @@
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("configApiHandler");
 

--- a/apps/backend/routes/domains/coze.route.ts
+++ b/apps/backend/routes/domains/coze.route.ts
@@ -3,8 +3,8 @@
  * 处理所有扣子相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("cozeHandler");
 

--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,9 +4,9 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import type { RouteDefinition } from "@/routes/types.js";
+import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import type { AppContext } from "../../types/hono.context.js";
-import type { RouteDefinition } from "../types.js";
 
 /**
  * 端点处理器方法名类型

--- a/apps/backend/routes/domains/mcp.route.ts
+++ b/apps/backend/routes/domains/mcp.route.ts
@@ -3,8 +3,8 @@
  * 处理 MCP 协议相关的 API 路由（仅 POST 模式）
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("mcpRouteHandler");
 

--- a/apps/backend/routes/domains/mcpserver.route.ts
+++ b/apps/backend/routes/domains/mcpserver.route.ts
@@ -3,8 +3,8 @@
  * 处理 MCP 服务器管理相关的 API 路由
  */
 
+import type { HandlerDependencies, RouteDefinition } from "@/routes/types.js";
 import type { Context } from "hono";
-import type { HandlerDependencies, RouteDefinition } from "../types.js";
 
 /**
  * MCP 服务器处理器包装函数

--- a/apps/backend/routes/domains/misc.route.ts
+++ b/apps/backend/routes/domains/misc.route.ts
@@ -3,8 +3,8 @@
  * 处理不特定于某个模块的通用 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("serviceApiHandler");
 

--- a/apps/backend/routes/domains/services.route.ts
+++ b/apps/backend/routes/domains/services.route.ts
@@ -3,8 +3,8 @@
  * 处理所有服务管理相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("serviceApiHandler");
 

--- a/apps/backend/routes/domains/static.route.ts
+++ b/apps/backend/routes/domains/static.route.ts
@@ -3,8 +3,8 @@
  * 处理静态文件服务相关的路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("staticFileHandler");
 

--- a/apps/backend/routes/domains/status.route.ts
+++ b/apps/backend/routes/domains/status.route.ts
@@ -3,8 +3,8 @@
  * 处理所有状态相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("statusApiHandler");
 

--- a/apps/backend/routes/domains/tool-logs.route.ts
+++ b/apps/backend/routes/domains/tool-logs.route.ts
@@ -3,8 +3,8 @@
  * 处理工具调用日志相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("mcpToolLogHandler");
 

--- a/apps/backend/routes/domains/tools.route.ts
+++ b/apps/backend/routes/domains/tools.route.ts
@@ -3,8 +3,8 @@
  * 处理所有工具相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("mcpToolHandler");
 

--- a/apps/backend/routes/domains/update.route.ts
+++ b/apps/backend/routes/domains/update.route.ts
@@ -3,8 +3,8 @@
  * 处理更新相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("updateApiHandler");
 

--- a/apps/backend/routes/domains/version.route.ts
+++ b/apps/backend/routes/domains/version.route.ts
@@ -3,8 +3,8 @@
  * 处理所有版本相关的 API 路由
  */
 
-import type { RouteDefinition } from "../types.js";
-import { createHandler } from "../types.js";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler } from "@/routes/types.js";
 
 const h = createHandler("versionApiHandler");
 


### PR DESCRIPTION
将 apps/backend/routes/domains/ 目录下 13 个文件中的相对路径导入
替换为路径别名 @/routes/types.js 和 @/types/hono.context.js，
以保持与项目路径别名系统的一致性。

修改的文件:
- config.route.ts
- coze.route.ts
- endpoint.route.ts (同时修复了 hono.context.js 的导入)
- mcp.route.ts
- mcpserver.route.ts
- misc.route.ts
- services.route.ts
- static.route.ts
- status.route.ts
- tool-logs.route.ts
- tools.route.ts
- update.route.ts
- version.route.ts

Closes #1274

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>