### PR TITLE
fix: 修复 EndpointManager.disconnect() 缺少 await 导致资源未正确清理

### DIFF
--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -290,7 +290,7 @@ export class EndpointManager extends EventEmitter {
         throw new Error(`接入点不存在: ${sliceEndpoint(endpoint)}`);
       }
 
-      endpointInstance.disconnect();
+      await endpointInstance.disconnect();
 
       const status = this.connectionStates.get(endpoint);
       if (status) {
@@ -310,11 +310,7 @@ export class EndpointManager extends EventEmitter {
     const promises: Promise<void>[] = [];
 
     for (const endpoint of this.endpoints.values()) {
-      promises.push(
-        Promise.resolve().then(() => {
-          endpoint.disconnect();
-        })
-      );
+      promises.push(endpoint.disconnect());
     }
 
     await Promise.allSettled(promises);


### PR DESCRIPTION
- 为指定端点断开添加 await 关键字
- 修正断开所有端点时的 Promise 处理逻辑，移除不必要的 Promise.resolve().then() 包装
- 确保 endpoint.disconnect() 的异步清理操作（如 MCP 适配器清理和 WebSocket 连接关闭）完成后再继续执行

修复问题 #1728

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>