### PR TITLE
refactor: 删除 cache.constants.ts 中重复的 PAGINATION_LIMITS 常量

### DIFF
--- a/apps/backend/constants/__tests__/constants.test.ts
+++ b/apps/backend/constants/__tests__/constants.test.ts
@@ -30,7 +30,6 @@ import {
   MCP_TIMEOUTS,
   MESSAGE_SIZE_LIMITS,
   PAGINATION_CONSTANTS,
-  PAGINATION_LIMITS,
   RETRY_CONFIG,
   RETRY_DELAYS,
   STATUS_EVENTS,
@@ -279,23 +278,16 @@ describe("缓存相关常量", () => {
     });
   });
 
-  describe("PAGINATION_LIMITS", () => {
+  describe("PAGINATION_CONSTANTS", () => {
     it("应该包含正确的分页限制", () => {
-      expect(PAGINATION_LIMITS.DEFAULT_LIMIT).toBe(50);
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBe(200);
+      expect(PAGINATION_CONSTANTS.DEFAULT_LIMIT).toBe(50);
+      expect(PAGINATION_CONSTANTS.MAX_LIMIT).toBe(200);
     });
 
     it("最大限制应该大于默认限制", () => {
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBeGreaterThan(
-        PAGINATION_LIMITS.DEFAULT_LIMIT
-      );
-    });
-
-    it("应该与 PAGINATION_CONSTANTS 兼容", () => {
-      expect(PAGINATION_LIMITS.DEFAULT_LIMIT).toBe(
+      expect(PAGINATION_CONSTANTS.MAX_LIMIT).toBeGreaterThan(
         PAGINATION_CONSTANTS.DEFAULT_LIMIT
       );
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBe(PAGINATION_CONSTANTS.MAX_LIMIT);
     });
   });
 

--- a/apps/backend/constants/cache.constants.ts
+++ b/apps/backend/constants/cache.constants.ts
@@ -23,16 +23,6 @@ export const MESSAGE_SIZE_LIMITS = {
 } as const;
 
 /**
- * 分页限制常量
- */
-export const PAGINATION_LIMITS = {
-  /** 默认每页记录数 */
-  DEFAULT_LIMIT: 50,
-  /** 最大每页记录数 */
-  MAX_LIMIT: 200,
-} as const;
-
-/**
  * 缓存文件相关常量
  */
 export const CACHE_FILE_CONFIG = {


### PR DESCRIPTION
删除与 api.constants.ts 中 PAGINATION_CONSTANTS 重复定义的
PAGINATION_LIMITS，遵循 DRY 原则。

修改内容：
- 删除 cache.constants.ts 中的 PAGINATION_LIMITS 导出
- 更新测试文件，移除 PAGINATION_LIMITS 相关测试
- 为 PAGINATION_CONSTANTS 添加测试用例

修复 #1390

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>