### PR TITLE
fix: 修复 MCPManager.connect() 中 Promise.allSettled 导致错误处理无效的问题

### DIFF
--- a/packages/mcp-core/src/manager.ts
+++ b/packages/mcp-core/src/manager.ts
@@ -105,7 +105,9 @@ export class MCPManager extends EventEmitter {
 
   /**
    * 连接所有已添加的 MCP 服务
-   * 所有服务并行连接，单个服务失败不会影响其他服务
+   * 所有服务并行连接，任何一个服务连接失败都会抛出异常
+   *
+   * @throws 当任何一个服务连接失败时抛出异常
    *
    * @example
    * ```typescript
@@ -148,7 +150,7 @@ export class MCPManager extends EventEmitter {
       }
     );
 
-    await Promise.allSettled(promises);
+    await Promise.all(promises);
   }
 
   /**


### PR DESCRIPTION
- 将 Promise.allSettled 改为 Promise.all，使连接失败时能正确抛出异常
- 更新 JSDoc 注释，说明任何一个服务连接失败都会抛出异常

修复前，Promise.allSettled 会将错误包装成 {status: 'rejected', reason} 对象，
导致 try-catch 块中的 throw error 无效，调用方无法捕获连接失败。

修复后，当任何一个 MCP 服务连接失败时，connect() 方法会正确抛出异常，
调用方可以通过 try-catch 捕获并处理连接失败。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>