### PR TITLE
fix(endpoint): 将 console 方法替换为统一的 Logger 系统

### DIFF
--- a/packages/endpoint/src/endpoint.ts
+++ b/packages/endpoint/src/endpoint.ts
@@ -27,6 +27,7 @@ import {
 } from "./types.js";
 import { validateToolCallParams } from "./utils.js";
 import { sliceEndpoint } from "./utils.js";
+import { logger } from "./utils/logger.js";
 
 // 导出错误类型供外部使用
 export {
@@ -182,7 +183,7 @@ export class Endpoint {
         inputSchema: ensureToolJSONSchemaFn(toolInfo.inputSchema),
       }));
     } catch (error) {
-      console.error(
+      logger.error(
         `获取工具列表失败: ${error instanceof Error ? error.message : String(error)}`
       );
       return [];
@@ -212,7 +213,7 @@ export class Endpoint {
    */
   private async attemptConnection(): Promise<void> {
     this.connectionState = ConnectionState.CONNECTING;
-    console.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     return new Promise((resolve, reject) => {
       // 设置连接超时
@@ -234,7 +235,7 @@ export class Endpoint {
           const message: MCPMessage = JSON.parse(data.toString());
           this.handleMessage(message);
         } catch (error) {
-          console.error("MCP 消息解析错误:", error);
+          logger.error("MCP 消息解析错误:", error);
         }
       });
 
@@ -262,7 +263,7 @@ export class Endpoint {
     this.connectionStatus = true;
     this.connectionState = ConnectionState.CONNECTED;
 
-    console.debug("MCP WebSocket 连接已建立");
+    logger.debug("MCP WebSocket 连接已建立");
   }
 
   /**
@@ -278,7 +279,7 @@ export class Endpoint {
       this.connectionTimeout = null;
     }
 
-    console.error("MCP WebSocket 错误:", error.message);
+    logger.error("MCP WebSocket 错误:", error.message);
 
     // 清理当前连接
     this.cleanupConnection();
@@ -291,7 +292,7 @@ export class Endpoint {
     this.connectionStatus = false;
     this.serverInitialized = false;
     this.connectionState = ConnectionState.DISCONNECTED;
-    console.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
+    logger.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
   }
 
   /**
@@ -309,7 +310,7 @@ export class Endpoint {
           this.ws.terminate();
         }
       } catch (error) {
-        console.debug("WebSocket 关闭时出现错误（已忽略）:", error);
+        logger.debug("WebSocket 关闭时出现错误（已忽略）:", error);
       }
 
       this.ws = null;
@@ -333,10 +334,10 @@ export class Endpoint {
    * 处理 MCP 消息
    */
   private handleMessage(message: MCPMessage): void {
-    console.debug("收到 MCP 消息:", JSON.stringify(message, null, 2));
+    logger.debug("收到 MCP 消息:", JSON.stringify(message, null, 2));
 
     if (!message.method) {
-      console.debug("收到没有 method 字段的消息，忽略");
+      logger.debug("收到没有 method 字段的消息，忽略");
       return;
     }
 
@@ -355,30 +356,30 @@ export class Endpoint {
           },
         });
         this.serverInitialized = true;
-        console.debug("MCP 服务器初始化完成");
+        logger.debug("MCP 服务器初始化完成");
         break;
 
       case "tools/list": {
         const toolsList = this.getTools();
         this.sendResponse(message.id, { tools: toolsList });
-        console.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
+        logger.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
         break;
       }
 
       case "tools/call": {
         this.handleToolCall(message).catch((error) => {
-          console.error("处理工具调用时发生未捕获错误:", error);
+          logger.error("处理工具调用时发生未捕获错误:", error);
         });
         break;
       }
 
       case "ping":
         this.sendResponse(message.id, {});
-        console.debug("回应 MCP ping 消息");
+        logger.debug("回应 MCP ping 消息");
         break;
 
       default:
-        console.warn(`未知的 MCP 请求: ${message.method}`);
+        logger.warn(`未知的 MCP 请求: ${message.method}`);
     }
   }
 
@@ -386,7 +387,7 @@ export class Endpoint {
    * 发送响应消息
    */
   private sendResponse(id: number | string, result: unknown): void {
-    console.debug(
+    logger.debug(
       `尝试发送响应: id=${id}, isConnected=${this.connectionStatus}, wsReadyState=${this.ws?.readyState}`
     );
 
@@ -399,18 +400,18 @@ export class Endpoint {
 
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("响应已发送", {
+        logger.debug("响应已发送", {
           id,
           responseSize: JSON.stringify(response).length,
         });
       } catch (error) {
-        console.error("发送响应失败", {
+        logger.error("发送响应失败", {
           id,
           error,
         });
       }
     } else {
-      console.error("无法发送响应", {
+      logger.error("无法发送响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,
@@ -445,7 +446,7 @@ export class Endpoint {
    * 主动断开小智连接
    */
   public async disconnect(): Promise<void> {
-    console.info("主动断开小智连接");
+    logger.info("主动断开小智连接");
 
     // 清理 MCP 适配器
     await this.mcpAdapter.cleanup();
@@ -458,7 +459,7 @@ export class Endpoint {
    * 重连小智接入点
    */
   public async reconnect(): Promise<void> {
-    console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     // 先断开连接
     this.disconnect();
@@ -487,7 +488,7 @@ export class Endpoint {
     try {
       const params = validateToolCallParams(request.params);
 
-      console.info("开始处理工具调用", {
+      logger.info("开始处理工具调用", {
         requestId,
         toolName: params.name,
         hasArguments: !!params.arguments,
@@ -506,7 +507,7 @@ export class Endpoint {
         isError: result.isError || false,
       });
 
-      console.info("工具调用成功", {
+      logger.info("工具调用成功", {
         requestId,
         toolName: params.name,
         duration: `${Date.now() - startTime}ms`,
@@ -596,7 +597,7 @@ export class Endpoint {
 
     this.sendErrorResponse(requestId, errorResponse);
 
-    console.error("工具调用失败", {
+    logger.error("工具调用失败", {
       requestId,
       duration: `${duration}ms`,
       error: errorResponse,
@@ -618,10 +619,10 @@ export class Endpoint {
       };
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("已发送错误响应:", response);
+        logger.debug("已发送错误响应:", response);
       } catch (sendError) {
         // 发送错误响应失败，记录日志但不抛出异常
-        console.error("发送错误响应失败:", {
+        logger.error("发送错误响应失败:", {
           id,
           errorResponse: error,
           sendError: sendError instanceof Error
@@ -630,7 +631,7 @@ export class Endpoint {
         });
       }
     } else {
-      console.error("无法发送错误响应", {
+      logger.error("无法发送错误响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,

--- a/packages/endpoint/src/utils.ts
+++ b/packages/endpoint/src/utils.ts
@@ -10,6 +10,9 @@ import type {
   XiaozhiTokenPayload,
 } from "./types.js";
 
+// 导出 logger 工具
+export { logger, Logger, LogLevel } from "./utils/logger.js";
+
 /**
  * 截断端点 URL 用于日志显示
  *

--- a/packages/endpoint/src/utils/logger.ts
+++ b/packages/endpoint/src/utils/logger.ts
@@ -1,0 +1,80 @@
+/**
+ * Logger 工具模块
+ * 提供统一的日志输出接口，支持日志级别控制
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+/**
+ * Logger 类
+ */
+export class Logger {
+  private level: LogLevel;
+  private prefix: string;
+
+  /**
+   * 构造函数
+   * @param prefix - 日志前缀
+   * @param level - 日志级别，默认 INFO
+   */
+  constructor(prefix = "", level: LogLevel = LogLevel.INFO) {
+    this.prefix = prefix;
+    this.level = level;
+  }
+
+  /**
+   * 设置日志级别
+   */
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  /**
+   * 输出调试级别日志
+   */
+  debug(...args: unknown[]): void {
+    if (this.level <= LogLevel.DEBUG) {
+      console.debug(`[${this.prefix}]`, ...args);
+    }
+  }
+
+  /**
+   * 输出信息级别日志
+   */
+  info(...args: unknown[]): void {
+    if (this.level <= LogLevel.INFO) {
+      console.info(`[${this.prefix}]`, ...args);
+    }
+  }
+
+  /**
+   * 输出警告级别日志
+   */
+  warn(...args: unknown[]): void {
+    if (this.level <= LogLevel.WARN) {
+      console.warn(`[${this.prefix}]`, ...args);
+    }
+  }
+
+  /**
+   * 输出错误级别日志
+   */
+  error(...args: unknown[]): void {
+    if (this.level <= LogLevel.ERROR) {
+      console.error(`[${this.prefix}]`, ...args);
+    }
+  }
+}
+
+/**
+ * 默认 logger 实例
+ */
+export const logger = new Logger("Endpoint");


### PR DESCRIPTION
- 创建 packages/endpoint/src/utils/logger.ts 工具模块
- 替换 endpoint.ts 中 28 处 console 调用为 logger 调用
- 在 utils.ts 中导出 logger 相关类型和实例

修复 #1881

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1881