### PR TITLE
fix: 移除 mcp-server-list.tsx 中的 console.error 调用

### DIFF
--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -146,7 +146,6 @@ export function McpServerList({
       setEnabledTools(formattedEnabledTools);
       setDisabledTools(formattedDisabledTools);
     } catch (error) {
-      console.error("获取工具列表失败:", error);
       const errorMessage =
         error instanceof Error ? error.message : "获取工具列表失败";
       toast.error(errorMessage);
@@ -186,8 +185,9 @@ export function McpServerList({
       // 并行刷新配置数据和工具列表
       await Promise.all([refreshConfig(), fetchTools()]);
     } catch (error) {
-      console.error("刷新数据失败:", error);
-      toast.error("刷新数据失败");
+      const errorMessage =
+        error instanceof Error ? error.message : "刷新数据失败";
+      toast.error(errorMessage);
     } finally {
       setIsRefreshing(false);
     }
@@ -214,8 +214,9 @@ export function McpServerList({
       setEnabledTools(formattedEnabledTools);
       setDisabledTools(formattedDisabledTools);
     } catch (error) {
-      console.error("刷新工具列表失败:", error);
-      toast.error("刷新工具列表失败");
+      const errorMessage =
+        error instanceof Error ? error.message : "刷新工具列表失败";
+      toast.error(errorMessage);
     }
   }, [formatTool]);
 
@@ -293,7 +294,6 @@ export function McpServerList({
       // 重新获取工具列表以更新状态
       await refreshToolLists();
     } catch (error) {
-      console.error("切换工具状态失败:", error);
       toast.error(error instanceof Error ? error.message : "切换工具状态失败");
     }
   };
@@ -309,7 +309,6 @@ export function McpServerList({
       toast.success(`删除工具 ${cozeToolToRemove} 成功`);
       await refreshToolLists();
     } catch (error) {
-      console.error("删除 Coze 工具失败:", error);
       toast.error(
         error instanceof Error ? error.message : "删除 Coze 工具失败"
       );
@@ -440,13 +439,8 @@ export function McpServerList({
       // 刷新工具列表
       await refreshToolLists();
     } catch (error) {
-      console.error("更新工具参数配置失败:", error);
-
-      let errorMessage = "更新工具参数配置失败，请重试";
-      if (error instanceof Error) {
-        errorMessage = error.message;
-      }
-
+      const errorMessage =
+        error instanceof Error ? error.message : "更新工具参数配置失败，请重试";
       toast.error(errorMessage);
     } finally {
       setParameterConfigDialog({ open: false });


### PR DESCRIPTION
将 6 处 console.error 调用替换为仅使用 toast 通知，保持代码规范一致性。

修复位置:
- fetchTools: 获取工具列表失败
- handleRefreshData: 刷新数据失败
- refreshToolLists: 刷新工具列表失败
- _handleToggleTool: 切换工具状态失败
- handleConfirmRemoveCozeTool: 删除 Coze 工具失败
- handleParameterConfigConfirm: 更新工具参数配置失败

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>