### PR TITLE
fix: 修复 CozeApiError 接口重复定义违反 DRY 原则

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -13,6 +13,7 @@
     "@xiaozhi-client/config": "workspace:*",
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*",
     "@xiaozhi-client/version": "workspace:*",
     "ajv": "^8.17.1",
     "chalk": "^5.6.0",

--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -9,7 +9,8 @@
     "baseUrl": ".",
     "types": ["vitest/globals"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["./*"],
+      "@xiaozhi-client/shared-types": ["../../packages/shared-types/src"]
     }
   },
   "include": ["./**/*.ts"],

--- a/apps/backend/types/coze.ts
+++ b/apps/backend/types/coze.ts
@@ -129,17 +129,8 @@ export interface CozeWorkflowsParams {
   workflow_mode?: "workflow";
 }
 
-/**
- * 扣子 API 错误响应
- */
-export interface CozeApiError extends Error {
-  /** 错误代码 */
-  code: string;
-  /** HTTP 状态码 */
-  statusCode?: number;
-  /** 原始响应数据 */
-  response?: any;
-}
+// 从共享类型重新导出 CozeApiError，避免重复定义
+export type { CozeApiError } from "@xiaozhi-client/shared-types";
 
 /**
  * 扣子平台配置接口

--- a/packages/shared-types/src/coze/api.ts
+++ b/packages/shared-types/src/coze/api.ts
@@ -13,7 +13,7 @@ export interface CozeApiDetail {
 /**
  * 扣子 API 基础响应接口
  */
-export interface CozeApiResponse<T = any> {
+export interface CozeApiResponse<T = unknown> {
   /** 响应状态码，0表示成功 */
   code: number;
   /** 响应数据 */
@@ -37,21 +37,9 @@ export interface CozeWorkflowsResponse
   extends CozeApiResponse<CozeWorkflowsData> {}
 
 /**
- * 扣子 API 错误响应
- */
-export interface CozeApiError extends Error {
-  /** 错误代码 */
-  code: string;
-  /** HTTP 状态码 */
-  statusCode?: number;
-  /** 原始响应数据 */
-  response?: any;
-}
-
-/**
  * 缓存项接口
  */
-export interface CacheItem<T = any> {
+export interface CacheItem<T = unknown> {
   /** 缓存数据 */
   data: T;
   /** 缓存时间戳 */
@@ -66,3 +54,6 @@ import type { CozeWorkspacesData } from "./workspace";
 
 // 重新导出这些类型，便于外部使用
 export type { CozeWorkspacesData, CozeWorkflowsParams, CozeWorkflowsData };
+
+// 从共享类型重新导出 CozeApiError，避免重复定义
+export type { CozeApiError } from "../api/errors";

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -11,6 +11,7 @@ export type {
   WorkflowParameter,
   WorkflowParameterConfig,
   CozeWorkflowsParams,
+  CozeApiError,
 } from "./coze";
 
 // MCP 相关类型

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -191,6 +191,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../../packages/mcp-core
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../../packages/shared-types
       '@xiaozhi-client/version':
         specifier: workspace:*
         version: link:../../packages/version


### PR DESCRIPTION
- 删除 apps/backend/types/coze.ts 中的重复 CozeApiError 定义，改为从共享类型重新导出
- 删除 packages/shared-types/src/coze/api.ts 中的重复 CozeApiError 定义，改为从 errors.ts 重新导出
- 修复 CozeApiResponse 和 CacheItem 中的 any 类型为 unknown，提升类型安全性
- 在 packages/shared-types/src/index.ts 中添加 CozeApiError 导出
- 在 apps/backend/tsconfig.json 中添加 shared-types 源码路径映射
- 在 apps/backend/package.json 中添加 shared-types 依赖

修复 #1523

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>