### PR TITLE
fix(deps): 统一 monorepo 中 ws 和 @types/ws 依赖版本

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,7 +29,7 @@
     "pino": "^10.3.1",
     "prism-media": "^1.3.5",
     "pino-pretty": "^13.1.1",
-    "ws": "^8.14.2",
+    "ws": "^8.16.0",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -46,7 +46,7 @@
   "devDependencies": {
     "@types/node": "^20.10.0",
     "@types/uuid": "^9.0.7",
-    "@types/ws": "^8.5.10",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/packages/endpoint/package.json
+++ b/packages/endpoint/package.json
@@ -31,7 +31,7 @@
     "start:shared": "tsx examples/shared-mcp-to-multi-endpoints.ts"
   },
   "dependencies": {
-    "ws": "^8.14.2",
+    "ws": "^8.16.0",
     "@xiaozhi-client/mcp-core": "workspace:*",
     "@xiaozhi-client/config": "workspace:*"
   },
@@ -40,7 +40,7 @@
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "@types/ws": "^8.5.0",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.3.5",
     "tsx": "^4.19.2",
     "typescript": "^5.9.2",

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -27,14 +27,14 @@
   },
   "dependencies": {
     "eventsource": "^4.0.0",
-    "ws": "^8.14.2"
+    "ws": "^8.16.0"
   },
   "peerDependencies": {
     "@modelcontextprotocol/sdk": "^1.26.0"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",
-    "@types/ws": "^8.5.0",
+    "@types/ws": "^8.18.1",
     "tsup": "^8.3.5",
     "typescript": "^5.9.2",
     "vitest": "^3.2.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -247,7 +247,7 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.9.0)
       ws:
-        specifier: ^8.14.2
+        specifier: ^8.16.0
         version: 8.19.0
       zod:
         specifier: ^4.3.6
@@ -544,7 +544,7 @@ importers:
         specifier: ^9.0.7
         version: 9.0.8
       '@types/ws':
-        specifier: ^8.5.10
+        specifier: ^8.18.1
         version: 8.18.1
       tsup:
         specifier: ^8.3.5
@@ -624,14 +624,14 @@ importers:
         specifier: workspace:*
         version: link:../mcp-core
       ws:
-        specifier: ^8.14.2
+        specifier: ^8.16.0
         version: 8.19.0
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.9
       '@types/ws':
-        specifier: ^8.5.0
+        specifier: ^8.18.1
         version: 8.18.1
       tsup:
         specifier: ^8.3.5
@@ -655,14 +655,14 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       ws:
-        specifier: ^8.14.2
+        specifier: ^8.16.0
         version: 8.19.0
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
         version: 24.10.9
       '@types/ws':
-        specifier: ^8.5.0
+        specifier: ^8.18.1
         version: 8.18.1
       tsup:
         specifier: ^8.3.5


### PR DESCRIPTION
将所有包中的 ws 依赖统一到 ^8.16.0，@types/ws 统一到 ^8.18.1，
避免因版本不一致导致的类型冲突和磁盘空间浪费。

变更内容：
- apps/backend: ws ^8.14.2 → ^8.16.0
- packages/endpoint: ws ^8.14.2 → ^8.16.0, @types/ws ^8.5.0 → ^8.18.1
- packages/mcp-core: ws ^8.14.2 → ^8.16.0, @types/ws ^8.5.0 → ^8.18.1
- packages/asr: @types/ws ^8.5.10 → ^8.18.1

Fixes #1912

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1912