### PR TITLE
refactor: 提取公共的配置验证逻辑到 ensureConfigExists 方法

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -111,21 +111,32 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   }
 
   /**
+   * 确保配置文件存在
+   * @returns configManager 实例
+   * @throws 如果配置文件不存在
+   */
+  private ensureConfigExists(spinner: ora.Ora): any {
+    const configManager = this.getService<any>("configManager");
+
+    if (!configManager.configExists()) {
+      spinner.fail("配置文件不存在");
+      console.log(
+        chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
+      );
+      throw new Error("配置文件不存在");
+    }
+
+    return configManager;
+  }
+
+  /**
    * 处理获取配置命令
    */
   private async handleGet(key: string): Promise<void> {
     const spinner = ora("读取配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
-
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
-        return;
-      }
+      const configManager = this.ensureConfigExists(spinner);
 
       const config = configManager.getConfig();
 
@@ -226,15 +237,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("更新配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
-
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
-        return;
-      }
+      const configManager = this.ensureConfigExists(spinner);
 
       switch (key) {
         case "mcpEndpoint":


### PR DESCRIPTION
修复 #1504 - handleGet 和 handleSet 方法中存在重复的配置验证逻辑违反 DRY 原则

- 创建私有方法 ensureConfigExists() 统一处理配置检查逻辑
- 更新 handleGet 和 handleSet 方法使用新的公共方法
- 提高代码可维护性并确保配置验证逻辑的一致性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>