### PR TITLE
refactor: 移除 EventType 枚举中注释掉的旧值

### DIFF
--- a/apps/backend/lib/tts/protocols.ts
+++ b/apps/backend/lib/tts/protocols.ts
@@ -10,15 +10,10 @@ export enum EventType {
 
   // Connection events (1-99)
   StartConnection = 1,
-  // StartTask = 1,
   FinishConnection = 2,
-  // FinishTask = 2,
   ConnectionStarted = 50,
-  // TaskStarted = 50,
   ConnectionFailed = 51,
-  // TaskFailed = 51,
   ConnectionFinished = 52,
-  // TaskFinished = 52,
 
   // Session events (100-199)
   StartSession = 100,
@@ -29,7 +24,6 @@ export enum EventType {
   SessionFinished = 152,
   SessionFailed = 153,
   UsageResponse = 154,
-  // ChargeData = 154,
 
   // General events (200-299)
   TaskRequest = 200,


### PR DESCRIPTION
移除以下已废弃的枚举值注释：
- StartTask, FinishTask (已被 StartConnection, FinishConnection 替代)
- TaskStarted, TaskFailed, TaskFinished (已被 ConnectionStarted, ConnectionFailed, ConnectionFinished 替代)
- ChargeData (已被 UsageResponse 替代)

这些注释代码违反了代码整洁原则，应该依赖 Git 历史而非注释来保留变更记录。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>