### PR TITLE
fix: 将 service.handler.ts 中的硬编码超时值提取为常量

### DIFF
--- a/apps/backend/constants/timeout.constants.ts
+++ b/apps/backend/constants/timeout.constants.ts
@@ -68,3 +68,13 @@ export const RETRY_CONFIG = {
   /** 退避乘数 */
   BACKOFF_MULTIPLIER: 2,
 } as const;
+
+/**
+ * 服务重启相关延迟常量
+ */
+export const SERVICE_RESTART_DELAYS = {
+  /** 重启执行延迟 */
+  EXECUTION_DELAY: 500,
+  /** 成功状态通知延迟 */
+  SUCCESS_NOTIFICATION_DELAY: 5000,
+} as const;

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -1,6 +1,7 @@
 import { spawn } from "node:child_process";
 import { logger } from "@/Logger.js";
 import type { Logger } from "@/Logger.js";
+import { SERVICE_RESTART_DELAYS } from "@/constants/timeout.constants.js";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
@@ -53,7 +54,7 @@ export class ServiceApiHandler {
           // 服务重启需要一些时间，延迟发送成功状态
           setTimeout(() => {
             this.statusService.updateRestartStatus("completed");
-          }, 5000);
+          }, SERVICE_RESTART_DELAYS.SUCCESS_NOTIFICATION_DELAY);
         } catch (error) {
           c.get("logger").error("服务重启失败:", error);
           this.statusService.updateRestartStatus(
@@ -61,7 +62,7 @@ export class ServiceApiHandler {
             error instanceof Error ? error.message : "未知错误"
           );
         }
-      }, 500);
+      }, SERVICE_RESTART_DELAYS.EXECUTION_DELAY);
 
       return c.success(null, "重启请求已接收");
     } catch (error) {


### PR DESCRIPTION
- 添加 SERVICE_RESTART_DELAYS 常量到 timeout.constants.ts
  - EXECUTION_DELAY: 500ms (重启执行延迟)
  - SUCCESS_NOTIFICATION_DELAY: 5000ms (成功状态通知延迟)
- 更新 service.handler.ts 使用新常量而非硬编码值

Fixes #1436

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>