### PR TITLE
fix: 移除 internal-mcp-manager.ts 中的 `as any` 类型断言

### DIFF
--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -9,6 +9,7 @@ import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { ensureToolJSONSchema } from "./types.js";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -105,7 +106,7 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        inputSchema: ensureToolJSONSchema(mcpTool.inputSchema),
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,

--- a/packages/endpoint/src/types.ts
+++ b/packages/endpoint/src/types.ts
@@ -80,8 +80,9 @@ export type JSONSchema =
 /**
  * 确保对象符合 MCP Tool JSON Schema 格式
  * 返回类型兼容 MCP SDK 的 Tool 类型
+ * 接受 unknown 类型，在运行时进行类型检查
  */
-export function ensureToolJSONSchema(schema: JSONSchema): {
+export function ensureToolJSONSchema(schema: unknown): {
   type: "object";
   properties?: Record<string, object>;
   required?: string[];


### PR DESCRIPTION
- 在 `internal-mcp-manager.ts` 中导入并使用 `ensureToolJSONSchema` 函数
- 修改 `ensureToolJSONSchema` 函数签名，从 `JSONSchema` 改为 `unknown`，以接受 MCP Manager 返回的类型
- 函数内部已有运行时类型检查，可以安全处理 `unknown` 类型
- 符合项目类型安全要求，避免使用 `any` 类型

Fixes #1693

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>