### PR TITLE
fix: 将 TaskInfo 接口的 any 类型替换为更安全的类型

### DIFF
--- a/packages/shared-types/src/mcp/task.ts
+++ b/packages/shared-types/src/mcp/task.ts
@@ -28,12 +28,12 @@ export interface CacheStateTransition {
 export interface TaskInfo {
   taskId: string;
   toolName: string;
-  arguments: any;
+  arguments: Record<string, unknown>;
   status: TaskStatus;
   startTime: string;
   endTime?: string;
   error?: string;
-  result?: any;
+  result?: unknown;
 }
 
 /**


### PR DESCRIPTION
将 TaskInfo 接口中的 arguments 字段从 any 改为 Record<string, unknown>，
result 字段从 any 改为 unknown，提高类型安全性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>