### PR TITLE
fix(cli): 启用类型声明文件生成以保持构建一致性

### DIFF
--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
   outDir: "../../dist/cli",
   clean: true,
   sourcemap: true,
-  dts: false,
+  dts: {
+    entry: ["src/index.ts"],
+    compilerOptions: {
+      composite: false,
+    },
+  },
   minify: process.env.NODE_ENV === "production",
   splitting: false,
   bundle: true,


### PR DESCRIPTION
将 packages/cli/tsup.config.ts 中的 dts: false 修改为正确的 dts
配置，与其他包（如 @xiaozhi-client/mcp-core）保持一致。

修复后，CLI 包将生成 dist/cli/index.d.ts 类型声明文件，
提升开发体验和 IDE 类型提示支持。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1826