### PR TITLE
docs: 为 config.route.ts 添加文件级 JSDoc 注释

### DIFF
--- a/apps/backend/routes/domains/config.route.ts
+++ b/apps/backend/routes/domains/config.route.ts
@@ -1,3 +1,8 @@
+/**
+ * 配置管理路由配置
+ * 处理所有配置管理相关的 API 路由
+ */
+
 import type { RouteDefinition } from "@/routes/types.js";
 import { createHandler } from "@/routes/types.js";
 


### PR DESCRIPTION
修复 #1300

- 添加与其他路由文件一致的文件级 JSDoc 模块文档
- 保持与同目录下其他 13 个路由文件的文档风格一致

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>