### PR TITLE
fix(types): 移除 test-voice-session.service.ts 中的 any 类型

### DIFF
--- a/apps/backend/services/test-voice-session.service.ts
+++ b/apps/backend/services/test-voice-session.service.ts
@@ -11,6 +11,7 @@
 
 import { Readable } from "node:stream";
 import { logger } from "@/Logger.js";
+import type { ESP32Connection } from "@/lib/esp32/connection.js";
 import { synthesizeSpeechStream } from "@/lib/tts/binary.js";
 import { configManager } from "@xiaozhi-client/config";
 import * as prism from "prism-media";
@@ -51,7 +52,7 @@ export class TestVoiceSessionService implements IVoiceSessionService {
   private readonly isProcessingBuffer = new Map<string, boolean>();
 
   /** 每个设备的连接引用（用于缓冲区处理） */
-  private readonly deviceConnections = new Map<string, any>();
+  private readonly deviceConnections = new Map<string, ESP32Connection>();
 
   /**
    * 设置 ESP32 服务引用
@@ -161,7 +162,7 @@ export class TestVoiceSessionService implements IVoiceSessionService {
    * @param deviceId - 设备 ID
    * @returns ESP32 连接实例
    */
-  private getConnection(deviceId: string) {
+  private getConnection(deviceId: string): ESP32Connection | undefined {
     if (!this.esp32Service) {
       logger.warn("[TestVoiceSessionService] ESP32 服务未设置");
       return undefined;
@@ -180,7 +181,7 @@ export class TestVoiceSessionService implements IVoiceSessionService {
   private setupDemuxerEvents(
     deviceId: string,
     demuxer: prism.opus.OggDemuxer,
-    connection: any
+    connection: ESP32Connection
   ) {
     demuxer.on("data", (opusPacket: Buffer) => {
       // 只负责将包推入缓冲区，不做异步操作


### PR DESCRIPTION
将 deviceConnections、getConnection() 和 setupDemuxerEvents() 中的 any 类型替换为具体的 ESP32Connection 类型，提高类型安全性。

- 导入 ESP32Connection 类型
- 修改 deviceConnections 字段类型: Map<string, any> → Map<string, ESP32Connection>
- 添加 getConnection() 返回类型: ESP32Connection | undefined
- 修改 setupDemuxerEvents() 参数类型: connection: any → connection: ESP32Connection

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1831