### PR TITLE
fix(routes): 统一 esp32.route.ts 使用 @/ 路径别名

### DIFF
--- a/apps/backend/routes/domains/esp32.route.ts
+++ b/apps/backend/routes/domains/esp32.route.ts
@@ -10,9 +10,9 @@
  * 注意：设备采用自动激活模式，无需管理API
  */
 
+import type { RouteDefinition } from "@/routes/types.js";
+import { type HandlerDependencies, createHandler } from "@/routes/types.js";
 import type { Context } from "hono";
-import type { RouteDefinition } from "../types.js";
-import { type HandlerDependencies, createHandler } from "../types.js";
 
 const h = createHandler("esp32Handler");
 


### PR DESCRIPTION
将 esp32.route.ts 中的相对路径导入改为使用 @/routes/types.js 别名，
与其他 route 文件（mcp.route.ts、tts.route.ts、tools.route.ts）保持一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1895