### PR TITLE
refactor: 重构 RouteManager.applyRouteDefinition 消除 DRY 违反

### DIFF
--- a/apps/backend/routes/RouteManager.ts
+++ b/apps/backend/routes/RouteManager.ts
@@ -116,51 +116,20 @@ export class RouteManager {
       }
     };
 
-    // 使用 switch-case 避免 Hono 4.11.4 的类型推断问题
-    // 注意：Hono 4.11.4 对展开中间件数组的类型推断更加严格，需要使用类型断言
-    switch (method) {
-      case "GET":
-        if (middleware.length > 0) {
-          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
-          app.get(path, ...middleware, wrappedHandler);
-        } else {
-          app.get(path, wrappedHandler);
-        }
-        break;
-      case "POST":
-        if (middleware.length > 0) {
-          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
-          app.post(path, ...middleware, wrappedHandler);
-        } else {
-          app.post(path, wrappedHandler);
-        }
-        break;
-      case "PUT":
-        if (middleware.length > 0) {
-          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
-          app.put(path, ...middleware, wrappedHandler);
-        } else {
-          app.put(path, wrappedHandler);
-        }
-        break;
-      case "DELETE":
-        if (middleware.length > 0) {
-          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
-          app.delete(path, ...middleware, wrappedHandler);
-        } else {
-          app.delete(path, wrappedHandler);
-        }
-        break;
-      case "PATCH":
-        if (middleware.length > 0) {
-          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
-          app.patch(path, ...middleware, wrappedHandler);
-        } else {
-          app.patch(path, wrappedHandler);
-        }
-        break;
-      default:
-        throw new Error(`不支持的 HTTP 方法: ${method}`);
+    // 使用动态方法调用避免重复代码
+    // 注意：Hono 4.11.4 对展开中间件数组的类型推断更加严格，需要使用 any 类型
+    const methodLower = method.toLowerCase() as Lowercase<typeof method>;
+    const validMethods = new Set(["get", "post", "put", "delete", "patch"]);
+
+    if (!validMethods.has(methodLower)) {
+      throw new Error(`不支持的 HTTP 方法: ${method}`);
+    }
+
+    // 使用 any 类型绕过 Hono 的严格类型检查，因为展开中间件数组时无法正确推断类型
+    if (middleware.length > 0) {
+      (app[methodLower] as any)(path, ...middleware, wrappedHandler);
+    } else {
+      (app[methodLower] as any)(path, wrappedHandler);
     }
   }
 


### PR DESCRIPTION
使用动态方法调用替代 switch-case，将代码从 60+ 行减少到 ~35 行。

修改内容：
- 移除 5 个重复的 HTTP 方法 case 分支
- 使用动态方法调用统一处理中间件逻辑
- 保留原有的类型注释说明

相关 Issue: #1401

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>