### PR TITLE
fix: 为 ServiceManager 中的 spawn 调用添加错误处理

### DIFF
--- a/packages/cli/src/services/__tests__/DaemonMode.integration.test.ts
+++ b/packages/cli/src/services/__tests__/DaemonMode.integration.test.ts
@@ -112,8 +112,11 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 12345,
         unref: vi.fn(),
+        on: vi.fn(),
         stdout: null,
-        stderr: null,
+        stderr: {
+          on: vi.fn(),
+        },
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -135,7 +138,7 @@ describe("Daemon 模式集成测试", () => {
         ["/test/WebServerLauncher.js"],
         {
           detached: true,
-          stdio: ["ignore", "ignore", "ignore"],
+          stdio: ["ignore", "pipe", "pipe"],
           env: expect.objectContaining({
             XIAOZHI_CONFIG_DIR: "/test/config",
             XIAOZHI_DAEMON: "true",
@@ -160,6 +163,10 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 12346,
         unref: vi.fn(),
+        on: vi.fn(),
+        stderr: {
+          on: vi.fn(),
+        },
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -178,7 +185,7 @@ describe("Daemon 模式集成测试", () => {
         ["/test/WebServerLauncher.js"],
         {
           detached: true,
-          stdio: ["ignore", "ignore", "ignore"],
+          stdio: ["ignore", "pipe", "pipe"],
           env: expect.objectContaining({
             XIAOZHI_CONFIG_DIR: "/test/config",
             XIAOZHI_DAEMON: "true",
@@ -200,6 +207,10 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 54321,
         unref: vi.fn(),
+        on: vi.fn(),
+        stderr: {
+          on: vi.fn(),
+        },
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -219,7 +230,7 @@ describe("Daemon 模式集成测试", () => {
         ["/test/cli.js", "start", "--server", "4000"],
         {
           detached: true,
-          stdio: ["ignore", "ignore", "ignore"],
+          stdio: ["ignore", "pipe", "pipe"],
           env: expect.objectContaining({
             XIAOZHI_CONFIG_DIR: "/test/config",
             XIAOZHI_DAEMON: "true",
@@ -288,8 +299,11 @@ describe("Daemon 模式集成测试", () => {
       const mockChild = {
         pid: 99999,
         unref: vi.fn(),
+        on: vi.fn(),
         stdout: { pipe: vi.fn() },
-        stderr: { pipe: vi.fn() },
+        stderr: {
+          on: vi.fn(),
+        },
       };
       mockSpawn.mockReturnValue(mockChild as any);
 
@@ -303,16 +317,15 @@ describe("Daemon 模式集成测试", () => {
         "process.exit unexpectedly called"
       );
 
-      // Verify stdio is completely ignored (no piping)
-      expect(mockChild.stdout.pipe).not.toHaveBeenCalled();
-      expect(mockChild.stderr.pipe).not.toHaveBeenCalled();
+      // Verify stdio is set to pipe for stdout and stderr (to capture errors)
+      expect(mockChild.stderr.on).toHaveBeenCalled();
 
       // Verify process is detached and unreferenced
       const spawnCall = mockSpawn.mock.calls[0];
       expect(spawnCall[2]).toEqual(
         expect.objectContaining({
           detached: true,
-          stdio: ["ignore", "ignore", "ignore"],
+          stdio: ["ignore", "pipe", "pipe"],
         })
       );
       expect(mockChild.unref).toHaveBeenCalled();

--- a/packages/cli/src/services/__tests__/ServiceManager.test.ts
+++ b/packages/cli/src/services/__tests__/ServiceManager.test.ts
@@ -338,6 +338,10 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
+          stderr: {
+            on: vi.fn(),
+          },
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -357,7 +361,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
           ["/mock/path/WebServerLauncher.js"],
           {
             detached: true,
-            stdio: ["ignore", "ignore", "ignore"],
+            stdio: ["ignore", "pipe", "pipe"],
             env: expect.objectContaining({
               XIAOZHI_CONFIG_DIR: "/mock/config",
               XIAOZHI_DAEMON: "true",
@@ -388,6 +392,10 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
+          stderr: {
+            on: vi.fn(),
+          },
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -405,7 +413,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
           ["/mock/path/WebServerLauncher.js"],
           {
             detached: true,
-            stdio: ["ignore", "ignore", "ignore"],
+            stdio: ["ignore", "pipe", "pipe"],
             env: expect.objectContaining({
               XIAOZHI_CONFIG_DIR: "/mock/config",
               XIAOZHI_DAEMON: "true",
@@ -424,6 +432,10 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 5678,
           unref: vi.fn(),
+          on: vi.fn(),
+          stderr: {
+            on: vi.fn(),
+          },
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -443,7 +455,7 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
           ["/mock/path/cli.js", "start", "--server", "3000"],
           {
             detached: true,
-            stdio: ["ignore", "ignore", "ignore"],
+            stdio: ["ignore", "pipe", "pipe"],
             env: expect.objectContaining({
               XIAOZHI_CONFIG_DIR: "/mock/config",
               XIAOZHI_DAEMON: "true",
@@ -508,6 +520,10 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: undefined,
           unref: vi.fn(),
+          on: vi.fn(),
+          stderr: {
+            on: vi.fn(),
+          },
         };
         mockSpawn.mockReturnValue(mockChild as any);
 
@@ -516,14 +532,12 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
           daemon: true,
         };
 
-        // Should handle undefined PID gracefully
+        // Should handle undefined PID gracefully by exiting with error
         await expect(serviceManager.start(daemonOptions)).rejects.toThrow(
           /process\.exit/
         );
-        expect(mockProcessManager.savePidInfo).toHaveBeenCalledWith(
-          0,
-          "daemon"
-        );
+        // 当 PID 为 undefined 时，新代码会在保存 PID 之前就退出
+        expect(mockProcessManager.savePidInfo).not.toHaveBeenCalled();
       });
 
       it("应传递正确的环境变量", async () => {
@@ -536,6 +550,10 @@ describe("ServiceManagerImpl 服务管理器实现", () => {
         const mockChild = {
           pid: 1234,
           unref: vi.fn(),
+          on: vi.fn(),
+          stderr: {
+            on: vi.fn(),
+          },
         };
         mockSpawn.mockReturnValue(mockChild as any);
 


### PR DESCRIPTION
修复了 `startMcpServerMode` 和 `startWebServerInDaemon` 方法中 spawn 调用缺少错误处理的问题。

主要更改：
- 将 stdio 从 ["ignore", "ignore", "ignore"] 改为 ["ignore", "pipe", "pipe"] 以捕获错误输出
- 添加 child.pid 检查，确保子进程成功创建
- 添加 'error' 事件监听器处理 spawn 错误
- 添加 'exit' 事件监听器检测子进程启动失败
- 添加 stderr 监听器以便调试
- 在 startMcpServerMode 中添加 CLI 脚本文件存在性检查
- 更新相关测试用例以匹配新的实现

Fixes #1764

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1764