### PR TITLE
fix: 移除 WebServer 中 endpointManager 的未清理事件监听器

### DIFF
--- a/apps/backend/__tests__/webserver/webserver.cleanup.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.cleanup.test.ts
@@ -119,6 +119,7 @@ vi.mock("@/lib/endpoint/index", () => ({
     setServiceManager: vi.fn(),
     getConnectionStatus: vi.fn().mockReturnValue([]),
     on: vi.fn(),
+    off: vi.fn(),
   })),
 }));
 

--- a/apps/backend/__tests__/webserver/webserver.integration.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.integration.test.ts
@@ -324,6 +324,7 @@ vi.mock("@xiaozhi-client/endpoint", () => ({
     setServiceManager: vi.fn(),
     getConnectionStatus: vi.fn().mockReturnValue([]),
     on: vi.fn(),
+    off: vi.fn(),
   })),
   EndpointConnection: vi.fn().mockImplementation(() => ({
     setServiceManager: vi.fn(),

--- a/apps/backend/__tests__/webserver/webserver.unit.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.unit.test.ts
@@ -58,6 +58,7 @@ vi.mock("@/lib/endpoint/index.js", () => ({
     setServiceManager: vi.fn(),
     getConnectionStatus: vi.fn().mockReturnValue([]),
     on: vi.fn(),
+    off: vi.fn(),
   })),
 }));
 
@@ -93,6 +94,7 @@ function createMockEndpointManager(): any {
     setServiceManager: vi.fn(),
     getConnectionStatus: vi.fn().mockReturnValue([]),
     on: vi.fn(),
+    off: vi.fn(),
     addEndpoint: vi.fn(),
     getEndpoints: vi.fn().mockReturnValue([]),
   };


### PR DESCRIPTION
修复 WebServer 中 endpointManager 事件监听器未移除导致的潜在内存泄漏问题：

- 添加私有字段保存事件监听器引用
- 在 initializeXiaozhiConnection 方法中保存监听器函数引用
- 在 destroy() 方法中正确移除事件监听器
- 更新相关测试文件的 mock 以包含 off() 方法

修复问题: #1644

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>