### PR TITLE
refactor: 删除 apps/backend/types/toolApi.ts 中冗余的 ExtendedCustomMCPTool 接口

### DIFF
--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -278,24 +278,3 @@ export interface ToolConfigOptions {
   /** 工具分组 */
   group?: string;
 }
-
-/**
- * 扩展的 CustomMCPTool 接口
- * 包含额外的元数据信息
- */
-export interface ExtendedCustomMCPTool {
-  /** 基础工具配置 */
-  name: string;
-  description: string;
-  inputSchema: any;
-  handler: any;
-  /** 使用统计信息 */
-  stats?: {
-    usageCount?: number;
-    lastUsedTime?: string;
-  };
-  /** 工具元数据 */
-  metadata?: ToolMetadata;
-  /** 配置选项 */
-  config?: ToolConfigOptions;
-}


### PR DESCRIPTION
- 该接口使用 any 类型（inputSchema 和 handler 字段）
- 接口在 apps/backend 中未被使用
- 正确定义已存在于 packages/shared-types/src/api/toolApi.ts

Fixes #1757

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1757