### PR TITLE
fix: 修复 sidebar.tsx 中的英文错误消息和用户界面文本违反本地化规范

### DIFF
--- a/apps/frontend/src/components/ui/sidebar.tsx
+++ b/apps/frontend/src/components/ui/sidebar.tsx
@@ -47,7 +47,7 @@ const SidebarContext = React.createContext<SidebarContextProps | null>(null);
 function useSidebar() {
   const context = React.useContext(SidebarContext);
   if (!context) {
-    throw new Error("useSidebar must be used within a SidebarProvider.");
+    throw new Error("useSidebar 必须在 SidebarProvider 内使用");
   }
 
   return context;
@@ -213,8 +213,8 @@ const Sidebar = React.forwardRef<
             side={side}
           >
             <SheetHeader className="sr-only">
-              <SheetTitle>Sidebar</SheetTitle>
-              <SheetDescription>Displays the mobile sidebar.</SheetDescription>
+              <SheetTitle>侧边栏</SheetTitle>
+              <SheetDescription>显示移动端侧边栏。</SheetDescription>
             </SheetHeader>
             <div className="flex h-full w-full flex-col">{children}</div>
           </SheetContent>
@@ -289,7 +289,7 @@ const SidebarTrigger = React.forwardRef<
       {...props}
     >
       <PanelLeft />
-      <span className="sr-only">Toggle Sidebar</span>
+      <span className="sr-only">切换侧边栏</span>
     </Button>
   );
 });
@@ -305,10 +305,10 @@ const SidebarRail = React.forwardRef<
     <button
       ref={ref}
       data-sidebar="rail"
-      aria-label="Toggle Sidebar"
+      aria-label="切换侧边栏"
       tabIndex={-1}
       onClick={toggleSidebar}
-      title="Toggle Sidebar"
+      title="切换侧边栏"
       className={cn(
         "absolute inset-y-0 z-20 hidden w-4 -translate-x-1/2 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-[2px] hover:after:bg-sidebar-border group-data-[side=left]:-right-4 group-data-[side=right]:left-0 sm:flex",
         "[[data-side=left]_&]:cursor-w-resize [[data-side=right]_&]:cursor-e-resize",


### PR DESCRIPTION
将以下英文字符串翻译为中文：
- useSidebar 错误消息："useSidebar must be used within a SidebarProvider." → "useSidebar 必须在 SidebarProvider 内使用"
- SheetTitle："Sidebar" → "侧边栏"
- SheetDescription："Displays the mobile sidebar." → "显示移动端侧边栏。"
- SidebarTrigger sr-only 文本："Toggle Sidebar" → "切换侧边栏"
- SidebarRail aria-label 和 title："Toggle Sidebar" → "切换侧边栏"

Closes #1584

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>