### PR TITLE
refactor: 提取重复的端点重连逻辑为私有方法

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -712,6 +712,66 @@ export class WebServer {
   }
 
   /**
+   * 处理端点重连逻辑
+   * @param trigger 触发原因
+   * @param serverName 服务名称（批量添加时为 undefined）
+   * @param logMessage 日志消息
+   * @param successMessage 成功消息
+   */
+  private async handleEndpointReconnect(
+    trigger: "mcp_server_added" | "mcp_server_batch_added",
+    serverName: string | undefined,
+    logMessage: string,
+    successMessage: string
+  ): Promise<void> {
+    this.logger.info(logMessage);
+
+    if (!this.endpointManager) {
+      this.logger.warn("EndpointManager 未初始化，跳过重连");
+      return;
+    }
+
+    // 批量添加时，如果没有成功添加的服务，跳过重连
+    if (trigger === "mcp_server_batch_added" && serverName === undefined) {
+      return;
+    }
+
+    try {
+      const connectionStatuses = this.endpointManager.getConnectionStatus();
+      const connectedEndpointCount = connectionStatuses.filter(
+        (status) => status.connected
+      ).length;
+
+      if (connectedEndpointCount === 0) {
+        this.logger.debug("当前没有已连接的端点，跳过重连");
+        return;
+      }
+
+      this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
+
+      await this.endpointManager.reconnect();
+
+      this.logger.info(successMessage);
+
+      this.eventBus.emitEvent("endpoint:reconnect:completed", {
+        trigger,
+        serverName,
+        endpointCount: connectedEndpointCount,
+        timestamp: Date.now(),
+      });
+    } catch (error) {
+      this.logger.error("接入点重连失败:", error);
+
+      this.eventBus.emitEvent("endpoint:reconnect:failed", {
+        trigger,
+        serverName,
+        error: error instanceof Error ? error.message : String(error),
+        timestamp: Date.now(),
+      });
+    }
+  }
+
+  /**
    * 设置 MCP 服务添加事件监听
    * 当添加新的 MCP 服务后，自动重连接入点以同步服务列表
    */
@@ -720,52 +780,12 @@ export class WebServer {
     this.eventBus.onEvent(
       "mcp:server:added",
       async (eventData: EventBusEvents["mcp:server:added"]) => {
-        this.logger.info(
-          `检测到 MCP 服务添加: ${eventData.serverName}，工具数量: ${eventData.tools.length}`
+        await this.handleEndpointReconnect(
+          "mcp_server_added",
+          eventData.serverName,
+          `检测到 MCP 服务添加: ${eventData.serverName}，工具数量: ${eventData.tools.length}`,
+          "接入点重连成功，新服务工具已同步"
         );
-
-        if (!this.endpointManager) {
-          this.logger.warn("EndpointManager 未初始化，跳过重连");
-          return;
-        }
-
-        try {
-          // 获取当前连接的端点数量
-          const connectionStatuses = this.endpointManager.getConnectionStatus();
-          const connectedEndpointCount = connectionStatuses.filter(
-            (status) => status.connected
-          ).length;
-
-          if (connectedEndpointCount === 0) {
-            this.logger.debug("当前没有已连接的端点，跳过重连");
-            return;
-          }
-
-          this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
-
-          // 重连所有端点
-          await this.endpointManager.reconnect();
-
-          this.logger.info("接入点重连成功，新服务工具已同步");
-
-          // 发送重连完成事件
-          this.eventBus.emitEvent("endpoint:reconnect:completed", {
-            trigger: "mcp_server_added",
-            serverName: eventData.serverName,
-            endpointCount: connectedEndpointCount,
-            timestamp: Date.now(),
-          });
-        } catch (error) {
-          this.logger.error("接入点重连失败:", error);
-
-          // 发送重连失败事件
-          this.eventBus.emitEvent("endpoint:reconnect:failed", {
-            trigger: "mcp_server_added",
-            serverName: eventData.serverName,
-            error: error instanceof Error ? error.message : String(error),
-            timestamp: Date.now(),
-          });
-        }
       }
     );
 
@@ -773,51 +793,15 @@ export class WebServer {
     this.eventBus.onEvent(
       "mcp:server:batch_added",
       async (eventData: EventBusEvents["mcp:server:batch_added"]) => {
-        this.logger.info(
-          `检测到批量 MCP 服务添加: ${eventData.addedCount} 个成功，${eventData.failedCount} 个失败`
-        );
-
-        if (!this.endpointManager || eventData.addedCount === 0) {
+        if (eventData.addedCount === 0) {
           return;
         }
-
-        try {
-          // 获取当前连接的端点数量
-          const connectionStatuses = this.endpointManager.getConnectionStatus();
-          const connectedEndpointCount = connectionStatuses.filter(
-            (status) => status.connected
-          ).length;
-
-          if (connectedEndpointCount === 0) {
-            this.logger.debug("当前没有已连接的端点，跳过重连");
-            return;
-          }
-
-          this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
-
-          // 重连所有端点
-          await this.endpointManager.reconnect();
-
-          this.logger.info("接入点重连成功，批量服务工具已同步");
-
-          // 发送重连完成事件
-          this.eventBus.emitEvent("endpoint:reconnect:completed", {
-            trigger: "mcp_server_batch_added",
-            serverName: undefined,
-            endpointCount: connectedEndpointCount,
-            timestamp: Date.now(),
-          });
-        } catch (error) {
-          this.logger.error("接入点重连失败:", error);
-
-          // 发送重连失败事件
-          this.eventBus.emitEvent("endpoint:reconnect:failed", {
-            trigger: "mcp_server_batch_added",
-            serverName: undefined,
-            error: error instanceof Error ? error.message : String(error),
-            timestamp: Date.now(),
-          });
-        }
+        await this.handleEndpointReconnect(
+          "mcp_server_batch_added",
+          undefined,
+          `检测到批量 MCP 服务添加: ${eventData.addedCount} 个成功，${eventData.failedCount} 个失败`,
+          "接入点重连成功，批量服务工具已同步"
+        );
       }
     );
   }


### PR DESCRIPTION
- 在 WebServer.ts 中将 mcp:server:added 和 mcp:server:batch_added
  事件监听器中的重复重连逻辑提取为 handleEndpointReconnect 私有方法
- 修复了代码重复问题，提升了可维护性
- 正确定义了 trigger 参数类型为 "mcp_server_added" | "mcp_server_batch_added"

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>