### PR TITLE
fix: 让 mcp-core tsconfig 继承根配置以消除重复

### DIFF
--- a/packages/mcp-core/tsconfig.json
+++ b/packages/mcp-core/tsconfig.json
@@ -1,28 +1,14 @@
 {
+  "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "target": "ES2022",
-    "module": "ESNext",
-    "lib": ["ES2022"],
-    "moduleResolution": "bundler",
-    "resolveJsonModule": true,
-    "allowJs": false,
-    "checkJs": false,
     "outDir": "./dist",
     "rootDir": "./src",
-    "declaration": true,
-    "declarationMap": true,
-    "sourceMap": true,
     "composite": true,
-    "strict": true,
+    "lib": ["ES2022"],
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noImplicitOverride": true,
     "noPropertyAccessFromIndexSignature": false,
-    "allowSyntheticDefaultImports": true,
-    "esModuleInterop": true,
-    "skipLibCheck": true,
-    "forceConsistentCasingInFileNames": true
+    "allowJs": false
   },
   "include": ["src/**/*"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"]


### PR DESCRIPTION
- 使用 extends 继承根 tsconfig.json 配置
- 移除 15+ 个重复的编译器选项
- 显式覆盖 allowJs 为 false（根配置为 true）
- 确保配置一致性和 DRY 原则

修复 #1536

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>