### PR TITLE
fix: 将 ValidationRule 和 ValidationError 中的 any 类型替换为 unknown

### DIFF
--- a/packages/shared-types/src/api/validation.ts
+++ b/packages/shared-types/src/api/validation.ts
@@ -9,7 +9,7 @@ export interface ValidationRule {
   /** 规则名称 */
   name: string;
   /** 验证函数 */
-  validate: (value: any) => boolean | string;
+  validate: (value: unknown) => boolean | string;
   /** 错误消息模板 */
   message: string;
   /** 是否必填 */
@@ -49,7 +49,7 @@ export interface ValidationError {
   /** 验证规则名称 */
   rule: string;
   /** 原始值 */
-  value: any;
+  value: unknown;
 }
 
 /**


### PR DESCRIPTION
修复 packages/shared-types/src/api/validation.ts 中的类型安全问题：
- ValidationRule.validate 参数：any → unknown
- ValidationError.value 字段：any → unknown

使用 unknown 类型提升类型安全性，强制使用前进行类型检查，
避免运行时错误，同时保持对不同值类型的支持能力。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>