### PR TITLE
fix: 添加 asr:build 依赖到 backend type-check 目标

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -62,7 +62,7 @@
         "command": "pnpm check:type",
         "cwd": "apps/backend"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "asr:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
修复了 pnpm check:type 失败的问题，原因是 backend 的 type-check
目标依赖于 @xiaozhi-client/asr 包的类型声明，但 nx 配置中
缺少 asr:build 依赖。

在 apps/backend/project.json 的 type-check 目标中添加了
"asr:build" 到 dependsOn 数组，确保 asr 包在类型检查前
先构建完成。

修复前：dependsOn: ["config:build", "endpoint:build", "version:build"]
修复后：dependsOn: ["config:build", "endpoint:build", "version:build", "asr:build"]

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1908