### PR TITLE
fix: 修复 process 信号监听器内存泄漏问题

### DIFF
--- a/apps/backend/WebServerLauncher.ts
+++ b/apps/backend/WebServerLauncher.ts
@@ -43,8 +43,8 @@ async function main() {
       process.exit(0);
     };
 
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
   } catch (error) {
     console.error("WebServer 启动失败:", error);
     process.exit(1);

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -154,7 +154,7 @@ export class DaemonManagerImpl implements IDaemonManager {
       const tail = spawn(command, args, { stdio: "inherit" });
 
       // 处理中断信号
-      process.on("SIGINT", () => {
+      process.once("SIGINT", () => {
         console.log("\n断开连接，服务继续在后台运行");
         tail.kill();
         process.exit(0);

--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -278,8 +278,8 @@ export class ServiceManagerImpl implements IServiceManager {
         process.exit(0);
       };
 
-      process.on("SIGINT", cleanup);
-      process.on("SIGTERM", cleanup);
+      process.once("SIGINT", cleanup);
+      process.once("SIGTERM", cleanup);
 
       await server.start();
     }
@@ -338,8 +338,8 @@ export class ServiceManagerImpl implements IServiceManager {
       process.exit(0);
     };
 
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
 
     // 保存 PID 信息
     this.processManager.savePidInfo(process.pid, "foreground");


### PR DESCRIPTION
使用 process.once() 替代 process.on() 注册信号监听器，确保监听器在执行后自动移除，避免 MaxListenersExceededWarning 警告和潜在内存泄漏。

涉及文件：
- apps/backend/WebServerLauncher.ts
- packages/cli/src/services/ServiceManager.ts (两处)
- packages/cli/src/services/DaemonManager.ts

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>