### PR TITLE
fix(cli): 将 FormatUtils 中的 any 类型替换为 unknown 提升类型安全性

### DIFF
--- a/packages/cli/src/utils/FormatUtils.ts
+++ b/packages/cli/src/utils/FormatUtils.ts
@@ -92,8 +92,8 @@ export class FormatUtils {
   /**
    * 格式化配置键值对
    */
-  static formatConfigPair(key: string, value: any): string {
-    if (typeof value === "object") {
+  static formatConfigPair(key: string, value: unknown): string {
+    if (typeof value === "object" && value !== null) {
       return `${key}: ${JSON.stringify(value, null, 2)}`;
     }
     return `${key}: ${value}`;
@@ -122,7 +122,7 @@ export class FormatUtils {
   /**
    * 格式化表格数据
    */
-  static formatTable(data: Record<string, any>[]): string {
+  static formatTable(data: Record<string, unknown>[]): string {
     if (data.length === 0) return "";
 
     const keys = Object.keys(data[0]);
@@ -177,7 +177,7 @@ export class FormatUtils {
   /**
    * 格式化 JSON
    */
-  static formatJson(obj: any, indent = 2): string {
+  static formatJson(obj: unknown, indent = 2): string {
     try {
       return JSON.stringify(obj, null, indent);
     } catch (error) {


### PR DESCRIPTION
修复 issue #1799

- 将 formatConfigPair 的 value 参数从 any 改为 unknown
- 将 formatTable 的 data 参数从 Record<string, any>[] 改为 Record<string, unknown>[]
- 将 formatJson 的 obj 参数从 any 改为 unknown
- 在 formatConfigPair 中添加 null 检查以确保类型安全

这些更改提高了类型安全性，调用这些方法时必须进行类型检查才能访问具体属性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1799