### PR TITLE
fix: 在 shared-types 的 tsup.config.ts 中添加 target: "node18"

### DIFF
--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -10,6 +10,7 @@ export default defineConfig({
     utils: "src/utils/index.ts",
   },
   format: ["esm"],
+  target: "node18",
   outDir: "../../dist/shared-types",
   dts: {
     compilerOptions: {


### PR DESCRIPTION
修复问题 #1282

此更改确保 shared-types 包与其他所有包使用一致的构建目标：
- apps/backend
- packages/cli
- packages/config
- packages/endpoint
- packages/mcp-core
- packages/version
- mcps/calculator-mcp
- mcps/datetime-mcp

这样可以：
1. 确保语法兼容性：避免生成 Node.js 18 不支持的现代语法
2. 保持构建输出一致性：所有包使用相同的转译目标
3. 防止潜在的运行时错误

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>