### PR TITLE
refactor: 统一服务层架构，将业务服务移至 services/ 目录

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,30 +145,34 @@ xiaozhi-client 是一个务实的开源 MCP 客户端：
 
 3. **服务层** (`apps/backend/services/`) - 业务服务和工具
 
-   - `MCPServiceManager.ts` - **重新导出**，指向 `@/lib/mcp/manager.js`（向后兼容）
-   - `MCPService.ts` - **重新导出**，指向 `@/lib/mcp/connection.js`（向后兼容）
-   - `MCPServer.ts` - 兼容性包装器，提供向后兼容的 API
-   - 其他业务服务和工具类
+   - `event-bus.service.ts` - 事件总线服务，提供发布-订阅模式的事件处理机制
+   - `notification.service.ts` - 通知服务，处理系统通知和消息推送
+   - `status.service.ts` - 统一的状态管理服务，管理客户端连接状态、MCP 服务状态等
+   - `coze-api.service.ts` - 扣子 API 服务，负责与扣子 API 的交互
+   - `tool-call-log.service.ts` - 工具调用日志服务，负责读取和查询工具调用日志
+   - `index.ts` - 统一导出接口
 
-3. **处理器层** (`apps/backend/handlers/`) - 请求处理器
+   注：MCPServiceManager 和 MCPService 保留在 `lib/mcp/` 作为核心 MCP 协议实现，通过 `lib/mcp/index.ts` 统一导出
+
+4. **处理器层** (`apps/backend/handlers/`) - 请求处理器
 
    - 处理各种 API 请求和业务逻辑
 
-4. **路由层** (`apps/backend/routes/`) - 路由定义
+5. **路由层** (`apps/backend/routes/`) - 路由定义
 
    - API 路由配置和映射
 
-5. **中间件层** (`apps/backend/middlewares/`) - 中间件
+6. **中间件层** (`apps/backend/middlewares/`) - 中间件
 
    - 请求/响应处理中间件
 
-6. **工具层** (`apps/backend/utils/`) - 共享工具和辅助函数
+7. **工具层** (`apps/backend/utils/`) - 共享工具和辅助函数
 
-7. **类型定义** (`apps/backend/types/`) - TypeScript 类型定义
+8. **类型定义** (`apps/backend/types/`) - TypeScript 类型定义
 
-8. **错误处理** (`apps/backend/errors/`) - 统一错误定义和处理
+9. **错误处理** (`apps/backend/errors/`) - 统一错误定义和处理
 
-9. **常量定义** (`apps/backend/constants/`) - 常量定义
+10. **常量定义** (`apps/backend/constants/`) - 常量定义
 
 ### 主要功能
 

--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -3,7 +3,7 @@
  * 提供扣子工作空间和工作流相关的 RESTful API 接口
  */
 
-import { CozeApiService } from "@/lib/coze";
+import { CozeApiService } from "@/services/coze-api.service.js";
 import type { CozeWorkflowsParams } from "@/types/coze";
 import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";

--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -4,8 +4,8 @@
  */
 
 import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
-import type { ToolCallQuery } from "@/lib/mcp/log.js";
-import { ToolCallLogService } from "@/lib/mcp/log.js";
+import type { ToolCallQuery } from "@/services/tool-call-log.service.js";
+import { ToolCallLogService } from "@/services/tool-call-log.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
 import { z } from "zod";

--- a/apps/backend/lib/coze/index.ts
+++ b/apps/backend/lib/coze/index.ts
@@ -5,7 +5,7 @@
  * - config: 扣子 API 环境配置（中英文环境）
  * - @coze/api: 扣子官方 SDK 的完整导出
  * - createCozeClient: 创建扣子 API 客户端的工厂函数
