### PR TITLE
fix: 修复 manager.ts 中 addServiceConfig 方法错误消息使用英文的问题

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1263,7 +1263,9 @@ export class MCPServiceManager extends EventEmitter {
       serviceName = internalConfig.name;
       finalConfig = internalConfig;
     } else {
-      throw new Error("Invalid arguments for addServiceConfig");
+      throw new Error(
+        "addServiceConfig 参数无效：期望 (name: string, config: MCPServiceConfig) 或 (config: InternalMCPServiceConfig)"
+      );
     }
 
     // 增强配置


### PR DESCRIPTION
将错误消息 "Invalid arguments for addServiceConfig" 改为中文
"addServiceConfig 参数无效：期望 (name: string, config: MCPServiceConfig) 或 (config: InternalMCPServiceConfig)"，
符合项目本地化规范。

Fixes #1540

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>