### PR TITLE
fix: 修复 CVE-2026-2391 安全漏洞 - 升级 qs 依赖

### DIFF
--- a/package.json
+++ b/package.json
@@ -122,7 +122,8 @@
       "body-parser@>=2.2.0 <2.2.1": ">=2.2.1",
       "mdast-util-to-hast@>=13.0.0 <13.2.1": ">=13.2.1",
       "lodash-es@>=4.0.0 <=4.17.22": ">=4.17.23",
-      "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": ">=1.26.0"
+      "@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3": ">=1.26.0",
+      "qs@>=6.7.0 <=6.14.1": ">=6.14.2"
     }
   },
   "packageManager": "pnpm@10.13.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,7 @@ overrides:
   mdast-util-to-hast@>=13.0.0 <13.2.1: '>=13.2.1'
   lodash-es@>=4.0.0 <=4.17.22: '>=4.17.23'
   '@modelcontextprotocol/sdk@>=1.10.0 <=1.25.3': '>=1.26.0'
+  qs@>=6.7.0 <=6.14.1: '>=6.14.2'
 
 importers:
 
@@ -6194,8 +6195,8 @@ packages:
   pump@3.0.3:
     resolution: {integrity: sha512-todwxLMY7/heScKmntwQG8CXVkWUOdYxIvY2s0VWAAMh/nd8SoYiRaKjlr7+iCs984f2P8zvrfWcDDYVb73NfA==}
 
-  qs@6.14.1:
-    resolution: {integrity: sha512-4EK3+xJl8Ts67nLYNwqw/dsFVnCf+qR7RgXSK9jEEm9unao3njwMDdmsdvoKBKHzxd7tCYz5e5M+SnMjdtXGQQ==}
+  qs@6.15.0:
+    resolution: {integrity: sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==}
     engines: {node: '>=0.6'}
 
   queue-microtask@1.2.3:
@@ -10680,7 +10681,7 @@ snapshots:
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
-      qs: 6.14.1
+      qs: 6.15.0
       raw-body: 3.0.2
       type-is: 2.0.1
     transitivePeerDependencies:
@@ -11613,7 +11614,7 @@ snapshots:
       once: 1.4.0
       parseurl: 1.3.3
       proxy-addr: 2.0.7
-      qs: 6.14.1
+      qs: 6.15.0
       range-parser: 1.2.1
       router: 2.2.0
       send: 1.2.1
@@ -13562,7 +13563,7 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  qs@6.14.1:
+  qs@6.15.0:
     dependencies:
       side-channel: 1.1.0
 
@@ -14293,7 +14294,7 @@ snapshots:
       formidable: 3.5.4
       methods: 1.1.2
       mime: 2.6.0
-      qs: 6.14.1
+      qs: 6.15.0
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
- 添加 pnpm override 强制升级 qs 到 >=6.14.2
- 修复 CVE-2026-2391 (GHSA-w7fw-mjwx-w883)
- 该漏洞允许攻击者通过逗号分隔的值绕过 arrayLimit 限制导致 DoS 攻击
- 依赖路径: express > qs

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>