### PR TITLE
refactor(cli): 移除 ProcessManager.gracefulKillProcess 中的重复进程停止逻辑

### DIFF
--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -153,33 +153,7 @@ export class ProcessManagerImpl implements IProcessManager {
    */
   async gracefulKillProcess(pid: number): Promise<void> {
     try {
-      // 尝试优雅停止
-      process.kill(pid, "SIGTERM");
-
-      // 等待进程停止
-      let attempts = 0;
-      const maxAttempts = 30; // 3秒超时
-
-      while (attempts < maxAttempts) {
-        await new Promise((resolve) => setTimeout(resolve, 100));
-
-        try {
-          process.kill(pid, 0);
-          attempts++;
-        } catch {
-          // 进程已停止
-          return;
-        }
-      }
-
-      // 如果还在运行，强制停止
-      try {
-        process.kill(pid, 0);
-        process.kill(pid, "SIGKILL");
-        await new Promise((resolve) => setTimeout(resolve, 500));
-      } catch {
-        // 进程已停止
-      }
+      await PlatformUtils.killProcess(pid, "SIGTERM");
     } catch (error) {
       throw new ProcessError(
         `无法停止进程: ${error instanceof Error ? error.message : String(error)}`,


### PR DESCRIPTION
- 将 ProcessManager.gracefulKillProcess 重构为委托给 PlatformUtils.killProcess
- 更新相关测试以验证委托行为而非内部实现
- 消除约 28 行重复代码，遵循 DRY 原则

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1845