### PR TITLE
fix(cli): 将 Container.ts 中的 require() 替换为 ESM 标准 import()

### DIFF
--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,8 +17,8 @@ const program = new Command();
  */
 async function initializeCLI(): Promise<void> {
   try {
-    // 创建依赖注入容器
-    const container = DIContainer.create();
+    // 创建依赖注入容器（使用异步创建以支持 ESM 动态导入）
+    const container = await DIContainer.create();
 
     // 创建命令注册器
     const commandRegistry = new CommandRegistry(container);


### PR DESCRIPTION
修复问题 #1454

- 将 DIContainer.create() 方法改为异步方法
- 使用 Promise.all() 并行加载所有服务模块
- 移除 4 处 CommonJS require() 调用，改用 ESM 标准 import()
- 移除不必要的类型断言 (as any)
- 更新 index.ts 中的调用方以支持异步初始化
- 在 createContainer() 函数中添加 await 关键字

此修改确保代码与项目的 ESM 配置保持一致，提高代码规范性和未来兼容性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>