### PR TITLE
fix: 为 getCurrentVersion() 添加错误处理，防止 JSON 解析失败导致应用崩溃

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -154,11 +154,18 @@ export class NPMManager {
    * 获取当前版本
    */
   async getCurrentVersion(): Promise<string> {
-    const { stdout } = await execAsync(
-      "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
-    );
-    const info = JSON.parse(stdout);
-    return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+    try {
+      const { stdout } = await execAsync(
+        "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
+      );
+      const info = JSON.parse(stdout) as {
+        dependencies?: Record<string, { version: string }>;
+      };
+      return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+    } catch (error) {
+      logger.error("获取当前版本失败", { error });
+      return "unknown";
+    }
   }
 
   /**


### PR DESCRIPTION
- 添加 try-catch 块包裹 execAsync 和 JSON.parse 调用
- 当 JSON 解析失败或 npm 命令执行失败时，返回 "unknown" 而非抛出未捕获异常
- 添加错误日志记录，便于问题排查

修复 issue #1821

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1821