### PR TITLE
perf: 优化 keyValuePairsToMultilineText 避免重复遍历对象

### DIFF
--- a/apps/frontend/src/utils/mcpFormConverter.ts
+++ b/apps/frontend/src/utils/mcpFormConverter.ts
@@ -269,12 +269,14 @@ function buildCommandString(config: {
 export function keyValuePairsToMultilineText(
   obj: Record<string, string> | undefined
 ): string {
-  if (!obj || Object.keys(obj).length === 0) {
+  if (!obj) {
     return "";
   }
-  return Object.entries(obj)
-    .map(([key, value]) => `${key}: ${value}`)
-    .join("\n");
+  const entries = Object.entries(obj);
+  if (entries.length === 0) {
+    return "";
+  }
+  return entries.map(([key, value]) => `${key}: ${value}`).join("\n");
 }
 
 /**


### PR DESCRIPTION
将 Object.keys() 和 Object.entries() 两次遍历优化为一次，提升性能

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>