### PR TITLE
fix: 在 handler 中使用 WebSocketLike 类型替代 any 提升类型安全性

### DIFF
--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -19,7 +19,7 @@ interface MockNotificationService extends Partial<NotificationService> {
 
 interface MockWebSocket {
   send: ReturnType<typeof vi.fn>;
-  readyState?: number;
+  readyState: number;
 }
 
 // Mock dependencies

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -1,7 +1,7 @@
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import { HEARTBEAT_MONITORING } from "@/constants/index.js";
-import type { NotificationService } from "@/services/notification.service.js";
+import type { NotificationService, WebSocketLike } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
@@ -40,7 +40,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -76,7 +76,7 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(ws: WebSocketLike, clientId: string): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -194,7 +194,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -2,7 +2,7 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
-import type { NotificationService } from "@/services/notification.service.js";
+import type { NotificationService, WebSocketLike } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
 import type { AppConfig } from "@xiaozhi-client/config";
@@ -41,7 +41,7 @@ export class RealtimeNotificationHandler {
    * @deprecated 部分消息类型已废弃，建议使用 HTTP API
    */
   async handleMessage(
-    ws: any,
+    ws: WebSocketLike,
     message: WebSocketMessage,
     clientId: string
   ): Promise<void> {
@@ -98,7 +98,7 @@ export class RealtimeNotificationHandler {
    * 处理获取配置请求
    * @deprecated 使用 GET /api/config 替代
    */
-  private async handleGetConfig(ws: any, clientId: string): Promise<void> {
+  private async handleGetConfig(ws: WebSocketLike, clientId: string): Promise<void> {
     this.logDeprecationWarning("WebSocket getConfig", "GET /api/config");
 
     try {
@@ -121,7 +121,7 @@ export class RealtimeNotificationHandler {
    * @deprecated 使用 PUT /api/config 替代
    */
   private async handleUpdateConfig(
-    ws: any,
+    ws: WebSocketLike,
     configData: AppConfig,
     clientId: string
   ): Promise<void> {
@@ -168,7 +168,7 @@ export class RealtimeNotificationHandler {
    * 处理获取状态请求
    * @deprecated 使用 GET /api/status 替代
    */
-  private async handleGetStatus(ws: any, clientId: string): Promise<void> {
+  private async handleGetStatus(ws: WebSocketLike, clientId: string): Promise<void> {
     this.logDeprecationWarning("WebSocket getStatus", "GET /api/status");
 
     try {
@@ -190,7 +190,7 @@ export class RealtimeNotificationHandler {
    * 处理重启服务请求
    * @deprecated 使用 POST /api/services/restart 替代
    */
-  private async handleRestartService(ws: any, clientId: string): Promise<void> {
+  private async handleRestartService(ws: WebSocketLike, clientId: string): Promise<void> {
     this.logDeprecationWarning(
       "WebSocket restartService",
       "POST /api/services/restart"
@@ -233,7 +233,7 @@ export class RealtimeNotificationHandler {
   /**
    * 发送初始数据给新连接的客户端
    */
-  async sendInitialData(ws: any, clientId: string): Promise<void> {
+  async sendInitialData(ws: WebSocketLike, clientId: string): Promise<void> {
     try {
       this.logger.debug("发送初始数据给客户端", { clientId });
 
@@ -275,7 +275,7 @@ export class RealtimeNotificationHandler {
   /**
    * 处理客户端连接
    */
-  handleClientConnect(ws: any, clientId: string): void {
+  handleClientConnect(ws: WebSocketLike, clientId: string): void {
     this.logger.debug(`客户端连接: ${clientId}`);
     this.notificationService.registerClient(clientId, ws);
   }


### PR DESCRIPTION
- 在 realtime-notification.handler.ts 中使用 WebSocketLike 类型
- 在 heartbeat.handler.ts 中使用 WebSocketLike 类型
- 修复测试文件中 MockWebSocket 接口的 readyState 类型
- 将所有 ws: any 参数替换为 ws: WebSocketLike

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>