### PR TITLE
fix: 修复 InternalMCPManagerAdapter 内存泄漏问题

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      removeListener: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);


### PR DESCRIPTION
- 将构造函数中的匿名事件监听器改为实例方法
- 在 cleanup() 方法中添加移除事件监听器的逻辑
- 更新测试文件中的 mock 对象，添加 removeListener 方法

修复了 #1618

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>