### PR TITLE
refactor: 提取可复用的日期验证 Schema 消除重复代码

### DIFF
--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -7,6 +7,7 @@ import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
 import type { ToolCallQuery } from "@/lib/mcp/log.js";
 import { ToolCallLogService } from "@/lib/mcp/log.js";
 import type { AppContext } from "@/types/hono.context.js";
+import { createDateSchema } from "@/utils/index.js";
 import type { Context } from "hono";
 import { z } from "zod";
 import { BaseHandler } from "./base.handler.js";
@@ -41,32 +42,8 @@ const ToolCallQuerySchema = z
       .string()
       .optional()
       .transform((val) => (val ? val.toLowerCase() === "true" : undefined)),
-    startDate: z
-      .string()
-      .optional()
-      .refine(
-        (val) => {
-          if (!val) return true;
-          const date = Date.parse(val);
-          return !Number.isNaN(date);
-        },
-        {
-          message: "startDate 参数格式无效",
-        }
-      ),
-    endDate: z
-      .string()
-      .optional()
-      .refine(
-        (val) => {
-          if (!val) return true;
-          const date = Date.parse(val);
-          return !Number.isNaN(date);
-        },
-        {
-          message: "endDate 参数格式无效",
-        }
-      ),
+    startDate: createDateSchema("startDate"),
+    endDate: createDateSchema("endDate"),
   })
   .refine(
     (data) => {

--- a/apps/backend/utils/index.ts
+++ b/apps/backend/utils/index.ts
@@ -9,3 +9,5 @@ export { VersionUtils } from "@xiaozhi-client/version";
 // WebSocket 辅助工具
 export { sendWebSocketError } from "./websocket-helper.js";
 export type { WebSocketLike } from "./websocket-helper.js";
+// Zod Schema 工具函数
+export { createDateSchema } from "./schema-utils.js";

--- a/apps/backend/utils/schema-utils.ts
+++ b/apps/backend/utils/schema-utils.ts
@@ -1,0 +1,34 @@
+/**
+ * Zod Schema 相关工具函数
+ * 提供可复用的 Zod 验证 Schema，避免重复代码
+ */
+
+import { z } from "zod";
+
+/**
+ * 创建日期字符串验证 Schema
+ * @param fieldName - 字段名称（用于错误消息）
+ * @returns Zod Schema 用于验证可选的日期字符串
+ *
+ * @example
+ * ```ts
+ * const MySchema = z.object({
+ *   startDate: createDateSchema("startDate"),
+ *   endDate: createDateSchema("endDate"),
+ * });
+ * ```
+ */
+export const createDateSchema = (fieldName: string) =>
+  z
+    .string()
+    .optional()
+    .refine(
+      (val) => {
+        if (!val) return true;
+        const date = Date.parse(val);
+        return !Number.isNaN(date);
+      },
+      {
+        message: `${fieldName} 参数格式无效`,
+      }
+    );


### PR DESCRIPTION
提取 createDateSchema 工具函数到 schema-utils.ts，统一日期验证逻辑，避免在多处重复相同的验证代码。

- 新增 apps/backend/utils/schema-utils.ts 提供 createDateSchema 函数
- 更新 mcp-tool-log.handler.ts 使用新的可复用 Schema
- 在 utils/index.ts 中导出新的工具函数

Fixes #1368

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>