### PR TITLE
fix: 移除 config 包中的 inferTransportTypeFromUrl 重复实现，改用 mcp-core 导入

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,6 +25,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@xiaozhi-client/mcp-core": "workspace:*",
     "comment-json": "^4.2.5",
     "dayjs": "^1.11.13",
     "json5": "^2.2.3"

--- a/packages/config/src/adapter.ts
+++ b/packages/config/src/adapter.ts
@@ -4,6 +4,10 @@
  */
 
 import { dirname, isAbsolute, resolve } from "node:path";
+import {
+  inferTransportTypeFromUrl,
+  MCPTransportType,
+} from "@xiaozhi-client/mcp-core";
 import type {
   HTTPMCPServerConfig,
   LocalMCPServerConfig,
@@ -26,12 +30,8 @@ export class ConfigValidationError extends Error {
   }
 }
 
-// 定义简化的 MCP 传输类型
-export enum MCPTransportType {
-  STDIO = "stdio",
-  SSE = "sse",
-  HTTP = "http",
-}
+// 重新导出 MCP 传输类型，以保持向后兼容性
+export { MCPTransportType } from "@xiaozhi-client/mcp-core";
 
 // 定义简化的 MCPServiceConfig 接口
 export interface MCPServiceConfig {
@@ -41,31 +41,6 @@ export interface MCPServiceConfig {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
-}
-
-/**
- * URL 类型推断函数
- * 基于 URL 路径末尾推断传输类型
- */
-function inferTransportTypeFromUrl(url: string): MCPTransportType {
-  try {
-    const parsedUrl = new URL(url);
-    const pathname = parsedUrl.pathname;
-
-    // 检查路径末尾
-    if (pathname.endsWith("/sse")) {
-      return MCPTransportType.SSE;
-    }
-    if (pathname.endsWith("/mcp")) {
-      return MCPTransportType.HTTP;
-    }
-
-    // 默认类型
-    return MCPTransportType.HTTP;
-  } catch (error) {
-    // URL 解析失败时使用默认类型
-    return MCPTransportType.HTTP;
-  }
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
 
   packages/config:
     dependencies:
+      '@xiaozhi-client/mcp-core':
+        specifier: workspace:*
+        version: link:../mcp-core
       comment-json:
         specifier: ^4.2.5
         version: 4.5.1


### PR DESCRIPTION
移除 packages/config/src/adapter.ts 中的 inferTransportTypeFromUrl 函数重复实现，
改为从 @xiaozhi-client/mcp-core 导入，遵循 DRY 原则。

变更内容：
- 在 packages/config/package.json 中添加 @xiaozhi-client/mcp-core 依赖
- 从 @xiaozhi-client/mcp-core 导入 inferTransportTypeFromUrl 和 MCPTransportType
- 删除本地的 inferTransportTypeFromUrl 函数定义和 MCPTransportType 枚举
- 通过重新导出保持向后兼容性

修复 #1446

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>