### PR TITLE
fix: 修复 tool-call-logs-dialog.tsx 中的本地化问题

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -77,7 +77,7 @@ export function ToolCallLogsDialog() {
         }
       } catch (err) {
         setError("网络请求失败");
-        console.error("Failed to fetch tool call logs:", err);
+        console.error("获取工具调用日志失败:", err);
       } finally {
         if (isRefresh) {
           setRefreshing(false);


### PR DESCRIPTION
将 console.error 英文消息改为中文，以符合项目的本地化规范要求。

- 将 "Failed to fetch tool call logs:" 改为 "获取工具调用日志失败:"

Fixes #1807

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1807