### PR TITLE
fix: 使用统一的 Logger 系统替代 console.warn

### DIFF
--- a/apps/backend/middlewares/endpointManager.middleware.ts
+++ b/apps/backend/middlewares/endpointManager.middleware.ts
@@ -3,6 +3,7 @@
  * 负责将 endpointManager 注入到请求上下文中
  */
 
+import { logger } from "@/Logger.js";
 import type { MiddlewareHandler } from "hono";
 import type { AppContext } from "../types/hono.context.js";
 
@@ -30,7 +31,9 @@ export const endpointManagerMiddleware = (): MiddlewareHandler<AppContext> => {
     } catch (error) {
       // 记录错误但不阻断请求
       if (error instanceof Error && error.message.includes("未初始化")) {
-        console.warn("小智连接管理器未初始化，使用 null 值:", error.message);
+        logger.warn("小智连接管理器未初始化，使用 null 值", {
+          message: error.message,
+        });
         c.set("endpointManager", null);
       } else {
         throw error;


### PR DESCRIPTION
修复 apps/backend/middlewares/endpointManager.middleware.ts 中使用 console.warn 进行错误日志记录的问题，改用项目统一的 Logger 系统（基于 pino 的 @/Logger.js），确保日志格式一致、上下文信息完整、生产环境可收集。

- 导入 logger from @/Logger.js
- 将 console.warn 替换为 logger.warn，使用对象格式传递参数
- 符合项目代码规范一致性要求

Fixes #1297

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>