### PR TITLE
fix: 修复 checkPortAvailability 函数中 response 变量可能未定义导致的运行时错误

### DIFF
--- a/apps/frontend/src/utils/portUtils.ts
+++ b/apps/frontend/src/utils/portUtils.ts
@@ -18,7 +18,7 @@ export async function checkPortAvailability(
 
     // 尝试连接到服务端的健康检查端点
     // 先尝试 WebServer 的 /api/status 端点，如果失败再尝试 MCPServer 的 /health 端点
-    let response: Response;
+    let response: Response | undefined;
     try {
       response = await fetch(`http://localhost:${port}/api/status`, {
         method: "GET",
@@ -26,14 +26,18 @@ export async function checkPortAvailability(
       });
     } catch {
       // 如果 /api/status 失败，尝试 /health 端点
-      response = await fetch(`http://localhost:${port}/health`, {
-        method: "GET",
-        signal: controller.signal,
-      });
+      try {
+        response = await fetch(`http://localhost:${port}/health`, {
+          method: "GET",
+          signal: controller.signal,
+        });
+      } catch {
+        // 两个端点都失败，response 保持为 undefined
+      }
     }
 
     clearTimeout(timeoutId);
-    return response.ok;
+    return response?.ok ?? false;
   } catch (error) {
     // 连接失败或超时
     return false;


### PR DESCRIPTION
当两个健康检查端点（/api/status 和 /health）都失败时，原代码会尝试访问未定义的 response 变量，
导致 TypeError: Cannot read properties of undefined (reading 'ok')。

修复方案：
- 将 response 类型改为 Response | undefined
- 在第二个 fetch 外层添加 try-catch 嵌套
- 使用可选链 response?.ok ?? false 安全返回结果

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>