### PR TITLE
fix: 移除 endpoint.route.ts 中重复定义的 createErrorResponse 函数

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -19,18 +19,6 @@ type EndpointHandlerMethod =
   | "removeEndpoint";
 
 /**
- * 统一的错误响应函数
- */
-const createErrorResponse = (code: string, message: string) => {
-  return {
-    error: {
-      code,
-      message,
-    },
-  };
-};
-
-/**
  * 端点处理器包装函数
  * 从中间件获取 endpointHandler 并调用相应方法
  */
@@ -42,11 +30,12 @@ const withEndpointHandler = async (
   const endpointHandler = c.get("endpointHandler");
 
   if (!endpointHandler) {
-    const errorResponse = createErrorResponse(
+    return c.fail(
       "ENDPOINT_HANDLER_NOT_AVAILABLE",
-      "端点处理器尚未初始化，请稍后再试"
+      "端点处理器尚未初始化，请稍后再试",
+      undefined,
+      503
     );
-    return c.json(errorResponse, 503);
   }
 
   // 调用对应的处理方法
@@ -55,11 +44,12 @@ const withEndpointHandler = async (
     return await endpointHandler[handlerName](c);
   } catch (error) {
     console.error(`端点处理器错误 [${handlerName}]:`, error);
-    const errorResponse = createErrorResponse(
+    return c.fail(
       "ENDPOINT_HANDLER_ERROR",
-      error instanceof Error ? error.message : "端点处理失败"
+      error instanceof Error ? error.message : "端点处理失败",
+      undefined,
+      500
     );
-    return c.json(errorResponse, 500);
   }
 };
 


### PR DESCRIPTION
- 移除重复的 createErrorResponse 函数定义
- 使用推荐的 c.fail() 方法替代 c.json() + createErrorResponse 组合
- 修复 DRY 原则违规问题

参考 issue #1560

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>