### PR TITLE
fix: 替换 cozeApi.ts 中的 any 类型为更安全的类型

### DIFF
--- a/apps/frontend/src/services/cozeApi.ts
+++ b/apps/frontend/src/services/cozeApi.ts
@@ -12,7 +12,7 @@ import type {
 /**
  * API 响应格式
  */
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   message?: string;
@@ -22,7 +22,7 @@ interface ApiErrorResponse {
   error: {
     code: string;
     message: string;
-    details?: any;
+    details?: Record<string, unknown>;
   };
 }
 


### PR DESCRIPTION
- 将 ApiResponse<T = any> 改为 ApiResponse<T = unknown>
- 将 ApiErrorResponse.details?: any 改为 details?: Record<string, unknown>
- 提升类型安全性，强制使用时进行类型检查

修复 #1666

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>