### PR TITLE
fix: 将 WebSocket store 中的 send 方法参数类型从 any 改为 unknown

### DIFF
--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -85,7 +85,7 @@ interface WebSocketActions {
   connect: () => Promise<void>;
   disconnect: () => void;
   reconnect: () => Promise<void>;
-  send: (message: any) => boolean;
+  send: (message: unknown) => boolean;
 
   // URL 管理
   updateUrl: (url: string) => void;
@@ -224,7 +224,7 @@ export const useWebSocketStore = create<WebSocketStore>()(
         }
       },
 
-      send: (message: any): boolean => {
+      send: (message: unknown): boolean => {
         try {
           return webSocketManager.send(message);
         } catch (error) {


### PR DESCRIPTION
- 修复 WebSocketActions.send 接口定义中的 any 类型
- 修复 send 方法实现中的 any 类型
- 与 WebSocketManager.send() 的类型定义保持一致

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>