### PR TITLE
refactor: 移除 ProcessManager 和 PlatformUtils 之间的重复代码

### DIFF
--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -153,33 +153,7 @@ export class ProcessManagerImpl implements IProcessManager {
    */
   async gracefulKillProcess(pid: number): Promise<void> {
     try {
-      // 尝试优雅停止
-      process.kill(pid, "SIGTERM");
-
-      // 等待进程停止
-      let attempts = 0;
-      const maxAttempts = 30; // 3秒超时
-
-      while (attempts < maxAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        try {
-          process.kill(pid, 0);
-          attempts++;
-        } catch {
-          // 进程已停止
-          return;
-        }
-      }
-
-      // 如果还在运行，强制停止
-      try {
-        process.kill(pid, 0);
-        process.kill(pid, "SIGKILL");
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      } catch {
-        // 进程已停止
-      }
+      await PlatformUtils.killProcess(pid, "SIGTERM");
     } catch (error) {
       throw new ProcessError(
         `无法停止进程: ${error instanceof Error ? error.message : String(error)}`,

--- a/packages/cli/src/services/__tests__/ProcessManager.test.ts
+++ b/packages/cli/src/services/__tests__/ProcessManager.test.ts
@@ -139,43 +139,20 @@ describe("ProcessManagerImpl", () => {
   });
 
   describe("gracefulKillProcess", () => {
-    let originalKill: typeof process.kill;
-
-    beforeEach(() => {
-      originalKill = process.kill;
-      process.kill = vi.fn();
-    });
-
-    afterEach(() => {
-      process.kill = originalKill;
-    });
-
-    it("should gracefully kill process", async () => {
-      let killCallCount = 0;
-      (process.kill as any).mockImplementation((pid: number, signal: any) => {
-        killCallCount++;
-        if (killCallCount > 1) {
-          throw new Error("ESRCH"); // Process stopped
-        }
-      });
+    it("should delegate to PlatformUtils.killProcess with SIGTERM", async () => {
+      mockPlatformUtils.killProcess.mockResolvedValue();
 
       await processManager.gracefulKillProcess(1234);
 
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGTERM");
+      expect(mockPlatformUtils.killProcess).toHaveBeenCalledWith(1234, "SIGTERM");
     });
 
-    it("should force kill if graceful kill fails", async () => {
-      (process.kill as any).mockImplementation((pid: number, signal: any) => {
-        if (signal === "SIGKILL") {
-          throw new Error("ESRCH"); // Process stopped
-        }
-        // Process still running for SIGTERM and signal 0
-      });
+    it("should throw ProcessError when kill fails", async () => {
+      mockPlatformUtils.killProcess.mockRejectedValue(new Error("Kill failed"));
 
-      await processManager.gracefulKillProcess(1234);
-
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGTERM");
-      expect(process.kill).toHaveBeenCalledWith(1234, "SIGKILL");
+      await expect(processManager.gracefulKillProcess(1234)).rejects.toThrow(
+        "无法停止进程"
+      );
     });
   });
 


### PR DESCRIPTION
将 ProcessManager.gracefulKillProcess 重构为调用 PlatformUtils.killProcess，
消除 35 行重复代码，保持 API 兼容性。

遵循 DRY 原则，简化维护成本。

- ProcessManager.gracefulKillProcess 现在委托给 PlatformUtils.killProcess
- 更新相关测试以使用委托模式测试

Fixes #1613

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>