### PR TITLE
fix: 修复 event-bus.service.ts 中的 any 类型使用问题

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -87,7 +87,14 @@ describe("EventBus", () => {
     });
 
     it("should emit status:updated event successfully", () => {
-      const eventData = { status: { connected: true }, source: "test" };
+      const eventData = {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "ws://localhost:3000",
+          activeMCPServers: [],
+        },
+        source: "test",
+      };
       const listener = vi.fn();
 
       eventBus.onEvent("status:updated", listener);
@@ -486,7 +493,14 @@ describe("EventBus", () => {
 
       eventBus.emitEvent("config:updated", eventData);
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "ws://localhost:3000",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       const stats = eventBus.getEventStats();
 
@@ -537,7 +551,14 @@ describe("EventBus", () => {
     it("should clear all event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "ws://localhost:3000",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       let stats = eventBus.getEventStats();
       expect(Object.keys(stats)).toHaveLength(2);
@@ -562,7 +583,14 @@ describe("EventBus", () => {
         type: "customMCP",
         timestamp: new Date(),
       });
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: {
+          status: "connected" as const,
+          mcpEndpoint: "ws://localhost:3000",
+          activeMCPServers: [],
+        },
+        source: "test",
+      });
 
       const status = eventBus.getStatus();
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -15,6 +15,21 @@ import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
+import type { NotificationData } from "./notification.service.js";
+import type { ClientInfo } from "./status.service.js";
+
+/**
+ * MCP 服务添加操作结果
+ */
+interface MCPServerAddResult {
+  name: string;
+  success: boolean;
+  error?: string;
+  config?: MCPServerConfig;
+  tools?: string[];
+  status?: string;
+}
 
 /**
  * 事件类型定义
@@ -30,7 +45,7 @@ export interface EventBusEvents {
   "config:error": { error: Error; operation: string };
 
   // 状态相关事件
-  "status:updated": { status: any; source: string };
+  "status:updated": { status: ClientInfo; source: string };
   "status:error": { error: Error; operation: string };
 
   // 接入点状态变更事件
@@ -101,10 +116,18 @@ export interface EventBusEvents {
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };
   "websocket:client:disconnected": { clientId: string; timestamp: number };
-  "websocket:message:received": { type: string; data: any; clientId: string };
+  "websocket:message:received": {
+    type: string;
+    data: unknown;
+    clientId: string;
+  };
 
   // 通知相关事件
-  "notification:broadcast": { type: string; data: any; target?: string };
+  "notification:broadcast": {
+    type: string;
+    data: NotificationData;
+    target?: string;
+  };
   "notification:error": { error: Error; type: string };
 
   // MCP服务相关事件
@@ -125,7 +148,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };
@@ -159,7 +182,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {


### PR DESCRIPTION
- status:updated 事件的 status 字段使用 ClientInfo 类型
- websocket:message:received 事件的 data 字段使用 unknown 类型
- notification:broadcast 事件的 data 字段使用 NotificationData 类型
- mcp:server:added 事件的 config 字段使用 MCPServerConfig 类型
- mcp:server:batch_added 事件的 results 字段使用 MCPServerAddResult[] 类型
- 添加本地接口定义 MCPServerAddResult 用于批量添加结果
- 更新测试文件以使用正确的 ClientInfo 类型

修复 #1770

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1770