### PR TITLE
docs: 为 MCP 核心库添加文件级 JSDoc 注释

### DIFF
--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -20,7 +20,7 @@
  *
  * // 创建服务管理器
  * const manager = new MCPServiceManager(config);
- * await manager.connectAll();
+ * await manager.startAllServices();
  *
  * // 获取所有工具
  * const tools = manager.getAllTools();


### PR DESCRIPTION
为 apps/backend/lib/mcp/index.ts 添加文件级 JSDoc 注释，包括：
- 模块功能概述和导出内容列表
- @packageDocumentation 标记
- 使用示例

修复 #1420

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>