### PR TITLE
fix: 修复 TTS WebSocket message 事件处理器错误处理

### DIFF
--- a/apps/backend/lib/tts/protocols.ts
+++ b/apps/backend/lib/tts/protocols.ts
@@ -589,7 +589,8 @@ function setupMessageHandler(ws: WebSocket) {
           queue.push(msg);
         }
       } catch (error) {
-        throw new Error(`Error processing message: ${error}`);
+        // 通过 WebSocket error 事件发射错误，以便 ReceiveMessage 中的 errorHandler 能被触发
+        ws.emit("error", error);
       }
     });
 


### PR DESCRIPTION
将 apps/backend/lib/tts/protocols.ts 中 WebSocket message 事件处理器的错误处理从 throw 改为 ws.emit("error", error)，确保错误能正确传播到 ReceiveMessage Promise 的 reject。

Fixes #1682

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>