### PR TITLE
fix: 为 version-manager.tsx 中的函数添加 useCallback 以优化性能

### DIFF
--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -75,7 +75,7 @@ export function VersionManager() {
   }, []);
 
   // 检查更新
-  const checkForUpdates = async () => {
+  const checkForUpdates = useCallback(async () => {
     if (!currentVersion) return;
 
     try {
@@ -108,17 +108,17 @@ export function VersionManager() {
     } finally {
       setIsLoading(false);
     }
-  };
+  }, [currentVersion]);
 
   // 开始更新
-  const startUpdate = (version: string) => {
+  const startUpdate = useCallback((version: string) => {
     console.log("[VersionManager] 开始更新到版本:", version);
     setTargetVersion(version);
     setShowInstallDialog(true);
-  };
+  }, []);
 
   // 处理安装对话框关闭
-  const handleInstallDialogClose = () => {
+  const handleInstallDialogClose = useCallback(() => {
     setShowInstallDialog(false);
     setTargetVersion("");
     // 清理之前的定时器
@@ -130,7 +130,7 @@ export function VersionManager() {
       loadCurrentVersion();
       reloadTimerRef.current = null;
     }, 1000);
-  };
+  }, [loadCurrentVersion]);
 
   // 组件初始化时加载版本信息
   useEffect(() => {


### PR DESCRIPTION
- 使用 useCallback 包装 checkForUpdates 函数，依赖 currentVersion
- 使用 useCallback 包装 startUpdate 函数
- 使用 useCallback 包装 handleInstallDialogClose 函数，依赖 loadCurrentVersion

这可以避免每次组件重渲染时创建新的函数引用，减少不必要的子组件重渲染。

修复 Issue #1329

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>