### PR TITLE
chore: 忽略 worktrees 目录

### DIFF
--- a/.jscpd.json
+++ b/.jscpd.json
@@ -9,7 +9,8 @@
     "**/*.test.ts",
     "**/*.test.js",
     "**/*.spec.ts",
-    "**/*.spec.js"
+    "**/*.spec.js",
+    "worktrees/**"
   ],
   "format": ["typescript", "javascript"],
   "absolute": false

--- a/biome.json
+++ b/biome.json
@@ -15,7 +15,8 @@
       "pnpm-lock.yaml",
       "templates/**/*.js",
       "apps/backend/tsup.config.ts",
-      "package.json"
+      "package.json",
+      "worktrees/**"
     ]
   },
   "formatter": {

--- a/cspell.json
+++ b/cspell.json
@@ -26,7 +26,8 @@
     "**/*.tsbuildinfo",
     ".cspell/**",
     "xiaozhi.cache.json",
-    "tool-calls.jsonl"
+    "tool-calls.jsonl",
+    "worktrees/**"
   ],
   "ignoreWords": [],
   "flagWords": []


### PR DESCRIPTION
## Summary

- 在 jscpd、biome 和 cspell 配置中忽略 worktrees 目录
- 工作流中使用 worktrees 时，无需对其进行检查

## Test plan

- [x] 配置变更，无需测试

🤖 Generated with [Claude Code](https://claude.com/claude-code)