### PR TITLE
docs: 为 apps/backend/types/mcp.ts 添加完整的文件级 JSDoc 注释

### DIFF
--- a/apps/backend/types/mcp.ts
+++ b/apps/backend/types/mcp.ts
@@ -1,5 +1,13 @@
 /**
  * MCP 相关类型定义
+ *
+ * 定义了与 MCP（Model Context Protocol）相关的所有类型，包括：
+ * - 工具调用结果和响应格式
+ * - JSON-RPC 2.0 消息和错误类型
+ * - MCP 工具缓存相关类型和工具函数
+ * - 超时处理和任务状态管理
+ *
+ * @module types/mcp
  */
 
 import { createHash } from "node:crypto";


### PR DESCRIPTION
- 扩展文件级 JSDoc 注释，添加详细的模块说明
- 与其他类型文件（api.response.ts、hono.context.ts）的文档标准保持一致
- 包含 @module 标签以支持自动文档生成

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>