### PR TITLE
fix: 将 CozeWorkflow.inputSchema 类型从 any 改为 JSONSchema

### DIFF
--- a/apps/frontend/src/services/toolsApi.ts
+++ b/apps/frontend/src/services/toolsApi.ts
@@ -5,6 +5,7 @@
 
 import type {
   CozeWorkflow,
+  JSONSchema,
   WorkflowParameterConfig,
 } from "@xiaozhi-client/shared-types";
 import { apiClient } from "./api";
@@ -25,8 +26,8 @@ export interface AddToolRequest {
 export interface AddToolResponse {
   name: string;
   description: string;
-  inputSchema: any;
-  handler: any;
+  inputSchema: JSONSchema;
+  handler: unknown;
 }
 
 /**
@@ -35,7 +36,7 @@ export interface AddToolResponse {
 export interface ApiError {
   code: string;
   message: string;
-  details?: any;
+  details?: unknown;
 }
 
 /**
@@ -101,7 +102,7 @@ export class ToolsApiService {
   /**
    * 获取自定义工具列表
    */
-  async getCustomTools(): Promise<any[]> {
+  async getCustomTools(): Promise<unknown[]> {
     try {
       const tools = await this.executeWithRetry(async () => {
         return await apiClient.getCustomTools();

--- a/packages/shared-types/src/coze/workflow.ts
+++ b/packages/shared-types/src/coze/workflow.ts
@@ -2,6 +2,8 @@
  * 扣子工作流相关类型定义
  */
 
+import type { JSONSchema } from "../mcp/schema.js";
+
 /**
  * 扣子工作流创建者信息
  */
@@ -35,7 +37,7 @@ export interface CozeWorkflow {
   /** 是否已添加为工具（前端运行时属性） */
   isAddedAsTool?: boolean;
   /** 输入参数Schema（前端运行时属性） */
-  inputSchema?: any;
+  inputSchema?: JSONSchema;
   /** 工具名称（前端运行时属性） */
   toolName?: string | null;
 }


### PR DESCRIPTION
修复 issue #1740，提升类型安全性：

- packages/shared-types/src/coze/workflow.ts:
  - 添加 JSONSchema 类型导入
  - 将 inputSchema 字段类型从 any 改为 JSONSchema

- apps/frontend/src/services/toolsApi.ts:
  - 将 AddToolResponse.inputSchema 从 any 改为 JSONSchema
  - 将 AddToolResponse.handler 从 any 改为 unknown
  - 将 ApiError.details 从 any 改为 unknown
  - 将 getCustomTools 返回类型从 Promise<any[]> 改为 Promise<unknown[]>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1740