### PR TITLE
fix: 替换已弃用的 String.prototype.substr() 为 slice()

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -624,7 +624,7 @@ export class WebServer {
       // 生成客户端 ID
       const clientId = `client-${Date.now()}-${Math.random()
         .toString(36)
-        .substr(2, 9)}`;
+        .slice(2, 11)}`;
 
       this.logger.debug(`WebSocket 客户端已连接: ${clientId}`);
       this.logger.debug(

--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -35,7 +35,7 @@ export class NPMManager {
    * 安装指定版本 - 这是核心功能
    */
   async installVersion(version: string): Promise<void> {
-    const installId = `install-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const installId = `install-${Date.now()}-${Math.random().toString(36).slice(2, 11)}`;
     const startTime = Date.now();
 
     logger.info("开始安装", { version, installId });


### PR DESCRIPTION
替换两处使用已弃用的 substr() 方法：
- apps/backend/lib/npm/manager.ts:38
- apps/backend/WebServer.ts:627

substr() 在 Node.js 和现代 JavaScript 中已被标记为弃用，
使用 slice() 方法替代以符合现代 JavaScript 最佳实践。

Fixes #1469

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>