### PR TITLE
fix: 修复 service.handler.ts 中服务重启过程的 setTimeout 定时器未跟踪和清理导致资源泄漏

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -1065,6 +1065,9 @@ export class WebServer {
     // 异步销毁 ESP32 服务（fire and forget）
     this.esp32Service.destroy();
 
+    // 清理服务处理器中的待处理定时器
+    this.serviceApiHandler.cleanupPendingRestarts();
+
     // 销毁事件总线
     destroyEventBus();
 


### PR DESCRIPTION
- 在 ServiceApiHandler 中添加 restartTimers 集合跟踪所有重启相关的定时器
- 修改 restartService() 方法，保存并跟踪两个嵌套的 setTimeout 定时器 ID
- 添加 cleanupPendingRestarts() 方法用于清理所有待处理的定时器
- 在 WebServer.destroy() 方法中调用 serviceApiHandler.cleanupPendingRestarts()
- 添加 cleanupPendingRestarts 单元测试验证清理功能

修复问题 #1748

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1748