### PR TITLE
refactor: 提取共享的 store loading 操作工具函数

### DIFF
--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -22,16 +22,16 @@ import type {
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { type LoadingState, createLoadingActions } from "./utils";
 
 /**
  * 配置加载状态
+ * 复用 LoadingState 基础类型，确保与其他 store 一致
  */
-interface ConfigLoadingState {
+interface ConfigLoadingState extends LoadingState {
   isLoading: boolean;
   isUpdating: boolean;
   isRefreshing: boolean;
-  lastUpdated: number | null;
-  lastError: Error | null;
 }
 
 /**
@@ -139,25 +139,8 @@ export const useConfigStore = create<ConfigStore>()(
         );
       },
 
-      setLoading: (loading: Partial<ConfigLoadingState>) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, ...loading },
-          }),
-          false,
-          "setLoading"
-        );
-      },
-
-      setError: (error: Error | null) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, lastError: error },
-          }),
-          false,
-          "setError"
-        );
-      },
+      // 使用共享的 loading 操作方法
+      ...createLoadingActions<ConfigStore>(set),
 
       // ==================== 异步操作 ====================
 

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -16,6 +16,7 @@ import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { type LoadingState, createLoadingActions } from "./utils";
 
 /**
  * 重启状态接口
@@ -63,13 +64,12 @@ interface FullStatus {
 
 /**
  * 状态加载状态
+ * 复用 LoadingState 基础类型，确保与其他 store 一致
  */
-interface StatusLoadingState {
+interface StatusLoadingState extends LoadingState {
   isLoading: boolean;
   isRefreshing: boolean;
   isRestarting: boolean;
-  lastUpdated: number | null;
-  lastError: Error | null;
 }
 
 /**
@@ -283,25 +283,8 @@ export const useStatusStore = create<StatusStore>()(
         );
       },
 
-      setLoading: (loading: Partial<StatusLoadingState>) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, ...loading },
-          }),
-          false,
-          "setLoading"
-        );
-      },
-
-      setError: (error: Error | null) => {
-        set(
-          (state) => ({
-            loading: { ...state.loading, lastError: error },
-          }),
-          false,
-          "setError"
-        );
-      },
+      // 使用共享的 loading 操作方法
+      ...createLoadingActions<StatusStore>(set),
 
       // ==================== 异步操作 ====================
 

--- a/apps/frontend/src/stores/utils.ts
+++ b/apps/frontend/src/stores/utils.ts
@@ -1,0 +1,65 @@
+/**
+ * Store 工具函数
+ *
+ * 提供可复用的状态管理函数，避免在多个 store 中重复实现相同逻辑
+ */
+
+import type { NamedSet } from "zustand/middleware";
+
+/**
+ * 加载状态接口
+ */
+export interface LoadingState {
+  isLoading?: boolean;
+  isUpdating?: boolean;
+  isRefreshing?: boolean;
+  isRestarting?: boolean;
+  lastUpdated?: number | null;
+  lastError?: Error | null;
+}
+
+/**
+ * 创建标准的 loading 和 error 状态管理方法
+ *
+ * @param set - Zustand 的 set 函数
+ * @returns 包含 setLoading 和 setError 方法的对象
+ *
+ * @example
+ * ```typescript
+ * import { createLoadingActions } from './utils';
+ *
+ * export const useMyStore = create<MyStore>()(
+ *   devtools((set) => ({
+ *     ...initialState,
+ *     ...createLoadingActions(set),
+ *   }))
+ * );
+ * ```
+ */
+export function createLoadingActions<T extends { loading: LoadingState }>(
+  set: NamedSet<T>
+) {
+  return {
+    setLoading: (loading: Partial<LoadingState>) => {
+      set(
+        (state: T) =>
+          ({
+            loading: { ...state.loading, ...loading },
+          }) as Partial<T>,
+        false,
+        "setLoading"
+      );
+    },
+
+    setError: (error: Error | null) => {
+      set(
+        (state: T) =>
+          ({
+            loading: { ...state.loading, lastError: error },
+          }) as Partial<T>,
+        false,
+        "setError"
+      );
+    },
+  };
+}


### PR DESCRIPTION
提取 `createLoadingActions` 工具函数到 `stores/utils.ts`，
消除 config.ts 和 status.ts 中重复的 setLoading 和 setError 方法实现。

- 新增 `stores/utils.ts` 模块，提供可复用的 loading 状态管理函数
- 更新 `config.ts` 和 `status.ts` 使用共享工具函数
- 移除重复代码，减少 44 行代码
- 保持类型安全和向后兼容

Fixes #1462

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>