### PR TITLE
fix: 修复 CLI 命令处理器中的类型安全问题

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -12,6 +12,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { ServiceType } from "../interfaces/ServiceTypes";
 
 /**
  * 配置管理命令处理器
@@ -79,7 +80,8 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         throw new Error("格式必须是 json, json5 或 jsonc");
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
 
       if (configManager.configExists()) {
         spinner.warn("配置文件已存在");
@@ -117,7 +119,8 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("读取配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");
@@ -226,7 +229,8 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("更新配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");
@@ -246,7 +250,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           if (Number.isNaN(interval) || interval <= 0) {
             throw new Error("心跳检测间隔必须是正整数");
           }
-          configManager.updateHeartbeatInterval(interval);
+          configManager.setHeartbeatInterval(interval);
           spinner.succeed(`心跳检测间隔已设置为: ${interval}ms`);
           break;
         }
@@ -255,7 +259,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           if (Number.isNaN(timeout) || timeout <= 0) {
             throw new Error("心跳超时时间必须是正整数");
           }
-          configManager.updateHeartbeatTimeout(timeout);
+          configManager.setHeartbeatTimeout(timeout);
           spinner.succeed(`心跳超时时间已设置为: ${timeout}ms`);
           break;
         }
@@ -264,7 +268,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           if (Number.isNaN(interval) || interval <= 0) {
             throw new Error("重连间隔必须是正整数");
           }
-          configManager.updateReconnectInterval(interval);
+          configManager.setReconnectInterval(interval);
           spinner.succeed(`重连间隔已设置为: ${interval}ms`);
           break;
         }

--- a/packages/cli/src/commands/EndpointCommandHandler.ts
+++ b/packages/cli/src/commands/EndpointCommandHandler.ts
@@ -11,6 +11,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { ServiceType } from "../interfaces/ServiceTypes";
 
 /**
  * 端点管理命令处理器
@@ -74,7 +75,8 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("读取端点配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
       const endpoints = configManager.getMcpEndpoints();
       spinner.succeed("端点列表");
 
@@ -101,7 +103,8 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("添加端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
       configManager.addMcpEndpoint(url);
       spinner.succeed(`成功添加端点: ${url}`);
 
@@ -122,7 +125,8 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("移除端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
       configManager.removeMcpEndpoint(url);
       spinner.succeed(`成功移除端点: ${url}`);
 
@@ -143,7 +147,8 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("设置端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager =
+        this.getService<ServiceType<"configManager">>("configManager");
 
       if (urls.length === 1) {
         configManager.updateMcpEndpoint(urls[0]);

--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -12,6 +12,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { ServiceType } from "../interfaces/ServiceTypes";
 
 /**
  * 项目管理命令处理器
@@ -54,8 +55,9 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     const spinner = ora("初始化项目...").start();
 
     try {
-      const templateManager = this.getService<any>("templateManager");
-      const fileUtils = this.getService<any>("fileUtils");
+      const templateManager =
+        this.getService<ServiceType<"templateManager">>("templateManager");
+      const fileUtils = this.getService<ServiceType<"fileUtils">>("fileUtils");
 
       // 确定目标目录
       const targetPath = path.join(process.cwd(), projectName);
@@ -73,7 +75,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
         // 使用模板创建项目
         await this.createFromTemplate(
           projectName,
-          options.template,
+          options.template as string, // 已通过 if 检查
           targetPath,
           spinner,
           templateManager
@@ -219,7 +221,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     input: string,
     templates: string[]
   ): string | null {
-    const formatUtils = this.getService<any>("formatUtils");
+    const formatUtils =
+      this.getService<ServiceType<"formatUtils">>("formatUtils");
 
     let bestMatch = null;
     let bestSimilarity = 0;

--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -10,6 +10,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { ServiceType } from "../interfaces/ServiceTypes";
 
 /**
  * 服务管理命令处理器
@@ -89,7 +90,8 @@ export class ServiceCommandHandler extends BaseCommandHandler {
         consola.level = 5; // debug 级别
       }
 
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager =
+        this.getService<ServiceType<"serviceManager">>("serviceManager");
 
       if (options.stdio) {
         // stdio 模式已迁移到 HTTP 方式
@@ -99,7 +101,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
 
       // 传统模式
       await serviceManager.start({
-        daemon: options.daemon || false,
+        daemon: (options.daemon as boolean) || false,
       });
     } catch (error) {
       this.handleError(error as Error);
@@ -111,7 +113,8 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStop(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager =
+        this.getService<ServiceType<"serviceManager">>("serviceManager");
       await serviceManager.stop();
     } catch (error) {
       this.handleError(error as Error);
@@ -123,7 +126,8 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStatus(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager =
+        this.getService<ServiceType<"serviceManager">>("serviceManager");
       const status = await serviceManager.getStatus();
 
       if (status.running) {
@@ -147,9 +151,10 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleRestart(options: CommandOptions): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager =
+        this.getService<ServiceType<"serviceManager">>("serviceManager");
       await serviceManager.restart({
-        daemon: options.daemon || false,
+        daemon: (options.daemon as boolean) || false,
       });
     } catch (error) {
       this.handleError(error as Error);
@@ -161,7 +166,8 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleAttach(): Promise<void> {
     try {
-      const daemonManager = this.getService<any>("daemonManager");
+      const daemonManager =
+        this.getService<ServiceType<"daemonManager">>("daemonManager");
       await daemonManager.attachToLogs();
     } catch (error) {
       this.handleError(error as Error);

--- a/packages/cli/src/interfaces/ServiceTypes.ts
+++ b/packages/cli/src/interfaces/ServiceTypes.ts
@@ -1,0 +1,177 @@
+/**
+ * 服务类型定义
+ *
+ * 此文件定义了 DI 容器中所有服务的类型接口
+ * 用于替代 getService<any>() 中的 any 类型，提高类型安全性
+ */
+
+import type { ConfigManager } from "@xiaozhi-client/config";
+import type {
+  DaemonManager,
+  ProcessManager,
+  ServiceManager,
+  TemplateManager,
+} from "./Service";
+
+/**
+ * FileUtils 接口
+ */
+export interface IFileUtils {
+  /** 检查文件是否存在 */
+  exists(filePath: string): boolean;
+  /** 确保目录存在 */
+  ensureDir(dirPath: string): void;
+  /** 读取文件内容 */
+  readFile(filePath: string, encoding?: BufferEncoding): string;
+  /** 写入文件内容 */
+  writeFile(
+    filePath: string,
+    content: string,
+    options?: { overwrite?: boolean }
+  ): void;
+  /** 复制文件 */
+  copyFile(
+    srcPath: string,
+    destPath: string,
+    options?: { overwrite?: boolean }
+  ): void;
+  /** 删除文件 */
+  deleteFile(filePath: string): void;
+  /** 复制目录 */
+  copyDirectory(
+    srcDir: string,
+    destDir: string,
+    options?: {
+      recursive?: boolean;
+      exclude?: string[];
+      overwrite?: boolean;
+    }
+  ): void;
+  /** 删除目录 */
+  deleteDirectory(dirPath: string, options?: { recursive?: boolean }): void;
+  /** 获取文件信息 */
+  getFileInfo(filePath: string): {
+    size: number;
+    isFile: boolean;
+    isDirectory: boolean;
+    mtime: Date;
+    ctime: Date;
+  };
+  /** 列出目录内容 */
+  listDirectory(
+    dirPath: string,
+    options?: {
+      recursive?: boolean;
+      includeHidden?: boolean;
+    }
+  ): string[];
+  /** 创建临时文件 */
+  createTempFile(prefix?: string, suffix?: string): string;
+  /** 检查文件权限 */
+  checkPermissions(filePath: string, mode?: number): boolean;
+  /** 获取文件扩展名 */
+  getExtension(filePath: string): string;
+  /** 获取文件名（不含扩展名） */
+  getBaseName(filePath: string): string;
+  /** 规范化路径 */
+  normalizePath(filePath: string): string;
+  /** 解析相对路径为绝对路径 */
+  resolvePath(filePath: string, basePath?: string): string;
+}
+
+/**
+ * FormatUtils 接口
+ */
+export interface IFormatUtils {
+  /** 格式化运行时间 */
+  formatUptime(ms: number): string;
+  /** 格式化文件大小 */
+  formatFileSize(bytes: number): string;
+  /** 格式化时间戳 */
+  formatTimestamp(timestamp: number, format?: "full" | "date" | "time"): string;
+  /** 格式化进程 ID */
+  formatPid(pid: number): string;
+  /** 格式化端口号 */
+  formatPort(port: number): string;
+  /** 格式化 URL */
+  formatUrl(
+    protocol: string,
+    host: string,
+    port: number,
+    path?: string
+  ): string;
+  /** 格式化配置键值对 */
+  formatConfigPair(key: string, value: unknown): string;
+  /** 格式化错误消息 */
+  formatError(error: Error, includeStack?: boolean): string;
+  /** 格式化列表 */
+  formatList(items: string[], bullet?: string): string;
+  /** 格式化表格数据 */
+  formatTable(data: Record<string, unknown>[]): string;
+  /** 格式化进度条 */
+  formatProgressBar(current: number, total: number, width?: number): string;
+  /** 格式化命令行参数 */
+  formatCommandArgs(command: string, args: string[]): string;
+  /** 截断长文本 */
+  truncateText(text: string, maxLength: number, suffix?: string): string;
+  /** 格式化 JSON */
+  formatJson(obj: unknown, indent?: number): string;
+  /** 格式化布尔值 */
+  formatBoolean(value: boolean, trueText?: string, falseText?: string): string;
+  /** 计算字符串相似度 */
+  calculateSimilarity(str1: string, str2: string): number;
+}
+
+/**
+ * DaemonManager 接口
+ */
+export interface IDaemonManager {
+  /** 启动守护进程 */
+  startDaemon(serverFactory: () => Promise<any>): Promise<void>;
+  /** 停止守护进程 */
+  stopDaemon(): Promise<void>;
+  /** 连接到守护进程日志 */
+  attachToLogs(logFileName?: string): Promise<void>;
+}
+
+/**
+ * ErrorHandler 接口
+ */
+export interface IErrorHandler {
+  /** 处理错误 */
+  handle(error: Error): void;
+}
+
+/**
+ * DI 容器服务键到类型的映射
+ */
+export interface IServiceMap {
+  /** 配置管理器 */
+  configManager: ConfigManager;
+  /** 服务管理器 */
+  serviceManager: ServiceManager;
+  /** 模板管理器 */
+  templateManager: TemplateManager;
+  /** 文件工具 */
+  fileUtils: IFileUtils;
+  /** 格式化工具 */
+  formatUtils: IFormatUtils;
+  /** 守护进程管理器 */
+  daemonManager: IDaemonManager;
+  /** 错误处理器 */
+  errorHandler: IErrorHandler;
+  /** 进程管理器 */
+  processManager: ProcessManager;
+}
+
+/**
+ * 获取服务类型的安全辅助类型
+ *
+ * @example
+ * ```typescript
+ * // 使用 ServiceType 获取正确的类型
+ * const configManager = this.getService<ServiceType<"configManager">("configManager");
+ * // configManager 的类型为 ConfigManager
+ * ```
+ */
+export type ServiceType<K extends keyof IServiceMap> = IServiceMap[K];

