### PR TITLE
refactor: 提取示例代码共享工具模块消除重复代码

### DIFF
--- a/packages/endpoint/examples/manage-endpoints.ts
+++ b/packages/endpoint/examples/manage-endpoints.ts
@@ -26,6 +26,12 @@
  */
 
 import { Endpoint, EndpointManager } from "@xiaozhi-client/endpoint";
+import {
+  cleanupConnections,
+  displayTools,
+  handleError,
+  handleUncaughtError,
+} from "./shared/endpoint-helpers";
 
 /**
  * 主函数
@@ -132,24 +138,10 @@ async function main(): Promise<void> {
     console.log();
 
     // 8. 显示接入点 1 的工具
-    console.log("📦 接入点 1 - 工具列表:");
-    for (const tool of tools1) {
-      console.log(`  - ${tool.name}`);
-      if (tool.description) {
-        console.log(`    描述: ${tool.description}`);
-      }
-    }
-    console.log();
+    displayTools(tools1, "接入点 1 - 工具列表");
 
     // 9. 显示接入点 2 的工具
-    console.log("📦 接入点 2 - 工具列表:");
-    for (const tool of tools2) {
-      console.log(`  - ${tool.name}`);
-      if (tool.description) {
-        console.log(`    描述: ${tool.description}`);
-      }
-    }
-    console.log();
+    displayTools(tools2, "接入点 2 - 工具列表");
 
     // 10. 验证一致性
     const hasCalculatorInEndpoint1 = tools1.some((t) =>
@@ -209,41 +201,12 @@ async function main(): Promise<void> {
       // 无限期保持，直到用户中断
     });
   } catch (error) {
-    console.error();
-    console.error("❌ 执行过程中出错:");
-    if (error instanceof Error) {
-      console.error(`   错误信息: ${error.message}`);
-      if (error.stack) {
-        console.error(
-          `   堆栈: ${error.stack.split("\n").slice(1, 3).join("\n")}`
-        );
-      }
-    }
-    console.error();
+    handleError(error, [endpoint1, endpoint2].filter((e): e is Endpoint => e !== undefined), [`${endpointId1}`, `${endpointId2}`]);
   } finally {
     // 13. 断开连接
-    console.log();
-    console.log("正在断开连接...");
-
-    try {
-      if (endpoint1) {
-        await endpoint1.disconnect();
-      }
-      if (endpoint2) {
-        await endpoint2.disconnect();
-      }
-      console.log("✅ 连接已断开");
-    } catch {
-      console.log("⚠️  断开连接时出现错误（可能已断开）");
-    }
-
-    console.log();
-    console.log("=== 示例结束 ===");
+    await cleanupConnections([endpoint1, endpoint2]);
   }
 }
 
 // 运行主函数
-main().catch((error) => {
-  console.error("未捕获的错误:", error);
-  process.exit(1);
-});
+main().catch(handleUncaughtError);

--- a/packages/endpoint/examples/shared/endpoint-helpers.ts
+++ b/packages/endpoint/examples/shared/endpoint-helpers.ts
@@ -1,0 +1,128 @@
+/**
+ * 示例代码共享工具模块
+ *
+ * 功能说明：
+ * - 提供统一的错误处理逻辑
+ * - 提供工具列表显示功能
+ * - 提供连接状态显示功能
+ * - 提供清理逻辑
+ *
+ * 目的：消除示例代码中的重复代码，遵循 DRY 原则
+ */
+
+import type { Endpoint } from "@xiaozhi-client/endpoint";
+
+/**
+ * 显示连接状态
+ */
+export function displayConnectionStatus(
+  endpoint: Endpoint,
+  label?: string
+): void {
+  const status = endpoint.getStatus();
+  console.log(`${label || "连接状态"}:`);
+  console.log(`  已连接: ${status.connected ? "是" : "否"}`);
+  console.log(`  已初始化: ${status.initialized ? "是" : "否"}`);
+  console.log(`  连接状态: ${status.connectionState}`);
+  console.log(`  可用工具数: ${status.availableTools}`);
+  console.log();
+}
+
+/**
+ * 显示工具列表
+ */
+export function displayTools(
+  tools: readonly { name: string; description?: string; inputSchema?: unknown }[],
+  label?: string
+): void {
+  console.log(`📦 ${label || "工具列表"}:`);
+  for (const tool of tools) {
+    console.log(`  - ${tool.name}`);
+    if (tool.description) {
+      console.log(`    描述: ${tool.description}`);
+    }
+    // 显示输入参数 schema（如果有的话）
+    if (tool.inputSchema && typeof tool.inputSchema === "object" && Object.keys(tool.inputSchema).length > 0) {
+      const properties = (tool.inputSchema as { properties?: Record<string, unknown> }).properties;
+      if (properties && Object.keys(properties).length > 0) {
+        console.log(`    参数: ${Object.keys(properties).join(", ")}`);
+      }
+    }
+  }
+  console.log();
+}
+
+/**
+ * 处理错误并显示连接状态
+ */
+export function handleError(
+  error: unknown,
+  endpoint: Endpoint | Endpoint[] | undefined,
+  endpointLabels?: string[]
+): void {
+  console.error();
+  console.error("❌ 执行过程中出错:");
+  if (error instanceof Error) {
+    console.error(`   错误信息: ${error.message}`);
+    if (error.stack) {
+      console.error(`   堆栈: ${error.stack.split("\n").slice(1, 3).join("\n")}`);
+    }
+  }
+  console.error();
+
+  // 显示连接状态（如果可能）
+  const endpoints = Array.isArray(endpoint) ? endpoint : endpoint ? [endpoint] : [];
+  const labels = endpointLabels || [];
+
+  for (let i = 0; i < endpoints.length; i++) {
+    const ep = endpoints[i];
+    const label = labels[i] ? `${labels[i]} - ` : "";
+
+    try {
+      const status = ep.getStatus();
+      console.error(`${label}当前连接状态:`);
+      console.error(`  已连接: ${status.connected ? "是" : "否"}`);
+      console.error(`  连接状态: ${status.connectionState}`);
+      if (status.lastError) {
+        console.error(`  最后错误: ${status.lastError}`);
+      }
+    } catch {
+      // 忽略获取状态的错误
+    }
+  }
+}
+
+/**
+ * 断开连接并清理
+ */
+export async function cleanupConnections(
+  endpoints: (Endpoint | undefined)[],
+  showEndMessage = true
+): Promise<void> {
+  console.log();
+  console.log("正在断开连接...");
+
+  try {
+    for (const endpoint of endpoints) {
+      if (endpoint) {
+        await endpoint.disconnect();
+      }
+    }
+    console.log("✅ 连接已断开");
+  } catch {
+    console.log("⚠️  断开连接时出现错误（可能已断开）");
+  }
+
+  if (showEndMessage) {
+    console.log();
+    console.log("=== 示例结束 ===");
+  }
+}
+
+/**
+ * 全局未捕获错误处理器
+ */
+export function handleUncaughtError(error: unknown): void {
+  console.error("未捕获的错误:", error);
+  process.exit(1);
+}

