### PR TITLE
fix: 移除 form-fields.tsx 中的 any 类型使用以提升类型安全性

### DIFF
--- a/apps/frontend/src/components/form-fields.tsx
+++ b/apps/frontend/src/components/form-fields.tsx
@@ -21,8 +21,12 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type { FieldConfig } from "@/types/form-config";
-import type { UseFormReturn } from "react-hook-form";
-import type { z } from "zod";
+import type {
+  ControllerRenderProps,
+  FieldPath,
+  FieldValues,
+  UseFormReturn,
+} from "react-hook-form";
 
 /**
  * 渲染单个表单字段
@@ -31,11 +35,11 @@ import type { z } from "zod";
  * @param disabled - 是否禁用（覆盖配置中的 disabled）
  */
 export function renderFormField<
-  T extends z.ZodType,
-  Output extends Record<string, any> = z.infer<T> & Record<string, any>,
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
 >(
-  config: FieldConfig<T, Output>,
-  form: UseFormReturn<Output>,
+  config: FieldConfig<TFieldValues, TName>,
+  form: UseFormReturn<TFieldValues>,
   disabled?: boolean
 ) {
   const {
@@ -60,7 +64,7 @@ export function renderFormField<
   // 辅助函数：根据类型渲染输入组件
   // 必须在 FormControl 外部提前决定渲染哪个组件
   // 因为 FormControl 使用的 Slot 组件通过 React.Children.only 严格要求只有一个子元素
-  const renderInput = (field: any) => {
+  const renderInput = (field: ControllerRenderProps<TFieldValues, TName>) => {
     switch (type) {
       case "text":
         return (
@@ -93,7 +97,7 @@ export function renderFormField<
               <SelectValue placeholder={placeholder} />
             </SelectTrigger>
             <SelectContent>
-              {options?.map((option) => (
+              {options?.map((option: { value: string; label: string }) => (
                 <SelectItem key={option.value} value={option.value}>
                   {option.label}
                 </SelectItem>
@@ -110,7 +114,7 @@ export function renderFormField<
     <FormField
       key={String(name)}
       control={form.control}
-      name={String(name) as any}
+      name={name}
       render={({ field }) => (
         <FormItem>
           <FormLabel>
@@ -138,12 +142,12 @@ export function renderFormField<
  * @param disabled - 是否禁用
  */
 export function renderSelectFieldWithHandler<
-  T extends z.ZodType,
-  Output extends Record<string, any> = z.infer<T> & Record<string, any>,
-  V extends string = string,
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
+  V extends string,
 >(
-  config: FieldConfig<T, Output>,
-  form: UseFormReturn<Output>,
+  config: FieldConfig<TFieldValues, TName>,
+  form: UseFormReturn<TFieldValues>,
   onValueChange: (value: V) => void,
   disabled?: boolean
 ) {
@@ -159,7 +163,7 @@ export function renderSelectFieldWithHandler<
     <FormField
       key={String(name)}
       control={form.control}
-      name={String(name) as any}
+      name={name}
       render={({ field }) => (
         <FormItem>
           <FormLabel>
@@ -176,7 +180,7 @@ export function renderSelectFieldWithHandler<
                 <SelectValue placeholder={placeholder} />
               </SelectTrigger>
               <SelectContent>
-                {options?.map((option) => (
+                {options?.map((option: { value: string; label: string }) => (
                   <SelectItem key={option.value} value={option.value}>
                     {option.label}
                   </SelectItem>

--- a/apps/frontend/src/config/mcp-form-fields.ts
+++ b/apps/frontend/src/config/mcp-form-fields.ts
@@ -5,12 +5,14 @@
 
 import type { mcpFormSchema } from "@/schemas/mcp-form";
 import type { FieldConfig } from "@/types/form-config";
-import type { UseFormReturn } from "react-hook-form";
+import type { FieldPath } from "react-hook-form";
 import type { z } from "zod";
+
+type McpFormValues = z.infer<typeof mcpFormSchema>;
 
 /**
  * MCP 服务表单字段配置数组
- * 使用类型断言处理 discriminated union 的类型推断限制
+ * 使用 satisfies 进行类型验证，同时保持值的推断
  */
 export const mcpFormFields = [
   {
@@ -19,7 +21,7 @@ export const mcpFormFields = [
     label: "MCP 类型",
     required: true,
     placeholder: "选择 MCP 类型",
-    description: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) => {
+    description: (form) => {
       const mcpType = form.watch("type");
       if (mcpType === "stdio") return "本地通过命令行启动的 MCP 服务";
       if (mcpType === "http") return "通过 HTTP 协议访问的远程 MCP 服务";
@@ -47,8 +49,7 @@ export const mcpFormFields = [
     required: true,
     placeholder: "例如: npx -y xxx",
     description: "完整的启动命令，空格分隔命令和参数",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "stdio",
+    condition: (form) => form.watch("type") === "stdio",
   },
   {
     name: "env",
@@ -57,8 +58,7 @@ export const mcpFormFields = [
     placeholder: "KEY1=value1\nKEY2=value2",
     description: "每行一个环境变量，支持 KEY=value 或 KEY: value 格式",
     className: "min-h-[100px] font-mono text-sm",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "stdio",
+    condition: (form) => form.watch("type") === "stdio",
   },
   {
     name: "url",
@@ -68,8 +68,7 @@ export const mcpFormFields = [
     inputType: "url",
     placeholder: "https://example.com/mcp",
     description: "MCP 服务的完整 URL 地址",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "http" || form.watch("type") === "sse",
+    condition: (form) => form.watch("type") === "http" || form.watch("type") === "sse",
   },
   {
     name: "headers",
@@ -79,7 +78,6 @@ export const mcpFormFields = [
       "Authorization: Bearer your-key\nContent-Type: application/json",
     description: "每行一个请求头，格式: Header-Name: value",
     className: "min-h-[100px] font-mono text-sm",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "http" || form.watch("type") === "sse",
+    condition: (form) => form.watch("type") === "http" || form.watch("type") === "sse",
   },
-] as FieldConfig<typeof mcpFormSchema>[];
+] satisfies FieldConfig<McpFormValues, FieldPath<McpFormValues>>[];

--- a/apps/frontend/src/types/form-config.ts
+++ b/apps/frontend/src/types/form-config.ts
@@ -3,8 +3,7 @@
  * 用于配置驱动的表单字段渲染
  */
 
-import type { UseFormReturn } from "react-hook-form";
-import type { z } from "zod";
+import type { FieldPath, FieldValues, UseFormReturn } from "react-hook-form";
 
 /**
  * 支持的字段类型
@@ -13,15 +12,15 @@ export type FieldType = "text" | "textarea" | "select";
 
 /**
  * 字段配置接口
- * @template T - Zod Schema 类型
- * @template Output - 推断的输出类型，必须满足 FieldValues 约束
+ * @template TFieldValues - 表单值类型，必须满足 FieldValues 约束
+ * @template TName - 字段名称类型，必须是 TFieldValues 的有效字段路径
  */
 export interface FieldConfig<
-  T extends z.ZodType,
-  Output extends Record<string, any> = z.infer<T> & Record<string, any>,
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>,
 > {
   /** 字段名称 */
-  name: keyof Output;
+  name: TName;
   /** 字段类型 */
   type: FieldType;
   /** 标签 */
@@ -31,11 +30,11 @@ export interface FieldConfig<
   /** 占位符 */
   placeholder?: string;
   /** 描述（支持静态字符串或动态函数） */
-  description?: string | ((form: UseFormReturn<Output>) => string);
+  description?: string | ((form: UseFormReturn<TFieldValues>) => string);
   /** select 选项（仅 type=select 时有效） */
   options?: Array<{ value: string; label: string }>;
   /** 显示条件函数，返回 true 时显示该字段 */
-  condition?: (form: UseFormReturn<Output>) => boolean;
+  condition?: (form: UseFormReturn<TFieldValues>) => boolean;
   /** textarea 行数 */
   rows?: number;
   /** 额外类名 */


### PR DESCRIPTION
- 导入 ControllerRenderProps, FieldPath, FieldValues 类型
- 修改函数签名使用正确的类型参数
- renderInput 函数使用 ControllerRenderProps<TFieldValues, TName> 类型
- 移除 as any 类型断言，直接使用 name 属性
- 为 option 参数添加显式类型注解
- 简化 FieldConfig 接口只接受 2 个类型参数
- 更新 mcp-form-fields.ts 使用新的类型定义

Fixes #1573

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>