### PR TITLE
fix: 为 getCurrentVersion 方法添加 JSON.parse 错误处理

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -135,11 +135,24 @@ export class NPMManager {
    * 获取当前版本
    */
   async getCurrentVersion(): Promise<string> {
-    const { stdout } = await execAsync(
-      "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
-    );
-    const info = JSON.parse(stdout);
-    return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+    try {
+      const { stdout } = await execAsync(
+        "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
+      );
+
+      try {
+        const info = JSON.parse(stdout);
+        return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+      } catch (parseError) {
+        // JSON 解析失败，返回 unknown
+        logger.warn("npm list 返回无效的 JSON 格式", { stdout });
+        return "unknown";
+      }
+    } catch (execError) {
+      // npm 命令执行失败，返回 unknown
+      logger.error("获取当前版本失败", { error: execError });
+      return "unknown";
+    }
   }
 
   /**


### PR DESCRIPTION
- 添加嵌套 try-catch 处理 execAsync 和 JSON.parse 可能的异常
- 当 npm 命令返回非 JSON 格式时，记录警告并返回 'unknown'
- 当 npm 命令执行失败时，记录错误并返回 'unknown'
- 参考 getAvailableVersions 方法的错误处理模式

修复 #1376

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>