### PR TITLE
perf(frontend): 优化表单 condition 函数中的 form.watch 调用

### DIFF
--- a/apps/frontend/src/config/mcp-form-fields.ts
+++ b/apps/frontend/src/config/mcp-form-fields.ts
@@ -68,8 +68,10 @@ export const mcpFormFields = [
     inputType: "url",
     placeholder: "https://example.com/mcp",
     description: "MCP 服务的完整 URL 地址",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "http" || form.watch("type") === "sse",
+    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) => {
+      const type = form.watch("type");
+      return type === "http" || type === "sse";
+    },
   },
   {
     name: "headers",
@@ -79,7 +81,9 @@ export const mcpFormFields = [
       "Authorization: Bearer your-key\nContent-Type: application/json",
     description: "每行一个请求头，格式: Header-Name: value",
     className: "min-h-[100px] font-mono text-sm",
-    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) =>
-      form.watch("type") === "http" || form.watch("type") === "sse",
+    condition: (form: UseFormReturn<z.infer<typeof mcpFormSchema>>) => {
+      const type = form.watch("type");
+      return type === "http" || type === "sse";
+    },
   },
 ] as FieldConfig<typeof mcpFormSchema>[];


### PR DESCRIPTION
修复 #1804

- 在 url 和 headers 字段的 condition 函数中，将重复的 form.watch("type") 调用合并为单次调用
- 减少不必要的表单重新渲染，提升性能

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1804