### PR TITLE
fix: 禁用 nx-release-publish 任务缓存

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -34,7 +34,8 @@
     },
     "nx-release-publish": {
       "dependsOn": ["^nx-release-publish", "build"],
-      "inputs": ["default", "^production"]
+      "inputs": ["default", "^production"],
+      "cache": false
     }
   },
   "release": {


### PR DESCRIPTION
## Summary
- 禁用 `nx-release-publish` 任务的 NX 缓存，避免发布时使用过期的缓存

🤖 Generated with [Claude Code](https://claude.com/claude-code)