### PR TITLE
fix: 使用 process.once() 替代 process.on() 防止 MaxListenersExceededWarning

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -278,8 +278,8 @@ export class ServiceManagerImpl implements IServiceManager {
         process.exit(0);
       };
 
-      process.on("SIGINT", cleanup);
-      process.on("SIGTERM", cleanup);
+      process.once("SIGINT", cleanup);
+      process.once("SIGTERM", cleanup);
 
       await server.start();
     }
@@ -338,8 +338,8 @@ export class ServiceManagerImpl implements IServiceManager {
       process.exit(0);
     };
 
-    process.on("SIGINT", cleanup);
-    process.on("SIGTERM", cleanup);
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
 
     // 保存 PID 信息
     this.processManager.savePidInfo(process.pid, "foreground");


### PR DESCRIPTION
在 ServiceManager.ts 中，多个方法使用 process.on() 注册 SIGINT 和
SIGTERM 信号监听器，但这些监听器从未被移除。当服务管理器的
方法被多次调用时（特别是在测试环境中），这些监听器会累积，
最终触发 MaxListenersExceededWarning 警告。

此修复将 process.on() 替换为 process.once()，确保信号处理函数
只执行一次后自动移除，避免监听器累积问题。

修复位置:
- startMcpServerMode() 方法 (前台模式)
- startWebServerInForeground() 方法

Fixes #1673

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>