### PR TITLE
refactor: 修复 mcp-manage.handler.ts 中的封装违规问题

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1088,6 +1088,40 @@ export class MCPServiceManager extends EventEmitter {
   }
 
   /**
+   * 获取服务状态信息
+   * @param serverName 服务名称
+   * @returns 服务状态对象，包含连接状态和工具列表，如果服务不存在则返回 undefined
+   */
+  public getServiceState(serverName: string): {
+    isConnected: boolean;
+    tools: Tool[];
+  } | undefined {
+    const service = this.services.get(serverName);
+    if (!service) {
+      return undefined;
+    }
+
+    return {
+      isConnected: service.isConnected(),
+      tools: service.getTools(),
+    };
+  }
+
+  /**
+   * 获取服务的工具列表
+   * @param serverName 服务名称
+   * @returns 工具列表，如果服务不存在或未连接则返回空数组
+   */
+  public getServiceTools(serverName: string): Tool[] {
+    const service = this.services.get(serverName);
+    if (!service || !service.isConnected()) {
+      return [];
+    }
+
+    return service.getTools();
+  }
+
+  /**
    * 获取所有已连接的服务名称
    */
   getConnectedServices(): string[] {


### PR DESCRIPTION
在 MCPServiceManager 中添加公共方法以替代类型断言访问私有属性：

- 在 MCPServiceManager 中添加 getServiceState() 和 getServiceTools() 公共方法
- 更新 mcp-manage.handler.ts 使用新的公共方法而非 as unknown as 类型断言
- 删除不再需要的 MCPServiceManagerAccess 接口定义
- 修复 addMCPServerSingle 方法中重复的 toolNames 变量声明
- 更新相关测试用例以使用新的公共方法

这修复了 Issue #1328 中描述的违反封装原则的问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>