### PR TITLE
fix: NetworkService 使用统一的 Logger 系统替代 console.log

### DIFF
--- a/apps/frontend/src/lib/logger.ts
+++ b/apps/frontend/src/lib/logger.ts
@@ -1,0 +1,150 @@
+/**
+ * 前端统一日志工具
+ * 提供结构化的日志记录功能，支持不同日志级别
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+/**
+ * 日志配置接口
+ */
+export interface LoggerConfig {
+  /** 日志级别 */
+  level?: LogLevel;
+  /** 是否启用日志 */
+  enabled?: boolean;
+  /** 日志前缀 */
+  prefix?: string;
+}
+
+/**
+ * Logger 类
+ */
+class Logger {
+  private config: Required<LoggerConfig>;
+
+  constructor(config: LoggerConfig = {}) {
+    this.config = {
+      level: config.level ?? LogLevel.INFO,
+      enabled: config.enabled ?? true,
+      prefix: config.prefix ?? "",
+    };
+  }
+
+  /**
+   * 设置日志级别
+   */
+  setLevel(level: LogLevel): void {
+    this.config.level = level;
+  }
+
+  /**
+   * 启用/禁用日志
+   */
+  setEnabled(enabled: boolean): void {
+    this.config.enabled = enabled;
+  }
+
+  /**
+   * 检查是否应该记录该级别的日志
+   */
+  private shouldLog(level: LogLevel): boolean {
+    if (!this.config.enabled) {
+      return false;
+    }
+
+    const levels = [
+      LogLevel.DEBUG,
+      LogLevel.INFO,
+      LogLevel.WARN,
+      LogLevel.ERROR,
+    ];
+    const currentLevelIndex = levels.indexOf(this.config.level);
+    const logLevelIndex = levels.indexOf(level);
+
+    return logLevelIndex >= currentLevelIndex;
+  }
+
+  /**
+   * 格式化日志消息
+   */
+  private formatMessage(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    const prefix = this.config.prefix ? `[${this.config.prefix}] ` : "";
+    return `${timestamp} ${prefix}${level.toUpperCase()}: ${message}`;
+  }
+
+  /**
+   * 记录 DEBUG 级别日志
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.DEBUG)) {
+      console.debug(this.formatMessage(LogLevel.DEBUG, message), ...args);
+    }
+  }
+
+  /**
+   * 记录 INFO 级别日志
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.INFO)) {
+      console.info(this.formatMessage(LogLevel.INFO, message), ...args);
+    }
+  }
+
+  /**
+   * 记录 WARN 级别日志
+   */
+  warn(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.WARN)) {
+      console.warn(this.formatMessage(LogLevel.WARN, message), ...args);
+    }
+  }
+
+  /**
+   * 记录 ERROR 级别日志
+   */
+  error(message: string, error?: Error | unknown, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.ERROR)) {
+      console.error(
+        this.formatMessage(LogLevel.ERROR, message),
+        error,
+        ...args
+      );
+    }
+  }
+}
+
+/**
+ * 创建带有指定前缀的 Logger 实例
+ */
+export function createLogger(prefix: string): Logger {
+  return new Logger({ prefix });
+}
+
+/**
+ * 默认的全局 Logger 实例
+ */
+export const logger = new Logger();
+
+/**
+ * 设置全局日志级别
+ */
+export function setGlobalLogLevel(level: LogLevel): void {
+  logger.setLevel(level);
+}
+
+/**
+ * 启用/禁用全局日志
+ */
+export function setGlobalLoggerEnabled(enabled: boolean): void {
+  logger.setEnabled(enabled);
+}

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -3,6 +3,7 @@
  * 整合 HTTP API 客户端和 WebSocket 管理器
  */
 
+import { createLogger } from "@/lib/logger";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 import { type ApiClient, apiClient } from "./api";
 import {
@@ -19,6 +20,7 @@ export class NetworkService {
   private apiClient: ApiClient;
   private webSocketManager: WebSocketManager;
   private initialized = false;
+  private logger = createLogger("NetworkService");
 
   constructor() {
     this.apiClient = apiClient;
@@ -33,20 +35,20 @@ export class NetworkService {
       return;
     }
 
-    console.log("[NetworkService] 初始化网络服务");
+    this.logger.info("初始化网络服务");
 
     // 启动 WebSocket 连接
     this.webSocketManager.connect();
 
     this.initialized = true;
-    console.log("[NetworkService] 网络服务初始化完成");
+    this.logger.info("网络服务初始化完成");
   }
 
   /**
    * 销毁网络服务
    */
   destroy(): void {
-    console.log("[NetworkService] 销毁网络服务");
+    this.logger.info("销毁网络服务");
     this.webSocketManager.disconnect();
     this.initialized = false;
   }


### PR DESCRIPTION
- 新增前端统一 Logger 工具类 (apps/frontend/src/lib/logger.ts)
- 在 NetworkService 中使用 createLogger 替代 console.log
- 支持多种日志级别 (DEBUG, INFO, WARN, ERROR)
- 支持日志前缀和动态配置

修复 #1596

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>