### PR TITLE
fix(endpoint): 将 manager.ts 中的 console 方法替换为统一的 Logger 系统

### DIFF
--- a/packages/endpoint/src/index.ts
+++ b/packages/endpoint/src/index.ts
@@ -43,6 +43,7 @@
 export { Endpoint } from "./endpoint.js";
 export { EndpointManager } from "./manager.js";
 export { SharedMCPAdapter } from "./shared-mcp-adapter.js";
+export { createLogger, LogLevel } from "./logger.js";
 
 // =========================
 // 类型导出

--- a/packages/endpoint/src/logger.ts
+++ b/packages/endpoint/src/logger.ts
@@ -1,0 +1,77 @@
+/**
+ * Logger 工具
+ * 提供统一的日志接口
+ */
+
+/**
+ * 日志级别
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+/**
+ * Logger 类
+ */
+class Logger {
+  constructor(private readonly context: string) {}
+
+  /**
+   * 输出调试信息
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (LogLevel.DEBUG >= Logger.getGlobalLevel()) {
+      console.debug(`[${this.context}] ${message}`, ...args);
+    }
+  }
+
+  /**
+   * 输出一般信息
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (LogLevel.INFO >= Logger.getGlobalLevel()) {
+      console.info(`[${this.context}] ${message}`, ...args);
+    }
+  }
+
+  /**
+   * 输出警告信息
+   */
+  warn(message: string, ...args: unknown[]): void {
+    if (LogLevel.WARN >= Logger.getGlobalLevel()) {
+      console.warn(`[${this.context}] ${message}`, ...args);
+    }
+  }
+
+  /**
+   * 输出错误信息
+   */
+  error(message: string, ...args: unknown[]): void {
+    if (LogLevel.ERROR >= Logger.getGlobalLevel()) {
+      console.error(`[${this.context}] ${message}`, ...args);
+    }
+  }
+
+  private static globalLevel = LogLevel.DEBUG;
+
+  static setGlobalLevel(level: LogLevel): void {
+    Logger.globalLevel = level;
+  }
+
+  static getGlobalLevel(): LogLevel {
+    return Logger.globalLevel;
+  }
+}
+
+/**
+ * 创建 Logger 实例
+ *
+ * @param context - 上下文名称
+ * @returns Logger 实例
+ */
+export function createLogger(context: string): Logger {
+  return new Logger(context);
+}


### PR DESCRIPTION
- 创建 endpoint 包的 logger 工具 (src/logger.ts)
- 替换 manager.ts 中所有 25 处 console 调用为 logger 调用
- 导出 createLogger 和 LogLevel 供其他模块使用
- 修复 issue #1910

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1910