### PR TITLE
fix(websocket): 移除 websocket.ts 和 websocket-compat.ts 之间的循环依赖

### DIFF
--- a/apps/frontend/src/components/web-url-setting-button.test.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.test.tsx
@@ -58,6 +58,11 @@ vi.mock("@/providers/WebSocketProvider", () => ({
 }));
 
 vi.mock("@/stores/websocket", () => ({
+  useWebSocketConnected: vi.fn(() => false),
+  useWebSocketPortChangeStatus: vi.fn(() => undefined),
+}));
+
+vi.mock("@/stores/websocket-compat", () => ({
   useWebSocketConfig: vi.fn(() => ({
     webUI: {
       port: 9999,
@@ -66,8 +71,6 @@ vi.mock("@/stores/websocket", () => ({
     mcpEndpoint: "test-endpoint",
     mcpServers: {},
   })),
-  useWebSocketConnected: vi.fn(() => false),
-  useWebSocketPortChangeStatus: vi.fn(() => undefined),
 }));
 
 // 模拟 sonner toast 组件

--- a/apps/frontend/src/stores/index.ts
+++ b/apps/frontend/src/stores/index.ts
@@ -100,6 +100,16 @@ export { useWebSocketStore } from "./websocket";
 export { useConfigStore } from "./config";
 export { useStatusStore } from "./status";
 
+// 导出废弃的兼容性选择器（从 websocket-compat.ts 直接导入以避免循环依赖）
+export {
+  useWebSocketConfig,
+  useWebSocketStatus,
+  useWebSocketMcpEndpoint,
+  useWebSocketMcpServers,
+  useWebSocketMcpServerConfig,
+  useWebSocketRestartStatus,
+} from "./websocket-compat";
+
 // 导出所有选择器 hooks（避免命名冲突）
 export {
   // WebSocket store exports
@@ -115,12 +125,6 @@ export {
   useWebSocketActions,
   useWebSocketControls,
   useWebSocketData,
-  // 废弃的导出（向后兼容）
-  useWebSocketConfig,
-  useWebSocketStatus,
-  useWebSocketRestartStatus,
-  useWebSocketMcpServers,
-  useWebSocketMcpServerConfig,
 } from "./websocket";
 
 export {

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -372,51 +372,17 @@ export const useWebSocketConnectionTimes = () =>
   );
 
 // ==================== 向后兼容的选择器（废弃） ====================
-
-// 导入兼容性选择器
-import {
-  useWebSocketConfig as useWebSocketConfigCompat,
-  useWebSocketMcpEndpoint as useWebSocketMcpEndpointCompat,
-  useWebSocketMcpServerConfig as useWebSocketMcpServerConfigCompat,
-  useWebSocketMcpServers as useWebSocketMcpServersCompat,
-  useWebSocketRestartStatus as useWebSocketRestartStatusCompat,
-  useWebSocketStatus as useWebSocketStatusCompat,
-} from "./websocket-compat";
-
-/**
- * @deprecated 配置数据已迁移到 stores/config.ts，请使用 useConfig()
- */
-export const useWebSocketConfig = useWebSocketConfigCompat;
-
-/**
- * @deprecated 状态数据已迁移到 stores/status.ts，请使用 useClientStatus()
- */
-export const useWebSocketStatus = useWebSocketStatusCompat;
-
-/**
- * @deprecated 重启状态已迁移到 stores/status.ts，请使用 useRestartStatus()
- */
-export const useWebSocketRestartStatus = useWebSocketRestartStatusCompat;
-
-/**
- * @deprecated MCP 服务器数据已迁移到 stores/config.ts，请使用 useMcpServers()
- */
-export const useWebSocketMcpServers = useWebSocketMcpServersCompat;
-
-/**
- * @deprecated MCP 服务器配置已迁移到 stores/config.ts，请使用 useMcpServerConfig()
- */
-export const useWebSocketMcpServerConfig = useWebSocketMcpServerConfigCompat;
-
-/**
- * @deprecated MCP 端点已迁移到 stores/config.ts，请使用 useMcpEndpoint()
- */
-export const useWebSocketMcpEndpoint = useWebSocketMcpEndpointCompat;
-
-/**
- * @deprecated MCP 端点已迁移到 stores/config.ts，请使用 useMcpEndpoint()
- */
-export const useMcpEndpoint = useWebSocketMcpEndpointCompat;
+//
+// 注意：这些选择器已迁移到 ./websocket-compat.ts 以避免循环依赖
+// 请从 @/stores/websocket-compat 或 @/stores 导入这些废弃的选择器
+//
+// 迁移指南：
+// - useWebSocketConfig → useConfig from "./config"
+// - useWebSocketStatus → useClientStatus from "./status"
+// - useWebSocketMcpEndpoint → useMcpEndpoint from "./config"
+// - useWebSocketMcpServers → useMcpServers from "./config"
+// - useWebSocketMcpServerConfig → useMcpServerConfig from "./config"
+// - useWebSocketRestartStatus → useRestartStatus from "./status"
 
 // ==================== 复合选择器 ====================
 

--- a/apps/frontend/src/test/compatibility.test.tsx
+++ b/apps/frontend/src/test/compatibility.test.tsx
@@ -11,7 +11,7 @@ import {
   useWebSocketMcpServers,
   useWebSocketRestartStatus,
   useWebSocketStatus,
-} from "@stores/websocket";
+} from "@stores/websocket-compat";
 import { render } from "@testing-library/react";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";


### PR DESCRIPTION
- 从 websocket.ts 移除对 websocket-compat.ts 的导入
- 更新 stores/index.ts，从 websocket-compat.ts 直接导入废弃选择器
- 更新测试文件的导入路径
- 添加迁移指南注释

修复 #1610

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>