### PR TITLE
fix: 修复 WebSocketProvider 中的 any 类型问题

### DIFF
--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -1,4 +1,6 @@
 import { useNetworkService } from "@hooks/useNetworkService";
+import type { FullStatus } from "@services/api";
+import type { ConnectionState } from "@services/websocket";
 import { initializeStores } from "@stores/index";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import {
@@ -13,7 +15,7 @@ interface NetworkServiceContextType {
   // HTTP API 方法
   getConfig: () => Promise<AppConfig>;
   updateConfig: (config: AppConfig) => Promise<void>;
-  getStatus: () => Promise<any>;
+  getStatus: () => Promise<FullStatus>;
   refreshStatus: () => Promise<void>;
   restartService: () => Promise<void>;
 
@@ -34,7 +36,7 @@ interface NetworkServiceContextType {
   // 工具方法
   loadInitialData: () => Promise<void>;
   isWebSocketConnected: () => boolean;
-  getWebSocketState: () => any;
+  getWebSocketState: () => ConnectionState;
 }
 
 const NetworkServiceContext = createContext<NetworkServiceContextType | null>(


### PR DESCRIPTION
- 将 NetworkServiceContextType.getStatus 返回类型从 Promise<any> 改为 Promise<FullStatus>
- 将 NetworkServiceContextType.getWebSocketState 返回类型从 any 改为 ConnectionState
- 添加必要的类型导入：FullStatus 和 ConnectionState

修复 #1419

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>