### PR TITLE
fix: 将 ApiError 和 ToolValidationError 中的 any 类型替换为 unknown

### DIFF
--- a/packages/shared-types/src/api/errors.ts
+++ b/packages/shared-types/src/api/errors.ts
@@ -46,7 +46,7 @@ export interface ApiError {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: unknown;
   /** 错误堆栈（开发环境） */
   stack?: string;
 }
@@ -62,7 +62,7 @@ export interface ToolValidationError {
   /** 验证字段名称 */
   field?: string;
   /** 错误详情 */
-  details?: any;
+  details?: unknown;
 }
 
 /**
@@ -74,5 +74,5 @@ export interface CozeApiError extends Error {
   /** HTTP 状态码 */
   statusCode?: number;
   /** 原始响应数据 */
-  response?: any;
+  response?: unknown;
 }


### PR DESCRIPTION
将 `packages/shared-types/src/api/errors.ts` 中的 `any` 类型替换为 `unknown`：
- ApiError.details: any → unknown
- ToolValidationError.details: any → unknown
- CozeApiError.response: any → unknown (额外修复)

这提升了类型安全性，强制使用者在使用 details 字段时进行类型检查，
符合 TypeScript 最佳实践。

Fixes #1742

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1742