### PR TITLE
fix: 将 toolsApi.ts 中的 any 类型替换为具体类型提升类型安全性

### DIFF
--- a/apps/frontend/src/services/toolsApi.ts
+++ b/apps/frontend/src/services/toolsApi.ts
@@ -5,6 +5,7 @@
 
 import type {
   CozeWorkflow,
+  JSONSchema,
   WorkflowParameterConfig,
 } from "@xiaozhi-client/shared-types";
 import { apiClient } from "./api";
@@ -25,8 +26,8 @@ export interface AddToolRequest {
 export interface AddToolResponse {
   name: string;
   description: string;
-  inputSchema: any;
-  handler: any;
+  inputSchema: JSONSchema;
+  handler: Record<string, unknown>;
 }
 
 /**
@@ -35,7 +36,7 @@ export interface AddToolResponse {
 export interface ApiError {
   code: string;
   message: string;
-  details?: any;
+  details?: unknown;
 }
 
 /**
@@ -101,7 +102,7 @@ export class ToolsApiService {
   /**
    * 获取自定义工具列表
    */
-  async getCustomTools(): Promise<any[]> {
+  async getCustomTools(): Promise<AddToolResponse[]> {
     try {
       const tools = await this.executeWithRetry(async () => {
         return await apiClient.getCustomTools();


### PR DESCRIPTION
- 将 AddToolResponse.inputSchema 的类型从 any 替换为 JSONSchema
- 将 AddToolResponse.handler 的类型从 any 替换为 Record<string, unknown>
- 将 ApiError.details 的类型从 any 替换为 unknown
- 将 getCustomTools() 的返回类型从 Promise<any[]> 替换为 Promise<AddToolResponse[]>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>