### PR TITLE
fix: 修复 toolApi 中的 any 类型提升类型安全性

### DIFF
--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -5,6 +5,14 @@
 
 import type { JSONSchema as LibJSONSchema } from "@/lib/mcp/types.js";
 import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
+import type {
+  CustomMCPTool,
+  HandlerConfig,
+  HttpHandlerConfig as ConfigHttpHandlerConfig,
+  ProxyHandlerConfig as ConfigProxyHandlerConfig,
+  FunctionHandlerConfig as ConfigFunctionHandlerConfig,
+  MCPHandlerConfig as ConfigMCPHandlerConfig,
+} from "@xiaozhi-client/config";
 
 /**
  * JSON Schema 类型
@@ -173,7 +181,7 @@ export interface FunctionToolData {
   /** 函数描述 */
   description: string;
   /** 函数执行上下文 */
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   /** 超时时间 */
   timeout?: number;
   /** 可选的自定义名称 */
@@ -215,6 +223,14 @@ export enum ToolValidationError {
 }
 
 /**
+ * 工具验证错误详情类型
+ */
+export type ValidationErrorDetails =
+  | { field: string; expected: string; received: unknown }
+  | { reason: string; context: Record<string, unknown> }
+  | unknown;
+
+/**
  * 工具验证错误详情
  */
 export interface ToolValidationErrorDetail {
@@ -223,7 +239,7 @@ export interface ToolValidationErrorDetail {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: ValidationErrorDetails;
   /** 建议的解决方案 */
   suggestions?: string[];
 }
@@ -233,7 +249,7 @@ export interface ToolValidationErrorDetail {
  */
 export interface AddToolResponse {
   /** 成功添加的工具 */
-  tool: any;
+  tool: CustomMCPTool;
   /** 工具名称 */
   toolName: string;
   /** 工具类型 */
@@ -287,8 +303,8 @@ export interface ExtendedCustomMCPTool {
   /** 基础工具配置 */
   name: string;
   description: string;
-  inputSchema: any;
-  handler: any;
+  inputSchema: JSONSchema;
+  handler: HandlerConfig;
   /** 使用统计信息 */
   stats?: {
     usageCount?: number;

--- a/packages/shared-types/src/api/toolApi.ts
+++ b/packages/shared-types/src/api/toolApi.ts
@@ -90,7 +90,7 @@ export interface FunctionToolData {
   /** 函数描述 */
   description: string;
   /** 函数执行上下文 */
-  context?: Record<string, any>;
+  context?: Record<string, unknown>;
   /** 超时时间 */
   timeout?: number;
   /** 可选的自定义名称 */
@@ -132,6 +132,14 @@ export enum ToolValidationError {
 }
 
 /**
+ * 工具验证错误详情类型
+ */
+export type ValidationErrorDetails =
+  | { field: string; expected: string; received: unknown }
+  | { reason: string; context: Record<string, unknown> }
+  | unknown;
+
+/**
  * 工具验证错误详情
  */
 export interface ToolValidationErrorDetail {
@@ -140,7 +148,7 @@ export interface ToolValidationErrorDetail {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: ValidationErrorDetails;
   /** 建议的解决方案 */
   suggestions?: string[];
 }
@@ -150,7 +158,7 @@ export interface ToolValidationErrorDetail {
  */
 export interface AddToolResponse {
   /** 成功添加的工具 */
-  tool: any;
+  tool: CustomMCPToolWithStats;
   /** 工具名称 */
   toolName: string;
   /** 工具类型 */


### PR DESCRIPTION
- ToolValidationErrorDetail.details?: any → ValidationErrorDetails
- AddToolResponse.tool: any → CustomMCPTool/CustomMCPToolWithStats
- FunctionToolData.context: Record<string, any> → Record<string, unknown>
- ExtendedCustomMCPTool.inputSchema: any → JSONSchema
- ExtendedCustomMCPTool.handler: any → HandlerConfig

这解决了 issue #1564 中指出的类型安全问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>