### PR TITLE
fix: 修复 TTS WebSocket 连接失败时的资源泄漏问题

### DIFF
--- a/apps/backend/lib/tts/binary.ts
+++ b/apps/backend/lib/tts/binary.ts
@@ -55,8 +55,19 @@ export async function synthesizeSpeech(
   });
 
   await new Promise((resolve, reject) => {
-    ws.on("open", resolve);
-    ws.on("error", reject);
+    const onError = (error: Error) => {
+      // 关闭 WebSocket 连接（如果已连接或正在连接）
+      if (
+        ws.readyState === WebSocket.OPEN ||
+        ws.readyState === WebSocket.CONNECTING
+      ) {
+        ws.close();
+      }
+      reject(error);
+    };
+
+    ws.once("open", resolve);
+    ws.once("error", onError);
   });
 
   const request = {


### PR DESCRIPTION
在 synthesizeSpeech 函数中，当 WebSocket 连接失败触发 error 事件时，
现在会正确关闭 WebSocket 连接以防止资源泄漏。

- 添加 onError 处理函数，在错误时关闭 WebSocket
- 使用 once() 替代 on() 以避免内存泄漏
- 检查 readyState 确保只在连接状态下关闭

Fixes #1650

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>