### PR TITLE
fix: 移除 mcp-manage.handler.ts 中重复的 toolNames 声明

### DIFF
--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -364,7 +364,6 @@ export class MCPHandler {
       const toolNames = tools.map((tool) => tool.name);
 
       // 7. 发送事件通知
-      const toolNames = tools.map((tool) => tool.name);
       getEventBus().emitEvent("mcp:server:added", {
         serverName: name,
         config: normalizedConfig,


### PR DESCRIPTION
## 概要
- 修复 Biome linter 报告的 `noRedeclare` 错误
- 移除 `mcp-manage.handler.ts:367` 中重复的 `toolNames` 变量声明

## 问题
在 `apps/backend/handlers/mcp-manage.handler.ts` 文件中，`toolNames` 变量在同一作用域内被声明了两次：
- 第 364 行：`const toolNames = tools.map((tool) => tool.name);`
- 第 367 行：`const toolNames = tools.map((tool) => tool.name);`（重复）

## 修复方案
删除第 367 行的重复声明，保留第 364 行的声明。

## 测试计划
- [x] `pnpm lint:fix` 通过
- [x] 所有项目 lint 检查通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)