### PR TITLE
fix: 替换 shared-types 中 CozeApi* 和 CacheItem 的 any 类型为 unknown

### DIFF
--- a/packages/shared-types/src/coze/api.ts
+++ b/packages/shared-types/src/coze/api.ts
@@ -13,7 +13,7 @@ export interface CozeApiDetail {
 /**
  * 扣子 API 基础响应接口
  */
-export interface CozeApiResponse<T = any> {
+export interface CozeApiResponse<T = unknown> {
   /** 响应状态码，0表示成功 */
   code: number;
   /** 响应数据 */
@@ -45,13 +45,13 @@ export interface CozeApiError extends Error {
   /** HTTP 状态码 */
   statusCode?: number;
   /** 原始响应数据 */
-  response?: any;
+  response?: unknown;
 }
 
 /**
  * 缓存项接口
  */
-export interface CacheItem<T = any> {
+export interface CacheItem<T = unknown> {
   /** 缓存数据 */
   data: T;
   /** 缓存时间戳 */


### PR DESCRIPTION
- CozeApiResponse<T = any> → CozeApiResponse<T = unknown>
- CozeApiError.response?: any → response?: unknown
- CacheItem<T = any> → CacheItem<T = unknown>

使用 unknown 作为更安全的类型替代 any，要求使用前进行类型检查。

Fixes #1777

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1777