### PR TITLE
fix: 将 formatUtils 中的 any 类型替换为 unknown 提高类型安全性

### DIFF
--- a/apps/frontend/src/utils/formatUtils.ts
+++ b/apps/frontend/src/utils/formatUtils.ts
@@ -53,7 +53,7 @@ export const generateStableKey = (
  * @param data 要格式化的数据
  * @returns 格式化后的JSON字符串
  */
-export const formatJson = (data: any): string | null => {
+export const formatJson = (data: unknown): string | null => {
   if (!data) return null;
   try {
     return JSON.stringify(data, null, 2);
@@ -67,7 +67,7 @@ export const formatJson = (data: any): string | null => {
  * @param error 错误对象
  * @returns 错误字符串
  */
-export const formatError = (error: any): string => {
+export const formatError = (error: unknown): string => {
   if (typeof error === "string") return error;
   if (error instanceof Error) return error.message;
   return String(error);


### PR DESCRIPTION
- formatJson 函数参数从 any 改为 unknown
- formatError 函数参数从 any 改为 unknown
- 保持原有功能的同时提高类型安全性

修复 #1679

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>