### PR TITLE
feat(ci): 限制定时任务仅在夜间时段执行

### DIFF
--- a/.github/workflows/auto-claude-comment.yml
+++ b/.github/workflows/auto-claude-comment.yml
@@ -23,10 +23,10 @@ jobs:
           # 检查是否在允许的时间范围内
           if [ "$HOUR" -ge 16 ] && [ "$HOUR" -lt 22 ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(($HOUR+8))%24:xx)，允许执行"
+            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(( ($HOUR + 8) % 24 )):xx)，允许执行"
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
-            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(($HOUR+8))%24:xx)，不在执行时间范围内"
+            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(( ($HOUR + 8) % 24 )):xx)，不在执行时间范围内"
           fi
 
       - name: 检出代码

--- a/.github/workflows/issue-hunter.yml
+++ b/.github/workflows/issue-hunter.yml
@@ -34,10 +34,10 @@ jobs:
           # 检查是否在允许的时间范围内
           if [ "$HOUR" -ge 16 ] && [ "$HOUR" -lt 22 ]; then
             echo "should_run=true" >> $GITHUB_OUTPUT
-            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(($HOUR+8))%24:xx)，允许执行"
+            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(( ($HOUR + 8) % 24 )):xx)，允许执行"
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
-            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(($HOUR+8))%24:xx)，不在执行时间范围内"
+            echo "当前时间 UTC ${HOUR}:xx (北京时间 $(( ($HOUR + 8) % 24 )):xx)，不在执行时间范围内"
           fi
 
       - name: 检出代码


### PR DESCRIPTION
## 变更说明

为 GitHub Actions workflow 添加时间限制，使定时任务仅在夜间时段执行，以降低 GitHub Actions 配额消耗。

## 修改内容

### 涉及文件
- `.github/workflows/issue-hunter.yml`
- `.github/workflows/auto-claude-comment.yml`

### 具体变更
- 新增"检查执行时间"步骤，仅在 `schedule` 事件时运行
- 为所有关键步骤添加条件判断：`if: github.event_name != 'schedule' || steps.check_time.outputs.should_run == 'true'`
- 时间范围：UTC 16:00-22:00（北京时间 00:00-06:00）

## 执行逻辑

| 触发方式 | 执行条件 |
|---------|---------|
| 手动触发 (`workflow_dispatch`) | ✅ 始终执行 |
| 定时任务 (`schedule`) | ✅ 仅在 UTC 16:00-22:00（北京时间 00:00-06:00）执行 |

## 测试计划

- [ ] 验证手动触发不受影响
- [ ] 验证定时任务在允许时段正常执行
- [ ] 验证定时任务在非允许时段被跳过

🤖 Generated with [Claude Code](https://claude.com/claude-code)