### PR TITLE
docs: 为 frontend hooks 添加文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/hooks/useServerSearch.ts
+++ b/apps/frontend/src/hooks/useServerSearch.ts
@@ -1,3 +1,9 @@
+/**
+ * 服务器搜索 Hook
+ *
+ * 提供服务器列表搜索和筛选功能，支持根据通信类型和关键词进行筛选
+ */
+
 import type { ServerRowData } from "@/components/mcp-server/mcp-server-table";
 import { useCallback, useMemo, useState } from "react";
 

--- a/apps/frontend/src/hooks/useServerSortPersistence.ts
+++ b/apps/frontend/src/hooks/useServerSortPersistence.ts
@@ -1,5 +1,11 @@
 "use client";
 
+/**
+ * 服务器排序配置持久化 Hook
+ *
+ * 自动将用户选择的服务器排序方式保存到 localStorage，支持按名称、通信类型、工具数量等字段排序
+ */
+
 import type {
   ServerSortConfig,
   ServerSortField,

--- a/apps/frontend/src/hooks/useToolPagination.ts
+++ b/apps/frontend/src/hooks/useToolPagination.ts
@@ -1,3 +1,9 @@
+/**
+ * 工具分页 Hook
+ *
+ * 提供工具列表的分页功能，自动计算分页状态和当前页数据
+ */
+
 import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useCallback, useMemo, useState } from "react";
 

--- a/apps/frontend/src/hooks/useToolSearch.ts
+++ b/apps/frontend/src/hooks/useToolSearch.ts
@@ -1,3 +1,9 @@
+/**
+ * 工具搜索 Hook
+ *
+ * 提供工具列表搜索和筛选功能，支持根据服务名、工具名、描述进行筛选
+ */
+
 import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useCallback, useMemo, useState } from "react";
 

--- a/apps/frontend/src/hooks/useToolSortPersistence.ts
+++ b/apps/frontend/src/hooks/useToolSortPersistence.ts
@@ -1,5 +1,11 @@
 "use client";
 
+/**
+ * 工具排序配置持久化 Hook
+ *
+ * 自动将用户选择的工具排序方式保存到 localStorage，支持按名称、启用状态、使用次数、最后使用时间等字段排序
+ */
+
 import type { ToolSortConfig } from "@/components/mcp-tool/tool-sort-selector";
 import type { ToolSortField } from "@/components/mcp-tool/tool-sort-selector";
 import { useSortPersistence } from "@/hooks/useSortPersistence";


### PR DESCRIPTION
为 apps/frontend/src/hooks/ 目录下的 5 个 hook 文件添加了文件级 JSDoc 注释：
- useServerSearch.ts: 服务器搜索 Hook
- useServerSortPersistence.ts: 服务器排序配置持久化 Hook
- useToolPagination.ts: 工具分页 Hook
- useToolSearch.ts: 工具搜索 Hook
- useToolSortPersistence.ts: 工具排序配置持久化 Hook

这些注释与项目中 useNetworkService.ts 的文档标准保持一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>