### PR TITLE
fix(deps): 为 packages/cli 和 packages/config 添加缺失的 tsup 依赖

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -30,6 +30,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
+    "tsup": "^8.5.0",
     "typescript": "^5.9.2"
   }
 }

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -31,6 +31,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
+    "tsup": "^8.5.0",
     "typescript": "^5.9.2",
     "vitest": "^3.0.5"
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.9
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3
@@ -555,6 +558,9 @@ importers:
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.9
+      tsup:
+        specifier: ^8.5.0
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
       typescript:
         specifier: ^5.9.2
         version: 5.9.3


### PR DESCRIPTION
修复 Issue #1286

虽然由于 pnpm workspace 的依赖提升机制，这两个包可以访问根目录的 tsup 依赖，但这违反了依赖管理的最佳实践。

此修复确保：
- 依赖关系明确，可以从 package.json 中看出实际依赖
- 提高可移植性，单独发布或独立使用这些包时构建不会失败
- 避免版本不一致风险

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>