--- a/packages/endpoint/examples/single-endpoint.ts
+++ b/packages/endpoint/examples/single-endpoint.ts
@@ -33,6 +33,13 @@
  */
 
 import { Endpoint } from "@xiaozhi-client/endpoint";
+import {
+  cleanupConnections,
+  displayConnectionStatus,
+  displayTools,
+  handleError,
+  handleUncaughtError,
+} from "./shared/endpoint-helpers";
 
 /**
  * 主函数
@@ -86,33 +93,14 @@ async function main(): Promise<void> {
     console.log();
 
     // 4. 获取连接状态
-    const status = endpoint.getStatus();
-    console.log("连接状态:");
-    console.log(`  已连接: ${status.connected ? "是" : "否"}`);
-    console.log(`  已初始化: ${status.initialized ? "是" : "否"}`);
-    console.log(`  连接状态: ${status.connectionState}`);
-    console.log(`  可用工具数: ${status.availableTools}`);
-    console.log();
+    displayConnectionStatus(endpoint);
 
     // 5. 获取工具列表
     const tools = endpoint.getTools();
     console.log(`发现 ${tools.length} 个工具:`);
     console.log();
 
-    for (const tool of tools) {
-      console.log(`  📦 ${tool.name}`);
-      if (tool.description) {
-        console.log(`     描述: ${tool.description}`);
-      }
-      // 显示输入参数 schema（如果有的话）
-      if (tool.inputSchema && Object.keys(tool.inputSchema).length > 0) {
-        const properties = (tool.inputSchema as { properties?: Record<string, unknown> }).properties;
-        if (properties && Object.keys(properties).length > 0) {
-          console.log(`     参数: ${Object.keys(properties).join(", ")}`);
-        }
-      }
-    }
-    console.log();
+    displayTools(tools);
 
     // 6. 保持连接供测试使用
     console.log("=".repeat(50));
@@ -141,45 +129,12 @@ async function main(): Promise<void> {
       // 无限期保持，直到用户中断
     });
   } catch (error) {
-    console.error();
-    console.error("❌ 执行过程中出错:");
-    if (error instanceof Error) {
-      console.error(`   错误信息: ${error.message}`);
-      if (error.stack) {
-        console.error(`   堆栈: ${error.stack.split("\n").slice(1, 3).join("\n")}`);
-      }
-    }
-    console.error();
-
-    // 显示连接状态（如果可能）
-    if (endpoint) {
-      try {
-        const status = endpoint.getStatus();
-        console.error("当前连接状态:");
-        console.error(`  已连接: ${status.connected ? "是" : "否"}`);
-        console.error(`  连接状态: ${status.connectionState}`);
-        if (status.lastError) {
-          console.error(`  最后错误: ${status.lastError}`);
-        }
-      } catch {
-        // 忽略获取状态的错误
-      }
-    }
+    handleError(error, endpoint);
   } finally {
     // 7. 断开连接
-    console.log();
-    console.log("正在断开连接...");
-    if (endpoint) {
-      await endpoint.disconnect();
-      console.log("✅ 连接已断开");
-    }
-    console.log();
-    console.log("=== 示例结束 ===");
+    await cleanupConnections([endpoint]);
   }
 }
 
 // 运行主函数
-main().catch((error) => {
-  console.error("未捕获的错误:", error);
-  process.exit(1);
-});
+main().catch(handleUncaughtError);


### PR DESCRIPTION
- 创建 `packages/endpoint/examples/shared/endpoint-helpers.ts` 模块
- 提取通用的错误处理逻辑 (`handleError`)
- 提取工具列表显示功能 (`displayTools`)
- 提取连接状态显示功能 (`displayConnectionStatus`)
- 提取连接清理逻辑 (`cleanupConnections`)
- 提取未捕获错误处理器 (`handleUncaughtError`)
- 重构 `single-endpoint.ts` 使用共享工具
- 重构 `mcp-aggregation.ts` 使用共享工具
- 重构 `endpoint-isolation.ts` 使用共享工具
- 重构 `manage-endpoints.ts` 使用共享工具

减少了约 220 行重复代码，遵循 DRY 原则，提高了代码可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>