### PR TITLE
fix(endpoint): 移除 as any 类型断言，使用 ensureToolJSONSchema 函数

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -9,6 +9,7 @@ import { InternalMCPManagerAdapter } from "../internal-mcp-manager.js";
 // Mock 依赖
 vi.mock("@xiaozhi-client/mcp-core", () => ({
   MCPManager: vi.fn(),
+  ensureToolJSONSchema: vi.fn((schema: unknown) => schema),
 }));
 
 vi.mock("@xiaozhi-client/config", () => ({

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,11 +4,11 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
-import { MCPManager } from "@xiaozhi-client/mcp-core";
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { MCPManager, ensureToolJSONSchema } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -105,7 +105,7 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        inputSchema: ensureToolJSONSchema(mcpTool.inputSchema),
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,


### PR DESCRIPTION
- 在 internal-mcp-manager.ts 中导入 ensureToolJSONSchema 函数
- 将 inputSchema 的 as any 断言替换为类型安全的 ensureToolJSONSchema 调用
- 更新测试文件的 mock 以包含 ensureToolJSONSchema 函数

注意：console.info/error 的使用保持不变，因为 endpoint 是一个独立的库包，
使用 console 方法是库包的常见做法，便于使用者自行控制日志输出。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1793