### PR TITLE
fix(backend): 添加 TypeScript 项目引用配置

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -19,5 +19,11 @@
     "scripts/**/*",
     "templates/**/*",
     "**/*.config.ts"
+  ],
+  "references": [
+    { "path": "../../packages/config" },
+    { "path": "../../packages/endpoint" },
+    { "path": "../../packages/mcp-core" },
+    { "path": "../../packages/version" }
   ]
 }


### PR DESCRIPTION
为 apps/backend/tsconfig.json 添加 references 配置，正确声明对以下
workspace 依赖的项目引用：
- @xiaozhi-client/config
- @xiaozhi-client/endpoint
- @xiaozhi-client/mcp-core
- @xiaozhi-client/version

这确保了 TypeScript 能够按照正确的依赖顺序进行编译，并优化
增量编译性能。

修复 #1490

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>