### PR TITLE
fix: 统一 service.handler.ts 中的路径别名导入

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -6,8 +6,8 @@ import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
+import { requireMCPServiceManager } from "@/types/hono.context.js";
 import type { Context } from "hono";
-import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
  * 服务 API 处理器


### PR DESCRIPTION
将相对路径导入改为路径别名，确保从同一模块的导入使用一致的路径别名方式。
- 将 "../types/hono.context.js" 改为 "@/types/hono.context.js"
- 同时按 Biome 规则重新排序导入语句

修复 Issue #1305

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>