### PR TITLE
fix: 移除 coze-workflow-integration.tsx 中的 console 日志调用

### DIFF
--- a/apps/frontend/src/components/coze-workflow-integration.tsx
+++ b/apps/frontend/src/components/coze-workflow-integration.tsx
@@ -113,7 +113,6 @@ export function CozeWorkflowIntegration({
       !hasAutoSelected
     ) {
       const firstWorkspace = workspaces[0];
-      console.log(`自动选择第一个工作空间: ${firstWorkspace.name}`);
       selectWorkspace(firstWorkspace.id);
       setHasAutoSelected(true);
     }
@@ -225,8 +224,6 @@ export function CozeWorkflowIntegration({
       // 刷新工作流列表以确保状态同步
       await refreshWorkflows();
     } catch (error) {
-      console.error("添加工作流失败:", error);
-
       // 根据错误类型显示不同的错误信息
       let errorMessage = "添加工作流失败，请重试";
 
@@ -334,8 +331,6 @@ export function CozeWorkflowIntegration({
       // 刷新工作流列表以确保状态同步
       await refreshWorkflows();
     } catch (error) {
-      console.error("添加工作流失败:", error);
-
       // 根据错误类型显示不同的错误信息
       let errorMessage = "添加工作流失败，请重试";
 


### PR DESCRIPTION
- 移除第 116 行的 console.log 调试日志
- 移除第 228 行和第 337 行的 console.error（与 toast.error 冗余）
- 遵循项目代码规范一致性原则

Fixes #1384

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>