### PR TITLE
fix: 修复 removeEndpoint 方法缺少 await 导致资源未正确清理

### DIFF
--- a/apps/backend/handlers/endpoint.handler.ts
+++ b/apps/backend/handlers/endpoint.handler.ts
@@ -351,7 +351,7 @@ export class EndpointHandler {
           );
         }
         // 从管理器移除端点
-        this.endpointManager.removeEndpoint(newEndpoint);
+        await this.endpointManager.removeEndpoint(newEndpoint);
         throw configError;
       }
 
@@ -434,7 +434,7 @@ export class EndpointHandler {
       // 再从管理器移除端点
       // EndpointManager.removeEndpoint 内部会再次调用 disconnect（幂等操作）
       // 并清理状态和发射 endpointRemoved 事件
-      this.endpointManager.removeEndpoint(endpointInstance);
+      await this.endpointManager.removeEndpoint(endpointInstance);
       this.logger.debug(`端点已从管理器中移除: ${endpoint}`);
 
       // 发送事件通知

--- a/packages/endpoint/src/__tests__/manager.test.ts
+++ b/packages/endpoint/src/__tests__/manager.test.ts
@@ -126,38 +126,38 @@ describe("EndpointManager", () => {
       manager.addEndpoint(mockEndpoints[1]);
     });
 
-    it("应该成功移除端点", () => {
-      manager.removeEndpoint(mockEndpoints[0]);
+    it("应该成功移除端点", async () => {
+      await manager.removeEndpoint(mockEndpoints[0]);
 
       expect(manager.getEndpoints()).toHaveLength(1);
       expect(manager.getEndpoints()[0]).toBe("ws://endpoint2.example.com");
     });
 
-    it("应该发射 endpointRemoved 事件", () => {
+    it("应该发射 endpointRemoved 事件", async () => {
       const eventSpy = vi.fn();
       manager.on("endpointRemoved", eventSpy);
 
-      manager.removeEndpoint(mockEndpoints[0]);
+      await manager.removeEndpoint(mockEndpoints[0]);
 
       expect(eventSpy).toHaveBeenCalledWith({
         endpoint: "ws://endpoint1.example.com",
       });
     });
 
-    it("移除不存在的端点不应该报错", () => {
+    it("移除不存在的端点不应该报错", async () => {
       const nonexistentEndpoint = new Endpoint("ws://nonexistent.com");
 
-      expect(() => {
-        manager.removeEndpoint(nonexistentEndpoint);
-      }).not.toThrow();
+      await expect(
+        manager.removeEndpoint(nonexistentEndpoint)
+      ).resolves.not.toThrow();
     });
 
-    it("移除不存在的端点时不应该发射事件", () => {
+    it("移除不存在的端点时不应该发射事件", async () => {
       const eventSpy = vi.fn();
       manager.on("endpointRemoved", eventSpy);
 
       const nonexistentEndpoint = new Endpoint("ws://nonexistent.com");
-      manager.removeEndpoint(nonexistentEndpoint);
+      await manager.removeEndpoint(nonexistentEndpoint);
 
       expect(eventSpy).not.toHaveBeenCalled();
     });
@@ -632,13 +632,13 @@ describe("EndpointManager", () => {
       });
     });
 
-    it("应该正确发射 endpointRemoved 事件", () => {
+    it("应该正确发射 endpointRemoved 事件", async () => {
       const spy = vi.fn();
       manager.on("endpointRemoved", spy);
 
       manager.addEndpoint(mockEndpoints[0]);
       manager.addEndpoint(mockEndpoints[1]);
-      manager.removeEndpoint(mockEndpoints[0]);
+      await manager.removeEndpoint(mockEndpoints[0]);
 
       expect(spy).toHaveBeenCalledTimes(1);
       expect(spy).toHaveBeenCalledWith({
@@ -675,14 +675,14 @@ describe("EndpointManager", () => {
       expect(manager.isAnyConnected()).toBe(true);
     });
 
-    it("应该处理快速添加和移除", () => {
+    it("应该处理快速添加和移除", async () => {
       for (let i = 0; i < 10; i++) {
         manager.addEndpoint(new Endpoint(`ws://endpoint${i}.com`));
       }
 
       for (let i = 0; i < 10; i++) {
         if (i % 2 === 0) {
-          manager.removeEndpoint(mockEndpoints[0] || mockEndpoints[i]);
+          await manager.removeEndpoint(mockEndpoints[0] || mockEndpoints[i]);
         }
       }
 

--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -177,7 +177,7 @@ export class EndpointManager extends EventEmitter {
    *
    * @param endpoint - Endpoint 实例
    */
-  removeEndpoint(endpoint: Endpoint): void {
+  async removeEndpoint(endpoint: Endpoint): Promise<void> {
     const url = endpoint.getUrl();
 
     if (!this.endpoints.has(url)) {
@@ -190,7 +190,7 @@ export class EndpointManager extends EventEmitter {
     console.debug(`[EndpointManager] 移除接入点: ${sliceEndpoint(url)}`);
 
     // 断开连接
-    endpoint.disconnect();
+    await endpoint.disconnect();
 
     // 清理状态
     this.endpoints.delete(url);


### PR DESCRIPTION
将 EndpointManager.removeEndpoint 方法改为异步方法，并在调用
endpoint.disconnect() 时添加 await 关键字，确保异步清理操作
被正确等待，避免资源泄漏。

同时更新所有调用者和相关测试用例。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>