### PR TITLE
fix: 修复 apps/backend 中相对路径导入，统一使用 @/ 路径别名

### DIFF
--- a/apps/backend/middlewares/endpointManager.middleware.ts
+++ b/apps/backend/middlewares/endpointManager.middleware.ts
@@ -3,8 +3,8 @@
  * 负责将 endpointManager 注入到请求上下文中
  */
 
+import type { AppContext } from "@/types/hono.context.js";
 import type { MiddlewareHandler } from "hono";
-import type { AppContext } from "../types/hono.context.js";
 
 /**
  * 小智连接管理器中间件

--- a/apps/backend/middlewares/endpoints.middleware.ts
+++ b/apps/backend/middlewares/endpoints.middleware.ts
@@ -4,10 +4,10 @@
  */
 
 import { EndpointHandler } from "@/handlers/endpoint.handler.js";
+import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { MiddlewareHandler } from "hono";
-import type { AppContext } from "../types/hono.context.js";
 
 /**
  * 小智端点处理器中间件

--- a/apps/backend/routes/RouteManager.ts
+++ b/apps/backend/routes/RouteManager.ts
@@ -4,8 +4,8 @@
  */
 
 import type { Logger } from "@/Logger.js";
+import type { AppContext } from "@/types/hono.context.js";
 import type { Context, Hono, Next } from "hono";
-import type { AppContext } from "../types/hono.context.js";
 import {
   type RouteDefinition,
   type RouteRegistry,

--- a/apps/backend/routes/index.ts
+++ b/apps/backend/routes/index.ts
@@ -24,7 +24,7 @@ export * from "./domains/index.js";
 
 // 重新导出 Hono 相关类型以方便使用
 export type { Context } from "hono";
-export type { AppContext } from "../types/hono.context.js";
+export type { AppContext } from "@/types/hono.context.js";
 
 // 重新导出处理器类型
-export type { EndpointHandler, TTSApiHandler } from "../handlers/index.js";
+export type { EndpointHandler, TTSApiHandler } from "@/handlers/index.js";


### PR DESCRIPTION
将以下文件中的相对路径导入替换为 @/ 路径别名：
- apps/backend/routes/RouteManager.ts
- apps/backend/middlewares/endpoints.middleware.ts
- apps/backend/middlewares/endpointManager.middleware.ts
- apps/backend/routes/index.ts

修复 #1658

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>