### PR TITLE
refactor: 移除 adapter.ts 中重复的 inferTransportTypeFromUrl 函数

### DIFF
--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,6 +25,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@xiaozhi-client/mcp-core": "workspace:*",
     "comment-json": "^4.2.5",
     "dayjs": "^1.11.13",
     "json5": "^2.2.3"

--- a/packages/config/src/adapter.ts
+++ b/packages/config/src/adapter.ts
@@ -11,6 +11,10 @@ import type {
   SSEMCPServerConfig,
 } from "./manager.js";
 import { ConfigResolver } from "./resolver.js";
+import {
+  MCPTransportType,
+  inferTransportTypeFromUrl,
+} from "@xiaozhi-client/mcp-core";
 
 // 从外部导入 MCP 类型（这些类型将在运行时从 backend 包解析）
 // 为了避免循环依赖，这里使用动态导入的方式
@@ -26,12 +30,8 @@ export class ConfigValidationError extends Error {
   }
 }
 
-// 定义简化的 MCP 传输类型
-export enum MCPTransportType {
-  STDIO = "stdio",
-  SSE = "sse",
-  HTTP = "http",
-}
+// 重新导出 MCPTransportType 以保持向后兼容性
+export { MCPTransportType };
 
 // 定义简化的 MCPServiceConfig 接口
 export interface MCPServiceConfig {
@@ -41,31 +41,6 @@ export interface MCPServiceConfig {
   env?: Record<string, string>;
   url?: string;
   headers?: Record<string, string>;
-}
-
-/**
- * URL 类型推断函数
- * 基于 URL 路径末尾推断传输类型
- */
-function inferTransportTypeFromUrl(url: string): MCPTransportType {
-  try {
-    const parsedUrl = new URL(url);
-    const pathname = parsedUrl.pathname;
-
-    // 检查路径末尾
-    if (pathname.endsWith("/sse")) {
-      return MCPTransportType.SSE;
-    }
-    if (pathname.endsWith("/mcp")) {
-      return MCPTransportType.HTTP;
-    }
-
-    // 默认类型
-    return MCPTransportType.HTTP;
-  } catch (error) {
-    // URL 解析失败时使用默认类型
-    return MCPTransportType.HTTP;
-  }
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -545,6 +545,9 @@ importers:
 
   packages/config:
     dependencies:
+      '@xiaozhi-client/mcp-core':
+        specifier: workspace:*
+        version: link:../mcp-core
       comment-json:
         specifier: ^4.2.5
         version: 4.5.1


### PR DESCRIPTION
修复 #1450 - 违反 DRY 原则的重复实现

**变更内容:**
- 将 `inferTransportTypeFromUrl` 和 `MCPTransportType` 改为从 @xiaozhi-client/mcp-core 导入
- 删除 adapter.ts 中本地重复的 inferTransportTypeFromUrl 函数定义（第 46-65 行）
- 重新导出 MCPTransportType 以保持向后兼容性
- 添加 @xiaozhi-client/mcp-core 依赖到 packages/config

**影响:**
- 统一使用 mcp-core 中更完善的实现（包含日志输出和可选参数）
- 减少代码重复，符合 DRY 原则
- 统一维护入口，降低 bug 风险

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>