### PR TITLE
fix(shared-types): 将 ToolCallRecord 中的 any 类型替换为 unknown

### DIFF
--- a/packages/shared-types/src/utils/logger.ts
+++ b/packages/shared-types/src/utils/logger.ts
@@ -9,8 +9,8 @@ export interface ToolCallRecord {
   toolName: string; // 工具名称
   originalToolName?: string; // 原始工具名称（未格式化的）
   serverName?: string; // 服务器名称（coze、dify、n8n、custom等）
-  arguments?: any; // 调用参数
-  result?: any; // 响应结果
+  arguments?: unknown; // 调用参数
+  result?: unknown; // 响应结果
   success: boolean; // 是否成功
   duration?: number; // 调用耗时（毫秒）
   error?: string; // 错误信息（如果有）


### PR DESCRIPTION
- 修复 arguments 和 result 字段的类型安全性
- 使用 unknown 替代 any，保留灵活性同时提高类型安全
- 修复 #1828

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1828