### PR TITLE
fix: 替换 console.debug 为统一的 Logger 系统

### DIFF
--- a/packages/mcp-core/src/transport-factory.ts
+++ b/packages/mcp-core/src/transport-factory.ts
@@ -15,6 +15,7 @@ import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/
 import { EventSource } from "eventsource";
 import type { InternalMCPServiceConfig, MCPServerTransport } from "./types.js";
 import { MCPTransportType } from "./types.js";
+import { createLogger } from "./utils/index.js";
 
 // 全局 polyfill EventSource（用于 SSE）
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -24,6 +25,9 @@ if (typeof globalThisAny !== "undefined" && !globalThisAny.EventSource) {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   globalThisAny.EventSource = EventSource;
 }
+
+// 创建日志实例
+const logger = createLogger("TransportFactory");
 
 // Transport 基础接口
 export interface Transport {
@@ -39,9 +43,7 @@ export interface Transport {
 export function createTransport(
   config: InternalMCPServiceConfig
 ): MCPServerTransport {
-  console.debug(
-    `[TransportFactory] 创建 ${config.type} transport for ${config.name}`
-  );
+  logger.debug(`创建 ${config.type} transport for ${config.name}`);
 
   switch (config.type) {
     case MCPTransportType.STDIO:

--- a/packages/mcp-core/src/utils/index.ts
+++ b/packages/mcp-core/src/utils/index.ts
@@ -11,3 +11,6 @@ export {
   inferTransportTypeFromUrl,
   inferTransportTypeFromConfig,
 } from "./validators.js";
+
+// 日志工具
+export { createLogger } from "./logger.js";

--- a/packages/mcp-core/src/utils/logger.ts
+++ b/packages/mcp-core/src/utils/logger.ts
@@ -1,0 +1,105 @@
+/**
+ * 轻量级日志工具
+ *
+ * 为 mcp-core 包提供简单统一的日志输出接口
+ * 保持轻量级，不引入外部依赖
+ *
+ * @module utils/logger
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+}
+
+/**
+ * 轻量级日志类
+ */
+class Logger {
+  private context: string;
+
+  constructor(context: string) {
+    this.context = context;
+  }
+
+  /**
+   * 格式化日志消息
+   */
+  private formatMessage(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `[${timestamp}] [${level.toUpperCase()}] [${this.context}] ${message}`;
+  }
+
+  /**
+   * 输出调试日志
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.DEBUG)) {
+      const formatted = this.formatMessage(LogLevel.DEBUG, message);
+      // eslint-disable-next-line no-console
+      console.debug(formatted, ...args);
+    }
+  }
+
+  /**
+   * 输出信息日志
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.INFO)) {
+      const formatted = this.formatMessage(LogLevel.INFO, message);
+      // eslint-disable-next-line no-console
+      console.info(formatted, ...args);
+    }
+  }
+
+  /**
+   * 输出警告日志
+   */
+  warn(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.WARN)) {
+      const formatted = this.formatMessage(LogLevel.WARN, message);
+      // eslint-disable-next-line no-console
+      console.warn(formatted, ...args);
+    }
+  }
+
+  /**
+   * 输出错误日志
+   */
+  error(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.ERROR)) {
+      const formatted = this.formatMessage(LogLevel.ERROR, message);
+      // eslint-disable-next-line no-console
+      console.error(formatted, ...args);
+    }
+  }
+
+  /**
+   * 判断是否应该输出日志
+   * 通过环境变量 XIAOZHI_LOG_LEVEL 控制日志级别
+   */
+  private shouldLog(level: LogLevel): boolean {
+    const envLevel = (process.env.XIAOZHI_LOG_LEVEL || "info").toLowerCase();
+    const levels = [
+      LogLevel.DEBUG,
+      LogLevel.INFO,
+      LogLevel.WARN,
+      LogLevel.ERROR,
+    ];
+    return levels.indexOf(level) >= levels.indexOf(envLevel as LogLevel);
+  }
+}
+
+/**
+ * 创建带上下文的日志实例
+ * @param context 上下文标识
+ * @returns Logger 实例
+ */
+export function createLogger(context: string): Logger {
+  return new Logger(context);
+}


### PR DESCRIPTION
修复 Issue #1760 - packages/mcp-core/src/transport-factory.ts 中使用
console.debug 而非统一的 Logger 系统违反代码规范一致性

- 新增轻量级日志工具 (packages/mcp-core/src/utils/logger.ts)
  * 支持 debug, info, warn, error 日志级别
  * 通过环境变量 XIAOZHI_LOG_LEVEL 控制日志输出
  * 保持轻量级，不引入外部依赖
- 更新 transport-factory.ts 使用新的 Logger 系统
- 更新 utils/index.ts 导出 createLogger 函数

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1760