### PR TITLE
fix: 修复 shared-types 包 exports 路径与构建产物不匹配问题

### DIFF
--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -11,28 +11,29 @@
       "import": "./dist/index.js"
     },
     "./mcp": {
-      "types": "./dist/mcp/index.d.ts",
-      "import": "./dist/mcp/index.js"
+      "types": "./dist/mcp.d.ts",
+      "import": "./dist/mcp.js"
     },
     "./coze": {
-      "types": "./dist/coze/index.d.ts",
-      "import": "./dist/coze/index.js"
+      "types": "./dist/coze.d.ts",
+      "import": "./dist/coze.js"
     },
     "./api": {
-      "types": "./dist/api/index.d.ts",
-      "import": "./dist/api/index.js"
+      "types": "./dist/api.d.ts",
+      "import": "./dist/api.js"
     },
     "./config": {
-      "types": "./dist/config/index.d.ts",
-      "import": "./dist/config/index.js"
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.js"
     },
     "./utils": {
-      "types": "./dist/utils/index.d.ts",
-      "import": "./dist/utils/index.js"
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js"
     }
   },
   "files": [
-    "dist"
+    "dist",
+    "src"
   ],
   "scripts": {
     "build": "tsup",

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -1,4 +1,29 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync, statSync } from "node:fs";
+import { join, resolve } from "node:path";
 import { defineConfig } from "tsup";
+
+/**
+ * 递归复制目录
+ */
+function copyDirectory(src: string, dest: string): void {
+  if (!existsSync(dest)) {
+    mkdirSync(dest, { recursive: true });
+  }
+
+  const items = readdirSync(src);
+
+  for (const item of items) {
+    const srcPath = join(src, item);
+    const destPath = join(dest, item);
+    const stat = statSync(srcPath);
+
+    if (stat.isDirectory()) {
+      copyDirectory(srcPath, destPath);
+    } else {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
 
 export default defineConfig({
   entry: {
@@ -11,12 +36,12 @@ export default defineConfig({
   },
   format: ["esm"],
   target: "node18",
-  outDir: "../../dist/shared-types",
+  outDir: "./dist",
   dts: {
     compilerOptions: {
-      composite: false
-    }
-  }, // 启用 DTS 生成
+      composite: false,
+    },
+  },
   clean: true,
   sourcemap: true,
   minify: process.env.NODE_ENV === "production",
@@ -28,4 +53,15 @@ export default defineConfig({
     options.resolveExtensions = [".ts", ".js", ".json"];
   },
   external: [],
+  // 在所有构建完成后复制到项目根 dist 目录
+  async onSuccess() {
+    const srcDir = resolve("dist");
+    const destDir = resolve("../../dist/shared-types");
+
+    // 等待一小段时间确保所有文件都已写入
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    copyDirectory(srcDir, destDir);
+    console.log("✅ 已复制 shared-types 包构建产物到 dist/shared-types/");
+  },
 });


### PR DESCRIPTION
- 将 tsup.config.ts 中的 outDir 从 "../../dist/shared-types" 改为 "./dist"
- 添加 onSuccess 钩子，构建完成后复制产物到项目根 dist/shared-types 目录
- 更新 package.json 中 exports 字段的路径，匹配 tsup 实际输出的扁平文件结构
  - "./dist/mcp/index.d.ts" → "./dist/mcp.d.ts"
  - "./dist/api/index.d.ts" → "./dist/api.d.ts"
  - 等等...
- 更新 files 字段包含 src 目录

修复问题: #1474

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>