### PR TITLE
fix: 修复 version-display.tsx 使用 console.error 违反代码规范一致性问题

### DIFF
--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -10,6 +10,7 @@ import { apiClient } from "@/services/api";
 import { Button } from "@ui/button";
 import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";
 
 interface VersionDisplayProps {
@@ -42,7 +43,6 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         setVersionInfo(info);
       } catch (err) {
         setError(err instanceof Error ? err.message : "获取版本信息失败");
-        console.error("获取版本信息失败:", err);
       } finally {
         setLoading(false);
       }
@@ -66,7 +66,6 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         const updateInfo = await apiClient.getLatestVersion();
         setLatestVersionInfo(updateInfo);
       } catch (err) {
-        console.error("检查更新失败:", err);
         // 设置默认值，不显示错误给用户
         setLatestVersionInfo({
           currentVersion: versionInfo?.version || "unknown",
@@ -95,7 +94,9 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         }
         copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
       } catch (err) {
-        console.error("复制版本号失败:", err);
+        toast.error("复制版本号失败", {
+          description: err instanceof Error ? err.message : "未知错误",
+        });
       }
     }
   };


### PR DESCRIPTION
- 移除获取版本信息失败时的 console.error（已有 UI 错误显示）
- 移除检查更新失败时的 console.error（静默处理，不显示给用户）
- 为复制版本号失败添加 toast 错误通知，改善用户体验
- 所有错误信息已中文化，符合本地化规范

Fixes #1590

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>