### PR TITLE
fix: 修复 TTS WebSocket 连接失败时的资源泄漏

### DIFF
--- a/apps/backend/lib/tts/binary.ts
+++ b/apps/backend/lib/tts/binary.ts
@@ -56,7 +56,11 @@ export async function synthesizeSpeech(
 
   await new Promise((resolve, reject) => {
     ws.on("open", resolve);
-    ws.on("error", reject);
+    ws.on("error", (err) => {
+      // 确保在错误时关闭 WebSocket 连接，避免资源泄漏
+      ws.close();
+      reject(err);
+    });
   });
 
   const request = {


### PR DESCRIPTION
在 synthesizeSpeech 函数中，当 WebSocket 连接失败时，
错误处理中添加了 ws.close() 调用以确保连接被正确关闭，
避免资源泄漏。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>