### PR TITLE
fix(cli): 修复 backend 类型声明路径错误并删除 any 类型使用

### DIFF
--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -47,10 +47,10 @@ packages/cli/
 
 ## 外部依赖
 
-CLI 包通过 external 配置引用 backend 模块：
+CLI 包通过 external 配置引用 backend 模块和 workspace 包：
 
 - `@/WebServer` → `dist/backend/WebServer.js` (通过 WebServerLauncher)
-- `@/lib/config/manager` → `dist/backend/lib/config/manager.js`
+- `@xiaozhi-client/config` → `dist/config/index.js` (配置管理)
 
 ## 导入方式
 
@@ -62,11 +62,14 @@ import { DIContainer } from "./Container";
 import { CommandRegistry } from "./commands/index";
 ```
 
-### 外部依赖（使用路径别名）
+### 外部依赖（使用 workspace 包）
 
 ```typescript
-// 引用 backend 模块
-import { configManager } from "@/lib/config/manager";
+// 引用配置管理（从 workspace 包导入）
+import { configManager } from "@xiaozhi-client/config";
+
+// 引用 WebServer（使用路径别名，运行时解析为 backend 模块）
+import { WebServer } from "@/WebServer";
 ```
 
 ## 开发命令

--- a/packages/cli/src/services/__tests__/ServiceManager.test.ts
+++ b/packages/cli/src/services/__tests__/ServiceManager.test.ts
@@ -74,28 +74,6 @@ vi.mock("../../utils/PathUtils.js", () => ({
   },
 }));
 
-// Mock ConfigManager for WebServer
-vi.mock("@/lib/config/manager.js", () => {
-  const mockConfig = {
-    mcpEndpoint: "ws://localhost:3000",
-    mcpServers: {},
-    webServer: { port: 9999 },
-  };
-  const mockConfigManager = {
-    configExists: vi.fn().mockReturnValue(true),
-    getConfig: vi.fn().mockReturnValue(mockConfig),
-    loadConfig: vi.fn().mockResolvedValue(mockConfig),
-    getToolCallLogConfig: vi.fn().mockReturnValue({ enabled: false }),
-    getMcpServers: vi.fn().mockReturnValue({}),
-    getMcpEndpoint: vi.fn().mockReturnValue("ws://localhost:3000"),
-    getConfigDir: vi.fn().mockReturnValue("/mock/config"),
-  };
-  return {
-    configManager: mockConfigManager,
-    ConfigManager: vi.fn().mockImplementation(() => mockConfigManager),
-  };
-});
-
 // Mock fs
 vi.mock("node:fs", () => {
   const mockExistsSync = vi.fn().mockReturnValue(true);

--- a/packages/cli/src/types/backend.d.ts
+++ b/packages/cli/src/types/backend.d.ts
@@ -1,26 +1,38 @@
 /**
  * Backend 模块类型声明
- * 使用 any 类型避免递归解析 backend 代码
+ *
+ * 这些声明用于 CLI 包中引用 Backend 模块的类型
+ * 避免递归解析 backend 代码，同时提供类型安全
  */
 
-declare module "@/lib/config/manager.js" {
-  export interface LocalMCPServerConfig {
-    command: string;
-    args: string[];
-    env?: Record<string, string>;
-  }
-
-  export interface MCPServerConfig {
-    type?: string;
-    url?: string;
-    command?: string;
-    args?: string[];
-    headers?: Record<string, string>;
-  }
-
-  export const configManager: any;
-}
-
+/**
+ * WebServer 类型声明
+ * 对应 apps/backend/WebServer.ts
+ */
 declare module "@/WebServer.js" {
-  export class WebServer {}
+	/**
+	 * WebServer - Web 服务器主控制器
+	 */
+	export class WebServer {
+		/**
+		 * 创建 WebServer 实例
+		 * @param port - 可选的端口号，不指定则使用配置文件中的端口
+		 */
+		constructor(port?: number);
+
+		/**
+		 * 启动 Web 服务器
+		 */
+		start(): Promise<void>;
+
+		/**
+		 * 停止 Web 服务器
+		 */
+		stop(): Promise<void>;
+
+		/**
+		 * 销毁 WebServer 实例，清理所有资源
+		 */
+		destroy(): void;
+	}
 }


### PR DESCRIPTION
- 删除不存在的 @/lib/config/manager.js 模块声明
- 删除重复的类型定义和 any 类型的 configManager 导出
- 改进 @/WebServer.js 的类型声明，添加详细的 JSDoc 注释
- 移除测试文件中对不存在模块的不必要 mock
- 更新 README.md 文档，使用 @xiaozhi-client/config 包的正确引用

Fixes #1885

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1885