### PR TITLE
refactor: 提取共享的路径别名配置到 vite.config.ts

### DIFF
--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -3,6 +3,21 @@ import react from "@vitejs/plugin-react";
 import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 
+// 导出共享的路径别名配置
+export const pathAliases = {
+  "@": path.resolve(__dirname, "./src"),
+  "@components": path.resolve(__dirname, "./src/components"),
+  "@hooks": path.resolve(__dirname, "./src/hooks"),
+  "@services": path.resolve(__dirname, "./src/services"),
+  "@stores": path.resolve(__dirname, "./src/stores"),
+  "@utils": path.resolve(__dirname, "./src/utils"),
+  "@types": path.resolve(__dirname, "./src/types"),
+  "@lib": path.resolve(__dirname, "./src/lib"),
+  "@pages": path.resolve(__dirname, "./src/pages"),
+  "@providers": path.resolve(__dirname, "./src/providers"),
+  "@ui": path.resolve(__dirname, "./src/components/ui"),
+};
+
 export default defineConfig({
   plugins: [
     react(),
@@ -15,21 +30,7 @@ export default defineConfig({
         brotliSize: true,
       }),
   ].filter(Boolean),
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@components": path.resolve(__dirname, "./src/components"),
-      "@hooks": path.resolve(__dirname, "./src/hooks"),
-      "@services": path.resolve(__dirname, "./src/services"),
-      "@stores": path.resolve(__dirname, "./src/stores"),
-      "@utils": path.resolve(__dirname, "./src/utils"),
-      "@types": path.resolve(__dirname, "./src/types"),
-      "@lib": path.resolve(__dirname, "./src/lib"),
-      "@pages": path.resolve(__dirname, "./src/pages"),
-      "@providers": path.resolve(__dirname, "./src/providers"),
-      "@ui": path.resolve(__dirname, "./src/components/ui"),
-    },
-  },
+  resolve: { alias: pathAliases },
   server: {
     port: 5173,
     proxy: {

--- a/apps/frontend/vitest.config.ts
+++ b/apps/frontend/vitest.config.ts
@@ -1,24 +1,10 @@
-import path from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+import { pathAliases } from "./vite.config";
 
 export default defineConfig({
   plugins: [react()],
-  resolve: {
-    alias: {
-      "@": path.resolve(__dirname, "./src"),
-      "@components": path.resolve(__dirname, "./src/components"),
-      "@hooks": path.resolve(__dirname, "./src/hooks"),
-      "@services": path.resolve(__dirname, "./src/services"),
-      "@stores": path.resolve(__dirname, "./src/stores"),
-      "@utils": path.resolve(__dirname, "./src/utils"),
-      "@types": path.resolve(__dirname, "./src/types"),
-      "@lib": path.resolve(__dirname, "./src/lib"),
-      "@pages": path.resolve(__dirname, "./src/pages"),
-      "@providers": path.resolve(__dirname, "./src/providers"),
-      "@ui": path.resolve(__dirname, "./src/components/ui"),
-    },
-  },
+  resolve: { alias: pathAliases },
   test: {
     globals: true,
     environment: "happy-dom",


### PR DESCRIPTION
- 在 vite.config.ts 中导出 pathAliases 对象
- 在 vitest.config.ts 中导入并使用共享的 pathAliases
- 消除路径别名配置的重复代码，遵循 DRY 原则
- 减少维护负担，避免配置不一致的风险

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>