### PR TITLE
fix: 锁定 @types/node 到 24.x 以确保 Node.js 20.x 兼容性

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@nx/vite": "^22.3.3",
     "@nx/vitest": "^22.3.3",
     "@nx/workspace": "^22.3.3",
-    "@types/node": "^24.10.0",
+    "@types/node": "24.x",
     "@types/semver": "^7.7.1",
     "@vitest/coverage-v8": "^3.2.4",
     "concurrently": "^9.2.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -111,7 +111,7 @@ importers:
         specifier: ^22.3.3
         version: 22.4.2
       '@types/node':
-        specifier: ^24.10.0
+        specifier: 24.x
         version: 24.10.9
       '@types/semver':
         specifier: ^7.7.1


### PR DESCRIPTION
将 @types/node 版本从 ^24.10.0 更新为 24.x，以防止 pnpm 建议升级
到 25.x 版本，后者包含与 Node.js 20.x 运行时行为不一致的类型定义。

修复 #1552

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>