### PR TITLE
docs: 修复快速上手指南中 config set 命令示例缺少参数说明

### DIFF
--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -104,9 +104,17 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## 设置小智接入点
     小智AI配置MCP接入点的 [使用说明](https://ccnphfhqs21z.feishu.cn/wiki/HiPEwZ37XiitnwktX13cEM5KnSb)
+
+    `xiaozhi config set` 命令用于设置配置项，格式为 `<配置键名> <配置值>`。
+
     ```bash
-    xiaozhi config set mcpEndpoint "<从小智服务端获取到的接入点地址>"
+    # 设置 MCP 端点配置
+    xiaozhi config set mcpEndpoint "wss://api.xiaozhi.me/mcp/?token=YOUR_TOKEN"
     ```
+
+    <Callout type="info">
+      **提示**: 请从小智服务端获取实际的接入点地址，替换上面的示例 URL。
+    </Callout>
 
 ## 启动服务
     ```bash


### PR DESCRIPTION
- 添加命令格式说明：`<配置键名> <配置值>`
- 提供实际的 URL 格式示例（wss://api.xiaozhi.me/mcp/?token=YOUR_TOKEN）
- 添加 Callout 提示框，提醒用户替换为实际的接入点地址

修复 #1587

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>