### PR TITLE
fix: 将 collapsible-text.tsx 中的 console.warn 替换为统一的 Logger 系统

### DIFF
--- a/apps/frontend/src/components/common/collapsible-text.tsx
+++ b/apps/frontend/src/components/common/collapsible-text.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { logger } from "@/lib/logger";
 import { cn } from "@/lib/utils";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { useEffect, useState } from "react";
@@ -60,7 +61,7 @@ export function CollapsibleText({
     try {
       localStorage.setItem(storageKey, String(isExpanded));
     } catch (error) {
-      console.warn("无法写入 localStorage:", error);
+      logger.warn("无法写入 localStorage", error);
     }
   }, [isExpanded, storageKey]);
 

--- a/apps/frontend/src/lib/logger.ts
+++ b/apps/frontend/src/lib/logger.ts
@@ -1,0 +1,88 @@
+/**
+ * 前端日志系统模块
+ *
+ * 提供统一的日志记录功能，用于前端项目。
+ *
+ * ## 主要特性
+ *
+ * - **多种日志级别**：支持 debug、info、warn、error
+ * - **统一接口**：提供一致的日志记录 API
+ * - **环境感知**：在开发环境提供更详细的日志输出
+ * - **类型安全**：完整的 TypeScript 类型支持
+ *
+ * ## 使用示例
+ *
+ * ```typescript
+ * import { logger } from '@/lib/logger';
+ *
+ * // 记录信息
+ * logger.info('操作成功');
+ * logger.error('发生错误', error);
+ * logger.debug('调试信息', { data: 'value' });
+ * ```
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+/**
+ * 日志记录器类
+ */
+class Logger {
+  private readonly isDevelopment: boolean;
+
+  constructor() {
+    this.isDevelopment =
+      typeof process !== "undefined" && process.env?.NODE_ENV !== "production";
+  }
+
+  /**
+   * 记录调试级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (this.isDevelopment) {
+      console.debug(`[DEBUG] ${message}`, ...args);
+    }
+  }
+
+  /**
+   * 记录信息级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  info(message: string, ...args: unknown[]): void {
+    console.info(`[INFO] ${message}`, ...args);
+  }
+
+  /**
+   * 记录警告级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  warn(message: string, ...args: unknown[]): void {
+    console.warn(`[WARN] ${message}`, ...args);
+  }
+
+  /**
+   * 记录错误级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  error(message: string, ...args: unknown[]): void {
+    console.error(`[ERROR] ${message}`, ...args);
+  }
+}
+
+/**
+ * 全局 Logger 实例
+ */
+export const logger = new Logger();


### PR DESCRIPTION
- 创建前端专用的 Logger 工具类 (apps/frontend/src/lib/logger.ts)
- 支持 debug、info、warn、error 四种日志级别
- 环境感知：仅在非生产环境输出详细日志
- 更新 collapsible-text.tsx 使用 logger.warn 替代 console.warn

修复 Issue #1579

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>