--- a/packages/cli/src/utils/FormatUtils.ts
+++ b/packages/cli/src/utils/FormatUtils.ts
@@ -195,4 +195,48 @@ export class FormatUtils {
   ): string {
     return value ? trueText : falseText;
   }
+
+  /**
+   * 计算两个字符串的相似度（使用编辑距离算法）
+   * 返回值范围 [0, 1]，1 表示完全相同
+   */
+  static calculateSimilarity(str1: string, str2: string): number {
+    // 简单的字符串相似度计算
+    const len1 = str1.length;
+    const len2 = str2.length;
+
+    if (len1 === 0) return len2 === 0 ? 1 : 0;
+    if (len2 === 0) return 0;
+
+    // 使用 Levenshtein 距离算法
+    const matrix: number[][] = [];
+
+    // 初始化矩阵
+    for (let i = 0; i <= len2; i++) {
+      matrix[i] = [i];
+    }
+
+    for (let j = 0; j <= len1; j++) {
+      matrix[0][j] = j;
+    }
+
+    // 填充矩阵
+    for (let i = 1; i <= len2; i++) {
+      for (let j = 1; j <= len1; j++) {
+        if (str2.charAt(i - 1) === str1.charAt(j - 1)) {
+          matrix[i][j] = matrix[i - 1][j - 1];
+        } else {
+          matrix[i][j] = Math.min(
+            matrix[i - 1][j - 1] + 1, // 替换
+            matrix[i][j - 1] + 1, // 插入
+            matrix[i - 1][j] + 1 // 删除
+          );
+        }
+      }
+    }
+
+    // 计算相似度：1 - (编辑距离 / 最大长度)
+    const maxLen = Math.max(len1, len2);
+    return 1 - matrix[len2][len1] / maxLen;
+  }
 }


### PR DESCRIPTION
- 创建 ServiceTypes.ts 定义服务接口类型
- 替换 15 处 getService<any>() 为具体类型
- 添加 FormatUtils.calculateSimilarity 方法
- 修复 ConfigManager 方法名称（setHeartbeatInterval 等）
- 添加 IDaemonManager.attachToLogs 接口方法
- 修复 CommandOptions 类型断言

关闭 #1606

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>