### PR TITLE
fix(shared-types): 将类型守卫函数参数从 any 改为 unknown 提升类型安全性

### DIFF
--- a/packages/shared-types/src/mcp/tools.ts
+++ b/packages/shared-types/src/mcp/tools.ts
@@ -29,25 +29,32 @@ export interface TimeoutResponse {
 /**
  * 验证是否为工具调用结果
  */
-export function isToolCallResult(response: any): response is ToolCallResult {
+export function isToolCallResult(response: unknown): response is ToolCallResult {
+  if (!response || typeof response !== "object") {
+    return false;
+  }
+  const obj = response as Record<string, unknown>;
   return (
-    response &&
-    Array.isArray(response.content) &&
-    response.content.length > 0 &&
-    response.content[0].type === "text" &&
-    typeof response.content[0].text === "string"
+    Array.isArray(obj.content) &&
+    obj.content.length > 0 &&
+    typeof obj.content[0] === "object" &&
+    obj.content[0] !== null &&
+    (obj.content[0] as Record<string, unknown>).type === "text" &&
+    typeof (obj.content[0] as Record<string, unknown>).text === "string"
   );
 }
 
 /**
  * 验证是否为超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
+export function isTimeoutResponse(response: unknown): response is TimeoutResponse {
+  if (!response || typeof response !== "object") {
+    return false;
+  }
+  const obj = response as Record<string, unknown>;
   return (
-    response &&
-    typeof response === "object" &&
-    response.isTimeout === true &&
-    typeof response.timeoutMs === "number" &&
-    typeof response.message === "string"
+    obj.isTimeout === true &&
+    typeof obj.timeoutMs === "number" &&
+    typeof obj.message === "string"
   );
 }


### PR DESCRIPTION
- isToolCallResult 函数参数从 any 改为 unknown
- isTimeoutResponse 函数参数从 any 改为 unknown
- 添加更严格的类型检查和类型收窄逻辑
- 修复 #1809

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1809