### PR TITLE
fix: 升级 ajv 到 8.18.0 修复 CVE-2025-69873 安全漏洞

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -14,7 +14,7 @@
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
     "@xiaozhi-client/version": "workspace:*",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "chalk": "^5.6.0",
     "comment-json": "^4.2.5",
     "dayjs": "^1.11.13",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
     "@xiaozhi-client/version": "workspace:*",
-    "ajv": "^8.17.1",
+    "ajv": "^8.18.0",
     "chalk": "^5.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,8 +48,8 @@ importers:
         specifier: workspace:*
         version: link:packages/version
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       chalk:
         specifier: ^5.6.0
         version: 5.6.2
@@ -196,8 +196,8 @@ importers:
         specifier: workspace:*
         version: link:../../packages/version
       ajv:
-        specifier: ^8.17.1
-        version: 8.17.1
+        specifier: ^8.18.0
+        version: 8.18.0
       chalk:
         specifier: ^5.6.0
         version: 5.6.2
@@ -3761,8 +3761,8 @@ packages:
       ajv:
         optional: true
 
-  ajv@8.17.1:
-    resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
+  ajv@8.18.0:
+    resolution: {integrity: sha512-PlXPeEWMXMZ7sPYOHqmDyCJzcfNrUr3fGNKtezX14ykXOEIvyK81d+qydx89KY5O71FKMPaQ2vBfBFI5NHR63A==}
 
   ansi-colors@4.1.3:
     resolution: {integrity: sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==}
@@ -9020,8 +9020,8 @@ snapshots:
   '@modelcontextprotocol/sdk@1.26.0(zod@4.3.6)':
     dependencies:
       '@hono/node-server': 1.19.9(hono@4.11.7)
-      ajv: 8.17.1
-      ajv-formats: 3.0.1(ajv@8.17.1)
+      ajv: 8.18.0
+      ajv-formats: 3.0.1(ajv@8.18.0)
       content-type: 1.0.5
       cors: 2.8.6
       cross-spawn: 7.0.6
@@ -9231,7 +9231,7 @@ snapshots:
       '@nx/js': 22.5.1(@babel/traverse@7.29.0)(nx@22.5.1)
       '@nx/vitest': 22.5.1(@babel/traverse@7.29.0)(nx@22.5.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(happy-dom@20.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       '@phenomnomnominal/tsquery': 6.1.4(typescript@5.9.3)
-      ajv: 8.17.1
+      ajv: 8.18.0
       enquirer: 2.3.6
       picomatch: 4.0.2
       semver: 7.7.3
@@ -10617,11 +10617,11 @@ snapshots:
 
   agora-rte-extension@1.2.4: {}
 
-  ajv-formats@3.0.1(ajv@8.17.1):
+  ajv-formats@3.0.1(ajv@8.18.0):
     optionalDependencies:
-      ajv: 8.17.1
+      ajv: 8.18.0
 
-  ajv@8.17.1:
+  ajv@8.18.0:
     dependencies:
       fast-deep-equal: 3.1.3
       fast-uri: 3.1.0


### PR DESCRIPTION
将 ajv 从 8.17.1 升级到 8.18.0，修复 ReDoS (Regular Expression
Denial of Service) 安全漏洞。

该漏洞影响启用 `$data` 选项时的动态 schema 验证，攻击者可以通
过注入恶意正则表达式模式导致灾难性回溯，造成 DoS 攻击。

- 更新根 package.json 中的 ajv 版本
- 更新 apps/backend/package.json 中的 ajv 版本
- 更新 pnpm-lock.yaml

受影响的 CVE: CVE-2025-69873
修复版本: ajv >= 8.18.0

注: 项目代码未使用 `$data` 选项，不受此漏洞直接影响，但为防
范未来可能的使用，仍进行预防性升级。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1798