### PR TITLE
refactor: 统一前端路径别名为 @/ 以提高代码一致性

### DIFF
--- a/apps/frontend/src/components/__tests__/McpEndpointSettingButton.test.tsx
+++ b/apps/frontend/src/components/__tests__/McpEndpointSettingButton.test.tsx
@@ -1,7 +1,7 @@
+import { McpEndpointSettingButton } from "@/components/mcp-endpoint-setting-button";
 import * as api from "@/services/api";
 import * as websocket from "@/services/websocket";
 import * as stores from "@/stores/config";
-import { McpEndpointSettingButton } from "@components/mcp-endpoint-setting-button";
 import {
   act,
   fireEvent,

--- a/apps/frontend/src/components/__tests__/McpServerList.test.tsx
+++ b/apps/frontend/src/components/__tests__/McpServerList.test.tsx
@@ -1,4 +1,4 @@
-import { McpServerList } from "@components/mcp-server-list";
+import { McpServerList } from "@/components/mcp-server-list";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";
@@ -37,7 +37,7 @@ vi.mock("@/services/api", () => ({
 }));
 
 // 模拟其他组件
-vi.mock("@components/add-mcp-server-button", () => ({
+vi.mock("@/components/add-mcp-server-button", () => ({
   AddMcpServerButton: () => (
     <button type="button" data-testid="add-server">
       Add Server
@@ -45,7 +45,7 @@ vi.mock("@components/add-mcp-server-button", () => ({
   ),
 }));
 
-vi.mock("@components/remove-mcp-server-button", () => ({
+vi.mock("@/components/remove-mcp-server-button", () => ({
   RemoveMcpServerButton: ({ mcpServerName, onRemoveSuccess }: any) => (
     <button
       type="button"
@@ -57,15 +57,15 @@ vi.mock("@components/remove-mcp-server-button", () => ({
   ),
 }));
 
-vi.mock("@components/mcp-server-setting-button", () => ({
+vi.mock("@/components/mcp-server-setting-button", () => ({
   McpServerSettingButton: () => <div>Settings</div>,
 }));
 
-vi.mock("@components/restart-button", () => ({
+vi.mock("@/components/restart-button", () => ({
   RestartButton: () => <div>Restart</div>,
 }));
 
-vi.mock("@components/coze-workflow-integration", () => ({
+vi.mock("@/components/coze-workflow-integration", () => ({
   CozeWorkflowIntegration: () => <div>Coze Integration</div>,
 }));
 

--- a/apps/frontend/src/components/__tests__/RemoveMcpServerButton.test.tsx
+++ b/apps/frontend/src/components/__tests__/RemoveMcpServerButton.test.tsx
@@ -1,4 +1,4 @@
-import { RemoveMcpServerButton } from "@components/remove-mcp-server-button";
+import { RemoveMcpServerButton } from "@/components/remove-mcp-server-button";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";

--- a/apps/frontend/src/components/__tests__/VersionManager.test.tsx
+++ b/apps/frontend/src/components/__tests__/VersionManager.test.tsx
@@ -2,7 +2,7 @@
  * VersionManager 组件测试
  */
 
-import { VersionManager } from "@components/version-manager";
+import { VersionManager } from "@/components/version-manager";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 

--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -18,6 +18,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
 import { mcpFormSchema } from "@/schemas/mcp-form";
 import { apiClient } from "@/services/api";
 import {
@@ -27,7 +28,6 @@ import {
 } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Textarea } from "@ui/textarea";
 import { PlusIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";

--- a/apps/frontend/src/components/connection-settings.tsx
+++ b/apps/frontend/src/components/connection-settings.tsx
@@ -1,5 +1,5 @@
-import { Button } from "@ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@ui/card";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertCircle, CheckCircle2, Settings } from "lucide-react";
 import { useState } from "react";
 

--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -8,19 +8,19 @@
  * - 安装完成后提供操作选项
  */
 
-import { useNPMInstall } from "@hooks/useNPMInstall";
-import { Alert, AlertDescription } from "@ui/alert";
-import { Badge } from "@ui/badge";
-import { Button } from "@ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogFooter,
   DialogHeader,
   DialogTitle,
-} from "@ui/dialog";
-import { Progress } from "@ui/progress";
-import { ScrollArea } from "@ui/scroll-area";
+} from "@/components/ui/dialog";
+import { Progress } from "@/components/ui/progress";
+import { ScrollArea } from "@/components/ui/scroll-area";
+import { useNPMInstall } from "@/hooks/useNPMInstall";
 import {
   CheckCircleIcon,
   ChevronDownIcon,

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -18,6 +18,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
 import { useNetworkServiceActions } from "@/providers/WebSocketProvider";
 import { mcpFormSchema } from "@/schemas/mcp-form";
 import { useConfig } from "@/stores/config";
@@ -29,7 +30,6 @@ import {
 } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
-import { Textarea } from "@ui/textarea";
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 import { SettingsIcon } from "lucide-react";
 import { useCallback, useState } from "react";

--- a/apps/frontend/src/components/remove-mcp-server-button.tsx
+++ b/apps/frontend/src/components/remove-mcp-server-button.tsx
@@ -1,5 +1,3 @@
-import { cn } from "@/lib/utils";
-import { apiClient } from "@/services/api";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -10,7 +8,9 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from "@ui/alert-dialog";
+} from "@/components/ui/alert-dialog";
+import { cn } from "@/lib/utils";
+import { apiClient } from "@/services/api";
 import { TrashIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";

--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -1,4 +1,5 @@
 import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Tooltip,
   TooltipContent,
@@ -7,7 +8,6 @@ import {
 } from "@/components/ui/tooltip";
 import type { VersionInfo } from "@/services/api";
 import { apiClient } from "@/services/api";
-import { Button } from "@ui/button";
 import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";

--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -8,16 +8,16 @@
  * - 显示实时安装日志
  */
 
-import { apiClient } from "@services/api";
-import { Badge } from "@ui/badge";
-import { Button } from "@ui/button";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
 import {
   Card,
   CardContent,
   CardDescription,
   CardHeader,
   CardTitle,
-} from "@ui/card";
+} from "@/components/ui/card";
+import { apiClient } from "@/services/api";
 import {
   AlertCircle,
   Calendar,

--- a/apps/frontend/src/components/version-upgrade-dialog.tsx
+++ b/apps/frontend/src/components/version-upgrade-dialog.tsx
@@ -7,6 +7,7 @@
  * - 集成安装日志显示
  */
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -25,7 +26,6 @@ import {
 } from "@/components/ui/select";
 import { useNPMInstall } from "@/hooks/useNPMInstall";
 import { apiClient } from "@/services/api";
-import { Alert, AlertDescription, AlertTitle } from "@ui/alert";
 import { DownloadIcon, ShieldAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import semver from "semver";

--- a/apps/frontend/src/hooks/__tests__/use-network-service.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-network-service.test.ts
@@ -2,13 +2,13 @@
  * useNetworkService Hook 测试
  */
 
-import { ConnectionState, networkService } from "@services/index";
+import { ConnectionState, networkService } from "@/services/index";
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useNetworkService } from "../useNetworkService";
 
 // Mock 依赖
-vi.mock("@services/index", () => ({
+vi.mock("@/services/index", () => ({
   networkService: {
     initialize: vi.fn(),
     destroy: vi.fn(),
@@ -32,7 +32,7 @@ vi.mock("@services/index", () => ({
   },
 }));
 
-vi.mock("@stores/config", () => ({
+vi.mock("@/stores/config", () => ({
   useConfigStore: {
     getState: vi.fn(() => ({
       setConfig: vi.fn(),
@@ -40,7 +40,7 @@ vi.mock("@stores/config", () => ({
   },
 }));
 
-vi.mock("@stores/status", () => ({
+vi.mock("@/stores/status", () => ({
   useStatusStore: {
     getState: vi.fn(() => ({
       setClientStatus: vi.fn(),
@@ -50,7 +50,7 @@ vi.mock("@stores/status", () => ({
   },
 }));
 
-vi.mock("@stores/websocket", () => ({
+vi.mock("@/stores/websocket", () => ({
   useWebSocketActions: () => ({
     setConnectionState: vi.fn(),
     setWsUrl: vi.fn(),

--- a/apps/frontend/src/hooks/__tests__/useRestartNotifications.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useRestartNotifications.test.tsx
@@ -5,7 +5,7 @@
 import {
   RestartNotificationProvider,
   useRestartNotifications,
-} from "@hooks/useRestartNotifications";
+} from "@/hooks/useRestartNotifications";
 import { render, waitFor } from "@testing-library/react";
 import { vi } from "vitest";
 

--- a/apps/frontend/src/hooks/useConfigData.ts
+++ b/apps/frontend/src/hooks/useConfigData.ts
@@ -22,7 +22,7 @@ import {
   useModelScopeConfig,
   useSystemConfig,
   useWebUIConfig,
-} from "@stores/config";
+} from "@/stores/config";
 import type {
   AppConfig,
   ConnectionConfig,

--- a/apps/frontend/src/hooks/useCozeWorkflows.ts
+++ b/apps/frontend/src/hooks/useCozeWorkflows.ts
@@ -3,7 +3,7 @@
  * 提供工作空间和工作流数据的状态管理
  */
 
-import { cozeApiClient } from "@services/cozeApi";
+import { cozeApiClient } from "@/services/cozeApi";
 import type {
   CozeUIState,
   CozeWorkflow,

--- a/apps/frontend/src/hooks/useEndpointStatus.ts
+++ b/apps/frontend/src/hooks/useEndpointStatus.ts
@@ -1,7 +1,7 @@
 import {
   type EndpointStatusChangedEvent,
   webSocketManager,
-} from "@services/websocket";
+} from "@/services/websocket";
 /**
  * 端点状态变更 Hook
  * 用于订阅和处理端点连接状态的实时变更

--- a/apps/frontend/src/hooks/useNPMInstall.ts
+++ b/apps/frontend/src/hooks/useNPMInstall.ts
@@ -8,7 +8,7 @@
  * - 支持安装操作触发
  */
 
-import { webSocketManager } from "@services/websocket";
+import { webSocketManager } from "@/services/websocket";
 import { useCallback, useEffect, useState } from "react";
 
 /**

--- a/apps/frontend/src/hooks/useNetworkService.ts
+++ b/apps/frontend/src/hooks/useNetworkService.ts
@@ -3,11 +3,11 @@
  * 使用统一的网络服务管理器，实现 HTTP 和 WebSocket 的协调使用
  */
 
-import { ConnectionState, networkService } from "@services/index";
-import type { RestartStatus } from "@services/websocket";
-import { useConfigStore } from "@stores/config";
-import { useStatusStore } from "@stores/status";
-import { useWebSocketActions } from "@stores/websocket";
+import { ConnectionState, networkService } from "@/services/index";
+import type { RestartStatus } from "@/services/websocket";
+import { useConfigStore } from "@/stores/config";
+import { useStatusStore } from "@/stores/status";
+import { useWebSocketActions } from "@/stores/websocket";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 import { useCallback, useEffect, useRef } from "react";
 

--- a/apps/frontend/src/hooks/useStatusData.ts
+++ b/apps/frontend/src/hooks/useStatusData.ts
@@ -26,7 +26,7 @@ import {
   useStatusLoading,
   useStatusMcpEndpoint,
   useStatusWithLoading,
-} from "@stores/status";
+} from "@/stores/status";
 import { useCallback } from "react";
 
 /**

--- a/apps/frontend/src/hooks/useWebSocketConnection.ts
+++ b/apps/frontend/src/hooks/useWebSocketConnection.ts
@@ -5,7 +5,7 @@
  * 返回连接状态、错误信息、连接控制方法
  */
 
-import { ConnectionState, webSocketManager } from "@services/websocket";
+import { ConnectionState, webSocketManager } from "@/services/websocket";
 import {
   useWebSocketActions,
   useWebSocketConnected,
@@ -13,7 +13,7 @@ import {
   useWebSocketConnectionStats,
   useWebSocketLastError,
   useWebSocketUrl,
-} from "@stores/websocket";
+} from "@/stores/websocket";
 import { useCallback } from "react";
 
 /**

--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -1,5 +1,5 @@
-import { useNetworkService } from "@hooks/useNetworkService";
-import { initializeStores } from "@stores/index";
+import { useNetworkService } from "@/hooks/useNetworkService";
+import { initializeStores } from "@/stores/index";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import {
   type ReactNode,

--- a/apps/frontend/src/services/__tests__/tools-api.parameter-config.test.ts
+++ b/apps/frontend/src/services/__tests__/tools-api.parameter-config.test.ts
@@ -11,7 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ToolsApiService } from "../toolsApi";
 
 // Mock apiClient
-vi.mock("@services/api", () => ({
+vi.mock("@/services/api", () => ({
   apiClient: {
     addCustomTool: vi.fn(),
     removeCustomTool: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock("@services/api", () => ({
   },
 }));
 
-import { apiClient } from "@services/api";
+import { apiClient } from "@/services/api";
 
 describe("ToolsApiService - 参数配置功能", () => {
   let service: ToolsApiService;

--- a/apps/frontend/src/stores/__tests__/config.test.ts
+++ b/apps/frontend/src/stores/__tests__/config.test.ts
@@ -1,10 +1,10 @@
-import { apiClient } from "@services/api";
+import { apiClient } from "@/services/api";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useConfigStore } from "../config";
 
 // Mock API client
-vi.mock("@services/api", () => ({
+vi.mock("@/services/api", () => ({
   apiClient: {
     getConfig: vi.fn(),
     updateConfig: vi.fn(),

--- a/apps/frontend/src/stores/__tests__/status.test.ts
+++ b/apps/frontend/src/stores/__tests__/status.test.ts
@@ -1,13 +1,13 @@
-import { apiClient } from "@services/api";
+import { apiClient } from "@/services/api";
 import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { useStatusStore } from "../status";
 
 // 导入 API 中的 FullStatus 类型
-import type { FullStatus } from "@services/api";
+import type { FullStatus } from "@/services/api";
 
 // Mock API client
-vi.mock("@services/api", () => ({
+vi.mock("@/services/api", () => ({
   apiClient: {
     getStatus: vi.fn(),
     restartService: vi.fn(),

--- a/apps/frontend/src/stores/__tests__/websocket.test.ts
+++ b/apps/frontend/src/stores/__tests__/websocket.test.ts
@@ -1,4 +1,4 @@
-import { ConnectionState } from "@services/websocket";
+import { ConnectionState } from "@/services/websocket";
 import { beforeEach, describe, expect, it } from "vitest";
 import { useWebSocketStore } from "../websocket";
 

--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -9,8 +9,8 @@
  * - 集成 WebSocket 事件监听
  */
 
-import { apiClient } from "@services/api";
-import { webSocketManager } from "@services/websocket";
+import { apiClient } from "@/services/api";
+import { webSocketManager } from "@/services/websocket";
 import type {
   AppConfig,
   ConnectionConfig,

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -10,8 +10,8 @@
  * - 集成 WebSocket 事件监听
  */
 
-import { apiClient } from "@services/api";
-import { webSocketManager } from "@services/websocket";
+import { apiClient } from "@/services/api";
+import { webSocketManager } from "@/services/websocket";
 import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";

--- a/apps/frontend/src/stores/websocket-compat.ts
+++ b/apps/frontend/src/stores/websocket-compat.ts
@@ -5,7 +5,7 @@
  * 这些选择器将数据从新的专门 stores 中获取并以旧格式返回
  */
 
-import { ConnectionState } from "@services/websocket";
+import { ConnectionState } from "@/services/websocket";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 import { useConfigStore } from "./config";
 import { useStatusStore } from "./status";

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -13,7 +13,7 @@
  */
 
 import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
-import { ConnectionState, webSocketManager } from "@services/websocket";
+import { ConnectionState, webSocketManager } from "@/services/websocket";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";

--- a/apps/frontend/src/test/App.test.tsx
+++ b/apps/frontend/src/test/App.test.tsx
@@ -62,9 +62,9 @@ describe("App Routing", () => {
 
     // Reset stores using dynamic imports
     try {
-      const { useConfigStore } = await import("@stores/config");
-      const { useStatusStore } = await import("@stores/status");
-      const { useWebSocketStore } = await import("@stores/websocket");
+      const { useConfigStore } = await import("@/stores/config");
+      const { useStatusStore } = await import("@/stores/status");
+      const { useWebSocketStore } = await import("@/stores/websocket");
 
       useConfigStore.getState().reset();
       useStatusStore.getState().reset();

--- a/apps/frontend/src/test/CozeWorkflowIntegration.test.tsx
+++ b/apps/frontend/src/test/CozeWorkflowIntegration.test.tsx
@@ -2,9 +2,9 @@
  * CozeWorkflowIntegration 组件测试
  */
 
-import { CozeWorkflowIntegration } from "@components/coze-workflow-integration";
-import * as useCozeWorkflowsModule from "@hooks/useCozeWorkflows";
-import * as toolsApiModule from "@services/api";
+import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
+import * as useCozeWorkflowsModule from "@/hooks/useCozeWorkflows";
+import * as toolsApiModule from "@/services/api";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { CozeWorkflow, CozeWorkspace } from "@xiaozhi-client/shared-types";
@@ -19,12 +19,12 @@ vi.mock("sonner", () => ({
 }));
 
 // Mock useCozeWorkflows hook
-vi.mock("@hooks/useCozeWorkflows", () => ({
+vi.mock("@/hooks/useCozeWorkflows", () => ({
   useCozeWorkflows: vi.fn(),
 }));
 
 // Mock apiClient
-vi.mock("@services/api", () => ({
+vi.mock("@/services/api", () => ({
   apiClient: {
     getCustomTools: vi.fn(),
     addCustomTool: vi.fn(),

--- a/apps/frontend/src/test/compatibility.test.tsx
+++ b/apps/frontend/src/test/compatibility.test.tsx
@@ -2,8 +2,8 @@
  * 兼容性测试 - 验证废弃选择器仍然正常工作
  */
 
-import { useConfigStore } from "@stores/config";
-import { useStatusStore } from "@stores/status";
+import { useConfigStore } from "@/stores/config";
+import { useStatusStore } from "@/stores/status";
 import {
   useWebSocketConfig,
   useWebSocketMcpEndpoint,
@@ -11,7 +11,7 @@ import {
   useWebSocketMcpServers,
   useWebSocketRestartStatus,
   useWebSocketStatus,
-} from "@stores/websocket-compat";
+} from "@/stores/websocket-compat";
 import { render } from "@testing-library/react";
 import type React from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -42,8 +42,8 @@ const LegacyComponent: React.FC = () => {
 };
 
 // 导入新的选择器
-import { useConfig } from "@stores/config";
-import { useClientStatus } from "@stores/status";
+import { useConfig } from "@/stores/config";
+import { useClientStatus } from "@/stores/status";
 
 // 混合使用新旧选择器的组件
 const MixedComponent: React.FC = () => {

--- a/apps/frontend/src/test/coze-api.test.ts
+++ b/apps/frontend/src/test/coze-api.test.ts
@@ -2,7 +2,7 @@
  * 扣子 API 前端服务层集成测试
  */
 
-import { CozeApiClient } from "@services/cozeApi";
+import { CozeApiClient } from "@/services/cozeApi";
 import type {
   CozeWorkflowsResult,
   CozeWorkspace,

--- a/apps/frontend/src/test/integration.test.ts
+++ b/apps/frontend/src/test/integration.test.ts
@@ -2,10 +2,10 @@
  * 集成测试 - 验证 WebSocket 架构重构后的功能
  */
 
-import { ConnectionState, webSocketManager } from "@services/websocket";
-import { useConfigStore } from "@stores/config";
-import { useStatusStore } from "@stores/status";
-import { useWebSocketStore } from "@stores/websocket";
+import { ConnectionState, webSocketManager } from "@/services/websocket";
+import { useConfigStore } from "@/stores/config";
+import { useStatusStore } from "@/stores/status";
+import { useWebSocketStore } from "@/stores/websocket";
 import { beforeEach, describe, expect, it } from "vitest";
 
 describe("WebSocket 架构集成测试", () => {

--- a/apps/frontend/src/test/performance.test.tsx
+++ b/apps/frontend/src/test/performance.test.tsx
@@ -7,17 +7,17 @@ import {
   useConfigStore,
   useMcpEndpoint,
   useMcpServers,
-} from "@stores/config";
+} from "@/stores/config";
 import {
   useClientStatus,
   useRestartStatus,
   useStatusStore,
-} from "@stores/status";
+} from "@/stores/status";
 import {
   useWebSocketConnected,
   useWebSocketStore,
   useWebSocketUrl,
-} from "@stores/websocket";
+} from "@/stores/websocket";
 import { act, render } from "@testing-library/react";
 import type React from "react";
 import { useEffect } from "react";
@@ -178,7 +178,7 @@ describe("性能优化验证", () => {
   });
 
   it("应该验证 WebSocket 单例模式的性能优势", async () => {
-    const { webSocketManager } = await import("@services/websocket");
+    const { webSocketManager } = await import("@/services/websocket");
 
     // 多次获取实例应该返回同一个对象
     const instance1 = webSocketManager;

--- a/apps/frontend/src/test/use-coze-workflows.test.ts
+++ b/apps/frontend/src/test/use-coze-workflows.test.ts
@@ -2,8 +2,8 @@
  * useCozeWorkflows Hook 测试
  */
 
-import { useCozeWorkflows } from "@hooks/useCozeWorkflows";
-import { cozeApiClient } from "@services/cozeApi";
+import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
+import { cozeApiClient } from "@/services/cozeApi";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type {
   CozeWorkflowsResult,
@@ -12,7 +12,7 @@ import type {
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock cozeApiClient
-vi.mock("@services/cozeApi", () => {
+vi.mock("@/services/cozeApi", () => {
   const mockCozeApiClient = {
     fetchWorkspaces: vi.fn(),
     fetchWorkflows: vi.fn(),

--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -22,15 +22,6 @@
     "baseUrl": ".",
     "paths": {
       "@/*": ["./src/*"],
-      "@components/*": ["./src/components/*"],
-      "@hooks/*": ["./src/hooks/*"],
-      "@services/*": ["./src/services/*"],
-      "@stores/*": ["./src/stores/*"],
-      "@utils/*": ["./src/utils/*"],
-      "@lib/*": ["./src/lib/*"],
-      "@pages/*": ["./src/pages/*"],
-      "@providers/*": ["./src/providers/*"],
-      "@ui/*": ["./src/components/ui/*"],
       "@xiaozhi-client/shared-types": ["../../packages/shared-types/src"]
     }
   },

--- a/apps/frontend/vite.config.ts
+++ b/apps/frontend/vite.config.ts
@@ -18,16 +18,6 @@ export default defineConfig({
   resolve: {
     alias: {
       "@": path.resolve(__dirname, "./src"),
-      "@components": path.resolve(__dirname, "./src/components"),
-      "@hooks": path.resolve(__dirname, "./src/hooks"),
-      "@services": path.resolve(__dirname, "./src/services"),
-      "@stores": path.resolve(__dirname, "./src/stores"),
-      "@utils": path.resolve(__dirname, "./src/utils"),
-      "@types": path.resolve(__dirname, "./src/types"),
-      "@lib": path.resolve(__dirname, "./src/lib"),
-      "@pages": path.resolve(__dirname, "./src/pages"),
-      "@providers": path.resolve(__dirname, "./src/providers"),
-      "@ui": path.resolve(__dirname, "./src/components/ui"),
     },
   },
   server: {


### PR DESCRIPTION
- 将所有 @services/、@stores/、@hooks/、@components/、@ui/ 别名替换为 @/ 等效别名
- 从 vite.config.ts 和 tsconfig.json 中移除冗余的路径别名定义
- 保留 @/ 别名作为唯一的路径别名，符合项目路径别名系统规范
- 修复了 38 个文件中的路径别名使用

此更改解决了路径别名混用问题，提高了代码可读性和维护成本。

相关 Issue: #1717

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>