### PR TITLE
fix: 修复 MCPManager.cleanup() 未清理 retryTimers 定时器的资源泄漏问题

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1831,6 +1831,14 @@ export class MCPServiceManager extends EventEmitter {
   async cleanup(): Promise<void> {
     await this.stopAllServices();
 
+    // 清理所有重试定时器，防止内存泄漏和错误的回调执行
+    for (const [serviceName, timer] of this.retryTimers) {
+      clearTimeout(timer);
+      console.debug(`[MCPManager] 清理服务 ${serviceName} 的重试定时器`);
+    }
+    this.retryTimers.clear();
+    this.failedServices.clear();
+
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(
       "mcp:service:connected",


### PR DESCRIPTION
在 cleanup() 方法中添加了对 retryTimers Map 的清理逻辑，防止：
- 内存泄漏：setTimeout 定时器未被清理
- 错误的日志输出：已清理服务的定时器回调仍会执行
- 潜在的运行时错误：访问已清理的资源

修复内容：
- 遍历 retryTimers Map 并清除所有定时器
- 清空 retryTimers 和 failedServices 集合
- 添加调试日志以便追踪清理过程

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>