### PR TITLE
fix: 将 ApiResponse 和 ApiSuccessResponse 泛型默认值从 any 改为 unknown

### DIFF
--- a/packages/shared-types/src/api/common.ts
+++ b/packages/shared-types/src/api/common.ts
@@ -5,7 +5,7 @@
 /**
  * 通用 API 响应接口
  */
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   /** 响应状态码，0表示成功 */
   code: number;
   /** 响应数据 */
@@ -19,7 +19,7 @@ export interface ApiResponse<T = any> {
 /**
  * 成功响应接口
  */
-export interface ApiSuccessResponse<T = any> {
+export interface ApiSuccessResponse<T = unknown> {
   /** 响应状态码，固定为0 */
   code: 0;
   /** 响应数据 */


### PR DESCRIPTION
- 修复 shared-types 包中的类型安全问题
- ApiResponse<T = any> → ApiResponse<T = unknown>
- ApiSuccessResponse<T = any> → ApiSuccessResponse<T = unknown>
- 使用 unknown 保持类型安全，要求在使用时进行类型检查

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>