- * - CozeApiService: 扣子 API 服务的封装类
+ * - CozeApiService: 扣子 API 服务的封装类（重新导出，实际位于 @/services）
  *
  * @example
  * ```typescript
@@ -21,4 +21,5 @@
 export { default as config } from "./config";
 export * from "@coze/api";
 export { createCozeClient } from "./client";
-export { CozeApiService } from "./service";
+// 向后兼容：从 services/ 重新导出 CozeApiService
+export { CozeApiService } from "@/services/coze-api.service.js";

--- a/apps/backend/lib/mcp/custom.ts
+++ b/apps/backend/lib/mcp/custom.ts
@@ -22,11 +22,11 @@
  */
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import { CozeApiService } from "@/lib/coze";
 import type { RunWorkflowData } from "@/lib/coze";
 import type { MCPServiceManager } from "@/lib/mcp";
 import { MCPCacheManager } from "@/lib/mcp";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
+import { CozeApiService } from "@/services/coze-api.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type {
   EnhancedToolResultCache,

--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -8,7 +8,7 @@
  * - MCPCacheManager: MCP 缓存管理器，负责工具列表的缓存
  * - CustomMCPHandler: 自定义 MCP 处理器，处理 Coze 工作流等自定义工具
  * - ToolCallLogger: 工具调用记录器，提供 JSONL 格式的记录功能
- * - ToolCallLogService: 工具调用日志服务，提供查询功能
+ * - ToolCallLogService: 工具调用日志服务，提供查询功能（重新导出，实际位于 @/services）
  * - 类型定义: MCP 相关的所有 TypeScript 类型定义
  * - 工具函数: MCP 工具调用的辅助函数
  *
@@ -37,3 +37,9 @@ export * from "./message.js";
 export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+// 向后兼容：从 services/ 重新导出 ToolCallLogService
+export { ToolCallLogService } from "@/services/tool-call-log.service.js";
+export type {
+  ToolCallQuery,
+  ToolCallRecord,
+} from "@/services/tool-call-log.service.js";

--- a/apps/backend/services/coze-api.service.ts
+++ b/apps/backend/services/coze-api.service.ts
@@ -1,0 +1,142 @@
+/**
+ * 扣子 API 服务类
+ * 负责与扣子 API 的交互，包括工作空间和工作流的获取
+ */
+
+import type { RunWorkflowData, WorkSpace } from "@/lib/coze";
+import { createCozeClient } from "@/lib/coze/client.js";
+import type {
+  CozeWorkflowsData,
+  CozeWorkflowsParams,
+  CozeWorkflowsResponse,
+} from "@/types/coze";
+import NodeCache from "node-cache";
+
+/**
+ * 扣子 API 服务类
+ */
+export class CozeApiService {
+  private cache: NodeCache;
+  private token: string; // 保留 token 字段用于可能的后续扩展（如 token 刷新）
+  private client: ReturnType<typeof createCozeClient>;
+
+  constructor(token: string) {
+    this.token = token.trim();
+    this.client = createCozeClient(this.token);
+
+    // 初始化缓存
+    this.cache = new NodeCache({
+      stdTTL: 5 * 60, // 默认5分钟（工作流缓存使用此默认值）
+    });
+  }
+
+  /**
+   * 获取工作空间列表
+   */
+  async getWorkspaces(): Promise<WorkSpace[]> {
+    const cacheKey = "workspaces";
+    const cached = this.cache.get<WorkSpace[]>(cacheKey);
+    if (cached) return cached;
+
+    const { workspaces = [] } = await this.client.workspaces.list();
+
+    // 设置缓存，过期时间30分钟
+    this.cache.set(cacheKey, workspaces, 30 * 60);
+
+    return workspaces;
+  }
+
+  /**
+   * 获取工作流列表
+   */
+  async getWorkflows(params: CozeWorkflowsParams): Promise<CozeWorkflowsData> {
+    const { workspace_id, page_num = 1, page_size = 20 } = params;
+
+    if (!workspace_id || typeof workspace_id !== "string") {
+      throw new Error("工作空间ID不能为空");
+    }
+
+    const cacheKey = `workflows:${workspace_id}:${page_num}:${page_size}`;
+    const cached = this.cache.get<CozeWorkflowsData>(cacheKey);
+    if (cached) return cached;
+
+    const response = await this.client.get<
+      CozeWorkflowsParams,
+      CozeWorkflowsResponse
+    >("/v1/workflows", {
+      workspace_id,
+      page_num: page_num,
+      page_size: page_size,
+      workflow_mode: "workflow",
+    });
+
+    const result = response.data;
+
+    // 设置缓存，使用默认的5分钟过期时间
+    this.cache.set(cacheKey, result);
+
+    return result;
+  }
+
+  /**
+   * 运行工作流
+   * @param workflowId - 工作流ID
+   * @param parameters - 参数
+   * @returns 运行工作流数据
+   */
+  callWorkflow(
+    workflowId: string,
+    parameters: Record<string, unknown>
+  ): Promise<RunWorkflowData> {
+    return this.client.workflows.runs.create({
+      workflow_id: workflowId,
+      parameters,
+    });
+  }
+
+  /**
+   * 清除缓存
+   * @param pattern 可选的模式字符串，清除所有以该模式开头的缓存键
+   */
+  clearCache(pattern?: string): void {
+    if (!pattern) {
+      // 清除所有缓存
+      this.cache.flushAll();
+      return;
+    }
+
+    // node-cache 不支持模式匹配，需要手动实现
+    // 使用前缀匹配，避免意外匹配
+    const keys = this.cache.keys();
+    const keysToDelete = keys.filter((key) => key.startsWith(pattern));
+    this.cache.del(keysToDelete);
+  }
+
+  /**
+   * 获取缓存统计信息
+   */
+  getCacheStats(): {
+    size: number;
+    keys: string[];
+    hits: number;
+    misses: number;
+    hitRate: number;
+    ksize: number;
+    vsize: number;
+  } {
+    const stats = this.cache.getStats();
+    const keys = this.cache.keys();
+    const totalRequests = stats.hits + stats.misses;
+    const hitRate = totalRequests > 0 ? stats.hits / totalRequests : 0;
+
+    return {
+      size: stats.keys,
+      keys,
+      hits: stats.hits,
+      misses: stats.misses,
+      hitRate,
+      ksize: stats.ksize,
+      vsize: stats.vsize,
+    };
+  }
+}

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -5,11 +5,13 @@
  * - StatusService: 统一的状态管理服务，管理客户端连接状态、MCP 服务状态等
  * - NotificationService: 通知服务，处理系统通知和消息推送
  * - EventBus / getEventBus: 事件总线服务，提供发布-订阅模式的事件处理机制
+ * - CozeApiService: 扣子 API 服务，负责与扣子 API 的交互
+ * - ToolCallLogService: 工具调用日志服务，负责读取和查询工具调用日志
  * - CustomMCPHandler: 自定义 MCP 处理器（重新导出，保持向后兼容性）
  *
  * @example
  * ```typescript
