### PR TITLE
fix: 修复 WebSocket setUrl 方法中定时器泄漏问题

### DIFF
--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -7,7 +7,6 @@
  * - 支持多个 store 订阅 WebSocket 事件
  */
 
-import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 
 /**
@@ -402,7 +401,9 @@ export class WebSocketManager {
       // 如果当前已连接，重新连接到新 URL
       if (this.isConnected()) {
         this.disconnect();
-        setTimeout(() => this.connect(), WEBSOCKET_RECONNECT_DELAY);
+        // 使用现有的重连机制，确保定时器可以被正确清理
+        this.reconnectAttempts = 0;
+        this.scheduleReconnect();
       }
     }
   }


### PR DESCRIPTION
将 setUrl 方法中的 setTimeout 替换为 scheduleReconnect() 方法，
确保定时器引用被保存并能够在 clearTimers() 中正确清理。

修复问题 #1685

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>