### PR TITLE
fix: 修复 event-bus.service.ts 中的 any 类型使用以提升类型安全性

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -4,6 +4,7 @@ import {
   destroyEventBus,
   getEventBus,
 } from "../event-bus.service.js";
+import type { ClientInfo } from "../status.service.js";
 
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
@@ -87,7 +88,12 @@ describe("EventBus", () => {
     });
 
     it("should emit status:updated event successfully", () => {
-      const eventData = { status: { connected: true }, source: "test" };
+      const clientInfo: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+      const eventData = { status: clientInfo, source: "test" };
       const listener = vi.fn();
 
       eventBus.onEvent("status:updated", listener);
@@ -483,10 +489,15 @@ describe("EventBus", () => {
 
     it("should return correct event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
+      const clientInfo: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
 
       eventBus.emitEvent("config:updated", eventData);
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", { status: clientInfo, source: "test" });
 
       const stats = eventBus.getEventStats();
 
@@ -536,8 +547,13 @@ describe("EventBus", () => {
   describe("clearEventStats", () => {
     it("should clear all event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
+      const clientInfo: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", { status: clientInfo, source: "test" });
 
       let stats = eventBus.getEventStats();
       expect(Object.keys(stats)).toHaveLength(2);
@@ -554,6 +570,11 @@ describe("EventBus", () => {
     it("should return correct status information", () => {
       const listener1 = vi.fn();
       const listener2 = vi.fn();
+      const clientInfo: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
 
       eventBus.onEvent("config:updated", listener1);
       eventBus.onEvent("status:updated", listener2);
@@ -562,7 +583,7 @@ describe("EventBus", () => {
         type: "customMCP",
         timestamp: new Date(),
       });
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", { status: clientInfo, source: "test" });
 
       const status = eventBus.getStatus();
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -2,6 +2,10 @@ import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
+import type { NotificationData } from "@/services/notification.service.js";
+import type { MCPServerAddResult } from "@/handlers/mcp-manage.handler.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
 
 /**
  * 事件类型定义
@@ -17,7 +21,7 @@ export interface EventBusEvents {
   "config:error": { error: Error; operation: string };
 
   // 状态相关事件
-  "status:updated": { status: any; source: string };
+  "status:updated": { status: ClientInfo | RestartStatus; source: string };
   "status:error": { error: Error; operation: string };
 
   // 接入点状态变更事件
@@ -88,10 +92,10 @@ export interface EventBusEvents {
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };
   "websocket:client:disconnected": { clientId: string; timestamp: number };
-  "websocket:message:received": { type: string; data: any; clientId: string };
+  "websocket:message:received": { type: string; data: NotificationData; clientId: string };
 
   // 通知相关事件
-  "notification:broadcast": { type: string; data: any; target?: string };
+  "notification:broadcast": { type: string; data: NotificationData; target?: string };
   "notification:error": { error: Error; type: string };
 
   // MCP服务相关事件
@@ -112,7 +116,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };
@@ -146,7 +150,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -74,7 +74,10 @@ export class NotificationService {
 
     // 监听状态更新事件
     this.eventBus.onEvent("status:updated", (data) => {
-      this.broadcastStatusUpdate(data.status);
+      // 仅处理 ClientInfo 类型的状态更新
+      if ("status" in data.status && "mcpEndpoint" in data.status) {
+        this.broadcastStatusUpdate(data.status);
+      }
     });
 
     // 监听重启状态事件


### PR DESCRIPTION
- 将 `status: any` 替换为 `ClientInfo | RestartStatus` 联合类型
- 将 `data: any` 替换为 `NotificationData` 类型
- 将 `config: any` 替换为 `MCPServerConfig` 类型
- 将 `results: any[]` 替换为 `MCPServerAddResult[]` 类型
- 添加必要的类型导入
- 更新相关测试文件使用正确的类型
- 修复 notification.service.ts 以处理联合类型

Fixes #1452

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>