### PR TITLE
fix: 修复 UI 组件文件中英文注释违反本地化规范

### DIFF
--- a/apps/frontend/src/components/ui/chart.tsx
+++ b/apps/frontend/src/components/ui/chart.tsx
@@ -6,7 +6,7 @@ import * as RechartsPrimitive from "recharts";
 
 import { cn } from "@/lib/utils";
 
-// Format: { THEME_NAME: CSS_SELECTOR }
+// 格式：{ 主题名称: CSS 选择器 }
 const THEMES = { light: "", dark: ".dark" } as const;
 
 export type ChartConfig = {

--- a/apps/frontend/src/components/ui/table.tsx
+++ b/apps/frontend/src/components/ui/table.tsx
@@ -3,7 +3,7 @@ import * as React from "react";
 import { cn } from "@/lib/utils";
 import { type VariantProps, cva } from "class-variance-authority";
 
-// Context 类型定义
+// 上下文类型定义
 interface TableSizeContextValue {
   size: "default" | "compact";
 }
@@ -12,7 +12,7 @@ const TableSizeContext = React.createContext<TableSizeContextValue>({
   size: "default",
 });
 
-// Table 变体
+// Table 组件变体样式
 const tableVariants = cva("w-full caption-bottom text-sm", {
   variants: {
     size: {
@@ -25,7 +25,7 @@ const tableVariants = cva("w-full caption-bottom text-sm", {
   },
 });
 
-// TableHead 变体
+// TableHead 组件变体样式
 const tableHeadVariants = cva(
   "text-left align-middle font-medium text-muted-foreground [&:has([role=checkbox])]:pr-0",
   {
@@ -41,7 +41,7 @@ const tableHeadVariants = cva(
   }
 );
 
-// TableCell 变体
+// TableCell 组件变体样式
 const tableCellVariants = cva("align-middle [&:has([role=checkbox])]:pr-0", {
   variants: {
     size: {


### PR DESCRIPTION
将 apps/frontend/src/components/ui/ 目录下文件中的英文注释翻译为中文：
- table.tsx: "Context 类型定义" → "上下文类型定义"
- table.tsx: "Table 变体" → "Table 组件变体样式"
- table.tsx: "TableHead 变体" → "TableHead 组件变体样式"
- table.tsx: "TableCell 变体" → "TableCell 组件变体样式"
- chart.tsx: "Format: { THEME_NAME: CSS_SELECTOR }" → "格式：{ 主题名称: CSS 选择器 }"

修复 #1431

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>