### PR TITLE
fix: 修复 DaemonManager.startDaemon 方法类型安全问题

### DIFF
--- a/packages/cli/src/interfaces/Service.ts
+++ b/packages/cli/src/interfaces/Service.ts
@@ -2,6 +2,8 @@
  * 服务接口定义
  */
 
+import type { WebServer } from "@/WebServer";
+
 /**
  * 服务管理器接口
  */
@@ -75,7 +77,7 @@ export interface ProcessManager {
  */
 export interface DaemonManager {
   /** 启动守护进程 */
-  startDaemon(serverFactory: () => Promise<any>): Promise<void>;
+  startDaemon(serverFactory: () => Promise<WebServer>): Promise<void>;
   /** 停止守护进程 */
   stopDaemon(): Promise<void>;
 }


### PR DESCRIPTION
将 serverFactory 参数类型从 Promise<any> 更改为 Promise<WebServer>，
提升类型安全性并确保接口定义与实际实现一致。

Fixes #1624

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>