### PR TITLE
fix: 使用 process.once() 替代 process.on() 修复 MaxListenersExceededWarning

### DIFF
--- a/apps/backend/WebServerLauncher.ts
+++ b/apps/backend/WebServerLauncher.ts
@@ -43,8 +43,8 @@ async function main() {
       process.exit(0);
     };
 
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
   } catch (error) {
     console.error("WebServer 启动失败:", error);
     process.exit(1);

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -154,7 +154,7 @@ export class DaemonManagerImpl implements IDaemonManager {
       const tail = spawn(command, args, { stdio: "inherit" });
 
       // 处理中断信号
-      process.on("SIGINT", () => {
+      process.once("SIGINT", () => {
         console.log("\n断开连接，服务继续在后台运行");
         tail.kill();
         process.exit(0);

--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -278,8 +278,8 @@ export class ServiceManagerImpl implements IServiceManager {
         process.exit(0);
       };
 
-      process.on("SIGINT", cleanup);
-      process.on("SIGTERM", cleanup);
+      process.once("SIGINT", cleanup);
+      process.once("SIGTERM", cleanup);
 
       await server.start();
     }
@@ -338,8 +338,8 @@ export class ServiceManagerImpl implements IServiceManager {
       process.exit(0);
     };
 
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
 
     // 保存 PID 信息
     this.processManager.savePidInfo(process.pid, "foreground");


### PR DESCRIPTION
将 process 信号监听器从 on() 改为 once()，避免监听器重复注册导致的内存泄漏警告。

修改文件：
- apps/backend/WebServerLauncher.ts:46-47 (2处)
- packages/cli/src/services/ServiceManager.ts:281-282, 341-342 (4处)
- packages/cli/src/services/DaemonManager.ts:157 (1处)

相关 Issue: #1370

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>