### PR TITLE
fix: updateCustomMCPToolStats 错误处理改为安全模式

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -861,11 +861,12 @@ export class MCPServiceManager extends EventEmitter {
       await configManager.updateToolUsageStatsWithLock(toolName, true);
       console.debug(`[MCPManager] 已更新 customMCP 工具 ${toolName} 使用统计`);
     } catch (error) {
-      console.error(
-        `[MCPManager] 更新 customMCP 工具 ${toolName} 统计失败:`,
+      // 统计更新失败不应该影响主流程
+      console.warn(
+        `[MCPManager] 更新 customMCP 工具 ${toolName} 统计失败，跳过统计更新:`,
         error
       );
-      throw error;
+      // 不重新抛出错误，允许主流程继续
     }
   }
 


### PR DESCRIPTION
- 移除 throw error，避免统计更新失败时中断主流程
- 将 console.error 改为 console.warn，与其他统计方法保持一致
- 添加中文注释说明统计更新失败不影响主流程

修复 #1571

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>