### PR TITLE
fix: 移除 RestartButton 组件中未使用的 restartStatus prop

### DIFF
--- a/apps/frontend/src/components/restart-button.test.tsx
+++ b/apps/frontend/src/components/restart-button.test.tsx
@@ -1,6 +1,6 @@
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
-import { RestartButton, type RestartStatus } from "./restart-button";
+import { RestartButton } from "./restart-button";
 
 // Mock status store
 const mockRestartService = vi.fn();
@@ -114,37 +114,12 @@ describe("RestartButton", () => {
     expect(button).toBeInTheDocument();
   });
 
-  it("should clear loading state when restartStatus becomes completed", () => {
-    // 直接传入 restartStatus prop 来测试状态变化
-    const restartStatus: RestartStatus = {
-      status: "completed",
-      timestamp: Date.now(),
-    };
-
-    render(<RestartButton restartStatus={restartStatus} />);
+  it("should not be in loading state when not restarting", () => {
+    render(<RestartButton />);
 
     const button = screen.getByRole("button");
 
     // 应该不是加载状态
-    expect(button).not.toBeDisabled();
-    expect(button).toHaveTextContent("重启服务");
-
-    const icon = button.querySelector("svg");
-    expect(icon).not.toHaveClass("animate-spin");
-  });
-
-  it("should clear loading state when restartStatus becomes failed", () => {
-    const { rerender } = render(<RestartButton />);
-
-    const restartStatus: RestartStatus = {
-      status: "failed",
-      error: "重启失败",
-      timestamp: Date.now(),
-    };
-
-    rerender(<RestartButton restartStatus={restartStatus} />);
-
-    const button = screen.getByRole("button");
     expect(button).not.toBeDisabled();
     expect(button).toHaveTextContent("重启服务");
 

--- a/apps/frontend/src/components/restart-button.tsx
+++ b/apps/frontend/src/components/restart-button.tsx
@@ -4,20 +4,9 @@ import clsx from "clsx";
 import { LoaderCircleIcon, PowerIcon } from "lucide-react";
 
 /**
- * 重启状态接口
- */
-export interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-}
-
-/**
  * RestartButton 组件属性接口
  */
 export interface RestartButtonProps {
-  /** 重启状态 */
-  restartStatus?: RestartStatus;
   /** 是否禁用按钮 */
   disabled?: boolean;
   /** 按钮样式变体 */


### PR DESCRIPTION
移除了 RestartButtonProps 接口中定义但从未使用的 restartStatus 属性和 RestartStatus 类型定义。该组件通过 useStatusStore 和 useRestartPollingStatus hooks 获取重启状态，不需要额外的 prop 传递。

Changes:
- 移除 RestartStatus 接口定义
- 从 RestartButtonProps 中移除 restartStatus 属性
- 更新测试用例，移除对未实现 prop 的测试
- 合并冗余测试用例（2个 → 1个）

Fixes #1714

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>