### PR TITLE
fix: 修复 WebServer 中 eventBus 事件监听器内存泄漏

### DIFF
--- a/apps/backend/__tests__/webserver/webserver.integration.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.integration.test.ts
@@ -55,6 +55,7 @@ vi.mock("../../Logger", () => {
 vi.mock("@/services/index.js", () => {
   const mockEventBus = {
     onEvent: vi.fn().mockReturnThis(),
+    offEvent: vi.fn().mockReturnThis(),
     emit: vi.fn(),
     emitEvent: vi.fn(),
     removeAllListeners: vi.fn(),


### PR DESCRIPTION
在 WebServer 的 destroy() 方法中添加了对 eventBus 事件监听器的清理，
防止内存泄漏。

主要变更：
- 添加 eventListenerUnsubscribers 数组用于追踪所有事件监听器
- 修改 setupEndpointStatusListener() 方法以追踪监听器
- 修改 setupMCPServerAddedListener() 方法以追踪两个监听器
- 在 destroy() 方法中移除所有已追踪的事件监听器
- 更新测试 mock 以支持 offEvent 方法

修复了 #1772

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1772