### PR TITLE
fix(cli): 添加 @xiaozhi-client/version 依赖声明

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@xiaozhi-client/config": "workspace:*",
+    "@xiaozhi-client/version": "workspace:*",
     "chalk": "^5.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",


### PR DESCRIPTION
- 修复 CLI 包缺少 @xiaozhi-client/version 依赖声明的问题
- 确保 npm 发布时正确安装运行时依赖
- 在 Container.ts 中使用了 VersionUtils 但未在 package.json 中声明

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1844