### PR TITLE
fix: 修复测试文件中的本地化规范违规问题（部分完成）

### DIFF
--- a/apps/backend/__tests__/config-sync-integration.test.ts
+++ b/apps/backend/__tests__/config-sync-integration.test.ts
@@ -9,7 +9,7 @@ import type { AppConfig } from "@xiaozhi-client/config";
 import { ConfigManager } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-// Mock fs module
+// 模拟 fs 模块
 vi.mock("node:fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:fs")>();
   return {
@@ -21,7 +21,7 @@ vi.mock("node:fs", async (importOriginal) => {
   };
 });
 
-// Mock path module
+// 模拟 path 模块
 vi.mock("node:path", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:path")>();
   return {
@@ -31,7 +31,7 @@ vi.mock("node:path", async (importOriginal) => {
   };
 });
 
-// Mock url module
+// 模拟 url 模块
 vi.mock("node:url", async (importOriginal) => {
   const actual = await importOriginal<typeof import("node:url")>();
   return {
@@ -40,7 +40,7 @@ vi.mock("node:url", async (importOriginal) => {
   };
 });
 
-// Mock logger
+// 模拟 logger
 vi.mock("../Logger", () => ({
   logger: {
     info: vi.fn(),
@@ -61,13 +61,13 @@ describe("配置同步集成测试", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Reset singleton instance
+    // 重置单例实例
     // @ts-ignore - accessing private static property for testing
     ConfigManager.instance = undefined;
 
     configManager = ConfigManager.getInstance();
 
-    // Setup default mocks
+    // 设置默认模拟
     mockResolve.mockImplementation(
       (dir: string, file: string) => `${dir}/${file}`
     );

--- a/apps/backend/__tests__/logger.test.ts
+++ b/apps/backend/__tests__/logger.test.ts
@@ -3,7 +3,7 @@ import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger, logger } from "../Logger.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
   writeFileSync: vi.fn(),
@@ -28,7 +28,7 @@ vi.mock("chalk", () => ({
   },
 }));
 
-// Mock pino with proper structure
+// 使用正确结构模拟 pino
 vi.mock("pino", () => {
   const mockDestination = vi.fn(() => ({
     write: vi.fn(),
@@ -64,7 +64,7 @@ vi.mock("pino", () => {
   };
 });
 
-// Mock console.error to avoid actual output during tests
+// 模拟 console.error 以避免测试期间的实际输出
 const originalConsoleError = console.error;
 const mockConsoleError = vi.fn();
 
@@ -80,13 +80,13 @@ describe("Logger", async () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock pino destination
+    // 模拟 pino destination
     mockDestination = {
       write: vi.fn(),
       end: vi.fn(),
     };
 
-    // Mock pino instance
+    // 模拟 pino 实例
     mockPinoInstance = {
       info: vi.fn(),
       warn: vi.fn(),
@@ -95,12 +95,12 @@ describe("Logger", async () => {
       fatal: vi.fn(),
     };
 
-    // Setup pino mocks
+    // 设置 pino 模拟
     mockPino.mockReturnValue(mockPinoInstance);
     (mockPino as any).multistream = vi.fn().mockReturnValue(mockPinoInstance);
     (mockPino as any).destination = vi.fn().mockReturnValue(mockDestination);
 
-    // Setup fs mocks
+    // 设置 fs 模拟
     mockPath.join.mockImplementation((...args) => args.join("/"));
     mockPath.dirname.mockImplementation((p) =>
       p.split("/").slice(0, -1).join("/")
@@ -110,10 +110,10 @@ describe("Logger", async () => {
       return ext ? name.replace(ext, "") : name;
     });
 
-    // Mock console.error
+    // 模拟 console.error
     console.error = mockConsoleError;
 
-    // Reset environment
+    // 重置环境
     process.env.XIAOZHI_DAEMON = undefined;
   });
 
@@ -309,14 +309,14 @@ describe("Logger", async () => {
       const testLogger = new Logger();
       testLogger.initLogFile("/test/project");
 
-      // Should not throw error
+      // 不应该抛出错误
       expect(() => testLogger.close()).not.toThrow();
     });
 
     it("应该在日志文件不存在时处理 close", () => {
       const testLogger = new Logger();
 
-      // Should not throw error
+      // 不应该抛出错误
       expect(() => testLogger.close()).not.toThrow();
     });
   });
@@ -337,14 +337,14 @@ describe("Logger", async () => {
     it("应该设置日志文件选项", () => {
       testLogger.setLogFileOptions(5 * 1024 * 1024, 10);
 
-      // Should not throw error
+      // 不应该抛出错误
       expect(() => testLogger.setLogFileOptions(1024, 3)).not.toThrow();
     });
 
     it("应该清理旧日志", () => {
       testLogger.initLogFile("/test/project");
 
-      // Should not throw error
+      // 不应该抛出错误
       expect(() => testLogger.cleanupOldLogs()).not.toThrow();
     });
 
@@ -376,11 +376,11 @@ describe("Logger", async () => {
         mtime: new Date(),
         ctime: new Date(),
         birthtime: new Date(),
-      } as any); // 20MB file
+      } as any); // 20MB 文件
 
       testLogger.initLogFile("/test/project");
 
-      // Should not throw error during rotation
+      // 轮转期间不应该抛出错误
       expect(() => testLogger.initLogFile("/test/project")).not.toThrow();
     });
   });
@@ -389,7 +389,7 @@ describe("Logger", async () => {
     it("应该处理安全的写入操作", () => {
       const testLogger = new Logger();
 
-      // Test that logging works even in edge cases
+      // 测试日志记录即使在边缘情况下也能工作
       expect(() => testLogger.info("Test message")).not.toThrow();
       expect(() => testLogger.error("Test error")).not.toThrow();
     });

--- a/apps/backend/errors/__tests__/error-helper.integration.test.ts
+++ b/apps/backend/errors/__tests__/error-helper.integration.test.ts
@@ -14,17 +14,17 @@ import {
   shouldAlert,
 } from "../error-helper.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js");
 
-describe("Advanced Features Integration", () => {
+describe("高级功能集成测试", () => {
   let mockLogger: any;
   let testConfigPath: string;
 
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       info: vi.fn(),
       error: vi.fn(),
@@ -34,7 +34,7 @@ describe("Advanced Features Integration", () => {
     };
     vi.mocked(Logger).mockImplementation(() => mockLogger);
 
-    // Create test configuration
+    // 创建测试配置
     const testConfigs: InternalMCPServiceConfig[] = [
       {
         name: "test-service",
@@ -58,17 +58,17 @@ describe("Advanced Features Integration", () => {
     vi.clearAllMocks();
     clearErrorHistory();
 
-    // Clean up test file
+    // 清理测试文件
     if (existsSync(testConfigPath)) {
       unlinkSync(testConfigPath);
     }
   });
 
-  describe("Error Handling Integration", () => {
-    it("should categorize errors correctly", () => {
+  describe("错误处理集成", () => {
+    it("应该正确分类错误", () => {
       const serviceName = "test-service";
 
-      // Simulate different types of errors
+      // 模拟不同类型的错误
       const toolError = new Error("Tool call failed");
       const connectionError = new Error("Connection failed");
       const configError = new Error("Invalid configuration");
@@ -77,16 +77,16 @@ describe("Advanced Features Integration", () => {
       const mcpConnectionError = categorizeError(connectionError, serviceName);
       const mcpConfigError = categorizeError(configError, serviceName);
 
-      // Verify error categorization
+      // 验证错误分类
       expect(mcpToolError.category).toBe(ErrorCategory.TOOL_CALL);
       expect(mcpConnectionError.category).toBe(ErrorCategory.CONNECTION);
       expect(mcpConfigError.category).toBe(ErrorCategory.CONFIGURATION);
     });
 
-    it("should trigger alerts for high error rates", () => {
+    it("应该为高错误率触发警报", () => {
       const serviceName = "test-service-2";
 
-      // Generate multiple errors to trigger alert
+      // 生成多个错误以触发警报
       const errors: MCPError[] = [];
       for (let i = 0; i < 12; i++) {
         const error = new Error(`Error ${i}`);
@@ -94,12 +94,12 @@ describe("Advanced Features Integration", () => {
         errors.push(mcpError);
 
         if (i === 11) {
-          // Last error should trigger alert
+          // 最后一个错误应该触发警报
           expect(shouldAlert(mcpError)).toBe(true);
         }
       }
 
-      // Verify error statistics
+      // 验证错误统计
       const errorStats = getErrorStatistics(serviceName);
       expect(errorStats.totalErrors).toBe(12);
     });

--- a/apps/backend/errors/__tests__/error-helper.test.ts
+++ b/apps/backend/errors/__tests__/error-helper.test.ts
@@ -11,7 +11,7 @@ import {
   shouldAlert,
 } from "../error-helper.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js");
 
 describe("ErrorHandler", () => {
@@ -20,7 +20,7 @@ describe("ErrorHandler", () => {
   beforeEach(() => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       info: vi.fn(),
       error: vi.fn(),
@@ -30,7 +30,7 @@ describe("ErrorHandler", () => {
     };
     vi.mocked(Logger).mockImplementation(() => mockLogger);
 
-    // Clear error history
+    // 清除错误历史
     clearErrorHistory();
   });
 

--- a/apps/backend/handlers/__tests__/basic.test.ts
+++ b/apps/backend/handlers/__tests__/basic.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 
-// Mock dependencies to avoid triggering real config loading
+// 模拟依赖以避免触发真实的配置加载
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -54,9 +54,9 @@ vi.mock("@/services/StatusService.js", () => ({
   })),
 }));
 
-describe("Handlers Basic Tests", () => {
-  it("should be able to import handler modules", async () => {
-    // Test that all handler modules can be imported without errors
+describe("处理器基础测试", () => {
+  it("应该能够导入处理器模块", async () => {
+    // 测试所有处理器模块都可以无错误导入
     const modules = [
       () => import("../config.handler.js"),
       () => import("../heartbeat.handler.js"),
@@ -71,7 +71,7 @@ describe("Handlers Basic Tests", () => {
     }
   });
 
-  it("should have proper class constructors", async () => {
+  it("应该具有正确的类构造函数", async () => {
     const { ConfigApiHandler } = await import("../config.handler.js");
     const { StaticFileHandler } = await import("../static-file.handler.js");
     const { ServiceApiHandler } = await import("../service.handler.js");

--- a/apps/backend/handlers/__tests__/config.handler.test.ts
+++ b/apps/backend/handlers/__tests__/config.handler.test.ts
@@ -71,7 +71,7 @@ describe("ConfigApiHandler", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),
@@ -81,7 +81,7 @@ describe("ConfigApiHandler", () => {
     const { logger } = await import("../../Logger.js");
     Object.assign(logger, mockLogger);
 
-    // Mock ConfigManager
+    // 模拟 ConfigManager
     mockConfigManager = {
       getConfig: vi.fn(),
       updateMcpEndpoint: vi.fn(),
@@ -173,14 +173,14 @@ describe("ConfigApiHandler", () => {
   });
 
   describe("constructor", () => {
-    it("should initialize with correct dependencies", () => {
+    it("应该使用正确的依赖项初始化", () => {
       expect(configApiHandler).toBeInstanceOf(ConfigApiHandler);
       expect(mockLogger.debug).not.toHaveBeenCalled();
     });
   });
 
   describe("getConfig", () => {
-    it("should return config successfully", async () => {
+    it("应该成功返回配置", async () => {
       mockConfigManager.getConfig.mockReturnValue(mockConfig);
 
       await configApiHandler.getConfig(mockContext);
@@ -191,7 +191,7 @@ describe("ConfigApiHandler", () => {
       expect(mockContext.success).toHaveBeenCalledWith(mockConfig);
     });
 
-    it("should handle config service error", async () => {
+    it("应该处理配置服务错误", async () => {
       const error = new Error("Config read failed");
       mockConfigManager.getConfig.mockImplementation(() => {
         throw error;
@@ -208,7 +208,7 @@ describe("ConfigApiHandler", () => {
       );
     });
 
-    it("should handle non-Error exceptions", async () => {
+    it("应该处理非 Error 异常", async () => {
       mockConfigManager.getConfig.mockImplementation(() => {
         throw "String error";
       });
@@ -225,7 +225,7 @@ describe("ConfigApiHandler", () => {
   });
 
   describe("updateConfig", () => {
-    it("should update config successfully", async () => {
+    it("应该成功更新配置", async () => {
       mockContext.req.json.mockResolvedValue(mockConfig);
 
       await configApiHandler.updateConfig(mockContext);
@@ -243,7 +243,7 @@ describe("ConfigApiHandler", () => {
       );
     });
 
-    it("should handle invalid request body - null", async () => {
+    it("应该处理无效请求体 - null", async () => {
       mockContext.req.json.mockResolvedValue(null);
       mockConfigManager.validateConfig.mockImplementation(() => {
         throw new Error("配置必须是有效的对象");
@@ -258,7 +258,7 @@ describe("ConfigApiHandler", () => {
       );
     });
 
-    it("should handle invalid request body - string", async () => {
+    it("应该处理无效请求体 - string", async () => {
       mockContext.req.json.mockResolvedValue("invalid config");
       mockConfigManager.validateConfig.mockImplementation(() => {
         throw new Error("配置必须是有效的对象");
@@ -273,7 +273,7 @@ describe("ConfigApiHandler", () => {
       );
     });
 
-    it("should handle config update error", async () => {
+    it("应该处理配置更新错误", async () => {
       const error = new Error("Config update failed");
       mockContext.req.json.mockResolvedValue(mockConfig);
       mockConfigManager.validateConfig.mockImplementation(() => {
@@ -289,7 +289,7 @@ describe("ConfigApiHandler", () => {
       );
     });
 
-    it("should handle JSON parsing error", async () => {
+    it("应该处理 JSON 解析错误", async () => {
       const jsonError = new Error("Invalid JSON");
       mockContext.req.json.mockRejectedValue(jsonError);
 
@@ -304,7 +304,7 @@ describe("ConfigApiHandler", () => {
   });
 
   describe("getMcpEndpoint", () => {
-    it("should return MCP endpoint successfully", async () => {
+    it("应该成功返回 MCP 端点", async () => {
       const endpoint = "ws://localhost:3000";
       mockConfigManager.getMcpEndpoint.mockReturnValue(endpoint);
 
@@ -316,7 +316,7 @@ describe("ConfigApiHandler", () => {
       expect(mockContext.success).toHaveBeenCalledWith({ endpoint });
     });
 
-    it("should handle MCP endpoint error", async () => {
+    it("应该处理 MCP 端点错误", async () => {
       const error = new Error("MCP endpoint read failed");
       mockConfigManager.getMcpEndpoint.mockImplementation(() => {
         throw error;
@@ -338,7 +338,7 @@ describe("ConfigApiHandler", () => {
   });
 
   describe("getMcpEndpoints", () => {
-    it("should return MCP endpoints list successfully", async () => {
+    it("应该成功返回 MCP 端点列表", async () => {
       const endpoints = ["ws://localhost:3000", "ws://localhost:3001"];
       mockConfigManager.getMcpEndpoints.mockReturnValue(endpoints);
 

--- a/apps/backend/handlers/__tests__/endpoint.handler.test.ts
+++ b/apps/backend/handlers/__tests__/endpoint.handler.test.ts
@@ -2,7 +2,7 @@ import type { ConnectionStatus } from "@xiaozhi-client/endpoint";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { EndpointHandler } from "../endpoint.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -95,7 +95,7 @@ describe("EndpointHandler", () => {
     // 获取 mockEventBus 的 emitEvent 方法
     mockEmitEvent = mockEventBusInstance.emitEvent;
 
-    // Create handler instance - getEventBus 已经在模块级别被 mock
+    // 创建处理器实例 - getEventBus 已经在模块级别被 mock
     handler = new EndpointHandler(mockConnectionManager as any, configManager);
 
     // 手动替换 handler 的 eventBus，确保使用 mock 实例

--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -22,7 +22,7 @@ interface MockWebSocket {
   readyState?: number;
 }
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("@/Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -38,7 +38,7 @@ vi.mock("@xiaozhi-client/config", () => ({
   },
 }));
 
-// Mock timers
+// 模拟定时器
 vi.useFakeTimers();
 
 describe("HeartbeatHandler", () => {
@@ -85,7 +85,7 @@ describe("HeartbeatHandler", () => {
     vi.clearAllMocks();
     vi.clearAllTimers();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),
@@ -95,27 +95,27 @@ describe("HeartbeatHandler", () => {
     const { logger } = await import("@/Logger.js");
     Object.assign(logger, mockLogger);
 
-    // Mock ConfigManager
+    // 模拟 ConfigManager
     mockConfigService = {
       getConfig: vi.fn().mockReturnValue(mockConfig),
     };
     const { configManager } = await import("@xiaozhi-client/config");
     Object.assign(configManager, mockConfigService);
 
-    // Mock StatusService
+    // 模拟 StatusService
     mockStatusService = {
       updateClientInfo: vi.fn(),
       getLastHeartbeat: vi.fn(),
       isClientConnected: vi.fn(),
     };
 
-    // Mock NotificationService
+    // 模拟 NotificationService
     mockNotificationService = {
       cleanupDisconnectedClients: vi.fn(),
       getClientStats: vi.fn(),
     };
 
-    // Mock WebSocket
+    // 模拟 WebSocket
     mockWebSocket = {
       send: vi.fn(),
       readyState: 1, // WebSocket.OPEN
@@ -133,7 +133,7 @@ describe("HeartbeatHandler", () => {
   });
 
   describe("constructor", () => {
-    it("should initialize with correct dependencies", () => {
+    it("应该使用正确的依赖项初始化", () => {
       expect(heartbeatHandler).toBeInstanceOf(HeartbeatHandler);
       expect(mockLogger.debug).not.toHaveBeenCalled();
     });
@@ -147,7 +147,7 @@ describe("HeartbeatHandler", () => {
       vi.spyOn(Date, "now").mockReturnValue(1234567890);
     });
 
-    it("should handle client status update successfully", async () => {
+    it("应该成功处理客户端状态更新", async () => {
       await heartbeatHandler.handleClientStatus(
         mockWebSocket,
         mockHeartbeatMessage,
@@ -184,7 +184,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle status service error", async () => {
+    it("应该处理状态服务错误", async () => {
       const error = new Error("Status update failed");
       mockStatusService.updateClientInfo.mockImplementation(() => {
         throw error;
@@ -213,7 +213,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle non-Error exceptions", async () => {
+    it("应该处理非 Error 异常", async () => {
       mockStatusService.updateClientInfo.mockImplementation(() => {
         throw "String error";
       });
@@ -236,7 +236,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle config service error gracefully", async () => {
+    it("应该优雅地处理配置服务错误", async () => {
       const configError = new Error("Config fetch failed");
       mockConfigService.getConfig.mockImplementation(() => {
         throw configError;
@@ -248,20 +248,20 @@ describe("HeartbeatHandler", () => {
         clientId
       );
 
-      // Should still update status successfully
+      // 仍然应该成功更新状态
       expect(mockStatusService.updateClientInfo).toHaveBeenCalled();
       expect(mockLogger.debug).toHaveBeenCalledWith(
         `客户端状态更新成功: ${clientId}`
       );
 
-      // Should log config error but not fail the heartbeat
+      // 应该记录配置错误，但不应该导致心跳失败
       expect(mockLogger.error).toHaveBeenCalledWith(
         `发送最新配置失败: ${clientId}`,
         configError
       );
     });
 
-    it("should handle WebSocket send error in config update", async () => {
+    it("应该处理配置更新中的 WebSocket 发送错误", async () => {
       const sendError = new Error("WebSocket send failed");
       mockWebSocket.send.mockImplementation(() => {
         throw sendError;
@@ -285,7 +285,7 @@ describe("HeartbeatHandler", () => {
       vi.spyOn(Date, "now").mockReturnValue(1234567890);
     });
 
-    it("should not trigger timeout when no heartbeat exists", () => {
+    it("在没有心跳时不应该触发超时", () => {
       mockStatusService.getLastHeartbeat.mockReturnValue(undefined);
 
       heartbeatHandler.checkHeartbeatTimeout();
@@ -294,8 +294,8 @@ describe("HeartbeatHandler", () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
-    it("should not trigger timeout when heartbeat is recent", () => {
-      const recentHeartbeat = 1234567890 - 30000; // 30 seconds ago
+    it("在心跳最近时不应该触发超时", () => {
+      const recentHeartbeat = 1234567890 - 30000; // 30 秒前
       mockStatusService.getLastHeartbeat.mockReturnValue(recentHeartbeat);
 
       heartbeatHandler.checkHeartbeatTimeout();
@@ -304,8 +304,8 @@ describe("HeartbeatHandler", () => {
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
-    it("should trigger timeout when heartbeat is old", () => {
-      const oldHeartbeat = 1234567890 - 40000; // 40 seconds ago (> 35s timeout)
+    it("在心跳过旧时应该触发超时", () => {
+      const oldHeartbeat = 1234567890 - 40000; // 40 秒前（> 35 秒超时）
       mockStatusService.getLastHeartbeat.mockReturnValue(oldHeartbeat);
 
       heartbeatHandler.checkHeartbeatTimeout();
@@ -319,19 +319,19 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle exact timeout boundary", () => {
-      const exactTimeoutHeartbeat = 1234567890 - 35000; // Exactly 35 seconds ago
+    it("应该处理精确超时边界", () => {
+      const exactTimeoutHeartbeat = 1234567890 - 35000; // 正好 35 秒前
       mockStatusService.getLastHeartbeat.mockReturnValue(exactTimeoutHeartbeat);
 
       heartbeatHandler.checkHeartbeatTimeout();
 
-      // Should not trigger timeout at exact boundary
+      // 在精确边界时不应该触发超时
       expect(mockStatusService.updateClientInfo).not.toHaveBeenCalled();
       expect(mockLogger.warn).not.toHaveBeenCalled();
     });
 
-    it("should handle timeout boundary + 1ms", () => {
-      const timeoutHeartbeat = 1234567890 - 35001; // 35.001 seconds ago
+    it("应该处理超时边界 + 1ms", () => {
+      const timeoutHeartbeat = 1234567890 - 35001; // 35.001 秒前
       mockStatusService.getLastHeartbeat.mockReturnValue(timeoutHeartbeat);
 
       heartbeatHandler.checkHeartbeatTimeout();
@@ -347,7 +347,7 @@ describe("HeartbeatHandler", () => {
   });
 
   describe("startHeartbeatMonitoring", () => {
-    it("should start heartbeat monitoring with correct interval", () => {
+    it("应该以正确的时间间隔启动心跳监控", () => {
       const setIntervalSpy = vi.spyOn(global, "setInterval");
 
       const intervalId = heartbeatHandler.startHeartbeatMonitoring();
@@ -355,12 +355,12 @@ describe("HeartbeatHandler", () => {
       expect(mockLogger.debug).toHaveBeenCalledWith("启动心跳监控");
       expect(setIntervalSpy).toHaveBeenCalledWith(
         expect.any(Function),
-        10000 // 10 seconds
+        10000 // 10 秒
       );
       expect(intervalId).toBeDefined();
     });
 
-    it("should execute monitoring tasks on interval", () => {
+    it("应该在时间间隔执行监控任务", () => {
       mockStatusService.getLastHeartbeat.mockReturnValue(undefined);
       mockNotificationService.cleanupDisconnectedClients.mockImplementation(
         () => {}
@@ -368,7 +368,7 @@ describe("HeartbeatHandler", () => {
 
       heartbeatHandler.startHeartbeatMonitoring();
 
-      // Fast-forward time to trigger interval
+      // 快进时间以触发间隔
       vi.advanceTimersByTime(10000);
 
       expect(mockStatusService.getLastHeartbeat).toHaveBeenCalled();
@@ -377,7 +377,7 @@ describe("HeartbeatHandler", () => {
       ).toHaveBeenCalled();
     });
 
-    it("should handle cleanup error gracefully", () => {
+    it("应该优雅地处理清理错误", () => {
       const cleanupError = new Error("Cleanup failed");
       mockNotificationService.cleanupDisconnectedClients.mockImplementation(
         () => {
@@ -387,7 +387,7 @@ describe("HeartbeatHandler", () => {
 
       heartbeatHandler.startHeartbeatMonitoring();
 
-      // Fast-forward time to trigger interval
+      // 快进时间以触发间隔
       vi.advanceTimersByTime(10000);
 
       expect(mockLogger.error).toHaveBeenCalledWith(
@@ -398,7 +398,7 @@ describe("HeartbeatHandler", () => {
   });
 
   describe("stopHeartbeatMonitoring", () => {
-    it("should stop heartbeat monitoring", () => {
+    it("应该停止心跳监控", () => {
       const clearIntervalSpy = vi.spyOn(global, "clearInterval");
       const mockIntervalId = 12345 as any;
 
@@ -410,7 +410,7 @@ describe("HeartbeatHandler", () => {
   });
 
   describe("getHeartbeatStats", () => {
-    it("should return heartbeat statistics", () => {
+    it("应该返回心跳统计信息", () => {
       const mockStats = {
         totalClients: 5,
         connectedClients: 3,
@@ -430,7 +430,7 @@ describe("HeartbeatHandler", () => {
       });
     });
 
-    it("should handle undefined last heartbeat", () => {
+    it("应该处理未定义的最后一次心跳", () => {
       const mockStats = {
         totalClients: 0,
         connectedClients: 0,
@@ -458,7 +458,7 @@ describe("HeartbeatHandler", () => {
       vi.spyOn(Date, "now").mockReturnValue(1234567890);
     });
 
-    it("should handle client connection", () => {
+    it("应该处理客户端连接", () => {
       heartbeatHandler.handleClientConnect(clientId);
 
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -477,7 +477,7 @@ describe("HeartbeatHandler", () => {
   describe("handleClientDisconnect", () => {
     const clientId = "test-client-123";
 
-    it("should handle client disconnection", () => {
+    it("应该处理客户端断开连接", () => {
       heartbeatHandler.handleClientDisconnect(clientId);
 
       expect(mockLogger.debug).toHaveBeenCalledWith(
@@ -497,7 +497,7 @@ describe("HeartbeatHandler", () => {
       vi.spyOn(Date, "now").mockReturnValue(1234567890);
     });
 
-    it("should send heartbeat response successfully", () => {
+    it("应该成功发送心跳响应", () => {
       heartbeatHandler.sendHeartbeatResponse(mockWebSocket, clientId);
 
       expect(mockWebSocket.send).toHaveBeenCalledWith(
@@ -514,7 +514,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle WebSocket send error", () => {
+    it("应该处理 WebSocket 发送错误", () => {
       const sendError = new Error("WebSocket send failed");
       mockWebSocket.send.mockImplementation(() => {
         throw sendError;
@@ -530,7 +530,7 @@ describe("HeartbeatHandler", () => {
   });
 
   describe("validateHeartbeatMessage", () => {
-    it("should validate correct heartbeat message", () => {
+    it("应该验证正确的心跳消息", () => {
       const validMessage = {
         type: "clientStatus",
         data: {
@@ -546,7 +546,7 @@ describe("HeartbeatHandler", () => {
       expect(result).toBe(true);
     });
 
-    it("should validate minimal heartbeat message", () => {
+    it("应该验证最小心跳消息", () => {
       const minimalMessage = {
         type: "clientStatus",
         data: {},
@@ -557,25 +557,25 @@ describe("HeartbeatHandler", () => {
       expect(result).toBe(true);
     });
 
-    it("should reject null message", () => {
+    it("应该拒绝 null 消息", () => {
       const result = heartbeatHandler.validateHeartbeatMessage(null);
 
       expect(result).toBeFalsy();
     });
 
-    it("should reject undefined message", () => {
+    it("应该拒绝 undefined 消息", () => {
       const result = heartbeatHandler.validateHeartbeatMessage(undefined);
 
       expect(result).toBeFalsy();
     });
 
-    it("should reject non-object message", () => {
+    it("应该拒绝非对象消息", () => {
       const result = heartbeatHandler.validateHeartbeatMessage("invalid");
 
       expect(result).toBe(false);
     });
 
-    it("should reject message with wrong type", () => {
+    it("应该拒绝类型错误的消息", () => {
       const invalidMessage = {
         type: "wrongType",
         data: {},
@@ -586,7 +586,7 @@ describe("HeartbeatHandler", () => {
       expect(result).toBe(false);
     });
 
-    it("should reject message without data", () => {
+    it("应该拒绝没有 data 的消息", () => {
       const invalidMessage = {
         type: "clientStatus",
       };
@@ -596,7 +596,7 @@ describe("HeartbeatHandler", () => {
       expect(result).toBeFalsy();
     });
 
-    it("should reject message with non-object data", () => {
+    it("应该拒绝 data 为非对象的消息", () => {
       const invalidMessage = {
         type: "clientStatus",
         data: "invalid",
@@ -607,7 +607,7 @@ describe("HeartbeatHandler", () => {
       expect(result).toBe(false);
     });
 
-    it("should reject message with null data", () => {
+    it("应该拒绝 data 为 null 的消息", () => {
       const invalidMessage = {
         type: "clientStatus",
         data: null,
@@ -627,8 +627,8 @@ describe("HeartbeatHandler", () => {
       mockConfigService.getConfig.mockReturnValue(mockConfig);
     });
 
-    it("should handle complete client lifecycle", async () => {
-      // Client connects
+    it("应该处理完整的客户端生命周期", async () => {
+      // 客户端连接
       heartbeatHandler.handleClientConnect(clientId);
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
         {
@@ -638,7 +638,7 @@ describe("HeartbeatHandler", () => {
         `websocket-connect-${clientId}`
       );
 
-      // Client sends heartbeat
+      // 客户端发送心跳
       await heartbeatHandler.handleClientStatus(
         mockWebSocket,
         mockHeartbeatMessage,
@@ -652,13 +652,13 @@ describe("HeartbeatHandler", () => {
         `websocket-${clientId}`
       );
 
-      // Send heartbeat response
+      // 发送心跳响应
       heartbeatHandler.sendHeartbeatResponse(mockWebSocket, clientId);
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         expect.stringContaining('"type":"heartbeatResponse"')
       );
 
-      // Client disconnects
+      // 客户端断开连接
       heartbeatHandler.handleClientDisconnect(clientId);
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
         { status: "disconnected" },
@@ -666,12 +666,12 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle monitoring workflow", () => {
-      // Start monitoring
+    it("应该处理监控工作流程", () => {
+      // 启动监控
       const intervalId = heartbeatHandler.startHeartbeatMonitoring();
       expect(mockLogger.debug).toHaveBeenCalledWith("启动心跳监控");
 
-      // Simulate monitoring cycle
+      // 模拟监控周期
       mockStatusService.getLastHeartbeat.mockReturnValue(1234567890 - 40000);
       vi.advanceTimersByTime(10000);
 
@@ -683,13 +683,13 @@ describe("HeartbeatHandler", () => {
         mockNotificationService.cleanupDisconnectedClients
       ).toHaveBeenCalled();
 
-      // Stop monitoring
+      // 停止监控
       heartbeatHandler.stopHeartbeatMonitoring(intervalId);
       expect(mockLogger.debug).toHaveBeenCalledWith("停止心跳监控");
     });
 
-    it("should handle mixed success and error scenarios", async () => {
-      // First heartbeat succeeds
+    it("应该处理混合成功和错误场景", async () => {
+      // 第一次心跳成功
       await heartbeatHandler.handleClientStatus(
         mockWebSocket,
         mockHeartbeatMessage,
@@ -697,7 +697,7 @@ describe("HeartbeatHandler", () => {
       );
       expect(mockStatusService.updateClientInfo).toHaveBeenCalled();
 
-      // Second heartbeat fails due to status service error
+      // 第二次心跳因状态服务错误而失败
       const error = new Error("Status service failed");
       mockStatusService.updateClientInfo.mockImplementationOnce(() => {
         throw error;
@@ -713,7 +713,7 @@ describe("HeartbeatHandler", () => {
         error
       );
 
-      // Third heartbeat succeeds again
+      // 第三次心跳再次成功
       mockStatusService.updateClientInfo.mockImplementation(() => {});
       await heartbeatHandler.handleClientStatus(
         mockWebSocket,
@@ -734,7 +734,7 @@ describe("HeartbeatHandler", () => {
       mockConfigService.getConfig.mockReturnValue(mockConfig);
     });
 
-    it("should handle heartbeat message with minimal data", async () => {
+    it("应该处理具有最小数据的心跳消息", async () => {
       const minimalMessage = {
         type: "clientStatus" as const,
         data: {},
@@ -752,7 +752,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle heartbeat message with all optional fields", async () => {
+    it("应该处理包含所有可选字段的心跳消息", async () => {
       const fullMessage = {
         type: "clientStatus" as const,
         data: {
@@ -778,7 +778,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle very long client ID", async () => {
+    it("应该处理非常长的客户端 ID", async () => {
       const longClientId = "a".repeat(1000);
 
       await heartbeatHandler.handleClientStatus(
@@ -793,7 +793,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle special characters in client ID", async () => {
+    it("应该处理客户端 ID 中的特殊字符", async () => {
       const specialClientId = "client-123_测试@#$%^&*()";
 
       await heartbeatHandler.handleClientStatus(
@@ -808,7 +808,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle empty client ID", async () => {
+    it("应该处理空的客户端 ID", async () => {
       const emptyClientId = "";
 
       await heartbeatHandler.handleClientStatus(
@@ -823,7 +823,7 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle large number of active MCP servers", async () => {
+    it("应该处理大量活动的 MCP 服务器", async () => {
       const largeServerList = Array.from(
         { length: 100 },
         (_, i) => `server-${i}`
@@ -851,8 +851,8 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle Date.now() returning edge values", () => {
-      // Test with timestamp 0
+    it("应该处理 Date.now() 返回边缘值", () => {
+      // 测试时间戳为 0
       vi.spyOn(Date, "now").mockReturnValue(0);
       heartbeatHandler.handleClientConnect(clientId);
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
@@ -863,7 +863,7 @@ describe("HeartbeatHandler", () => {
         `websocket-connect-${clientId}`
       );
 
-      // Test with maximum safe integer
+      // 测试最大安全整数
       vi.spyOn(Date, "now").mockReturnValue(Number.MAX_SAFE_INTEGER);
       heartbeatHandler.handleClientConnect(clientId);
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
@@ -875,10 +875,10 @@ describe("HeartbeatHandler", () => {
       );
     });
 
-    it("should handle concurrent heartbeat processing", async () => {
+    it("应该处理并发心跳处理", async () => {
       const promises: Promise<void>[] = [];
 
-      // Simulate concurrent heartbeat messages
+      // 模拟并发心跳消息
       for (let i = 0; i < 10; i++) {
         promises.push(
           heartbeatHandler.handleClientStatus(
@@ -895,17 +895,17 @@ describe("HeartbeatHandler", () => {
       expect(mockConfigService.getConfig).toHaveBeenCalledTimes(10);
     });
 
-    it("should handle monitoring with rapid timer advances", () => {
+    it("应该处理快速定时器推进的监控", () => {
       mockStatusService.getLastHeartbeat.mockReturnValue(1234567890 - 40000);
 
       heartbeatHandler.startHeartbeatMonitoring();
 
-      // Rapidly advance timers multiple times
+      // 快速多次推进定时器
       for (let i = 0; i < 5; i++) {
         vi.advanceTimersByTime(10000);
       }
 
-      // Should have been called 5 times
+      // 应该被调用 5 次
       expect(mockStatusService.updateClientInfo).toHaveBeenCalledTimes(5);
       expect(
         mockNotificationService.cleanupDisconnectedClients

--- a/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
@@ -9,7 +9,7 @@ import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPToolHandler } from "../mcp-tool.handler.js";
 
-// Mock configManager
+// 模拟 configManager
 vi.mock("@xiaozhi-client/config", () => ({
   configManager: {
     addCustomMCPTool: vi.fn(),
@@ -25,7 +25,7 @@ vi.mock("@xiaozhi-client/config", () => ({
   },
 }));
 
-// Mock MCPServiceManager - 在 Context 中提供
+// 模拟 MCPServiceManager - 在 Context 中提供
 const mockServiceManager = {
   hasTool: vi.fn(() => false),
   hasCustomMCPTool: vi.fn(() => false),
@@ -43,7 +43,7 @@ const mockServiceManager = {
   startService: vi.fn(),
 };
 
-// Mock MCPCacheManager
+// 模拟 MCPCacheManager
 vi.mock("@/lib/mcp", () => ({
   MCPCacheManager: vi.fn().mockImplementation(() => ({
     getAllCachedTools: vi.fn().mockResolvedValue([]),
@@ -230,14 +230,14 @@ describe("MCPToolHandler - 核心功能测试", () => {
 
       mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
 
-      // Mock configManager methods to avoid complex dependencies
+      // 模拟 configManager 方法以避免复杂的依赖
       vi.mocked(configManager.addCustomMCPTool).mockImplementation(() => {});
       vi.mocked(configManager.getServerToolsConfig).mockReturnValue({});
       vi.mocked(configManager.updateServerToolsConfig).mockImplementation(
         () => {}
       );
 
-      // Mock MCPCacheManager
+      // 模拟 MCPCacheManager
       const { MCPCacheManager } = await import("@/lib/mcp");
       const mockMCPCacheManager = vi.mocked(MCPCacheManager);
       mockMCPCacheManager.mockImplementation(
@@ -255,7 +255,7 @@ describe("MCPToolHandler - 核心功能测试", () => {
 
       await handler.addCustomTool(mockContext as Context);
 
-      // Verify the request was processed correctly by checking the success response
+      // 通过检查成功响应验证请求是否正确处理
       expect(mockContext.success).toHaveBeenCalledWith(
         expect.objectContaining({
           toolName: "test-service__test-tool",
@@ -279,12 +279,12 @@ describe("MCPToolHandler - 核心功能测试", () => {
 
       mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
 
-      // Mock configManager methods for Coze workflow processing
+      // 为 Coze 工作流处理模拟 configManager 方法
       vi.mocked(configManager.addCustomMCPTool).mockImplementation(() => {});
 
       await handler.addCustomTool(mockContext as Context);
 
-      // Verify the request was processed correctly by checking the success response
+      // 通过检查成功响应验证请求是否正确处理
       expect(mockContext.success).toHaveBeenCalledWith(
         expect.objectContaining({
           toolName: expect.any(String),

--- a/apps/backend/handlers/__tests__/mcp-tool.integration.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.integration.test.ts
@@ -26,7 +26,7 @@ import {
 } from "vitest";
 import { MCPToolHandler } from "../mcp-tool.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     info: vi.fn(),
@@ -148,7 +148,7 @@ describe("MCPToolHandler - 单元测试", () => {
 
   describe("不同类型的 customMCP handler 测试", () => {
     it("应该支持 proxy 类型的 handler", async () => {
-      // Arrange
+      // 准备
       const proxyToolConfig = {
         name: "test_proxy_tool",
         description: "测试代理工具",
@@ -176,7 +176,7 @@ describe("MCPToolHandler - 单元测试", () => {
 
       mockContext.req.json.mockResolvedValue(requestBody);
 
-      // Mock configManager
+      // 模拟 configManager
       configManager.getCustomMCPTools = vi
         .fn()
         .mockReturnValue([proxyToolConfig]);
@@ -190,10 +190,10 @@ describe("MCPToolHandler - 单元测试", () => {
         isError: false,
       });
 
-      // Act
+      // 执行
       await mcpToolHandler.callTool(mockContext);
 
-      // Assert
+      // 断言
       expect(mockServiceManager.callTool).toHaveBeenCalledWith(
         "test_proxy_tool",
         { input: "测试输入" },

--- a/apps/backend/handlers/__tests__/mcp-tool.parameter-config.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.parameter-config.test.ts
@@ -9,7 +9,7 @@ import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPToolHandler } from "../mcp-tool.handler.js";
 
-// Mock configManager
+// 模拟 configManager
 vi.mock("@xiaozhi-client/config", () => ({
   configManager: {
     addCustomMCPTool: vi.fn(),

--- a/apps/backend/handlers/__tests__/mcp.handler.integration.test.ts
+++ b/apps/backend/handlers/__tests__/mcp.handler.integration.test.ts
@@ -2,7 +2,7 @@ import { EventEmitter } from "node:events";
 import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
 import { WebServer } from "../../WebServer.js";
 
-// Mock configManager
+// 模拟 configManager
 vi.mock("@xiaozhi-client/config", () => ({
   configManager: {
     configExists: vi.fn().mockReturnValue(true),
@@ -35,7 +35,7 @@ vi.mock("@/lib/mcp", () => ({
           capabilities: {},
           serverInfo: { name: "xiaozhi-client", version: "1.0.0" },
         },
-        id: message.id, // 返回请求中的ID
+        id: message.id, // 返回请求中的 ID
       });
     }),
   })),
@@ -243,7 +243,7 @@ describe("MCPRouteHandler 集成测试", () => {
   describe("性能和限制", () => {
     it("应该处理合理大小的消息", async () => {
       const largeParams = {
-        data: "x".repeat(1000), // 1KB of data
+        data: "x".repeat(1000), // 1KB 数据
       };
 
       const response = await fetch(`${baseUrl}/mcp`, {
@@ -264,7 +264,7 @@ describe("MCPRouteHandler 集成测试", () => {
 
     it("应该拒绝过大的消息", async () => {
       const oversizedParams = {
-        data: "x".repeat(2 * 1024 * 1024), // 2MB of data
+        data: "x".repeat(2 * 1024 * 1024), // 2MB 数据
       };
 
       const response = await fetch(`${baseUrl}/mcp`, {

--- a/apps/backend/handlers/__tests__/mcp.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp.handler.test.ts
@@ -1,12 +1,12 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPRouteHandler } from "../mcp.handler.js";
 
-// Mock MCPServiceManager - 在 Context 中提供
+// 模拟 MCPServiceManager - 在 Context 中提供
 const mockServiceManager = {
-  // Mock service manager
+  // 模拟服务管理器
 };
 
-// Mock MCPMessageHandler
+// 模拟 MCPMessageHandler
 vi.mock("@/lib/mcp", () => ({
   MCPMessageHandler: vi.fn().mockImplementation(() => ({
     handleMessage: vi.fn().mockResolvedValue({
@@ -46,7 +46,7 @@ describe("MCPRouteHandler", () => {
   });
 
   it("应该处理有效的 JSON-RPC 消息的 POST 请求", async () => {
-    // Mock Context object
+    // 模拟 Context 对象
     const mockContext = {
       req: {
         header: vi.fn((name: string) => {
@@ -193,7 +193,7 @@ describe("MCPRouteHandler", () => {
   });
 
   it("应该拒绝超过最大消息大小的 POST 请求", async () => {
-    const largeMessage = "x".repeat(2 * 1024 * 1024); // 2MB message
+    const largeMessage = "x".repeat(2 * 1024 * 1024); // 2MB 消息
     const mockContext = {
       req: {
         header: vi.fn((name: string) => {

--- a/apps/backend/handlers/__tests__/realtime-notification.handler.test.ts
+++ b/apps/backend/handlers/__tests__/realtime-notification.handler.test.ts
@@ -2,7 +2,7 @@ import type { AppConfig } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { RealtimeNotificationHandler } from "../realtime-notification.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -79,7 +79,7 @@ describe("RealtimeNotificationHandler", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),
@@ -89,7 +89,7 @@ describe("RealtimeNotificationHandler", () => {
     const { logger } = await import("../../Logger.js");
     Object.assign(logger, mockLogger);
 
-    // Mock ConfigManager
+    // 模拟 ConfigManager
     mockConfigService = {
       getConfig: vi.fn().mockReturnValue(mockConfig),
       getMcpEndpoint: vi.fn().mockReturnValue(mockConfig.mcpEndpoint),
@@ -108,7 +108,7 @@ describe("RealtimeNotificationHandler", () => {
     const { configManager } = await import("@xiaozhi-client/config");
     Object.assign(configManager, mockConfigService);
 
-    // Mock EventBus
+    // 模拟 EventBus
     mockEventBus = {
       emitEvent: vi.fn(),
       onEvent: vi.fn(),
@@ -116,7 +116,7 @@ describe("RealtimeNotificationHandler", () => {
     const { getEventBus } = await import("@/services/event-bus.service.js");
     vi.mocked(getEventBus).mockReturnValue(mockEventBus);
 
-    // Mock NotificationService
+    // 模拟 NotificationService
     mockNotificationService = {
       registerClient: vi.fn(),
       unregisterClient: vi.fn(),
@@ -124,13 +124,13 @@ describe("RealtimeNotificationHandler", () => {
       broadcast: vi.fn(),
     };
 
-    // Mock StatusService
+    // 模拟 StatusService
     mockStatusService = {
       getFullStatus: vi.fn(),
       updateRestartStatus: vi.fn(),
     };
 
-    // Mock WebSocket
+    // 模拟 WebSocket
     mockWebSocket = {
       send: vi.fn(),
       readyState: 1, // WebSocket.OPEN
@@ -146,7 +146,7 @@ describe("RealtimeNotificationHandler", () => {
     vi.clearAllMocks();
   });
 
-  // Helper function to verify error messages
+  // 辅助函数：验证错误消息
   const expectErrorMessage = (
     mockWebSocket: any,
     code: string,
@@ -347,7 +347,7 @@ describe("RealtimeNotificationHandler", () => {
     });
 
     it("should handle getConfig success", async () => {
-      // Access private method through type assertion for testing
+      // 通过类型断言访问私有方法进行测试
       const handler = realtimeHandler as any;
       await handler.handleGetConfig(mockWebSocket, clientId);
 
@@ -595,17 +595,17 @@ describe("RealtimeNotificationHandler", () => {
       expect(mockConfigService.getConfig).toHaveBeenCalledTimes(1);
       expect(mockStatusService.getFullStatus).toHaveBeenCalledTimes(1);
 
-      // Should send config update
+      // 应该发送配置更新
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "configUpdate", data: mockConfig })
       );
 
-      // Should send status update
+      // 应该发送状态更新
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "statusUpdate", data: mockStatus.client })
       );
 
-      // Should send restart status if available
+      // 如果可用，应该发送重启状态
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "restartStatus", data: mockStatus.restart })
       );
@@ -625,7 +625,7 @@ describe("RealtimeNotificationHandler", () => {
 
       await realtimeHandler.sendInitialData(mockWebSocket, clientId);
 
-      // Should send config and status updates
+      // 应该发送配置和状态更新
       expect(mockWebSocket.send).toHaveBeenCalledTimes(2);
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "configUpdate", data: mockConfig })
@@ -634,7 +634,7 @@ describe("RealtimeNotificationHandler", () => {
         JSON.stringify({ type: "statusUpdate", data: mockStatus.client })
       );
 
-      // Should not send restart status
+      // 不应该发送重启状态
       expect(mockWebSocket.send).not.toHaveBeenCalledWith(
         expect.stringContaining("restartStatus")
       );
@@ -675,25 +675,25 @@ describe("RealtimeNotificationHandler", () => {
     const clientId = "test-client-123";
 
     it("should handle complete message workflow", async () => {
-      // Setup mocks
+      // 设置模拟
       mockConfigService.getConfig.mockReturnValue(mockConfig);
       mockStatusService.getFullStatus.mockReturnValue(mockStatus);
 
-      // Test getConfig message
+      // 测试 getConfig 消息
       await realtimeHandler.handleMessage(
         mockWebSocket,
         { type: "getConfig" },
         clientId
       );
 
-      // Test getStatus message
+      // 测试 getStatus 消息
       await realtimeHandler.handleMessage(
         mockWebSocket,
         { type: "getStatus" },
         clientId
       );
 
-      // Test updateConfig message
+      // 测试 updateConfig 消息
       const configData = {
         mcpEndpoint: "ws://localhost:4000",
         mcpServers: {},
@@ -709,14 +709,14 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Test restartService message
+      // 测试 restartService 消息
       await realtimeHandler.handleMessage(
         mockWebSocket,
         { type: "restartService" },
         clientId
       );
 
-      // Verify all operations were called
+      // 验证所有操作都被调用
       expect(mockConfigService.getConfig).toHaveBeenCalledTimes(1);
       expect(mockStatusService.getFullStatus).toHaveBeenCalledTimes(1);
       // 验证 validateConfig 和 updateConfig 被调用
@@ -735,7 +735,7 @@ describe("RealtimeNotificationHandler", () => {
     });
 
     it("should handle mixed success and error scenarios", async () => {
-      // First message succeeds
+      // 第一条消息成功
       mockConfigService.getConfig.mockReturnValue(mockConfig);
       await realtimeHandler.handleMessage(
         mockWebSocket,
@@ -743,7 +743,7 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Second message fails
+      // 第二条消息失败
       const error = new Error("Status failed");
       mockStatusService.getFullStatus.mockImplementation(() => {
         throw error;
@@ -754,19 +754,19 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Third message is unknown type
+      // 第三条消息是未知类型
       await realtimeHandler.handleMessage(
         mockWebSocket,
         { type: "unknownType" },
         clientId
       );
 
-      // Verify success response
+      // 验证成功响应
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "config", data: mockConfig })
       );
 
-      // Verify error responses
+      // 验证错误响应
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         expect.stringContaining('"code":"STATUS_READ_ERROR"')
       );
@@ -776,7 +776,7 @@ describe("RealtimeNotificationHandler", () => {
     });
 
     it("should handle sendInitialData with partial failures", async () => {
-      // Config succeeds, status fails
+      // 配置成功，状态失败
       mockConfigService.getConfig.mockReturnValue(mockConfig);
       mockStatusService.getFullStatus.mockImplementation(() => {
         throw new Error("Status failed");
@@ -784,7 +784,7 @@ describe("RealtimeNotificationHandler", () => {
 
       await realtimeHandler.sendInitialData(mockWebSocket, clientId);
 
-      // Should still send error message
+      // 仍应发送错误消息
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         expect.stringContaining('"code":"INITIAL_DATA_ERROR"')
       );
@@ -805,7 +805,7 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Should handle error gracefully
+      // 应该优雅地处理错误
       expect(mockLogger.error).toHaveBeenCalled();
     });
 
@@ -820,7 +820,7 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Should handle error gracefully
+      // 应该优雅地处理错误
       expect(mockLogger.error).toHaveBeenCalled();
     });
 
@@ -855,7 +855,7 @@ describe("RealtimeNotificationHandler", () => {
         clientId
       );
 
-      // Should log the WebSocket send error
+      // 应该记录 WebSocket 发送错误
       expect(mockLogger.error).toHaveBeenCalledWith(
         "发送错误消息失败:",
         expect.any(Error)
@@ -879,7 +879,7 @@ describe("RealtimeNotificationHandler", () => {
 
       await realtimeHandler.sendInitialData(mockWebSocket, clientId);
 
-      // Should send the empty config
+      // 应该发送空配置
       expect(mockWebSocket.send).toHaveBeenCalledWith(
         JSON.stringify({ type: "configUpdate", data: {} })
       );

--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -2,7 +2,7 @@ import type { StatusService } from "@/services/status.service.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { ServiceApiHandler } from "../service.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -34,12 +34,12 @@ describe("ServiceApiHandler", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
 
-    // Mock StatusService
+    // 模拟 StatusService
     mockStatusService = {
       updateRestartStatus: vi.fn(),
     } as any;
 
-    // Mock MCPServiceManager
+    // 模拟 MCPServiceManager
     mockMcpServiceManager = {
       getStatus: vi.fn().mockReturnValue({
         isRunning: true,
@@ -48,7 +48,7 @@ describe("ServiceApiHandler", () => {
       }),
     };
 
-    // Mock Hono Context
+    // 模拟 Hono Context
     mockContext = {
       json: vi.fn().mockReturnValue(new Response()),
       success: vi.fn().mockReturnValue(new Response()),
@@ -72,14 +72,14 @@ describe("ServiceApiHandler", () => {
       }),
     };
 
-    // Mock spawn
+    // 模拟 spawn
     mockSpawn = vi.fn().mockReturnValue({
       unref: vi.fn(),
     });
     const { spawn } = await import("node:child_process");
     vi.mocked(spawn).mockImplementation(mockSpawn);
 
-    // Mock EventBus
+    // 模拟 EventBus
     mockEventBus = {
       emitEvent: vi.fn(),
     };
@@ -95,14 +95,14 @@ describe("ServiceApiHandler", () => {
   });
 
   describe("constructor", () => {
-    it("should initialize with correct dependencies", () => {
+    it("应该使用正确的依赖项初始化", () => {
       expect(handler).toBeInstanceOf(ServiceApiHandler);
       expect(mockEventBus).toBeDefined();
     });
   });
 
   describe("getServiceStatus", () => {
-    it("should return service status successfully", async () => {
+    it("应该成功返回服务状态", async () => {
       const mockStatus = {
         isRunning: true,
         pid: 12345,
@@ -118,7 +118,7 @@ describe("ServiceApiHandler", () => {
       expect(mockContext.success).toHaveBeenCalledWith(mockStatus);
     });
 
-    it("should handle service status error", async () => {
+    it("应该处理服务状态错误", async () => {
       const error = new Error("Status check failed");
       mockMcpServiceManager.getStatus.mockImplementation(() => {
         throw error;
@@ -134,7 +134,7 @@ describe("ServiceApiHandler", () => {
       );
     });
 
-    it("should handle non-Error exceptions", async () => {
+    it("应该处理非 Error 异常", async () => {
       mockMcpServiceManager.getStatus.mockImplementation(() => {
         throw "String error";
       });
@@ -151,7 +151,7 @@ describe("ServiceApiHandler", () => {
   });
 
   describe("getServiceHealth", () => {
-    it("should return service health successfully", async () => {
+    it("应该成功返回服务健康状态", async () => {
       const originalUptime = process.uptime;
       const originalMemoryUsage = process.memoryUsage;
       const originalVersion = process.version;
@@ -185,7 +185,7 @@ describe("ServiceApiHandler", () => {
         version: "v18.0.0",
       });
 
-      // Restore original functions
+      // 恢复原始函数
       process.uptime = originalUptime;
       process.memoryUsage = originalMemoryUsage;
       Object.defineProperty(process, "version", {
@@ -194,7 +194,7 @@ describe("ServiceApiHandler", () => {
       });
     });
 
-    it("should handle health check error", async () => {
+    it("应该处理健康检查错误", async () => {
       const originalUptime = process.uptime;
       process.uptime = vi.fn().mockImplementation(() => {
         throw new Error("Uptime error");
@@ -209,13 +209,13 @@ describe("ServiceApiHandler", () => {
         500
       );
 
-      // Restore original function
+      // 恢复原始函数
       process.uptime = originalUptime;
     });
   });
 
   describe("startService", () => {
-    it("should start service successfully", async () => {
+    it("应该成功启动服务", async () => {
       await handler.startService(mockContext);
 
       expect(mockSpawn).toHaveBeenCalledWith("xiaozhi", ["start", "--daemon"], {
@@ -229,7 +229,7 @@ describe("ServiceApiHandler", () => {
       expect(mockContext.success).toHaveBeenCalledWith(null, "启动请求已接收");
     });
 
-    it("should handle start service error", async () => {
+    it("应该处理启动服务错误", async () => {
       const error = new Error("Start failed");
       mockSpawn.mockImplementation(() => {
         throw error;
@@ -245,7 +245,7 @@ describe("ServiceApiHandler", () => {
       );
     });
 
-    it("should handle non-Error exceptions in start", async () => {
+    it("应该处理启动时的非 Error 异常", async () => {
       mockSpawn.mockImplementation(() => {
         throw "String error";
       });
@@ -260,7 +260,7 @@ describe("ServiceApiHandler", () => {
       );
     });
 
-    it("should use correct environment variables", async () => {
+    it("应该使用正确的环境变量", async () => {
       const originalEnv = process.env.XIAOZHI_CONFIG_DIR;
       process.env.XIAOZHI_CONFIG_DIR = "/custom/config/dir";
 
@@ -528,13 +528,13 @@ describe("ServiceApiHandler", () => {
         })
       );
 
-      // Cleanup
+      // 清理
       process.env.CUSTOM_VAR = undefined;
     });
   });
 
   describe("error handling edge cases", () => {
-    it("should handle spawn returning null", async () => {
+    it("应该处理 spawn 返回 null", async () => {
       mockSpawn.mockReturnValue(null);
 
       await handler.startService(mockContext);
@@ -547,7 +547,7 @@ describe("ServiceApiHandler", () => {
       );
     });
 
-    it("should handle spawn child without unref method", async () => {
+    it("应该处理没有 unref 方法的 spawn 子进程", async () => {
       mockSpawn.mockReturnValue({});
 
       await handler.startService(mockContext);
@@ -560,7 +560,7 @@ describe("ServiceApiHandler", () => {
       );
     });
 
-    it("should handle unref method throwing error", async () => {
+    it("应该处理 unref 方法抛出错误", async () => {
       mockSpawn.mockReturnValue({
         unref: vi.fn().mockImplementation(() => {
           throw new Error("Unref failed");
@@ -579,7 +579,7 @@ describe("ServiceApiHandler", () => {
   });
 
   describe("integration scenarios", () => {
-    it("should handle multiple concurrent restart requests", async () => {
+    it("应该处理多个并发的重启请求", async () => {
       const promise1 = handler.restartService(mockContext);
       const promise2 = handler.restartService(mockContext);
 
@@ -590,7 +590,7 @@ describe("ServiceApiHandler", () => {
       expect(mockContext.success).toHaveBeenCalledTimes(2);
     });
 
-    it("should handle service manager returning undefined status", async () => {
+    it("应该处理服务管理器返回未定义状态", async () => {
       mockMcpServiceManager.getStatus.mockReturnValue(undefined);
 
       await handler.restartService(mockContext);

--- a/apps/backend/handlers/__tests__/static-file.handler.test.ts
+++ b/apps/backend/handlers/__tests__/static-file.handler.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { StaticFileHandler } from "../static-file.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("node:fs", () => ({
   existsSync: vi.fn(),
 }));
@@ -41,7 +41,7 @@ describe("StaticFileHandler", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),
@@ -51,7 +51,7 @@ describe("StaticFileHandler", () => {
     const { logger } = await import("../../Logger.js");
     Object.assign(logger, mockLogger);
 
-    // Mock fs functions
+    // 模拟 fs 函数
     const fs = await import("node:fs");
     const fsPromises = await import("node:fs/promises");
     const path = await import("node:path");
@@ -63,14 +63,14 @@ describe("StaticFileHandler", () => {
     mockJoin = vi.mocked(path.join);
     mockFileURLToPath = vi.mocked(url.fileURLToPath);
 
-    // Setup default mocks
+    // 设置默认模拟
     mockFileURLToPath.mockReturnValue(
       "/project/dist/handlers/StaticFileHandler.js"
     );
     mockDirname.mockReturnValue("/project/dist/handlers");
     mockJoin.mockImplementation((...args: string[]) => args.join("/"));
 
-    // Mock Context
+    // 模拟 Context
     mockContext = {
       req: {
         url: "http://localhost:3000/",
@@ -80,7 +80,7 @@ describe("StaticFileHandler", () => {
         if (key === "logger") return mockLogger;
         return undefined;
       }),
-      logger: mockLogger, // 向后兼容
+      logger: mockLogger, // 向后兼容支持
       text: vi.fn().mockImplementation((text, status, headers) => ({
         status,
         text,
@@ -105,7 +105,7 @@ describe("StaticFileHandler", () => {
 
   describe("constructor", () => {
     it("应该使用正确的依赖项初始化", () => {
-      // Mock existsSync to return true for the first path
+      // 模拟 existsSync 为第一个路径返回 true
       mockExistsSync.mockReturnValueOnce(true);
 
       staticFileHandler = new StaticFileHandler();
@@ -218,7 +218,7 @@ describe("StaticFileHandler", () => {
     });
 
     it("当 web 路径不可用时应该返回错误页面", async () => {
-      mockExistsSync.mockReturnValue(false); // No web path found
+      mockExistsSync.mockReturnValue(false); // 未找到 web 路径
       staticFileHandler = new StaticFileHandler();
 
       const response = await staticFileHandler.handleStaticFile(mockContext);
@@ -231,8 +231,8 @@ describe("StaticFileHandler", () => {
     it("应该为 SPA 路由回退到 index.html", async () => {
       mockContext.req.url = "http://localhost:3000/app/dashboard";
       mockExistsSync
-        .mockReturnValueOnce(false) // File doesn't exist
-        .mockReturnValueOnce(true); // index.html exists
+        .mockReturnValueOnce(false) // 文件不存在
+        .mockReturnValueOnce(true); // index.html 存在
       mockReadFile.mockResolvedValue(Buffer.from("<html>SPA</html>"));
 
       const response = await staticFileHandler.handleStaticFile(mockContext);
@@ -258,8 +258,8 @@ describe("StaticFileHandler", () => {
     });
 
     it("应该处理 URL 解析错误", async () => {
-      // URL parsing error happens before try-catch, so we need to test differently
-      // The error will be thrown and caught by the outer try-catch
+      // URL 解析错误发生在 try-catch 之前，所以我们需要以不同方式测试
+      // 错误将被抛出并由外部 try-catch 捕获
       mockContext.req.url = "invalid-url";
 
       try {
@@ -278,7 +278,7 @@ describe("StaticFileHandler", () => {
     });
 
     it("应该为 HTML 文件返回正确的内容类型", () => {
-      // Access private method through type assertion for testing
+      // 通过类型断言访问私有方法进行测试
       const handler = staticFileHandler as any;
 
       expect(handler.getContentType("index.html")).toBe("text/html");
@@ -481,12 +481,12 @@ describe("StaticFileHandler", () => {
       mockExistsSync.mockReturnValue(false);
       staticFileHandler = new StaticFileHandler();
 
-      // Clear previous calls
+      // 清除之前的调用
       mockLogger.debug.mockClear();
       mockLogger.info.mockClear();
       mockLogger.warn.mockClear();
 
-      // Mock to return true on reinitialize
+      // 模拟重新初始化时返回 true
       mockExistsSync.mockReturnValueOnce(true);
 
       staticFileHandler.reinitializeWebPath();
@@ -592,7 +592,7 @@ describe("StaticFileHandler", () => {
     });
 
     it("应该处理完整的静态文件服务工作流程", async () => {
-      // Test serving different file types
+      // 测试提供不同文件类型
       const testCases = [
         {
           url: "http://localhost:3000/index.html",
@@ -634,8 +634,8 @@ describe("StaticFileHandler", () => {
       for (const route of spaRoutes) {
         mockContext.req.url = `http://localhost:3000${route}`;
         mockExistsSync
-          .mockReturnValueOnce(false) // Route file doesn't exist
-          .mockReturnValueOnce(true); // index.html exists
+          .mockReturnValueOnce(false) // 路由文件不存在
+          .mockReturnValueOnce(true); // index.html 存在
         mockReadFile.mockResolvedValue(Buffer.from("<html>SPA App</html>"));
 
         await staticFileHandler.handleStaticFile(mockContext);
@@ -647,7 +647,7 @@ describe("StaticFileHandler", () => {
     });
 
     it("应该优雅地处理错误场景", async () => {
-      // Test various error conditions
+      // 测试各种错误条件
       const errorCases = [
         {
           description: "file not found",
@@ -799,7 +799,7 @@ describe("StaticFileHandler", () => {
     });
 
     it("应该处理路径遍历检测", () => {
-      // Test the path traversal detection logic directly
+      // 直接测试路径遍历检测逻辑
       const handler = staticFileHandler as any;
 
       expect("../../../etc/passwd".includes("..")).toBe(true);

--- a/apps/backend/handlers/__tests__/status.handler.test.ts
+++ b/apps/backend/handlers/__tests__/status.handler.test.ts
@@ -2,7 +2,7 @@ import type { StatusService } from "@/services/status.service.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { StatusApiHandler } from "../status.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -19,7 +19,7 @@ describe("StatusApiHandler 状态 API 处理器", () => {
   let mockLogger: any;
 
   beforeEach(async () => {
-    // Setup mock logger first
+    // 首先设置模拟 logger
     const { logger } = await import("../../Logger.js");
     mockLogger = {
       debug: vi.fn(),
@@ -29,7 +29,7 @@ describe("StatusApiHandler 状态 API 处理器", () => {
     };
     Object.assign(logger, mockLogger);
 
-    // Setup mock StatusService
+    // 设置模拟 StatusService
     mockStatusService = {
       getFullStatus: vi.fn(),
       getClientStatus: vi.fn(),
@@ -42,7 +42,7 @@ describe("StatusApiHandler 状态 API 处理器", () => {
       reset: vi.fn(),
     } as any;
 
-    // Setup mock Context
+    // 设置模拟 Context
     mockContext = {
       get: vi.fn((key: string) => {
         if (key === "logger") return mockLogger;
@@ -88,7 +88,7 @@ describe("StatusApiHandler 状态 API 处理器", () => {
       },
     } as any;
 
-    // Create handler instance
+    // 创建处理器实例
     statusApiHandler = new StatusApiHandler(mockStatusService);
   });
 

--- a/apps/backend/handlers/__tests__/update.handler.test.ts
+++ b/apps/backend/handlers/__tests__/update.handler.test.ts
@@ -4,7 +4,7 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "../../Logger.js";
 import { UpdateApiHandler } from "../update.handler.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("@/lib/npm");
 vi.mock("../../Logger.js");
 vi.mock("@/services/event-bus.service.js");
@@ -76,7 +76,7 @@ describe("UpdateApiHandler", () => {
     // Reset all mocks
     vi.clearAllMocks();
 
-    // Setup mock logger
+    // 设置模拟 logger
     mockLogger = {
       info: vi.fn(),
       error: vi.fn(),
@@ -85,7 +85,7 @@ describe("UpdateApiHandler", () => {
     };
     Object.assign(logger, mockLogger);
 
-    // Setup mock event bus
+    // 设置模拟 event bus
     mockEventBus = {
       emitEvent: vi.fn(),
       onEvent: vi.fn(),
@@ -95,7 +95,7 @@ describe("UpdateApiHandler", () => {
       mockEventBus as unknown as ReturnType<typeof getEventBus>
     );
 
-    // Setup mock NPMManager
+    // 设置模拟 NPMManager
     mockNPMManager = {
       installVersion: vi.fn(),
     };
@@ -103,7 +103,7 @@ describe("UpdateApiHandler", () => {
       () => mockNPMManager as unknown as NPMManager
     );
 
-    // Create handler instance
+    // 创建处理器实例
     updateApiHandler = new UpdateApiHandler();
   });
 
@@ -113,7 +113,7 @@ describe("UpdateApiHandler", () => {
 
   describe("performUpdate", () => {
     test("应该成功安装指定版本", async () => {
-      // Arrange
+      // 准备
       const mockContext = createMockContext({
         req: {
           json: vi.fn().mockResolvedValue({ version: "1.7.9" }),
@@ -122,10 +122,10 @@ describe("UpdateApiHandler", () => {
 
       mockNPMManager.installVersion.mockResolvedValue(undefined);
 
-      // Act
+      // 执行
       await updateApiHandler.performUpdate(mockContext as unknown as Context);
 
-      // Assert
+      // 断言
       expect(mockNPMManager.installVersion).toHaveBeenCalledWith("1.7.9");
       expect(mockContext.success).toHaveBeenCalledWith(
         {
@@ -137,17 +137,17 @@ describe("UpdateApiHandler", () => {
     });
 
     test("应该拒绝空的版本号", async () => {
-      // Arrange
+      // 准备
       const mockContext = createMockContext({
         req: {
           json: vi.fn().mockResolvedValue({ version: "" }),
         },
       } as any);
 
-      // Act
+      // 执行
       await updateApiHandler.performUpdate(mockContext as unknown as Context);
 
-      // Assert
+      // 断言
       expect(mockContext.fail).toHaveBeenCalledWith(
         "INVALID_VERSION",
         "请求参数格式错误",

--- a/apps/backend/lib/mcp/__tests__/cache.test.ts
+++ b/apps/backend/lib/mcp/__tests__/cache.test.ts
@@ -13,7 +13,7 @@ import { MCPCacheManager } from "../cache";
 import type { InternalMCPServiceConfig } from "../types";
 import { MCPTransportType } from "../types";
 
-// Mock logger
+// 模拟 logger
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),

--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -5,7 +5,7 @@ import {
   getEventBus,
 } from "../event-bus.service.js";
 
-// Mock dependencies
+// 模拟依赖
 vi.mock("../../Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -22,7 +22,7 @@ describe("EventBus", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),
@@ -42,25 +42,25 @@ describe("EventBus", () => {
   });
 
   describe("constructor", () => {
-    it("should initialize with correct dependencies", () => {
+    it("应该使用正确的依赖项初始化", () => {
       expect(eventBus).toBeInstanceOf(EventBus);
       expect(mockLogger.debug).not.toHaveBeenCalled();
     });
 
-    it("should set max listeners", () => {
+    it("应该设置最大监听器数量", () => {
       // 测试环境下 maxListeners 应该是 200，避免 MaxListenersExceededWarning
       expect(eventBus.getMaxListeners()).toBe(200);
     });
 
-    it("should setup error handling", () => {
-      // Verify error event listener is set up
+    it("应该设置错误处理", () => {
+      // 验证错误事件监听器已设置
       expect(eventBus.listenerCount("error")).toBe(1);
       expect(eventBus.listenerCount("newListener")).toBe(1);
     });
   });
 
   describe("emitEvent", () => {
-    it("should emit config:updated event successfully", () => {
+    it("应该成功发射 config:updated 事件", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
       const listener = vi.fn();
 

--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -4,7 +4,7 @@ import { NotificationService } from "../notification.service.js";
 import type { WebSocketClient } from "../notification.service.js";
 import type { ClientInfo } from "../status.service.js";
 
-// Mock EventBus
+// 模拟 EventBus
 vi.mock("../event-bus.service.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     onEvent: vi.fn(),
@@ -12,7 +12,7 @@ vi.mock("../event-bus.service.js", () => ({
   }),
 }));
 
-// Mock Logger
+// 模拟 Logger
 vi.mock("@/Logger.js", () => ({
   logger: {
     debug: vi.fn(),
@@ -23,7 +23,7 @@ vi.mock("@/Logger.js", () => ({
   },
 }));
 
-// Mock ConfigManager
+// 模拟 ConfigManager
 vi.mock("@xiaozhi-client/config", () => ({
   configManager: {
     getConfig: vi.fn().mockReturnValue({
@@ -81,7 +81,7 @@ describe("NotificationService", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
 
-    // Mock EventBus
+    // 模拟 EventBus
     mockEventBus = {
       onEvent: vi.fn(),
       emitEvent: vi.fn(),
@@ -89,7 +89,7 @@ describe("NotificationService", () => {
     const { getEventBus } = await import("../event-bus.service.js");
     (getEventBus as any).mockReturnValue(mockEventBus);
 
-    // Mock Logger
+    // 模拟 Logger
     mockLogger = {
       debug: vi.fn(),
       info: vi.fn(),


### PR DESCRIPTION
修复了 apps/backend 部分测试文件中的英文注释和测试描述，改为中文。

主要更改：
- 将 "// Mock" 等英文注释翻译为 "// 模拟"
- 将 "// Arrange/Act/Assert" 翻译为 "// 准备/执行/断言"
- 将部分英文测试描述翻译为中文

受影响的文件 (21个):
- apps/backend/__tests__/config-sync-integration.test.ts
- apps/backend/__tests__/logger.test.ts
- apps/backend/constants/__tests__/constants.test.ts
- apps/backend/errors/__tests__/error-helper.integration.test.ts
- apps/backend/errors/__tests__/error-helper.test.ts
- apps/backend/handlers/__tests__/basic.test.ts
- apps/backend/handlers/__tests__/config.handler.test.ts
- apps/backend/handlers/__tests__/endpoint.handler.test.ts
- apps/backend/handlers/__tests__/heartbeat.handler.test.ts
- apps/backend/handlers/__tests__/mcp-tool.integration.test.ts
- apps/backend/handlers/__tests__/service.handler.test.ts
- apps/backend/handlers/__tests__/status.handler.test.ts
- apps/backend/handlers/__tests__/update.handler.test.ts
- apps/backend/lib/mcp/__tests__/cache.test.ts
- apps/backend/services/__tests__/event-bus.service.test.ts
- apps/backend/services/__tests__/notification.service.test.ts
- apps/backend/handlers/__tests__/mcp.handler.test.ts
- apps/backend/handlers/__tests__/mcp.handler.integration.test.ts
- apps/backend/handlers/__tests__/mcp-tool.core.test.ts
- apps/backend/handlers/__tests__/static-file.handler.test.ts
- apps/backend/handlers/__tests__/mcp-tool.parameter-config.test.ts
- apps/backend/handlers/__tests__/realtime-notification.handler.test.ts
- apps/backend/handlers/__tests__/mcp-manage.handler.test.ts

注意：这是部分修复，还有更多测试文件需要类似处理。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>