### PR TITLE
fix: 修复 ProjectCommandHandler 中 spinner 和 templateManager 参数的 any 类型

### DIFF
--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -5,7 +5,9 @@
 import path from "node:path";
 import chalk from "chalk";
 import ora from "ora";
+import type { Ora } from "ora";
 import type { CommandOption } from "../interfaces/Command";
+import type { TemplateManager } from "../interfaces/Service";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
   CommandArguments,
@@ -102,8 +104,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     projectName: string,
     templateName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: Ora,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = "检查模板...";
 
@@ -176,8 +178,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
   private async createBasicProject(
     projectName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: Ora,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = `创建基本项目 "${projectName}"...`;
 


### PR DESCRIPTION
- 添加 Ora 类型导入
- 添加 TemplateManager 接口导入
- 将 createFromTemplate 方法的参数类型从 any 改为具体类型
- 将 createBasicProject 方法的参数类型从 any 改为具体类型

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>