### PR TITLE
fix: 修复 service.handler.ts 中的 setTimeout 资源泄漏问题

### DIFF
--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -596,7 +596,7 @@ describe("ServiceApiHandler", () => {
       await handler.restartService(mockContext);
 
       // Fast-forward the initial timeout
-      vi.advanceTimersByTime(500);
+      await vi.advanceTimersByTimeAsync(500);
 
       // Should still attempt to execute restart
       expect(mockMcpServiceManager.getStatus).toHaveBeenCalled();


### PR DESCRIPTION
- 使用 Promise 链替代嵌套 setTimeout，消除定时器泄漏风险
- 添加 executeRestartWithDelay 方法，代码更清晰易维护
- 统一错误处理，改进代码结构
- 修复测试用例使用异步计时器推进

Fixes #1388

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>