### PR TITLE
fix(perf): 缓存平台检测结果避免每次键盘事件重新检测

### DIFF
--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -801,19 +801,24 @@ export function ToolDebugDialog({
     }
   }, []);
 
+  // 缓存平台检测结果，避免每次键盘事件都重新检测
+  const isMacPlatform = useMemo(() => {
+    return (
+      typeof window !== "undefined" &&
+      /Mac|iPhone|iPad|iPod/.test(navigator.platform)
+    );
+  }, []);
+
   // 检测操作系统并获取快捷键文本
   const getShortcutText = useCallback(() => {
-    if (typeof window === "undefined") return "⌘+Enter";
-    const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-    return isMac ? "⌘+Enter" : "Ctrl+Enter";
-  }, []);
+    return isMacPlatform ? "⌘+Enter" : "Ctrl+Enter";
+  }, [isMacPlatform]);
 
   // 处理键盘事件
   const handleKeyDown = useCallback(
     async (event: KeyboardEvent) => {
       // 检查是否是 Command+Enter (Mac) 或 Ctrl+Enter (Windows/Linux)
-      const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-      const isShortcutKey = isMac
+      const isShortcutKey = isMacPlatform
         ? event.metaKey && event.key === "Enter"
         : event.ctrlKey && event.key === "Enter";
 
@@ -842,6 +847,7 @@ export function ToolDebugDialog({
       validateJSON,
       handleCallTool,
       tool?.inputSchema?.properties,
+      isMacPlatform,
     ]
   );
 


### PR DESCRIPTION
修复 #1859

在 tool-debug-dialog.tsx 组件中，handleKeyDown 键盘事件处理函数
每次键盘事件都会重新检测平台类型，导致不必要的性能开销。

使用 useMemo 缓存平台检测结果：
- 添加 isMacPlatform 常量，在组件挂载时检测一次平台类型
- 更新 getShortcutText 使用缓存的 isMacPlatform
- 更新 handleKeyDown 使用缓存的 isMacPlatform

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1859