- * import { StatusService, NotificationService, getEventBus } from '@/services';
+ * import { StatusService, NotificationService, getEventBus, CozeApiService, ToolCallLogService } from '@/services';
  *
  * // 使用状态服务
  * const statusService = new StatusService();
@@ -20,11 +22,21 @@
  * eventBus.onEvent('event-name', (data) => {
  *   console.log('Event received:', data);
  * });
+ *
+ * // 使用扣子 API 服务
+ * const cozeService = new CozeApiService(token);
+ * const workspaces = await cozeService.getWorkspaces();
+ *
+ * // 使用工具调用日志服务
+ * const logService = new ToolCallLogService();
+ * const logs = await logService.getToolCallLogs();
  * ```
  */
 export * from "./status.service.js";
 export * from "./notification.service.js";
 export * from "./event-bus.service.js";
+export * from "./coze-api.service.js";
+export * from "./tool-call-log.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";

--- a/apps/backend/services/tool-call-log.service.ts
+++ b/apps/backend/services/tool-call-log.service.ts
@@ -1,0 +1,173 @@
+/**
+ * 工具调用日志服务模块
+ * 提供工具调用的写入和查询功能
+ */
+
+import * as fs from "node:fs";
+import { ToolCallLogger } from "@/lib/mcp/log.js";
+import type { ToolCallQuery, ToolCallRecord } from "@/lib/mcp/log.js";
+import { PathUtils } from "@/utils/path-utils.js";
+
+/**
+ * 工具调用日志服务类
+ * 负责读取和查询工具调用日志
+ */
+export class ToolCallLogService {
+  private configDir: string;
+
+  constructor(configDir?: string) {
+    this.configDir = configDir || PathUtils.getConfigDir();
+  }
+
+  /**
+   * 获取工具调用日志文件路径
+   */
+  private getLogFilePath(): string {
+    const toolCallLogger = new ToolCallLogger({}, this.configDir);
+    return toolCallLogger.getLogFilePath();
+  }
+
+  /**
+   * 检查日志文件是否存在
+   */
+  private checkLogFile(): void {
+    const logFilePath = this.getLogFilePath();
+    if (!fs.existsSync(logFilePath)) {
+      throw new Error("工具调用日志文件不存在");
+    }
+  }
+
+  /**
+   * 读取并解析工具调用日志
+   */
+  private parseLogFile(): ToolCallRecord[] {
+    const logFilePath = this.getLogFilePath();
+
+    try {
+      const content = fs.readFileSync(logFilePath, "utf8");
+      const lines = content
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim() !== "");
+
+      const records: ToolCallRecord[] = [];
+
+      for (const line of lines) {
+        try {
+          const record = JSON.parse(line);
+          // 添加时间戳字段（如果 pino 添加了时间信息）
+          if (record.time) {
+            record.timestamp = new Date(record.time).getTime();
+          }
+          // 如果没有时间戳，记录警告信息提示数据质量问题
+          if (!record.timestamp) {
+            console.warn("日志记录缺少时间戳", { line });
+          }
+          records.push(record);
+        } catch {
+          console.warn("跳过无效的日志行", { line });
+        }
+      }
+
+      // 按时间戳倒序排列（最新的在前）
+      records.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+
+      return records;
+    } catch (error) {
+      console.error("读取日志文件失败", { error });
+      throw new Error("无法读取工具调用日志文件");
+    }
+  }
+
+  /**
+   * 过滤工具调用记录
+   */
+  private filterRecords(
+    records: ToolCallRecord[],
+    query: ToolCallQuery
+  ): ToolCallRecord[] {
+    let filtered = [...records];
+
+    // 按工具名称过滤
+    if (query.toolName) {
+      filtered = filtered.filter((record) =>
+        record.toolName
+          .toLowerCase()
+          .includes(query.toolName?.toLowerCase() ?? "")
+      );
+    }
+
+    // 按服务器名称过滤
+    if (query.serverName) {
+      filtered = filtered.filter((record) =>
+        record.serverName
+          ?.toLowerCase()
+          .includes(query.serverName?.toLowerCase() ?? "")
+      );
+    }
+
+    // 按成功状态过滤
+    if (query.success !== undefined) {
+      filtered = filtered.filter((record) => record.success === query.success);
+    }
+
+    // 按时间范围过滤
+    if (query.startDate || query.endDate) {
+      const startTime = query.startDate
+        ? new Date(query.startDate).getTime()
+        : 0;
+      const endTime = query.endDate
+        ? new Date(query.endDate).getTime()
+        : Date.now();
+
+      filtered = filtered.filter((record) => {
+        const recordTime = record.timestamp || 0;
+        return recordTime >= startTime && recordTime <= endTime;
+      });
+    }
+
+    return filtered;
+  }
+
+  /**
+   * 获取工具调用日志
+   */
+  async getToolCallLogs(query: ToolCallQuery = {}): Promise<{
+    records: ToolCallRecord[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    this.checkLogFile();
+
+    const records = this.parseLogFile();
+    const filtered = this.filterRecords(records, query);
+    const total = filtered.length;
+
+    // 分页处理
+    const limit = Math.min(
+      query.limit || 50,
+      1000 // 最大限制 1000
+    );
+    const offset = query.offset || 0;
+    const paginated = filtered.slice(offset, offset + limit);
+    const hasMore = offset + limit < total;
+
+    console.log("返回工具调用日志", {
+      count: paginated.length,
+      total,
+    });
+
+    return {
+      records: paginated,
+      total,
+      hasMore,
+    };
+  }
+}
+
+// 重新导出类型定义
+export type {
+  ToolCallRecord,
+  ToolCallQuery,
+  ToolCallLogConfig,
+} from "@/lib/mcp/log.js";


### PR DESCRIPTION
按照 Issue #1575 的架构重构方案，将分散在 lib/ 目录中的业务服务统一迁移到 services/ 目录，实现更清晰的分层架构。

## 主要变更

### 新增文件
- `apps/backend/services/coze-api.service.ts` - 扣子 API 服务（从 lib/coze/service.ts 迁移）
- `apps/backend/services/tool-call-log.service.ts` - 工具调用日志服务（从 lib/mcp/log.ts 迁移）

### 修改文件
- `apps/backend/services/index.ts` - 添加新服务的导出
- `apps/backend/handlers/coze.handler.ts` - 更新导入路径
- `apps/backend/handlers/mcp-tool-log.handler.ts` - 更新导入路径
- `apps/backend/lib/coze/index.ts` - 重新导出 CozeApiService（向后兼容）
- `apps/backend/lib/mcp/index.ts` - 重新导出 ToolCallLogService（向后兼容）
- `apps/backend/lib/mcp/custom.ts` - 更新导入路径
- `CLAUDE.md` - 更新架构说明文档

## 架构改进

- **统一服务层位置**：所有业务服务现在位于 `services/` 目录
- **保持向后兼容**：通过 `lib/` 目录的重新导出，现有代码无需修改
- **清晰的职责分离**：`lib/` 专注于核心库功能，`services/` 专注于业务服务

## 质量检查

- ✅ Lint 通过 (Biome)
- ✅ 类型检查通过 (TypeScript)
- ✅ 测试通过 (905 tests passed)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>