### PR TITLE
perf: 优化 ConfigManager.getConfig() 方法使用缓存避免重复文件 I/O

### DIFF
--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -244,7 +244,8 @@ export class ConfigManager {
   private readonly STATS_UPDATE_TIMEOUT = 5000; // 5秒超时
 
   // 事件回调（用于解耦 EventBus 依赖）
-  private eventCallbacks: Map<string, Array<(data: unknown) => void>> = new Map();
+  private eventCallbacks: Map<string, Array<(data: unknown) => void>> =
+    new Map();
 
   private constructor() {
     // 使用模板目录中的默认配置文件
@@ -492,7 +493,10 @@ export class ConfigManager {
    * 获取配置（只读）
    */
   public getConfig(): Readonly<AppConfig> {
-    this.config = this.loadConfig();
+    // 使用缓存避免重复从文件系统加载配置
+    if (!this.config) {
+      this.config = this.loadConfig();
+    }
 
     // 返回深度只读副本
     return JSON.parse(JSON.stringify(this.config));


### PR DESCRIPTION
修复 issue #1398

修改内容：
- getConfig() 方法现在仅在缓存为空时才从文件系统加载配置
- 这避免了在高频调用场景（如心跳处理、实时通知）中的性能问题
- saveConfig() 和 reloadConfig() 已有完善的缓存失效机制，确保配置更新后能正确反映

性能影响：
- 每次调用 getConfig() 从同步读取文件 + 解析 JSON 变为仅读取内存缓存
- 在配置未变更的情况下，显著减少文件 I/O 和 CPU 开销

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>