### PR TITLE
fix: 将 mcp-endpoint-setting-button.tsx 中 WebSocket 事件处理函数的 any 类型替换为 EndpointStatusChangedEvent

### DIFF
--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -23,7 +23,10 @@ import {
 } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
 import { type EndpointStatusResponse, apiClient } from "@/services/api";
-import { webSocketManager } from "@/services/websocket";
+import {
+  type EndpointStatusChangedEvent,
+  webSocketManager,
+} from "@/services/websocket";
 import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
 import {
   BadgeInfoIcon,
@@ -386,7 +389,7 @@ export function McpEndpointSettingButton() {
     const unsubscribers = mcpEndpoints.map((endpoint) => {
       const unsubscribe = webSocketManager.subscribe(
         "data:endpointStatusChanged",
-        (event: any) => {
+        (event: EndpointStatusChangedEvent) => {
           // 只处理当前端点的事件
           if (event.endpoint === endpoint) {
             console.log(


### PR DESCRIPTION
修复 #1340

- 添加 EndpointStatusChangedEvent 类型导入
- 将 (event: any) 替换为 (event: EndpointStatusChangedEvent)
- 提升类型安全性，使 TypeScript 能够在编译时检测事件数据结构的错误

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>