### PR TITLE
fix: 在 endpoint.route.ts 中使用 Logger 系统替代 console.error

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,6 +4,7 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import { logger } from "@/Logger.js";
 import type { RouteDefinition } from "@/routes/types.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
@@ -54,7 +55,7 @@ const withEndpointHandler = async (
     // 使用类型安全的方式调用方法
     return await endpointHandler[handlerName](c);
   } catch (error) {
-    console.error(`端点处理器错误 [${handlerName}]:`, error);
+    logger.error(`端点处理器错误 [${handlerName}]`, error);
     const errorResponse = createErrorResponse(
       "ENDPOINT_HANDLER_ERROR",
       error instanceof Error ? error.message : "端点处理失败"


### PR DESCRIPTION
将 apps/backend/routes/domains/endpoint.route.ts 中的 console.error
替换为统一的 Logger 系统，以保持代码规范一致性。

修改内容：
- 添加 logger 导入: `import { logger } from "@/Logger.js"`
- 将 `console.error(...)` 替换为 `logger.error(...)`

关联 Issue: #1707

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>