### PR TITLE
refactor: 提取共享的 tsup 基础配置以遵循 DRY 原则

### DIFF
--- a/packages/endpoint/tsup.config.ts
+++ b/packages/endpoint/tsup.config.ts
@@ -1,42 +1,23 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.base.config";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  target: "node18",
-  outDir: "./dist",
-  clean: true,
-  sourcemap: true,
-  dts: {
-    entry: ["src/index.ts"],
-    compilerOptions: {
-      composite: false,
-    },
-  },
-  bundle: true,
-  splitting: false,
-  minify: false,
-  keepNames: true,
-  platform: "node",
-  esbuildOptions: (options) => {
-    // 在生产环境移除 console 和 debugger
-    if (process.env.NODE_ENV === "production") {
-      options.drop = ["console", "debugger"];
-    }
-    options.resolveExtensions = [".ts", ".js", ".json"];
-  },
+  ...baseConfig,
   external: [
     // Node.js 内置模块
     "ws",
+    "eventsource",
     "events",
     "node:events",
+    "node:fs",
+    "node:path",
+    "node:url",
+    "node:child_process",
+    "node:stream",
+    "node:http",
+    "node:https",
+    "node:net",
     // 外部依赖（peer dependencies）
     "@modelcontextprotocol/sdk",
-    // 工作区依赖
-    "@xiaozhi-client/config",
-    "@xiaozhi-client/mcp-core",
   ],
-  outExtension() {
-    return { js: ".js" };
-  },
 });

--- a/packages/mcp-core/tsup.config.ts
+++ b/packages/mcp-core/tsup.config.ts
@@ -1,48 +1,17 @@
 import { defineConfig } from "tsup";
+import { baseConfig } from "../../tsup.base.config";
 
 export default defineConfig({
-  entry: ["src/index.ts"],
-  format: ["esm"],
-  target: "node18",
-  outDir: "./dist",
-  clean: true,
-  sourcemap: true,
-  dts: {
-    entry: ["src/index.ts"],
-    compilerOptions: {
-      composite: false,
-    },
-  },
-  bundle: true,
-  splitting: false,
-  minify: false,
-  keepNames: true,
-  platform: "node",
-  esbuildOptions: (options) => {
-    // 在生产环境移除 console 和 debugger
-    if (process.env.NODE_ENV === "production") {
-      options.drop = ["console", "debugger"];
-    }
-    options.resolveExtensions = [".ts", ".js", ".json"];
-  },
+  ...baseConfig,
   external: [
     // Node.js 内置模块
     "ws",
-    "eventsource",
     "events",
     "node:events",
-    "node:fs",
-    "node:path",
-    "node:url",
-    "node:child_process",
-    "node:stream",
-    "node:http",
-    "node:https",
-    "node:net",
     // 外部依赖（peer dependencies）
     "@modelcontextprotocol/sdk",
+    // 工作区依赖
+    "@xiaozhi-client/config",
+    "@xiaozhi-client/mcp-core",
   ],
-  outExtension() {
-    return { js: ".js" };
-  },
 });

--- a/tsup.base.config.ts
+++ b/tsup.base.config.ts
@@ -1,0 +1,76 @@
+/**
+ * tsup 基础配置
+ *
+ * 为项目中的包提供共享的构建配置，遵循 DRY 原则。
+ * 各个包可以根据需要扩展此基础配置，主要差异在于 external 依赖。
+ */
+
+import { defineConfig } from "tsup";
+
+/**
+ * 基础配置对象
+ *
+ * 包含所有包共享的构建选项：
+ * - ESM 格式输出
+ * - Node.js 18 目标
+ * - 源映射支持
+ * - TypeScript 声明文件生成
+ * - 生产环境自动移除 console 和 debugger
+ */
+export const baseConfig = defineConfig({
+  /** 入口文件 */
+  entry: ["src/index.ts"],
+
+  /** 输出格式 */
+  format: ["esm"],
+
+  /** 编译目标 */
+  target: "node18",
+
+  /** 输出目录 */
+  outDir: "./dist",
+
+  /** 构建前清理输出目录 */
+  clean: true,
+
+  /** 生成源映射 */
+  sourcemap: true,
+
+  /** TypeScript 声明文件配置 */
+  dts: {
+    entry: ["src/index.ts"],
+    compilerOptions: {
+      composite: false,
+    },
+  },
+
+  /** 打包所有依赖 */
+  bundle: true,
+
+  /** 禁用代码分割 */
+  splitting: false,
+
+  /** 不压缩代码 */
+  minify: false,
+
+  /** 保留函数和类名称 */
+  keepNames: true,
+
+  /** 运行平台 */
+  platform: "node",
+
+  /** esbuild 选项 */
+  esbuildOptions: (options) => {
+    // 在生产环境移除 console 和 debugger
+    if (process.env.NODE_ENV === "production") {
+      options.drop = ["console", "debugger"];
+    }
+    // 模块解析扩展名
+    options.resolveExtensions = [".ts", ".js", ".json"];
+  },
+
+  /** 输出文件扩展名 */
+  outExtension() {
+    return { js: ".js" };
+  },
+});


### PR DESCRIPTION
- 新增 tsup.base.config.ts，包含所有包共享的构建配置
- 更新 packages/mcp-core/tsup.config.ts 使用基础配置
- 更新 packages/endpoint/tsup.config.ts 使用基础配置
- 将 30+ 行重复配置提取到单一位置，便于维护

修复 #1538

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>