### PR TITLE
fix: 修复 heartbeat.handler.ts 中的 WebSocket 参数类型安全问题

### DIFF
--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -10,6 +10,7 @@ import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
+import type { WebSocketLike } from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
 
 /**
@@ -46,7 +47,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -82,7 +83,7 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(ws: WebSocketLike, clientId: string): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -200,7 +201,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",
@@ -220,12 +221,14 @@ export class HeartbeatHandler {
   /**
    * 验证心跳消息格式
    */
-  validateHeartbeatMessage(message: any): message is HeartbeatMessage {
+  validateHeartbeatMessage(message: unknown): message is HeartbeatMessage {
     return (
-      message &&
+      message !== null &&
       typeof message === "object" &&
+      "type" in message &&
       message.type === "clientStatus" &&
-      message.data &&
+      "data" in message &&
+      message.data !== null &&
       typeof message.data === "object"
     );
   }


### PR DESCRIPTION
将 ws 参数从 any 类型改为使用已定义的 WebSocketLike 接口，
同时改进了 validateHeartbeatMessage 方法的类型守卫实现。

修改内容：
- 导入 WebSocketLike 接口
- handleClientStatus、sendLatestConfig、sendHeartbeatResponse 中的 ws 参数改为 WebSocketLike 类型
- validateHeartbeatMessage 的 message 参数从 any 改为 unknown，并改进类型守卫实现

修复 issue #1734

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>