### PR TITLE
fix: 替换 WebSocketProvider 中的 console 调用为统一的 Logger 系统

### DIFF
--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -8,6 +8,7 @@ import {
   useEffect,
   useState,
 } from "react";
+import { createLogger } from "@utils/logger";
 
 interface NetworkServiceContextType {
   // HTTP API 方法
@@ -45,6 +46,9 @@ interface NetworkServiceProviderProps {
   children: ReactNode;
 }
 
+// 创建 Logger 实例
+const logger = createLogger("WebSocketProvider");
+
 export function NetworkServiceProvider({
   children,
 }: NetworkServiceProviderProps) {
@@ -57,15 +61,15 @@ export function NetworkServiceProvider({
 
     const initStores = async () => {
       try {
-        console.log("[WebSocketProvider] 开始初始化 stores");
+        logger.info("开始初始化 stores");
         await initializeStores();
 
         if (mounted) {
           setStoresInitialized(true);
-          console.log("[WebSocketProvider] Stores 初始化完成");
+          logger.info("Stores 初始化完成");
         }
       } catch (error) {
-        console.error("[WebSocketProvider] Stores 初始化失败:", error);
+        logger.error("Stores 初始化失败:", error);
         // 即使初始化失败，也允许应用继续运行
         if (mounted) {
           setStoresInitialized(true);

--- a/apps/frontend/src/utils/logger.ts
+++ b/apps/frontend/src/utils/logger.ts
@@ -1,0 +1,74 @@
+/**
+ * 前端日志工具
+ *
+ * 提供统一的日志记录功能，支持不同级别的日志输出。
+ * 仅在开发环境输出 debug 级别日志。
+ */
+
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * 检查是否为开发环境
+ */
+function isDevMode(): boolean {
+  // 类型断言以支持 Vite 的 import.meta.env
+  return (import.meta as any).env?.DEV ?? true;
+}
+
+class Logger {
+  private prefix: string;
+
+  constructor(prefix: string) {
+    this.prefix = prefix;
+  }
+
+  /**
+   * 格式化日志消息
+   */
+  private formatMessage(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `[${timestamp}] [${level.toUpperCase()}] [${this.prefix}] ${message}`;
+  }
+
+  /**
+   * 输出 debug 级别日志（仅开发环境）
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (isDevMode()) {
+      console.debug(this.formatMessage("debug", message), ...args);
+    }
+  }
+
+  /**
+   * 输出 info 级别日志
+   */
+  info(message: string, ...args: unknown[]): void {
+    console.log(this.formatMessage("info", message), ...args);
+  }
+
+  /**
+   * 输出 warn 级别日志
+   */
+  warn(message: string, ...args: unknown[]): void {
+    console.warn(this.formatMessage("warn", message), ...args);
+  }
+
+  /**
+   * 输出 error 级别日志
+   */
+  error(message: string, ...args: unknown[]): void {
+    console.error(this.formatMessage("error", message), ...args);
+  }
+}
+
+/**
+ * 创建指定前缀的 Logger 实例
+ */
+export function createLogger(prefix: string): Logger {
+  return new Logger(prefix);
+}
+
+/**
+ * 默认 Logger 实例
+ */
+export const logger = new Logger("App");


### PR DESCRIPTION
- 创建前端 Logger 工具 (apps/frontend/src/utils/logger.ts)
- 支持 debug, info, warn, error 四种日志级别
- debug 级别仅在开发环境输出
- 修改 WebSocketProvider.tsx 使用统一 Logger
- 移除 console.log 和 console.error 调用

修复 #1484

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>