### PR TITLE
fix: 修复 onceEvent 方法中错误处理顺序导致的不一致问题

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -349,15 +349,15 @@ export class EventBus extends EventEmitter {
 
     // 创建包装器来实现一次性监听
     const onceListener = (data: EventBusEvents[K]) => {
+      // 先移除监听器，确保在任何情况下都清理
+      this.offEvent(eventName, onceListener);
+
       try {
         listener(data);
       } catch (error) {
         // 监听器抛出错误，发射到错误事件
         this.emit("error", error);
         throw error;
-      } finally {
-        // 在任何情况下都移除监听器
-        this.offEvent(eventName, onceListener);
       }
     };
 


### PR DESCRIPTION
修复前，onceEvent 方法的 finally 块在错误被重新抛出之前执行
offEvent，这会导致监听器被移除后错误才被抛出，造成错误处理
逻辑不一致。

修复后，将 offEvent 移到 try 块之前执行，确保：
1. 监听器在执行回调前被移除
2. 错误处理逻辑保持一致
3. 监听器只被调用一次，即使抛出错误

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>