### PR TITLE
fix: 修复 DaemonManager 中 logStream 文件句柄泄漏问题

### DIFF
--- a/packages/cli/src/services/__tests__/DaemonManager.test.ts
+++ b/packages/cli/src/services/__tests__/DaemonManager.test.ts
@@ -26,8 +26,8 @@ const mockProcessManager: ProcessManager = {
 // Mock child_process
 const mockChild = {
   pid: 1234,
-  stdout: { pipe: vi.fn() },
-  stderr: { pipe: vi.fn() },
+  stdout: { pipe: vi.fn(), unpipe: vi.fn() },
+  stderr: { pipe: vi.fn(), unpipe: vi.fn() },
   on: vi.fn(),
   unref: vi.fn(),
   kill: vi.fn(),
@@ -44,6 +44,7 @@ vi.mock("node:fs", () => ({
     mkdirSync: vi.fn(),
     createWriteStream: vi.fn(() => ({
       write: vi.fn(),
+      end: vi.fn(),
     })),
   },
 }));


### PR DESCRIPTION
- 将 logStream 保存为实例变量以便后续清理
- 新增 cleanupLogStream() 方法用于解除 pipe 连接并关闭流
- 在 stopDaemon() 中清理日志流
- 在进程退出和错误事件中清理日志流
- 在 cleanup() 方法中清理日志流
- 更新测试 mock 以支持 unpipe 和 end 方法

修复了 #1716 中描述的资源泄漏问题：每次启动守护进程都会泄漏一个文件句柄，频繁启动/重启会累积泄漏大量文件句柄。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>