### PR TITLE
perf: 优化 TypeFieldNormalizer.normalizeTypeField 性能

### DIFF
--- a/packages/mcp-core/src/utils/__tests__/type-normalizer.test.ts
+++ b/packages/mcp-core/src/utils/__tests__/type-normalizer.test.ts
@@ -145,7 +145,8 @@ describe("TypeFieldNormalizer.normalizeTypeField", () => {
       const config = { type: "http", url: "https://example.com" };
       const result = TypeFieldNormalizer.normalizeTypeField(config);
       expect(result).toEqual(config);
-      expect(result).not.toBe(config); // 应该是深拷贝
+      // 性能优化：如果 type 已经是标准格式，返回同一引用（无需深拷贝）
+      expect(result).toBe(config);
     });
 
     it("应该转换 streamable-http 为 http", () => {
@@ -188,7 +189,8 @@ describe("TypeFieldNormalizer.normalizeTypeField", () => {
       const config = { url: "https://example.com", name: "test" };
       const result = TypeFieldNormalizer.normalizeTypeField(config);
       expect(result).toEqual(config);
-      expect(result).not.toBe(config); // 应该是深拷贝
+      // 性能优化：如果没有 type 字段，返回同一引用（无需深拷贝）
+      expect(result).toBe(config);
     });
   });
 

--- a/packages/mcp-core/src/utils/type-normalizer.ts
+++ b/packages/mcp-core/src/utils/type-normalizer.ts
@@ -51,27 +51,28 @@ export namespace TypeFieldNormalizer {
       return config;
     }
 
-    // 创建配置的深拷贝以避免修改原始对象
-    const normalizedConfig = JSON.parse(JSON.stringify(config));
-
-    // 如果配置中没有 type 字段，直接返回
-    if (!("type" in normalizedConfig)) {
-      return normalizedConfig;
+    // 如果配置中没有 type 字段，直接返回原始对象
+    if (!("type" in config)) {
+      return config;
     }
 
-    const originalType = normalizedConfig.type;
+    const originalType = (config as { type?: string }).type;
 
-    // 如果已经是标准格式，直接返回
-    if (originalType === "stdio" || originalType === "sse" || originalType === "http") {
-      return normalizedConfig;
+    // 如果已经是标准格式，直接返回原始对象
+    if (
+      typeof originalType === "string" &&
+      (originalType === "stdio" || originalType === "sse" || originalType === "http")
+    ) {
+      return config;
     }
 
-    // 转换为标准格式
-    const normalizedType = normalizeTypeValue(originalType);
+    // 只有在需要修改 type 字段时才进行深拷贝
+    const normalizedConfig = JSON.parse(JSON.stringify(config)) as T;
+    const normalizedType = normalizeTypeValue(originalType as string);
 
     // 验证转换后的类型是否有效
     if (normalizedType === "stdio" || normalizedType === "sse" || normalizedType === "http") {
-      normalizedConfig.type = normalizedType;
+      normalizedConfig.type = normalizedType as T["type"];
     }
 
     return normalizedConfig;


### PR DESCRIPTION
仅在需要修改 type 字段时才进行深拷贝，避免不必要的性能开销。

主要变更：
- 提前检查 type 字段是否存在和是否已是标准格式
- 仅在 type 需要转换时才执行 JSON.parse(JSON.stringify())
- 对于标准格式或无 type 字段的配置，直接返回原始引用

性能影响：
- 批量添加服务器时显著减少深拷贝操作
- 单个服务器添加时的性能提升
- 更新服务器配置时的性能提升

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1833