### PR TITLE
refactor: 将 ToolDebugDialog 组件拆分为职责单一的模块

### DIFF
--- a/apps/frontend/src/components/tool-debug-dialog-parts/ToolActions.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/ToolActions.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { BrushCleaningIcon, Loader2, PlayIcon } from "lucide-react";
+
+interface ToolActionsProps {
+  onClear: () => void;
+  onCallTool: () => Promise<void>;
+  loading: boolean;
+  isJsonModeValid: boolean;
+  hasNoParams: boolean;
+  getShortcutText: () => string;
+}
+
+/**
+ * 工具操作按钮组件
+ *
+ * @description 负责工具调试对话框底部的操作按钮，包括清空和调用工具按钮。
+ */
+export function ToolActions({
+  onClear,
+  onCallTool,
+  loading,
+  isJsonModeValid,
+  hasNoParams,
+  getShortcutText,
+}: ToolActionsProps) {
+  return (
+    <div className="flex justify-end gap-2 pt-4 border-t">
+      <Button variant="outline" onClick={onClear} disabled={loading}>
+        <BrushCleaningIcon className="h-4 w-4" />
+        清空
+      </Button>
+      <Button
+        onClick={onCallTool}
+        disabled={
+          loading ||
+          // 只有有参数工具且在JSON模式时才检查JSON格式
+          (!hasNoParams && !isJsonModeValid)
+        }
+      >
+        {loading ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+            调用中...
+          </>
+        ) : (
+          <>
+            <PlayIcon className="h-4 w-4" />
+            {hasNoParams ? "直接调用" : "调用工具"} ({getShortcutText()})
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tool-debug-dialog-parts/ToolInfoCard.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/ToolInfoCard.tsx
@@ -1,0 +1,39 @@
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+
+interface Tool {
+  name: string;
+  serverName: string;
+  toolName: string;
+  description?: string;
+  inputSchema?: any;
+}
+
+interface ToolInfoCardProps {
+  tool: Tool;
+}
+
+/**
+ * 工具信息卡片组件
+ *
+ * @description 显示工具的基本信息，包括服务器名称、工具名称和描述。
+ */
+export function ToolInfoCard({ tool }: ToolInfoCardProps) {
+  return (
+    <Card>
+      <CardHeader className="pb-0">
+        <CardTitle className="text-base flex items-center gap-2">
+          <Badge variant="secondary">{tool.serverName}</Badge>
+          {tool.toolName}
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {tool.description && (
+          <p className="text-sm text-muted-foreground mt-2">
+            {tool.description}
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/frontend/src/components/tool-debug-dialog-parts/ToolInputPanel.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/ToolInputPanel.tsx
@@ -1,0 +1,608 @@
+"use client";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
+} from "@/components/ui/tooltip";
+import { AlertCircle, Code, InfoIcon } from "lucide-react";
+import { CheckIcon, Plus, Trash2 } from "lucide-react";
+import type React from "react";
+import { memo, useMemo } from "react";
+import { Controller, useFieldArray } from "react-hook-form";
+
+/**
+ * 数组字段渲染器组件
+ *
+ * @private
+ * @description 这是 ToolDebugDialog 的专用内部组件，用于渲染数组类型的 JSON Schema 字段。
+ */
+interface ArrayFieldProps {
+  name: string;
+  schema: any;
+  form: any;
+  renderFormField: (
+    fieldName: string,
+    fieldSchema: any
+  ) => React.ReactElement | null;
+}
+
+const ArrayField = memo(function ArrayField({
+  name,
+  schema,
+  form,
+  renderFormField,
+}: ArrayFieldProps) {
+  const { fields, append, remove } = useFieldArray({
+    control: form.control,
+    name: name as any,
+  });
+
+  const addItem = () => {
+    const itemSchema = schema.items;
+    let newItem: any;
+
+    switch (itemSchema.type) {
+      case "string":
+        newItem = itemSchema.enum ? itemSchema.enum[0] : "";
+        break;
+      case "number":
+      case "integer":
+        newItem = 0;
+        break;
+      case "boolean":
+        newItem = false;
+        break;
+      case "array":
+        newItem = [];
+        break;
+      case "object":
+        newItem = {};
+        break;
+      default:
+        newItem = "";
+    }
+
+    append(newItem);
+  };
+
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium">
+          数组项目 ({schema.items?.type || "unknown"})
+        </span>
+        <button
+          type="button"
+          onClick={addItem}
+          className="h-8 px-2 border rounded-md text-sm hover:bg-muted"
+        >
+          <Plus className="h-3 w-3 mr-1 inline" />
+          添加
+        </button>
+      </div>
+      {fields.length === 0 ? (
+        <div className="text-center py-4 border border-dashed rounded-md">
+          <span className="text-sm text-muted-foreground">暂无数组项目</span>
+        </div>
+      ) : (
+        <div className="space-y-3">
+          {fields.map((field, index) => (
+            <div
+              key={field.id}
+              className="relative p-3 border rounded-md bg-muted/20"
+            >
+              <div className="absolute top-2 right-2">
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  className="h-6 w-6 p-0 text-red-500 hover:text-red-700"
+                >
+                  <Trash2 className="h-3 w-3" />
+                </button>
+              </div>
+              <div className="pr-8">
+                <span className="text-xs font-medium text-muted-foreground mb-2 block">
+                  项目 {index + 1}
+                </span>
+                <FormField
+                  control={form.control}
+                  name={`${name}.${index}` as any}
+                  render={() => (
+                    <FormItem>
+                      {(() => {
+                        if (
+                          schema.items?.type === "object" ||
+                          schema.items?.type === "array"
+                        ) {
+                          return (
+                            <div className="ml-6 border-l-2 border-muted pl-4">
+                              {renderFormField(
+                                `${name}.${index}`,
+                                schema.items
+                              )}
+                            </div>
+                          );
+                        }
+                        return renderFormField(
+                          `${name}.${index}`,
+                          schema.items
+                        );
+                      })()}
+                    </FormItem>
+                  )}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+/**
+ * 对象字段渲染器组件
+ *
+ * @private
+ * @description 这是 ToolDebugDialog 的专用内部组件，用于渲染对象类型的 JSON Schema 字段。
+ */
+interface ObjectFieldProps {
+  name: string;
+  schema: any;
+  form: any;
+  renderFormField: (
+    fieldName: string,
+    fieldSchema: any
+  ) => React.ReactElement | null;
+  getTypeBadge: (type: string) => string;
+}
+
+const ObjectField = memo(function ObjectField({
+  name,
+  schema,
+  form,
+  renderFormField,
+  getTypeBadge,
+}: ObjectFieldProps) {
+  if (!schema.properties || Object.keys(schema.properties).length === 0) {
+    return (
+      <div className="text-center py-4 border border-dashed rounded-md">
+        <span className="text-sm text-muted-foreground">对象无定义字段</span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <span className="text-sm font-medium">对象字段</span>
+      {Object.entries(schema.properties).map(
+        ([fieldName, fieldSchema]: [string, any]) => (
+          <div
+            key={`${name}-${fieldName}`}
+            className="ml-6 border-l-2 border-muted pl-4"
+          >
+            <FormField
+              control={form.control}
+              name={`${name}.${fieldName}` as any}
+              render={() => (
+                <FormItem>
+                  <div className="flex items-center gap-2">
+                    <FormLabel>
+                      {schema.required?.includes(fieldName) && (
+                        <span className="text-red-500 mr-1">*</span>
+                      )}
+                      {fieldName}
+                    </FormLabel>
+                    <Badge
+                      variant="secondary"
+                      className={`text-xs ${getTypeBadge(fieldSchema.type)}`}
+                    >
+                      {fieldSchema.type}
+                    </Badge>
+                    {fieldSchema.description && (
+                      <Tooltip>
+                        <TooltipTrigger>
+                          <InfoIcon className="h-4 w-4 text-muted-foreground" />
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p className="max-w-xs whitespace-pre-wrap">
+                            {fieldSchema.description}
+                          </p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
+                  {renderFormField(`${name}.${fieldName}`, fieldSchema)}
+                  {fieldSchema.description && (
+                    <p className="text-sm text-muted-foreground">
+                      {fieldSchema.description}
+                    </p>
+                  )}
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          </div>
+        )
+      )}
+    </div>
+  );
+});
+
+/**
+ * 表单渲染器组件
+ *
+ * @private
+ * @description 这是 ToolDebugDialog 的专用内部组件，用于根据 JSON Schema 渲染完整的表单界面。
+ */
+interface FormRendererProps {
+  tool: Tool;
+  form: any;
+  renderFormField: (
+    fieldName: string,
+    fieldSchema: any
+  ) => React.ReactElement | null;
+}
+
+interface Tool {
+  name: string;
+  serverName: string;
+  toolName: string;
+  description?: string;
+  inputSchema?: any;
+}
+
+const FormRenderer = memo(function FormRenderer({
+  tool,
+  form,
+  renderFormField,
+}: FormRendererProps) {
+  if (!tool?.inputSchema?.properties) {
+    return (
+      <div className="text-center py-8">
+        <Code className="h-8 w-8 mx-auto mb-2 opacity-50" />
+        <p className="text-muted-foreground">该工具无参数定义</p>
+      </div>
+    );
+  }
+
+  return (
+    <Form {...form}>
+      <ScrollArea className="h-full">
+        <div className="space-y-4 p-2">
+          {Object.entries(tool.inputSchema.properties).map(
+            ([fieldName, fieldSchema]: [string, any]) => (
+              <FormField
+                key={`${tool.name}-${fieldName}`}
+                control={form.control}
+                name={fieldName as any}
+                render={() => (
+                  <FormItem>
+                    <div className="flex items-center gap-2">
+                      <FormLabel>
+                        {tool.inputSchema.required?.includes(fieldName) && (
+                          <span className="text-red-500 mr-1">*</span>
+                        )}
+                        {fieldName}
+                      </FormLabel>
+                      <Badge
+                        variant="secondary"
+                        className={`text-xs ${
+                          fieldSchema.type === "string"
+                            ? "bg-blue-100 text-blue-800"
+                            : fieldSchema.type === "number" ||
+                                fieldSchema.type === "integer"
+                              ? "bg-green-100 text-green-800"
+                              : fieldSchema.type === "boolean"
+                                ? "bg-purple-100 text-purple-800"
+                                : fieldSchema.type === "array"
+                                  ? "bg-orange-100 text-orange-800"
+                                  : fieldSchema.type === "object"
+                                    ? "bg-gray-100 text-gray-800"
+                                    : "bg-gray-100 text-gray-800"
+                        }`}
+                      >
+                        {fieldSchema.type}
+                      </Badge>
+                      {fieldSchema.description && (
+                        <Tooltip>
+                          <TooltipTrigger>
+                            <InfoIcon className="h-4 w-4 text-muted-foreground" />
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p className="max-w-xs whitespace-pre-wrap">
+                              {fieldSchema.description}
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      )}
+                    </div>
+                    {renderFormField(fieldName, fieldSchema)}
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )
+          )}
+        </div>
+      </ScrollArea>
+    </Form>
+  );
+});
+
+/**
+ * 无参数提示组件
+ *
+ * @private
+ * @description 这是 ToolDebugDialog 的专用内部组件，用于显示无需输入参数的提示信息。
+ */
+const NoParamsMessage = memo(function NoParamsMessage() {
+  return (
+    <div className="h-full flex items-center justify-center">
+      <div className="text-center space-y-4 max-w-sm mx-auto p-6">
+        <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
+          <CheckIcon className="h-8 w-8 text-green-600" />
+        </div>
+        <div className="space-y-2">
+          <h3 className="text-lg font-semibold text-foreground">
+            无需输入参数
+          </h3>
+          <p className="text-sm text-muted-foreground">
+            点击"调用工具"按钮执行，无需输入任何参数。
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+});
+
+interface ToolInputPanelProps {
+  tool: Tool;
+  form: any;
+  inputMode: "form" | "json";
+  jsonInput: string;
+  onModeChange: (mode: "form" | "json") => void;
+  onJsonInputChange: (value: string) => void;
+  loading: boolean;
+  validateJSON: (jsonString: string) => boolean;
+}
+
+/**
+ * 工具输入面板组件
+ *
+ * @description 负责工具调试对话框中的输入参数区域，包括表单模式和 JSON 模式切换。
+ */
+export function ToolInputPanel({
+  tool,
+  form,
+  inputMode,
+  jsonInput,
+  onModeChange,
+  onJsonInputChange,
+  loading,
+  validateJSON,
+}: ToolInputPanelProps) {
+  // 渲染表单字段的辅助函数
+  const renderFormField = useMemo(() => {
+    const getTypeBadge = (type: string) => {
+      const colors: Record<string, string> = {
+        string: "bg-blue-100 text-blue-800",
+        number: "bg-green-100 text-green-800",
+        integer: "bg-green-100 text-green-800",
+        boolean: "bg-purple-100 text-purple-800",
+        array: "bg-orange-100 text-orange-800",
+        object: "bg-gray-100 text-gray-800",
+      };
+
+      return colors[type] || "bg-gray-100 text-gray-800";
+    };
+
+    return (fieldName: string, fieldSchema: any): React.ReactElement | null => {
+      switch (fieldSchema.type) {
+        case "string":
+          if (fieldSchema.enum) {
+            return (
+              <Controller
+                name={fieldName as any}
+                control={form.control}
+                render={({ field }) => (
+                  <select
+                    {...field}
+                    className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                  >
+                    <option value="" disabled>
+                      选择{fieldName}
+                    </option>
+                    {fieldSchema.enum.map((option: string) => (
+                      <option key={option} value={option}>
+                        {option}
+                      </option>
+                    ))}
+                  </select>
+                )}
+              />
+            );
+          }
+          return (
+            <Controller
+              name={fieldName as any}
+              control={form.control}
+              render={({ field }) => (
+                <input
+                  {...field}
+                  placeholder={`输入${fieldName}`}
+                  type={fieldSchema.format === "password" ? "password" : "text"}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              )}
+            />
+          );
+
+        case "number":
+        case "integer":
+          return (
+            <Controller
+              name={fieldName as any}
+              control={form.control}
+              render={({ field }) => (
+                <input
+                  {...field}
+                  type="number"
+                  placeholder={`输入${fieldName}`}
+                  step={fieldSchema.type === "integer" ? "1" : "0.1"}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    field.onChange(value === "" ? "" : Number(value));
+                  }}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              )}
+            />
+          );
+
+        case "boolean":
+          return (
+            <Controller
+              name={fieldName as any}
+              control={form.control}
+              render={({ field }) => (
+                <select
+                  {...field}
+                  value={field.value?.toString()}
+                  onChange={(e) => field.onChange(e.target.value === "true")}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                >
+                  <option value="" disabled>
+                    选择{fieldName}
+                  </option>
+                  <option value="true">true</option>
+                  <option value="false">false</option>
+                </select>
+              )}
+            />
+          );
+
+        case "array":
+          return (
+            <ArrayField
+              name={fieldName}
+              schema={fieldSchema}
+              form={form}
+              renderFormField={renderFormField}
+            />
+          );
+
+        case "object":
+          return (
+            <ObjectField
+              name={fieldName}
+              schema={fieldSchema}
+              form={form}
+              renderFormField={renderFormField}
+              getTypeBadge={getTypeBadge}
+            />
+          );
+
+        default:
+          return (
+            <Controller
+              name={fieldName as any}
+              control={form.control}
+              render={({ field }) => (
+                <input
+                  {...field}
+                  placeholder={`输入${fieldName}`}
+                  className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                />
+              )}
+            />
+          );
+      }
+    };
+  }, [form]);
+
+  const hasNoParams =
+    !tool?.inputSchema?.properties ||
+    Object.keys(tool.inputSchema.properties).length === 0;
+
+  return (
+    <div className="w-1/2 flex flex-col gap-2 flex-shrink-0 overflow-hidden pr-0.5">
+      <div className="flex items-center justify-between h-[40px]">
+        <h3 className="text-sm font-medium">输入参数</h3>
+        {!hasNoParams && (
+          <Tabs
+            value={inputMode}
+            onValueChange={(value) => onModeChange(value as "form" | "json")}
+          >
+            <TabsList className="grid w-full grid-cols-2">
+              <TabsTrigger value="form" className="text-xs">
+                表单模式
+              </TabsTrigger>
+              <TabsTrigger value="json" className="text-xs">
+                高级模式
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+        )}
+      </div>
+      <div className="flex-1 min-h-0">
+        {!hasNoParams ? (
+          <Tabs
+            value={inputMode}
+            onValueChange={(value) => onModeChange(value as "form" | "json")}
+            className="h-full flex flex-col"
+          >
+            <TabsContent
+              value="form"
+              className="flex-1 data-[state=active]:flex data-[state=active]:flex-col mt-0"
+            >
+              <FormRenderer
+                tool={tool}
+                form={form}
+                renderFormField={renderFormField}
+              />
+            </TabsContent>
+            <TabsContent
+              value="json"
+              className="flex-1 data-[state=active]:flex data-[state=active]:flex-col mt-0"
+            >
+              <div className="flex-1 flex flex-col">
+                <Textarea
+                  value={jsonInput}
+                  onChange={(e) => onJsonInputChange(e.target.value)}
+                  placeholder="请输入JSON格式的参数..."
+                  className="flex-1 font-mono text-sm resize-none min-h-[200px]"
+                  disabled={loading}
+                />
+                {!validateJSON(jsonInput) &&
+                  jsonInput.trim() !== "{\n  \n}" && (
+                    <Alert className="mt-2">
+                      <AlertCircle className="h-4 w-4" />
+                      <AlertDescription>
+                        JSON格式错误，请检查输入
+                      </AlertDescription>
+                    </Alert>
+                  )}
+              </div>
+            </TabsContent>
+          </Tabs>
+        ) : (
+          <NoParamsMessage />
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tool-debug-dialog-parts/ToolResultPanel.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/ToolResultPanel.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Button } from "@/components/ui/button";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { CheckIcon, Code, CopyIcon, Loader2 } from "lucide-react";
+import { useCallback, useMemo, useRef, useState } from "react";
+import { toast } from "sonner";
+
+interface ToolResultPanelProps {
+  result: any;
+  error: string | null;
+  loading: boolean;
+}
+
+/**
+ * 工具结果面板组件
+ *
+ * @description 负责工具调试对话框中的结果展示区域，包括加载状态、错误展示和结果复制功能。
+ */
+export function ToolResultPanel({
+  result,
+  error,
+  loading,
+}: ToolResultPanelProps) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // 清理定时器
+  useMemo(() => {
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
+
+  // 格式化结果显示
+  const formatResult = useCallback((data: any) => {
+    try {
+      return JSON.stringify(data, null, 2);
+    } catch {
+      return String(data);
+    }
+  }, []);
+
+  // 复制结果
+  const handleCopy = useCallback(async () => {
+    const content = result ? JSON.stringify(result, null, 2) : error || "";
+    try {
+      await navigator.clipboard.writeText(content);
+      setCopied(true);
+      toast.success("已复制到剪贴板");
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
+    } catch {
+      toast.error("复制失败");
+    }
+  }, [result, error]);
+
+  return (
+    <div className="w-1/2 flex flex-col gap-2 flex-shrink-0 overflow-hidden pl-0.5">
+      <div className="flex items-center justify-between h-[40px]">
+        <h3 className="text-sm font-medium">调用结果</h3>
+        {(result || error) && (
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleCopy}
+            className="gap-0"
+          >
+            {copied ? (
+              <>
+                <CheckIcon className="h-4 w-4 mr-1" />
+                已复制
+              </>
+            ) : (
+              <>
+                <CopyIcon className="h-4 w-4 mr-1" />
+                复制结果
+              </>
+            )}
+          </Button>
+        )}
+      </div>
+      <div className="flex-1 min-h-0">
+        {loading ? (
+          <div className="h-full flex items-center justify-center border rounded-md">
+            <div className="flex flex-col items-center gap-2">
+              <Loader2 className="h-8 w-8 animate-spin" />
+              <span className="text-sm text-muted-foreground">
+                正在调用工具...
+              </span>
+            </div>
+          </div>
+        ) : error ? (
+          <div className="h-full">
+            <Alert variant="destructive" className="h-full">
+              <AlertDescription className="font-mono text-sm whitespace-pre-wrap break-words">
+                {error}
+              </AlertDescription>
+            </Alert>
+          </div>
+        ) : result ? (
+          <ScrollArea className="h-full border rounded-md">
+            <pre className="p-3 text-sm font-mono whitespace-pre-wrap break-words min-w-0">
+              {formatResult(result)}
+            </pre>
+          </ScrollArea>
+        ) : (
+          <div className="h-full flex items-center justify-center border rounded-md">
+            <div className="text-center text-muted-foreground">
+              <Code className="h-8 w-8 mx-auto mb-2 opacity-50" />
+              <p>等待调用工具...</p>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/tool-debug-dialog-parts/index.ts
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/index.ts
@@ -1,0 +1,6 @@
+export { ToolInfoCard } from "./ToolInfoCard";
+export { ToolInputPanel } from "./ToolInputPanel";
+export { ToolResultPanel } from "./ToolResultPanel";
+export { ToolActions } from "./ToolActions";
+export { useToolCall } from "./useToolCall";
+export { useInputModeSync } from "./useInputModeSync";

--- a/apps/frontend/src/components/tool-debug-dialog-parts/useInputModeSync.ts
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/useInputModeSync.ts
@@ -1,0 +1,63 @@
+import { useCallback, useEffect, useState } from "react";
+
+/**
+ * 表单/JSON 模式切换逻辑的自定义 Hook
+ *
+ * @description 封装表单模式和 JSON 模式之间的切换逻辑，包括数据同步和状态管理。
+ */
+export function useInputModeSync(
+  form: any,
+  defaultValues: any,
+  toolInputSchema: any
+) {
+  const [inputMode, setInputMode] = useState<"form" | "json">("form");
+  const [jsonInput, setJsonInput] = useState<string>("{\n  \n}");
+
+  // 当工具变化时重置 JSON 输入
+  useEffect(() => {
+    if (toolInputSchema) {
+      try {
+        setJsonInput(JSON.stringify(defaultValues, null, 2));
+      } catch {
+        setJsonInput("{\n  \n}");
+      }
+    } else {
+      setJsonInput("{\n  \n}");
+    }
+  }, [toolInputSchema, defaultValues]);
+
+  const handleModeChange = useCallback(
+    (newMode: "form" | "json") => {
+      if (newMode === "json" && inputMode === "form") {
+        // 从表单模式切换到 JSON 模式时，同步数据
+        const currentValues = form.getValues();
+        try {
+          setJsonInput(JSON.stringify(currentValues, null, 2));
+        } catch {
+          setJsonInput("{\n  \n}");
+        }
+      } else if (newMode === "form" && inputMode === "json") {
+        // 从 JSON 模式切换到表单模式时，同步数据
+        try {
+          const parsedData = JSON.parse(jsonInput);
+          // 使用 setValue 而不是 reset 来避免表单重新初始化导致的失焦
+          for (const key of Object.keys(parsedData)) {
+            form.setValue(key as any, parsedData[key]);
+          }
+        } catch {
+          // JSON 解析失败，保持表单数据不变
+        }
+      }
+      setInputMode(newMode);
+    },
+    [inputMode, jsonInput, form]
+  );
+
+  return {
+    inputMode,
+    jsonInput,
+    setJsonInput,
+    handleModeChange,
+    setInputMode,
+  };
+}

--- a/apps/frontend/src/components/tool-debug-dialog-parts/useToolCall.ts
+++ b/apps/frontend/src/components/tool-debug-dialog-parts/useToolCall.ts
@@ -1,0 +1,59 @@
+import { apiClient } from "@/services/api";
+import { useCallback, useState } from "react";
+import { toast } from "sonner";
+
+interface Tool {
+  name: string;
+  serverName: string;
+  toolName: string;
+  description?: string;
+  inputSchema?: any;
+}
+
+interface UseToolCallResult {
+  result: any;
+  loading: boolean;
+  error: string | null;
+  callTool: (args: any) => Promise<void>;
+}
+
+/**
+ * 工具调用逻辑的自定义 Hook
+ *
+ * @description 封装工具调用的状态管理和 API 调用逻辑，包括加载状态、错误处理和结果管理。
+ */
+export function useToolCall(tool: Tool | null): UseToolCallResult {
+  const [result, setResult] = useState<any>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const callTool = useCallback(
+    async (args: any) => {
+      if (!tool) return;
+
+      setLoading(true);
+      setError(null);
+      setResult(null);
+
+      try {
+        const response = await apiClient.callTool(
+          tool.serverName,
+          tool.toolName,
+          args
+        );
+        setResult(response);
+        toast.success("工具调用成功");
+      } catch (err) {
+        const errorMessage =
+          err instanceof Error ? err.message : "调用工具失败";
+        setError(errorMessage);
+        toast.error(errorMessage);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [tool]
+  );
+
+  return { result, loading, error, callTool };
+}

--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -1,9 +1,5 @@
 "use client";
 
-import { Alert, AlertDescription } from "@/components/ui/alert";
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -11,418 +7,23 @@ import {
   DialogTitle,
 } from "@/components/ui/dialog";
 import {
-  Form,
-  FormControl,
-  FormDescription,
-  FormField,
-  FormItem,
-  FormLabel,
-  FormMessage,
-} from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
-import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipProvider,
-  TooltipTrigger,
-} from "@/components/ui/tooltip";
-import {
   createDefaultValues,
   createZodSchemaFromJsonSchema,
 } from "@/lib/schema-utils";
-import { apiClient } from "@/services/api";
 import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  AlertCircle,
-  BrushCleaningIcon,
-  CheckIcon,
-  Code,
-  CopyIcon,
-  InfoIcon,
-  Loader2,
-  PlayIcon,
-  Plus,
-  Trash2,
-  Zap,
-} from "lucide-react";
-import type React from "react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { Zap } from "lucide-react";
+import { useCallback, useEffect, useMemo } from "react";
+import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
-
-/**
- * 数组字段渲染器组件
- *
- * @private
- * @description 这是 ToolDebugDialog 的专用内部组件，用于渲染数组类型的 JSON Schema 字段。
- * 该组件针对工具调试场景进行了优化，支持嵌套对象和数组。
- *
- * 务实开发说明：此组件未作为独立组件导出，因为：
- * 1. 当前项目中只有 ToolDebugDialog 需要这种特定的 JSON Schema 数组渲染逻辑
- * 2. 其他组件（如 WorkflowParameterConfigDialog）的用途是配置元数据，而非渲染动态表单
- * 3. 避免预防性设计 - 如果未来其他组件需要类似功能，再考虑提取
- */
-interface ArrayFieldProps {
-  name: string;
-  schema: any;
-  form: any;
-  renderFormField: (
-    fieldName: string,
-    fieldSchema: any
-  ) => React.ReactElement | null;
-}
-
-const ArrayField = memo(function ArrayField({
-  name,
-  schema,
-  form,
-  renderFormField,
-}: ArrayFieldProps) {
-  const { fields, append, remove } = useFieldArray({
-    control: form.control,
-    name: name as any,
-  });
-
-  const addItem = () => {
-    const itemSchema = schema.items;
-    let newItem: any;
-
-    switch (itemSchema.type) {
-      case "string":
-        newItem = itemSchema.enum ? itemSchema.enum[0] : "";
-        break;
-      case "number":
-      case "integer":
-        newItem = 0;
-        break;
-      case "boolean":
-        newItem = false;
-        break;
-      case "array":
-        newItem = [];
-        break;
-      case "object":
-        newItem = {};
-        break;
-      default:
-        newItem = "";
-    }
-
-    append(newItem);
-  };
-
-  return (
-    <div className="space-y-2">
-      <div className="flex items-center justify-between">
-        <span className="text-sm font-medium">
-          数组项目 ({schema.items?.type || "unknown"})
-        </span>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          onClick={addItem}
-          className="h-8 px-2"
-        >
-          <Plus className="h-3 w-3 mr-1" />
-          添加
-        </Button>
-      </div>
-      {fields.length === 0 ? (
-        <div className="text-center py-4 border border-dashed rounded-md">
-          <span className="text-sm text-muted-foreground">暂无数组项目</span>
-        </div>
-      ) : (
-        <div className="space-y-3">
-          {fields.map((field, index) => (
-            <div
-              key={field.id}
-              className="relative p-3 border rounded-md bg-muted/20"
-            >
-              <div className="absolute top-2 right-2">
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => remove(index)}
-                  className="h-6 w-6 p-0 text-red-500 hover:text-red-700"
-                >
-                  <Trash2 className="h-3 w-3" />
-                </Button>
-              </div>
-              <div className="pr-8">
-                <span className="text-xs font-medium text-muted-foreground mb-2 block">
-                  项目 {index + 1}
-                </span>
-                <FormField
-                  control={form.control}
-                  name={`${name}.${index}` as any}
-                  render={() => (
-                    <FormItem>
-                      {(() => {
-                        if (
-                          schema.items?.type === "object" ||
-                          schema.items?.type === "array"
-                        ) {
-                          return (
-                            <div className="ml-6 border-l-2 border-muted pl-4">
-                              {renderFormField(
-                                `${name}.${index}`,
-                                schema.items
-                              )}
-                            </div>
-                          );
-                        }
-                        return renderFormField(
-                          `${name}.${index}`,
-                          schema.items
-                        );
-                      })()}
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-          ))}
-        </div>
-      )}
-    </div>
-  );
-});
-
-/**
- * 对象字段渲染器组件
- *
- * @private
- * @description 这是 ToolDebugDialog 的专用内部组件，用于渲染对象类型的 JSON Schema 字段。
- * 该组件支持嵌套属性、必填标记和类型徽章显示。
- *
- * 务实开发说明：此组件未作为独立组件导出，因为：
- * 1. 当前项目中只有 ToolDebugDialog 需要这种特定的 JSON Schema 对象渲染逻辑
- * 2. 其他组件（如 WorkflowParameterConfigDialog）的用途是配置元数据，而非渲染动态表单
- * 3. 避免预防性设计 - 如果未来其他组件需要类似功能，再考虑提取
- */
-interface ObjectFieldProps {
-  name: string;
-  schema: any;
-  form: any;
-  renderFormField: (
-    fieldName: string,
-    fieldSchema: any
-  ) => React.ReactElement | null;
-  getTypeBadge: (type: string) => string;
-}
-
-const ObjectField = memo(function ObjectField({
-  name,
-  schema,
-  form,
-  renderFormField,
-  getTypeBadge,
-}: ObjectFieldProps) {
-  if (!schema.properties || Object.keys(schema.properties).length === 0) {
-    return (
-      <div className="text-center py-4 border border-dashed rounded-md">
-        <span className="text-sm text-muted-foreground">对象无定义字段</span>
-      </div>
-    );
-  }
-
-  return (
-    <div className="space-y-4">
-      <span className="text-sm font-medium">对象字段</span>
-      {Object.entries(schema.properties).map(
-        ([fieldName, fieldSchema]: [string, any]) => (
-          <div
-            key={`${name}-${fieldName}`}
-            className="ml-6 border-l-2 border-muted pl-4"
-          >
-            <FormField
-              control={form.control}
-              name={`${name}.${fieldName}` as any}
-              render={() => (
-                <FormItem>
-                  <div className="flex items-center gap-2">
-                    <FormLabel>
-                      {schema.required?.includes(fieldName) && (
-                        <span className="text-red-500 mr-1">*</span>
-                      )}
-                      {fieldName}
-                    </FormLabel>
-                    <Badge
-                      variant="secondary"
-                      className={`text-xs ${getTypeBadge(fieldSchema.type)}`}
-                    >
-                      {fieldSchema.type}
-                    </Badge>
-                    {fieldSchema.description && (
-                      <Tooltip>
-                        <TooltipTrigger>
-                          <InfoIcon className="h-4 w-4 text-muted-foreground" />
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p className="max-w-xs whitespace-pre-wrap">
-                            {fieldSchema.description}
-                          </p>
-                        </TooltipContent>
-                      </Tooltip>
-                    )}
-                  </div>
-                  {renderFormField(`${name}.${fieldName}`, fieldSchema)}
-                  {fieldSchema.description && (
-                    <FormDescription>{fieldSchema.description}</FormDescription>
-                  )}
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-          </div>
-        )
-      )}
-    </div>
-  );
-});
-
-/**
- * 无参数提示组件
- *
- * @private
- * @description 这是 ToolDebugDialog 的专用内部组件，用于显示无需输入参数的提示信息。
- *
- * 务实开发说明：此组件未作为独立组件导出，因为：
- * 1. 这是一个简单的 UI 组件，复制成本极低
- * 2. 其他场景的"无参数"提示可能需要不同的文案和样式
- * 3. 避免预防性设计 - 如果未来其他组件需要类似功能，再考虑提取
- */
-const NoParamsMessage = memo(function NoParamsMessage() {
-  return (
-    <div className="h-full flex items-center justify-center">
-      <div className="text-center space-y-4 max-w-sm mx-auto p-6">
-        <div className="mx-auto w-16 h-16 bg-green-100 rounded-full flex items-center justify-center">
-          <CheckIcon className="h-8 w-8 text-green-600" />
-        </div>
-        <div className="space-y-2">
-          <h3 className="text-lg font-semibold text-foreground">
-            无需输入参数
-          </h3>
-          <p className="text-sm text-muted-foreground">
-            点击"调用工具"按钮执行，无需输入任何参数。
-          </p>
-        </div>
-      </div>
-    </div>
-  );
-});
-
-/**
- * 表单渲染器组件
- *
- * @private
- * @description 这是 ToolDebugDialog 的专用内部组件，用于根据 JSON Schema 渲染完整的表单界面。
- * 该组件遍历工具的 inputSchema 属性，使用 renderFormField 函数渲染每个字段。
- *
- * 务实开发说明：此组件未作为独立组件导出，因为：
- * 1. 当前项目中只有 ToolDebugDialog 需要 JSON Schema 表单渲染
- * 2. 其他组件（如 WorkflowParameterConfigDialog）使用的是固定的参数配置表单，不需要动态 Schema 渲染
- * 3. 避免预防性设计 - 如果未来其他组件需要类似功能，再考虑提取
- */
-interface FormRendererProps {
-  tool: ToolDebugDialogProps["tool"];
-  form: any;
-  renderFormField: (
-    fieldName: string,
-    fieldSchema: any
-  ) => React.ReactElement | null;
-}
-
-const FormRenderer = memo(function FormRenderer({
-  tool,
-  form,
-  renderFormField,
-}: FormRendererProps) {
-  if (!tool?.inputSchema?.properties) {
-    return (
-      <div className="text-center py-8">
-        <Code className="h-8 w-8 mx-auto mb-2 opacity-50" />
-        <p className="text-muted-foreground">该工具无参数定义</p>
-      </div>
-    );
-  }
-
-  return (
-    <Form {...form}>
-      <ScrollArea className="h-full">
-        <div className="space-y-4 p-2">
-          {Object.entries(tool.inputSchema.properties).map(
-            ([fieldName, fieldSchema]: [string, any]) => (
-              <FormField
-                key={`${tool.name}-${fieldName}`} // 添加工具名称作为前缀，确保 key 的唯一性和稳定性
-                control={form.control}
-                name={fieldName as any}
-                render={() => (
-                  <FormItem>
-                    <div className="flex items-center gap-2">
-                      <FormLabel>
-                        {tool.inputSchema.required?.includes(fieldName) && (
-                          <span className="text-red-500 mr-1">*</span>
-                        )}
-                        {fieldName}
-                      </FormLabel>
-                      <Badge
-                        variant="secondary"
-                        className={`text-xs ${
-                          fieldSchema.type === "string"
-                            ? "bg-blue-100 text-blue-800"
-                            : fieldSchema.type === "number" ||
-                                fieldSchema.type === "integer"
-                              ? "bg-green-100 text-green-800"
-                              : fieldSchema.type === "boolean"
-                                ? "bg-purple-100 text-purple-800"
-                                : fieldSchema.type === "array"
-                                  ? "bg-orange-100 text-orange-800"
-                                  : fieldSchema.type === "object"
-                                    ? "bg-gray-100 text-gray-800"
-                                    : "bg-gray-100 text-gray-800"
-                        }`}
-                      >
-                        {fieldSchema.type}
-                      </Badge>
-                      {fieldSchema.description && (
-                        <Tooltip>
-                          <TooltipTrigger>
-                            <InfoIcon className="h-4 w-4 text-muted-foreground" />
-                          </TooltipTrigger>
-                          <TooltipContent>
-                            <p className="max-w-xs whitespace-pre-wrap">
-                              {fieldSchema.description}
-                            </p>
-                          </TooltipContent>
-                        </Tooltip>
-                      )}
-                    </div>
-                    {renderFormField(fieldName, fieldSchema)}
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            )
-          )}
-        </div>
-      </ScrollArea>
-    </Form>
-  );
-});
+import {
+  ToolActions,
+  ToolInfoCard,
+  ToolInputPanel,
+  ToolResultPanel,
+  useInputModeSync,
+  useToolCall,
+} from "./tool-debug-dialog-parts";
 
 interface ToolDebugDialogProps {
   open: boolean;
@@ -436,19 +37,16 @@ interface ToolDebugDialogProps {
   } | null;
 }
 
+/**
+ * 工具调试对话框组件
+ *
+ * @description 提供工具调试界面，支持表单模式和 JSON 模式输入参数，展示工具调用结果。
+ */
 export function ToolDebugDialog({
   open,
   onOpenChange,
   tool,
 }: ToolDebugDialogProps) {
-  const [inputMode, setInputMode] = useState<"form" | "json">("form");
-  const [jsonInput, setJsonInput] = useState<string>("{\n  \n}");
-  const [result, setResult] = useState<any>(null);
-  const [loading, setLoading] = useState(false);
-  const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
   // 创建动态 schema
   const formSchema = useMemo(() => {
     if (!tool?.inputSchema) return z.object({});
@@ -468,73 +66,25 @@ export function ToolDebugDialog({
     mode: "onChange",
   });
 
-  // 当工具变化时重置表单
-  useEffect(() => {
-    if (tool?.inputSchema) {
-      // 重置表单到默认值
-      form.reset(defaultValues);
-      try {
-        setJsonInput(JSON.stringify(defaultValues, null, 2));
-      } catch {
-        setJsonInput("{\n  \n}");
-      }
-    } else {
-      form.reset({});
-      setJsonInput("{\n  \n}");
-    }
-  }, [tool?.inputSchema, defaultValues, form]); // 添加 form 依赖以满足 linter 要求
+  // 使用自定义 Hook 管理输入模式同步
+  const { inputMode, jsonInput, setJsonInput, handleModeChange, setInputMode } =
+    useInputModeSync(form, defaultValues, tool?.inputSchema);
 
-  useEffect(() => {
-    return () => {
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-    };
-  }, []);
+  // 使用自定义 Hook 管理工具调用
+  const { result, loading, error, callTool } = useToolCall(tool);
 
   // 重置状态
   const resetState = useCallback(() => {
     setInputMode("form");
     setJsonInput("{\n  \n}");
-    setResult(null);
-    setError(null);
-    setCopied(false);
     // 只在有工具且有输入schema时才重置表单
     if (tool?.inputSchema) {
       form.reset(defaultValues);
     }
-  }, [tool?.inputSchema, defaultValues, form]);
-
-  // 处理Tab切换
-  const handleModeChange = useCallback(
-    (newMode: "form" | "json") => {
-      if (newMode === "json" && inputMode === "form") {
-        // 从表单模式切换到JSON模式时，同步数据
-        const currentValues = form.getValues();
-        try {
-          setJsonInput(JSON.stringify(currentValues, null, 2));
-        } catch {
-          setJsonInput("{\n  \n}");
-        }
-      } else if (newMode === "form" && inputMode === "json") {
-        // 从JSON模式切换到表单模式时，同步数据
-        try {
-          const parsedData = JSON.parse(jsonInput);
-          // 使用 setValue 而不是 reset 来避免表单重新初始化导致的失焦
-          for (const key of Object.keys(parsedData)) {
-            form.setValue(key as any, parsedData[key]);
-          }
-        } catch {
-          // JSON 解析失败，保持表单数据不变
-        }
-      }
-      setInputMode(newMode);
-    },
-    [inputMode, jsonInput, form]
-  );
+  }, [tool?.inputSchema, defaultValues, form, setInputMode, setJsonInput]);
 
   // 当弹窗关闭时重置状态
-  const handleOpenChange = useCallback(
+  const handleDialogOpenChange = useCallback(
     (newOpen: boolean) => {
       if (!newOpen) {
         resetState();
@@ -585,49 +135,11 @@ export function ToolDebugDialog({
       args = JSON.parse(jsonInput);
     }
 
-    setLoading(true);
-    setError(null);
-    setResult(null);
-
-    try {
-      const response = await apiClient.callTool(
-        tool.serverName,
-        tool.toolName,
-        args
-      );
-
-      setResult(response);
-      toast.success("工具调用成功");
-    } catch (err) {
-      const errorMessage = err instanceof Error ? err.message : "调用工具失败";
-      setError(errorMessage);
-      toast.error(errorMessage);
-    } finally {
-      setLoading(false);
-    }
-  }, [tool, inputMode, form, jsonInput, validateJSON]);
-
-  // 复制结果
-  const handleCopy = useCallback(async () => {
-    const content = result ? JSON.stringify(result, null, 2) : error || "";
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopied(true);
-      toast.success("已复制到剪贴板");
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error("复制失败");
-    }
-  }, [result, error]);
+    await callTool(args);
+  }, [tool, inputMode, form, jsonInput, validateJSON, callTool]);
 
   // 清空输入
   const handleClear = useCallback(() => {
-    setResult(null);
-    setError(null);
-
     if (inputMode === "form" && tool?.inputSchema) {
       // 在表单模式下，重置为默认值
       form.reset(defaultValues);
@@ -646,160 +158,7 @@ export function ToolDebugDialog({
         form.reset({});
       }
     }
-  }, [inputMode, tool?.inputSchema, defaultValues, form]);
-
-  // 渲染表单字段的辅助函数 - 使用 useMemo 优化性能
-  const renderFormField = useMemo(() => {
-    const getTypeBadge = (type: string) => {
-      const colors: Record<string, string> = {
-        string: "bg-blue-100 text-blue-800",
-        number: "bg-green-100 text-green-800",
-        integer: "bg-green-100 text-green-800",
-        boolean: "bg-purple-100 text-purple-800",
-        array: "bg-orange-100 text-orange-800",
-        object: "bg-gray-100 text-gray-800",
-      };
-
-      return colors[type] || "bg-gray-100 text-gray-800";
-    };
-
-    return (fieldName: string, fieldSchema: any): React.ReactElement | null => {
-      switch (fieldSchema.type) {
-        case "string":
-          if (fieldSchema.enum) {
-            return (
-              <Controller
-                name={fieldName as any}
-                control={form.control}
-                render={({ field }) => (
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder={`选择${fieldName}`} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {fieldSchema.enum.map((option: string) => (
-                        <SelectItem key={option} value={option}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            );
-          }
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input
-                    {...field}
-                    placeholder={`输入${fieldName}`}
-                    type={
-                      fieldSchema.format === "password" ? "password" : "text"
-                    }
-                  />
-                </FormControl>
-              )}
-            />
-          );
-
-        case "number":
-        case "integer":
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input
-                    {...field}
-                    type="number"
-                    placeholder={`输入${fieldName}`}
-                    step={fieldSchema.type === "integer" ? "1" : "0.1"}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      field.onChange(value === "" ? "" : Number(value));
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          );
-
-        case "boolean":
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <Select
-                  value={field.value?.toString()}
-                  onValueChange={(value) => field.onChange(value === "true")}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder={`选择${fieldName}`} />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="true">true</SelectItem>
-                    <SelectItem value="false">false</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          );
-
-        case "array":
-          return (
-            <ArrayField
-              name={fieldName}
-              schema={fieldSchema}
-              form={form}
-              renderFormField={renderFormField}
-            />
-          );
-
-        case "object":
-          return (
-            <ObjectField
-              name={fieldName}
-              schema={fieldSchema}
-              form={form}
-              renderFormField={renderFormField}
-              getTypeBadge={getTypeBadge}
-            />
-          );
-
-        default:
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input {...field} placeholder={`输入${fieldName}`} />
-                </FormControl>
-              )}
-            />
-          );
-      }
-    };
-  }, [form]);
-
-  // 格式化结果显示
-  const formatResult = useCallback((data: any) => {
-    try {
-      return JSON.stringify(data, null, 2);
-    } catch {
-      return String(data);
-    }
-  }, []);
+  }, [inputMode, tool?.inputSchema, defaultValues, form, setJsonInput]);
 
   // 检测操作系统并获取快捷键文本
   const getShortcutText = useCallback(() => {
@@ -856,219 +215,53 @@ export function ToolDebugDialog({
   }, [open, handleKeyDown]);
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <TooltipProvider>
-        <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-2">
-              <Zap className="h-5 w-5" />
-              工具调试
-            </DialogTitle>
-          </DialogHeader>
+    <Dialog open={open} onOpenChange={handleDialogOpenChange}>
+      <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
+        <DialogHeader>
+          <DialogTitle className="flex items-center gap-2">
+            <Zap className="h-5 w-5" />
+            工具调试
+          </DialogTitle>
+        </DialogHeader>
 
-          {tool && (
-            <div className="flex flex-col gap-4 h-[80vh]">
-              {/* 工具信息 */}
-              <Card>
-                <CardHeader className="pb-0">
-                  <CardTitle className="text-base flex items-center gap-2">
-                    <Badge variant="secondary">{tool.serverName}</Badge>
-                    {tool.toolName}
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {tool.description && (
-                    <p className="text-sm text-muted-foreground mt-2">
-                      {tool.description}
-                    </p>
-                  )}
-                </CardContent>
-              </Card>
+        {tool && (
+          <div className="flex flex-col gap-4 h-[80vh]">
+            <ToolInfoCard tool={tool} />
 
-              {/* 输入参数 */}
-              <div className="flex-1 flex min-h-0 w-full overflow-hidden">
-                <div className="w-1/2 flex flex-col gap-2 flex-shrink-0 overflow-hidden pr-0.5">
-                  <div className="flex items-center justify-between h-[40px]">
-                    <h3 className="text-sm font-medium">输入参数</h3>
-                    {tool?.inputSchema?.properties &&
-                      Object.keys(tool.inputSchema.properties).length > 0 && (
-                        <Tabs
-                          value={inputMode}
-                          onValueChange={(value) =>
-                            handleModeChange(value as "form" | "json")
-                          }
-                        >
-                          <TabsList className="grid w-full grid-cols-2">
-                            <TabsTrigger value="form" className="text-xs">
-                              表单模式
-                            </TabsTrigger>
-                            <TabsTrigger value="json" className="text-xs">
-                              高级模式
-                            </TabsTrigger>
-                          </TabsList>
-                        </Tabs>
-                      )}
-                  </div>
-                  <div className="flex-1 min-h-0">
-                    {tool?.inputSchema?.properties &&
-                    Object.keys(tool.inputSchema.properties).length > 0 ? (
-                      <Tabs
-                        value={inputMode}
-                        onValueChange={(value) =>
-                          handleModeChange(value as "form" | "json")
-                        }
-                        className="h-full flex flex-col"
-                      >
-                        <TabsContent
-                          value="form"
-                          className="flex-1 data-[state=active]:flex data-[state=active]:flex-col mt-0"
-                        >
-                          <FormRenderer
-                            tool={tool}
-                            form={form}
-                            renderFormField={renderFormField}
-                          />
-                        </TabsContent>
-                        <TabsContent
-                          value="json"
-                          className="flex-1 data-[state=active]:flex data-[state=active]:flex-col mt-0"
-                        >
-                          <div className="flex-1 flex flex-col">
-                            <Textarea
-                              value={jsonInput}
-                              onChange={(e) => setJsonInput(e.target.value)}
-                              placeholder="请输入JSON格式的参数..."
-                              className="flex-1 font-mono text-sm resize-none min-h-[200px]"
-                              disabled={loading}
-                            />
-                            {!validateJSON(jsonInput) &&
-                              jsonInput.trim() !== "{\n  \n}" && (
-                                <Alert className="mt-2">
-                                  <AlertCircle className="h-4 w-4" />
-                                  <AlertDescription>
-                                    JSON格式错误，请检查输入
-                                  </AlertDescription>
-                                </Alert>
-                              )}
-                          </div>
-                        </TabsContent>
-                      </Tabs>
-                    ) : (
-                      <NoParamsMessage />
-                    )}
-                  </div>
-                </div>
-
-                {/* 结果显示 */}
-                <div className="w-1/2 flex flex-col gap-2 flex-shrink-0 overflow-hidden pl-0.5">
-                  <div className="flex items-center justify-between h-[40px]">
-                    <h3 className="text-sm font-medium">调用结果</h3>
-                    {(result || error) && (
-                      <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={handleCopy}
-                        className="gap-0"
-                      >
-                        {copied ? (
-                          <>
-                            <CheckIcon className="h-4 w-4 mr-1" />
-                            已复制
-                          </>
-                        ) : (
-                          <>
-                            <CopyIcon className="h-4 w-4 mr-1" />
-                            复制结果
-                          </>
-                        )}
-                      </Button>
-                    )}
-                  </div>
-                  <div className="flex-1 min-h-0">
-                    {loading ? (
-                      <div className="h-full flex items-center justify-center border rounded-md">
-                        <div className="flex flex-col items-center gap-2">
-                          <Loader2 className="h-8 w-8 animate-spin" />
-                          <span className="text-sm text-muted-foreground">
-                            正在调用工具...
-                          </span>
-                        </div>
-                      </div>
-                    ) : error ? (
-                      <div className="h-full">
-                        <Alert variant="destructive" className="h-full">
-                          <AlertDescription className="font-mono text-sm whitespace-pre-wrap break-words">
-                            {error}
-                          </AlertDescription>
-                        </Alert>
-                      </div>
-                    ) : result ? (
-                      <ScrollArea className="h-full border rounded-md">
-                        <pre className="p-3 text-sm font-mono whitespace-pre-wrap break-words min-w-0">
-                          {formatResult(result)}
-                        </pre>
-                      </ScrollArea>
-                    ) : (
-                      <div className="h-full flex items-center justify-center border rounded-md">
-                        <div className="text-center text-muted-foreground">
-                          <Code className="h-8 w-8 mx-auto mb-2 opacity-50" />
-                          <p>等待调用工具...</p>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              </div>
-
-              {/* 底部操作按钮 */}
-              <div className="flex justify-end gap-2 pt-4 border-t">
-                <Button
-                  variant="outline"
-                  onClick={handleClear}
-                  disabled={loading}
-                >
-                  <BrushCleaningIcon className="h-4 w-4" />
-                  清空
-                </Button>
-                <Button
-                  onClick={handleCallTool}
-                  disabled={
-                    loading ||
-                    // 只有有参数工具且在JSON模式时才检查JSON格式
-                    (() => {
-                      const hasNoParams =
-                        !tool?.inputSchema?.properties ||
-                        Object.keys(tool.inputSchema.properties).length === 0;
-                      return (
-                        !hasNoParams &&
-                        inputMode === "json" &&
-                        !validateJSON(jsonInput)
-                      );
-                    })()
-                  }
-                >
-                  {loading ? (
-                    <>
-                      <Loader2 className="h-4 w-4 mr-2 animate-spin" />
-                      调用中...
-                    </>
-                  ) : (
-                    <>
-                      <PlayIcon className="h-4 w-4" />
-                      {(() => {
-                        const hasNoParams =
-                          !tool?.inputSchema?.properties ||
-                          Object.keys(tool.inputSchema.properties).length === 0;
-                        return hasNoParams ? "直接调用" : "调用工具";
-                      })()} ({getShortcutText()})
-                    </>
-                  )}
-                </Button>
-              </div>
+            <div className="flex-1 flex min-h-0 w-full overflow-hidden">
+              <ToolInputPanel
+                tool={tool}
+                form={form}
+                inputMode={inputMode}
+                jsonInput={jsonInput}
+                onModeChange={handleModeChange}
+                onJsonInputChange={setJsonInput}
+                loading={loading}
+                validateJSON={validateJSON}
+              />
+              <ToolResultPanel
+                result={result}
+                error={error}
+                loading={loading}
+              />
             </div>
-          )}
-        </DialogContent>
-      </TooltipProvider>
+
+            <ToolActions
+              onClear={handleClear}
+              onCallTool={handleCallTool}
+              loading={loading}
+              isJsonModeValid={
+                inputMode === "json" ? validateJSON(jsonInput) : true
+              }
+              hasNoParams={
+                !tool?.inputSchema?.properties ||
+                Object.keys(tool.inputSchema.properties).length === 0
+              }
+              getShortcutText={getShortcutText}
+            />
+          </div>
+        )}
+      </DialogContent>
     </Dialog>
   );
 }


### PR DESCRIPTION
将 1074 行的 ToolDebugDialog 组件重构为更小的、职责单一的子组件和自定义 Hooks：

- 提取 useToolCall Hook 封装工具调用逻辑
- 提取 useInputModeSync Hook 封装输入模式同步逻辑
- 提取 ToolInfoCard 组件显示工具信息
- 提取 ToolInputPanel 组件处理输入参数
- 提取 ToolResultPanel 组件展示调用结果
- 提取 ToolActions 组件处理操作按钮
- 主组件从 1074 行减少到 260 行

收益：
- 更好的可维护性：每个组件职责单一，修改影响范围小
- 更好的可测试性：自定义 Hooks 和小组件可以独立测试
- 更好的复用性：输入面板、结果面板可在其他场景复用
- 更好的可读性：主组件变成清晰的组合，易于理解

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>