### PR TITLE
fix: 统一 ErrorCategory 枚举定义，移除重复

### DIFF
--- a/apps/backend/errors/error-helper.ts
+++ b/apps/backend/errors/error-helper.ts
@@ -40,6 +40,11 @@ export enum ErrorCategory {
   AUTHENTICATION = "authentication",
   NETWORK = "network",
   UNKNOWN = "unknown",
+  // 以下值用于向后兼容 mcp-errors.ts 中的原有枚举值
+  VALIDATION = "validation",
+  OPERATION = "operation",
+  SYSTEM = "system",
+  EXTERNAL = "external",
 }
 
 /**

--- a/apps/backend/errors/mcp-errors.ts
+++ b/apps/backend/errors/mcp-errors.ts
@@ -10,6 +10,11 @@
  * @module mcp-errors
  */
 
+import { ErrorCategory } from "./error-helper.js";
+
+// 重新导出 ErrorCategory 以保持向后兼容性
+export { ErrorCategory };
+
 /**
  * MCP错误代码枚举
  *
@@ -68,18 +73,6 @@ export enum ErrorSeverity {
   MEDIUM = "medium", // 中等错误，影响部分功能
   HIGH = "high", // 严重错误，影响核心功能
   CRITICAL = "critical", // 致命错误，系统无法继续运行
-}
-
-/**
- * MCP错误类别
- */
-export enum ErrorCategory {
-  CONFIGURATION = "configuration", // 配置相关错误
-  CONNECTION = "connection", // 连接相关错误
-  VALIDATION = "validation", // 验证相关错误
-  OPERATION = "operation", // 操作相关错误
-  SYSTEM = "system", // 系统相关错误
-  EXTERNAL = "external", // 外部服务错误
 }
 
 /**


### PR DESCRIPTION
删除 mcp-errors.ts 中的重复 ErrorCategory 枚举定义，统一使用 error-helper.ts 中的定义。为保持向后兼容，在 error-helper.ts 中添加了 mcp-errors.ts 原有的枚举值（VALIDATION, OPERATION, SYSTEM, EXTERNAL）。

修复内容：
- 删除 mcp-errors.ts 中的重复 ErrorCategory 枚举
- 在 mcp-errors.ts 中从 error-helper.ts 导入 ErrorCategory
- 在 error-helper.ts 中添加缺失的枚举值
- 添加重新导出以保持向后兼容性

Fixes #1594

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>