### PR TITLE
fix: 为 spawnXiaozhiProcess 添加子进程错误和退出事件监听器

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -40,6 +40,20 @@ export class ServiceApiHandler {
       },
     });
 
+    // 监听子进程错误事件，确保启动失败时能够记录日志
+    child.on("error", (error) => {
+      this.logger.error(`启动 xiaozhi 进程失败: ${error.message}`, error);
+    });
+
+    // 监听子进程退出事件，检测非正常退出
+    child.on("exit", (code, signal) => {
+      if (code !== null && code !== 0) {
+        this.logger.warn(
+          `xiaozhi 进程异常退出 (退出码: ${code}, 信号: ${signal})`
+        );
+      }
+    });
+
     child.unref();
     this.logger.info(`MCP 服务命令已发送: xiaozhi ${args.join(" ")}`);
 


### PR DESCRIPTION
修复 Issue #1781 - 当 xiaozhi 命令不存在或无法执行时，错误将被静默忽略的问题。

在 apps/backend/handlers/service.handler.ts 的 spawnXiaozhiProcess 方法中添加：
- error 事件监听器：记录子进程启动失败错误
- exit 事件监听器：记录子进程非正常退出（退出码非 0）

同时更新相关测试用例以验证事件监听器正确设置。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1781