### PR TITLE
fix(endpoint): 修复 InternalMCPManagerAdapter 事件监听器内存泄漏

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      removeListener: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);


### PR DESCRIPTION
在 InternalMCPManagerAdapter 的 cleanup() 方法中添加事件监听器移除逻辑，
防止 mcpManager 持有对已销毁实例的引用导致的内存泄漏。

- 添加 connectedListener 和 errorListener 私有属性保存监听器引用
- 在构造函数中保存监听器引用而非使用匿名函数
- 在 cleanup() 中使用 removeListener() 移除事件监听器
- 更新测试 mock 添加 removeListener 方法

修复 #1858

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1858