### PR TITLE
docs: 为 service.handler.ts 添加完整的文件级 JSDoc 注释

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -10,7 +10,22 @@ import { requireMCPServiceManager } from "@/types/hono.context.js";
 import type { Context } from "hono";
 
 /**
- * 服务 API 处理器
+ * 服务 API HTTP 路由处理器
+ * 提供服务重启、停止等管理相关的 RESTful API 接口
+ *
+ * ## 核心功能
+ * - 服务重启：POST /api/services/restart
+ * - 服务停止：POST /api/services/stop
+ * - 服务启动：POST /api/services/start
+ * - 服务状态查询：GET /api/services/status
+ * - 服务健康检查：GET /api/services/health
+ * - 与 EventBus 集成：监听服务重启请求事件
+ * - 状态更新：通过 StatusService 更新服务重启状态
+ *
+ * ## 注意事项
+ * - 重启操作异步执行，不阻塞 HTTP 响应
+ * - 从 Hono Context 获取 MCPServiceManager 实例
+ * - 服务操作使用 child_process.spawn 执行系统命令
  */
 export class ServiceApiHandler {
   private logger: Logger;


### PR DESCRIPTION
更新 apps/backend/handlers/service.handler.ts 的文件级 JSDoc 注释，
使其与项目中其他 handler 文件（status.handler.ts、endpoint.handler.ts、
mcp-manage.handler.ts）的文档标准保持一致。

## 主要变更

- 添加详细的功能描述
- 列出所有核心 API 端点
- 说明注意事项（异步执行、Context 使用、系统命令执行）

Fixes #1550

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>