### PR TITLE
fix: 修复 packages/cli 中 @/WebServer 路径别名导致的 TypeScript 编译错误

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -269,7 +269,7 @@ export class ServiceManagerImpl implements IServiceManager {
       process.exit(0);
     } else {
       // 前台模式 - 直接启动 Web Server
-      const { WebServer } = await import("@/WebServer.js");
+      const { WebServer } = await import("@/WebServer");
       const server = new WebServer(port);
 
       // 处理退出信号
@@ -328,7 +328,7 @@ export class ServiceManagerImpl implements IServiceManager {
    * 前台模式启动 WebServer
    */
   private async startWebServerInForeground(): Promise<void> {
-    const { WebServer } = await import("@/WebServer.js");
+    const { WebServer } = await import("@/WebServer");
     const server = new WebServer();
 
     // 处理退出信号

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "../../dist/cli",
-    "rootDir": "src"
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../apps/backend/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],


### PR DESCRIPTION
- 在 packages/cli/tsconfig.json 中添加路径别名映射和 baseUrl
- 将动态导入从 @/WebServer.js 更改为 @/WebServer
- 添加 .d.ts 类型声明文件生成步骤

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>