### PR TITLE
fix: sendHeartbeat 方法使用 send() 复用错误处理逻辑

### DIFF
--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -700,7 +700,8 @@ export class WebSocketManager {
         },
       };
 
-      this.ws?.send(JSON.stringify(heartbeatMessage));
+      // 使用 send 方法而非直接调用 ws.send，以复用错误处理逻辑
+      this.send(heartbeatMessage);
     }
   }
 


### PR DESCRIPTION
将 sendHeartbeat 方法中的直接 ws.send 调用替换为类已有的 send 方法，
以复用现有的错误处理和事件发布机制，避免心跳发送失败时未捕获异常。

修复 #1393

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>