### PR TITLE
fix: 修复网络初始化失败时未更新连接状态的问题

### DIFF
--- a/apps/frontend/src/hooks/useNetworkService.ts
+++ b/apps/frontend/src/hooks/useNetworkService.ts
@@ -30,6 +30,16 @@ export function useNetworkService() {
     // 初始化网络服务
     networkService.initialize().catch((error) => {
       console.error("[NetworkService] 初始化失败:", error);
+
+      // 更新连接状态为已断开
+      webSocketActions.setConnectionState(ConnectionState.DISCONNECTED);
+
+      // 设置错误状态供 UI 展示
+      useStatusStore.getState().setError(
+        error instanceof Error
+          ? error
+          : new Error(`网络初始化失败: ${String(error)}`)
+      );
     });
 
     // 保存所有事件监听器的取消订阅函数


### PR DESCRIPTION
当 networkService.initialize() 失败时，现在会：
1. 更新连接状态为 DISCONNECTED
2. 将错误信息保存到 useStatusStore 中供 UI 展示

这解决了用户界面在网络初始化失败时卡在"连接中"状态的问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>