### PR TITLE
perf: 缓存 tools.map 结果避免重复映射操作

### DIFF
--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -361,18 +361,19 @@ export class MCPHandler {
       // 6. 获取服务状态和工具列表
       const serviceStatus = this.getServiceStatus(name);
       const tools = this.getServiceTools(name);
+      const toolNames = tools.map((tool) => tool.name);
 
       // 7. 发送事件通知
       getEventBus().emitEvent("mcp:server:added", {
         serverName: name,
         config: normalizedConfig,
-        tools: tools.map((tool) => tool.name),
+        tools: toolNames,
         timestamp: new Date(),
       });
 
       return {
         ...serviceStatus,
-        tools: tools.map((tool) => tool.name),
+        tools: toolNames,
       };
     } catch (error) {
       const mcpError = this.handleError(error, "addMCPServerSingle", {


### PR DESCRIPTION
修复 apps/backend/handlers/mcp-manage.handler.ts 中的性能问题，
将 tools.map((tool) => tool.name) 的结果缓存到 toolNames 变量中，
避免在事件发送和返回结果时执行两次相同的映射操作。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>