### PR TITLE
refactor: 修复 DIContainer any 类型问题，实现类型安全的依赖注入

### DIFF
--- a/packages/cli/src/interfaces/Config.ts
+++ b/packages/cli/src/interfaces/Config.ts
@@ -2,16 +2,22 @@
  * 配置接口定义
  */
 
+import type { ServiceKey } from "../Container";
+
 /**
  * 依赖注入容器接口
  */
 export interface IDIContainer {
   /** 注册服务 */
-  register<T>(key: string, factory: () => T): void;
+  register<K extends ServiceKey>(
+    key: K,
+    factory: () => unknown,
+    singleton?: boolean
+  ): void;
   /** 获取服务实例 */
-  get<T>(key: string): T;
+  get<K extends ServiceKey>(key: K): unknown;
   /** 检查服务是否已注册 */
-  has(key: string): boolean;
+  has(key: ServiceKey): boolean;
 }
 
 /**


### PR DESCRIPTION
- 添加 ServiceTypes 接口定义所有服务的类型映射
- 使用泛型类型 K extends ServiceKey 替代 any 类型
- 更新 DIContainer 类方法使用类型约束
- 移除服务注册中的 any 类型断言
- 更新 IDIContainer 接口以匹配新的类型签名
- 所有类型检查和测试通过

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1774