### PR TITLE
fix(Logger): 添加 initLogFile 方法的错误处理

### DIFF
--- a/apps/backend/Logger.ts
+++ b/apps/backend/Logger.ts
@@ -337,8 +337,20 @@ export class Logger {
     this.rotateLogFileIfNeeded();
 
     // 确保日志文件存在
-    if (!fs.existsSync(this.logFilePath)) {
-      fs.writeFileSync(this.logFilePath, "");
+    try {
+      if (!fs.existsSync(this.logFilePath)) {
+        fs.writeFileSync(this.logFilePath, "");
+      }
+    } catch (error) {
+      // 如果创建日志文件失败，记录警告但继续执行
+      // 允许应用在没有文件日志的情况下启动
+      console.warn(
+        `[Logger] 无法创建日志文件 ${this.logFilePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      // 清除日志路径，禁用文件日志
+      this.logFilePath = null;
     }
 
     // 重新创建 pino 实例以包含文件流


### PR DESCRIPTION
在 fs.writeFileSync 调用周围添加 try-catch 块，防止日志文件创建失败时导致应用启动失败。

修复内容：
- 添加 try-catch 错误处理到 initLogFile 方法
- 文件创建失败时记录警告并禁用文件日志，而不是抛出未捕获异常
- 允许应用在没有文件日志的情况下继续启动

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1887