### PR TITLE
perf(mcp-server-list): 优化 _handleToggleTool 方法避免不必要的临时数组创建

### DIFF
--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -249,9 +249,9 @@ export function McpServerList({
     // TODO: 用于未来工具切换功能
     try {
       // 首先找到对应的原始工具信息
-      const originalTool = [...enabledTools, ...disabledTools].find(
-        (tool) => tool.name === name
-      );
+      const originalTool =
+        enabledTools.find((tool) => tool.name === name) ||
+        disabledTools.find((tool) => tool.name === name);
 
       if (!originalTool) {
         toast.error("找不到对应的工具信息");


### PR DESCRIPTION
将数组展开操作改为顺序查找，避免创建临时数组，减少内存分配和垃圾回收压力。

- 将 [...enabledTools, ...disabledTools].find() 改为顺序查找
- 先在 enabledTools 中查找，未找到则在 disabledTools 中查找
- 提升工具切换时的性能

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1855