### PR TITLE
refactor(shared-types): 消除 ClientStatus 类型重复定义

### DIFF
--- a/packages/shared-types/src/frontend/index.ts
+++ b/packages/shared-types/src/frontend/index.ts
@@ -3,7 +3,10 @@
  */
 
 // UI状态相关类型
-export type { CozeWorkflowsResult, CozeUIState, ClientStatus } from "./ui";
+export type { CozeWorkflowsResult, CozeUIState } from "./ui";
+
+// 客户端状态类型（从 config/server 重新导出）
+export type { ClientStatus } from "../config/server";
 
 // API响应相关类型
 export type {

--- a/packages/shared-types/src/frontend/ui.ts
+++ b/packages/shared-types/src/frontend/ui.ts
@@ -29,13 +29,3 @@ export interface CozeUIState {
   /** 工作流列表错误信息 */
   workflowsError: string | null;
 }
-
-/**
- * 客户端状态
- */
-export interface ClientStatus {
-  status: "connected" | "disconnected";
-  mcpEndpoint: string;
-  activeMCPServers: string[];
-  lastHeartbeat?: number;
-}


### PR DESCRIPTION
将 ClientStatus 类型定义统一到 config/server.ts，
删除 frontend/ui.ts 中的重复定义。

这遵循 DRY 原则，确保类型定义只有一个权威来源，
降低维护成本并避免潜在的不一致问题。

修改文件：
- packages/shared-types/src/frontend/ui.ts: 删除 ClientStatus 定义
- packages/shared-types/src/frontend/index.ts: 从 config/server 重新导出

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1875