### PR TITLE
fix: 为 endpoint 包添加 TypeScript 项目引用配置

### DIFF
--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -9,5 +9,9 @@
     "declarationMap": true
   },
   "include": ["src/**/*.ts"],
-  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"]
+  "exclude": ["node_modules", "dist", "**/*.test.ts", "**/*.spec.ts"],
+  "references": [
+    { "path": "../mcp-core" },
+    { "path": "../config" }
+  ]
 }


### PR DESCRIPTION
在 packages/endpoint/tsconfig.json 中添加 references 配置，
引用 mcp-core 和 config 包，以启用正确的编译顺序和优化的增量编译。

修复 #1374

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>