### PR TITLE
perf: 移除 tool-call-logs-dialog 中不必要的人为延迟

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -66,7 +66,6 @@ export function ToolCallLogsDialog() {
       setError(null);
 
       try {
-        await new Promise((resolve) => setTimeout(resolve, 1000));
         const response = await fetch(`/api/tool-calls/logs?limit=${limit}`);
         const data: ApiResponse<ToolCallLogsResponse> = await response.json();
 


### PR DESCRIPTION
移除 fetchLogs 函数中的 1 秒人为延迟，提升日志加载速度。

修复 #1460

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>