### PR TITLE
refactor(mcp): 将 manager.ts 拆分为多个单一职责模块

### DIFF
--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -37,3 +37,7 @@ export * from "./message.js";
 export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+export * from "./service-registry.js";
+export * from "./retry-handler.js";
+export * from "./tool-stats.js";
+export * from "./status-reporter.js";

--- a/apps/backend/lib/mcp/retry-handler.ts
+++ b/apps/backend/lib/mcp/retry-handler.ts
@@ -1,0 +1,214 @@
+/**
+ * MCP 服务重试处理器
+ * 负责管理失败服务的重试逻辑
+ */
+
+import { logger } from "@/Logger.js";
+
+/**
+ * 重试回调函数类型
+ * @param serviceName 服务名称
+ * @returns 重试结果
+ */
+export type RetryCallback = (serviceName: string) => Promise<void>;
+
+/**
+ * 重试统计信息接口
+ */
+export interface RetryStats {
+  /** 失败的服务列表 */
+  failedServices: string[];
+  /** 活跃的重试列表 */
+  activeRetries: string[];
+  /** 失败服务总数 */
+  totalFailed: number;
+  /** 活跃重试总数 */
+  totalActiveRetries: number;
+}
+
+/**
+ * 服务重试处理器类
+ * 管理服务连接失败后的重试逻辑
+ */
+export class RetryHandler {
+  private retryTimers: Map<string, NodeJS.Timeout> = new Map();
+  private failedServices: Set<string> = new Set();
+  private retryCallback?: RetryCallback;
+
+  /**
+   * 设置重试回调函数
+   * @param callback 重试回调函数
+   */
+  setRetryCallback(callback: RetryCallback): void {
+    this.retryCallback = callback;
+  }
+
+  /**
+   * 安排失败服务的重试
+   * @param failedServices 失败的服务列表
+   * @param initialDelay 初始延迟时间（毫秒），默认 30000（30秒）
+   */
+  scheduleFailedServicesRetry(
+    failedServices: string[],
+    initialDelay = 30000
+  ): void {
+    if (failedServices.length === 0) return;
+
+    // 记录重试安排
+    logger.info(`[RetryHandler] 安排 ${failedServices.length} 个失败服务的重试`);
+
+    for (const serviceName of failedServices) {
+      this.failedServices.add(serviceName);
+      this.scheduleServiceRetry(serviceName, initialDelay);
+    }
+  }
+
+  /**
+   * 安排单个服务的重试
+   * @param serviceName 服务名称
+   * @param delay 延迟时间（毫秒）
+   */
+  private scheduleServiceRetry(serviceName: string, delay: number): void {
+    // 清除现有定时器
+    const existingTimer = this.retryTimers.get(serviceName);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.retryTimers.delete(serviceName);
+    }
+
+    logger.debug(`[RetryHandler] 安排服务 ${serviceName} 在 ${delay}ms 后重试`);
+
+    const timer = setTimeout(async () => {
+      this.retryTimers.delete(serviceName);
+      await this.executeRetry(serviceName);
+    }, delay);
+
+    this.retryTimers.set(serviceName, timer);
+  }
+
+  /**
+   * 执行重试
+   * @param serviceName 服务名称
+   */
+  private async executeRetry(serviceName: string): Promise<void> {
+    if (!this.failedServices.has(serviceName)) {
+      return; // 服务已经成功启动或不再需要重试
+    }
+
+    if (!this.retryCallback) {
+      logger.warn(`[RetryHandler] 没有设置重试回调，跳过 ${serviceName} 的重试`);
+      return;
+    }
+
+    try {
+      await this.retryCallback(serviceName);
+
+      // 重试成功
+      this.failedServices.delete(serviceName);
+      logger.info(`[RetryHandler] 服务 ${serviceName} 重试启动成功`);
+    } catch (error) {
+      logger.error(`[RetryHandler] 服务 ${serviceName} 重试启动失败`, {
+        error: (error as Error).message,
+      });
+
+      // 指数退避重试策略：延迟时间翻倍，最大不超过5分钟
+      const currentDelay = this.getRetryDelay(serviceName);
+      const nextDelay = Math.min(currentDelay * 2, 300000); // 最大5分钟
+
+      logger.debug(
+        `[RetryHandler] 服务 ${serviceName} 下次重试将在 ${nextDelay}ms 后进行`
+      );
+
+      this.scheduleServiceRetry(serviceName, nextDelay);
+    }
+  }
+
+  /**
+   * 获取当前重试延迟时间
+   * @param serviceName 服务名称
+   * @returns 当前延迟时间
+   */
+  private getRetryDelay(serviceName: string): number {
+    // 这里可以实现更复杂的状态跟踪来计算准确的延迟
+    // 简化实现：返回一个基于服务名称的哈希值的初始延迟
+    const hash = serviceName
+      .split("")
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    return 30000 + (hash % 60000); // 30-90秒之间的初始延迟
+  }
+
+  /**
+   * 标记服务重试成功
+   * @param serviceName 服务名称
+   */
+  markSuccess(serviceName: string): void {
+    this.failedServices.delete(serviceName);
+    this.stopRetry(serviceName);
+  }
+
+  /**
+   * 停止指定服务的重试
+   * @param serviceName 服务名称
+   */
+  stopRetry(serviceName: string): void {
+    const timer = this.retryTimers.get(serviceName);
+    if (timer) {
+      clearTimeout(timer);
+      this.retryTimers.delete(serviceName);
+      logger.debug(`[RetryHandler] 已停止服务 ${serviceName} 的重试`);
+    }
+    this.failedServices.delete(serviceName);
+  }
+
+  /**
+   * 停止所有服务的重试
+   */
+  stopAllRetries(): void {
+    logger.info("[RetryHandler] 停止所有服务重试");
+
+    for (const [serviceName, timer] of this.retryTimers) {
+      clearTimeout(timer);
+      logger.debug(`[RetryHandler] 已停止服务 ${serviceName} 的重试`);
+    }
+
+    this.retryTimers.clear();
+    this.failedServices.clear();
+  }
+
+  /**
+   * 检查服务是否失败
+   * @param serviceName 服务名称
+   * @returns 如果服务失败返回true
+   */
+  isFailed(serviceName: string): boolean {
+    return this.failedServices.has(serviceName);
+  }
+
+  /**
+   * 获取失败服务列表
+   * @returns 失败的服务名称数组
+   */
+  getFailedServices(): string[] {
+    return Array.from(this.failedServices);
+  }
+
+  /**
+   * 获取重试统计信息
+   * @returns 重试统计信息
+   */
+  getStats(): RetryStats {
+    return {
+      failedServices: Array.from(this.failedServices),
+      activeRetries: Array.from(this.retryTimers.keys()),
+      totalFailed: this.failedServices.size,
+      totalActiveRetries: this.retryTimers.size,
+    };
+  }
+
+  /**
+   * 清空所有状态
+   */
+  clear(): void {
+    this.stopAllRetries();
+  }
+}

--- a/apps/backend/lib/mcp/service-registry.ts
+++ b/apps/backend/lib/mcp/service-registry.ts
@@ -1,0 +1,175 @@
+/**
+ * MCP 服务注册表
+ * 负责 MCP 服务实例的存储、查找和管理
+ */
+
+import { logger } from "@/Logger.js";
+import { MCPService } from "@/lib/mcp";
+import type {
+  InternalMCPServiceConfig,
+  MCPServiceConfig,
+} from "@/lib/mcp/types";
+
+/**
+ * 服务注册表类
+ * 管理多个 MCP 服务实例和配置
+ */
+export class ServiceRegistry {
+  private services: Map<string, MCPService> = new Map();
+  private configs: Record<string, MCPServiceConfig> = {};
+
+  /**
+   * 添加服务配置
+   * @param serviceName 服务名称
+   * @param config 服务配置
+   */
+  addConfig(serviceName: string, config: MCPServiceConfig): void {
+    this.configs[serviceName] = config;
+    logger.debug(`[ServiceRegistry] 已添加服务配置: ${serviceName}`);
+  }
+
+  /**
+   * 更新服务配置
+   * @param serviceName 服务名称
+   * @param config 服务配置
+   */
+  updateConfig(serviceName: string, config: MCPServiceConfig): void {
+    this.configs[serviceName] = config;
+    logger.debug(`[ServiceRegistry] 已更新服务配置: ${serviceName}`);
+  }
+
+  /**
+   * 移除服务配置
+   * @param serviceName 服务名称
+   */
+  removeConfig(serviceName: string): void {
+    delete this.configs[serviceName];
+    logger.debug(`[ServiceRegistry] 已移除服务配置: ${serviceName}`);
+  }
+
+  /**
+   * 获取服务配置
+   * @param serviceName 服务名称
+   * @returns 服务配置或 undefined
+   */
+  getConfig(serviceName: string): MCPServiceConfig | undefined {
+    return this.configs[serviceName];
+  }
+
+  /**
+   * 获取所有服务配置
+   * @returns 所有服务配置
+   */
+  getAllConfigs(): Record<string, MCPServiceConfig> {
+    return { ...this.configs };
+  }
+
+  /**
+   * 检查服务配置是否存在
+   * @param serviceName 服务名称
+   * @returns 是否存在
+   */
+  hasConfig(serviceName: string): boolean {
+    return serviceName in this.configs;
+  }
+
+  /**
+   * 获取配置数量
+   * @returns 配置数量
+   */
+  getConfigCount(): number {
+    return Object.keys(this.configs).length;
+  }
+
+  /**
+   * 注册服务实例
+   * @param serviceName 服务名称
+   * @param service 服务实例
+   */
+  register(serviceName: string, service: MCPService): void {
+    this.services.set(serviceName, service);
+    logger.debug(`[ServiceRegistry] 已注册服务实例: ${serviceName}`);
+  }
+
+  /**
+   * 获取服务实例
+   * @param serviceName 服务名称
+   * @returns 服务实例或 undefined
+   */
+  get(serviceName: string): MCPService | undefined {
+    return this.services.get(serviceName);
+  }
+
+  /**
+   * 移除服务实例
+   * @param serviceName 服务名称
+   */
+  unregister(serviceName: string): void {
+    this.services.delete(serviceName);
+    logger.debug(`[ServiceRegistry] 已移除服务实例: ${serviceName}`);
+  }
+
+  /**
+   * 检查服务实例是否存在
+   * @param serviceName 服务名称
+   * @returns 是否存在
+   */
+  has(serviceName: string): boolean {
+    return this.services.has(serviceName);
+  }
+
+  /**
+   * 获取所有服务实例
+   * @returns 所有服务实例的副本
+   */
+  getAllServices(): Map<string, MCPService> {
+    return new Map(this.services);
+  }
+
+  /**
+   * 获取所有已连接的服务名称
+   * @returns 已连接的服务名称数组
+   */
+  getConnectedServices(): string[] {
+    const connectedServices: string[] = [];
+    for (const [serviceName, service] of this.services) {
+      if (service.isConnected()) {
+        connectedServices.push(serviceName);
+      }
+    }
+    return connectedServices;
+  }
+
+  /**
+   * 获取服务实例数量
+   * @returns 服务实例数量
+   */
+  size(): number {
+    return this.services.size;
+  }
+
+  /**
+   * 清空所有服务实例和配置
+   */
+  clear(): void {
+    this.services.clear();
+    this.configs = {};
+    logger.debug("[ServiceRegistry] 已清空所有服务实例和配置");
+  }
+
+  /**
+   * 获取所有配置的服务名称
+   * @returns 服务名称数组
+   */
+  getConfigNames(): string[] {
+    return Object.keys(this.configs);
+  }
+
+  /**
+   * 获取所有注册的服务名称
+   * @returns 服务名称数组
+   */
+  getServiceNames(): string[] {
+    return Array.from(this.services.keys());
+  }
+}

--- a/apps/backend/lib/mcp/status-reporter.ts
+++ b/apps/backend/lib/mcp/status-reporter.ts
@@ -1,0 +1,218 @@
+/**
+ * MCP 状态报告器
+ * 负责 MCP 服务状态的聚合和报告
+ */
+
+import { logger } from "@/Logger.js";
+import { MCPService } from "@/lib/mcp";
+import type { CustomMCPHandler } from "@/lib/mcp";
+import {
+  ConnectionState,
+  type ManagerStatus,
+  type MCPServiceConnectionStatus,
+  type ToolInfo,
+  type UnifiedServerConfig,
+  type UnifiedServerStatus,
+} from "@/lib/mcp/types";
+import type { RetryStats } from "./retry-handler";
+
+/**
+ * 统计更新监控信息接口
+ */
+export interface StatsUpdateInfo {
+  /** 活跃的锁列表 */
+  activeLocks: string[];
+  /** 锁总数 */
+  totalLocks: number;
+}
+
+/**
+ * 连接信息接口
+ */
+export interface ConnectionInfo {
+  /** 连接 ID */
+  id: string;
+  /** 连接名称 */
+  name: string;
+  /** 连接状态 */
+  state: ConnectionState;
+}
+
+/**
+ * 状态报告器依赖接口
+ */
+export interface StatusReporterDependencies {
+  /** 获取所有服务实例 */
+  getAllServices: () => Map<string, MCPService>;
+  /** 获取工具缓存 */
+  getToolsCache: () => Map<string, ToolInfo>;
+  /** 获取 CustomMCP 处理器 */
+  getCustomMCPHandler: () => CustomMCPHandler;
+  /** 获取重试统计 */
+  getRetryStats: () => RetryStats;
+  /** 获取统计更新监控信息 */
+  getStatsUpdateInfo: () => StatsUpdateInfo;
+}
+
+/**
+ * MCP 状态报告器类
+ * 负责聚合和报告 MCP 服务的各种状态信息
+ */
+export class StatusReporter {
+  private dependencies: StatusReporterDependencies;
+
+  constructor(deps: StatusReporterDependencies) {
+    this.dependencies = deps;
+  }
+
+  /**
+   * 获取管理器状态
+   * @returns 管理器状态
+   */
+  getServiceManagerStatus(): ManagerStatus {
+    // 计算总工具数量（包括 customMCP 工具，添加异常处理）
+    let customMCPToolCount = 0;
+    let customToolNames: string[] = [];
+
+    try {
+      customMCPToolCount =
+        this.dependencies.getCustomMCPHandler().getToolCount();
+      customToolNames =
+        this.dependencies.getCustomMCPHandler().getToolNames();
+      logger.debug(
+        `[StatusReporter] 成功获取 customMCP 状态: ${customMCPToolCount} 个工具`
+      );
+    } catch (error) {
+      logger.warn(
+        "[StatusReporter] 获取 CustomMCP 状态失败，将只包含标准 MCP 工具",
+        { error }
+      );
+      // 异常情况下，customMCP 工具数量为0，不影响标准 MCP 工具
+      customMCPToolCount = 0;
+      customToolNames = [];
+    }
+
+    const totalTools =
+      this.dependencies.getToolsCache().size + customMCPToolCount;
+
+    // 获取所有可用工具名称
+    const standardToolNames = Array.from(
+      this.dependencies.getToolsCache().keys()
+    );
+    const availableTools = [...standardToolNames, ...customToolNames];
+
+    const status: ManagerStatus = {
+      services: {},
+      totalTools,
+      availableTools,
+    };
+
+    // 添加标准 MCP 服务状态
+    for (const [serviceName, service] of this.dependencies.getAllServices()) {
+      const serviceStatus = service.getStatus();
+      status.services[serviceName] = {
+        connected: serviceStatus.connected,
+        clientName: `xiaozhi-${serviceName}-client`,
+      };
+    }
+
+    // 添加 CustomMCP 服务状态
+    if (customMCPToolCount > 0) {
+      status.services.customMCP = {
+        connected: true, // CustomMCP 工具总是可用的
+        clientName: "xiaozhi-customMCP-handler",
+      };
+    }
+
+    return status;
+  }
+
+  /**
+   * 获取统一服务器状态
+   * @param isRunning 服务器是否正在运行
+   * @param config 服务器配置
+   * @returns 统一服务器状态
+   */
+  getUnifiedStatus(
+    isRunning: boolean,
+    config: UnifiedServerConfig
+  ): UnifiedServerStatus {
+    const serviceStatus = this.getServiceManagerStatus();
+    return {
+      isRunning,
+      serviceStatus,
+      activeConnections: this.getActiveConnectionCount(),
+      config,
+      // 便捷访问属性
+      services: serviceStatus.services,
+      totalTools: serviceStatus.totalTools,
+      availableTools: serviceStatus.availableTools,
+    };
+  }
+
+  /**
+   * 获取统计更新监控信息
+   * @returns 统计更新监控信息
+   */
+  getStatsUpdateInfo(): StatsUpdateInfo {
+    return this.dependencies.getStatsUpdateInfo();
+  }
+
+  /**
+   * 获取所有连接信息
+   * @returns 连接信息列表
+   */
+  getAllConnections(): ConnectionInfo[] {
+    const connections: ConnectionInfo[] = [];
+
+    // 收集服务连接
+    for (const [serviceName, service] of this.dependencies.getAllServices()) {
+      if (service.isConnected()) {
+        connections.push({
+          id: `service-${serviceName}`,
+          name: serviceName,
+          state: ConnectionState.CONNECTED,
+        });
+      }
+    }
+
+    return connections;
+  }
+
+  /**
+   * 获取活跃连接数
+   * @returns 活跃连接数量
+   */
+  getActiveConnectionCount(): number {
+    return this.getAllConnections().filter(
+      (conn) => conn.state === ConnectionState.CONNECTED
+    ).length;
+  }
+
+  /**
+   * 获取失败服务列表
+   * @returns 失败的服务名称数组
+   */
+  getFailedServices(): string[] {
+    return this.dependencies.getRetryStats().failedServices;
+  }
+
+  /**
+   * 检查服务是否失败
+   * @param serviceName 服务名称
+   * @returns 如果服务失败返回true
+   */
+  isServiceFailed(serviceName: string): boolean {
+    return this.dependencies
+      .getRetryStats()
+      .failedServices.includes(serviceName);
+  }
+
+  /**
+   * 获取重试统计信息
+   * @returns 重试统计信息
+   */
+  getRetryStats(): RetryStats {
+    return this.dependencies.getRetryStats();
+  }
+}

--- a/apps/backend/lib/mcp/tool-stats.ts
+++ b/apps/backend/lib/mcp/tool-stats.ts
@@ -1,0 +1,223 @@
+/**
+ * MCP 工具统计管理器
+ * 负责工具使用统计信息的更新和跟踪
+ */
+
+import { logger } from "@/Logger.js";
+import { configManager } from "@xiaozhi-client/config";
+
+/**
+ * 工具统计信息接口
+ */
+export interface ToolStatsInfo {
+  /** 工具名称 */
+  toolName: string;
+  /** 服务名称 */
+  serviceName: string;
+  /** 原始工具名称 */
+  originalToolName: string;
+  /** 是否调用成功 */
+  isSuccess: boolean;
+  /** 当前时间 */
+  currentTime: string;
+}
+
+/**
+ * 工具统计管理器类
+ * 处理工具调用后的统计信息更新
+ */
+export class ToolStatsManager {
+  /**
+   * 更新工具调用统计信息
+   * @param info 工具统计信息
+   */
+  async updateStats(info: ToolStatsInfo): Promise<void> {
+    const {
+      toolName,
+      serviceName,
+      originalToolName,
+      isSuccess,
+      currentTime,
+    } = info;
+
+    try {
+      if (isSuccess) {
+        // 成功调用：更新使用统计
+        await this.updateCustomMCPToolStats(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolStats(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug(`[ToolStatsManager] 已更新工具 ${toolName} 的统计信息`);
+      } else {
+        // 失败调用：只更新最后使用时间
+        await this.updateCustomMCPToolLastUsedTime(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolLastUsedTime(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug("[ToolStatsManager] 已更新工具的失败调用统计信息", {
+          toolName,
+        });
+      }
+    } catch (error) {
+      logger.error("[ToolStatsManager] 更新工具统计信息失败", {
+        toolName,
+        error,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 安全更新工具统计（带错误处理）
+   * @param info 工具统计信息
+   */
+  async updateStatsSafe(info: ToolStatsInfo): Promise<void> {
+    try {
+      await this.updateStats(info);
+    } catch (error) {
+      const action = info.isSuccess ? "统计信息" : "失败统计信息";
+      logger.warn("[ToolStatsManager] 更新工具统计信息失败", {
+        toolName: info.toolName,
+        action,
+        error,
+      });
+      // 统计更新失败不应该影响主流程，所以这里只记录警告
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具统计信息
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateCustomMCPToolStats(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, true);
+      logger.debug(
+        `[ToolStatsManager] 已更新 customMCP 工具 ${toolName} 使用统计`
+      );
+    } catch (error) {
+      logger.error(
+        `[ToolStatsManager] 更新 customMCP 工具 ${toolName} 统计失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具最后使用时间
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateCustomMCPToolLastUsedTime(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, false); // 只更新时间，不增加计数
+      logger.debug(
+        `[ToolStatsManager] 已更新 customMCP 工具 ${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[ToolStatsManager] 更新 customMCP 工具 ${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具统计信息
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateMCPServerToolStats(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        true
+      );
+      logger.debug(
+        `[ToolStatsManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 统计`
+      );
+    } catch (error) {
+      logger.error(
+        `[ToolStatsManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 统计失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具最后使用时间
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateMCPServerToolLastUsedTime(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        false
+      ); // 只更新时间，不增加计数
+      logger.debug(
+        `[ToolStatsManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[ToolStatsManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 清理所有统计更新锁
+   */
+  clearAllLocks(): void {
+    try {
+      configManager.clearAllStatsUpdateLocks();
+      logger.info("[ToolStatsManager] 统计更新锁已清理");
+    } catch (error) {
+      logger.error("[ToolStatsManager] 清理统计更新锁失败", { error });
+    }
+  }
+}


### PR DESCRIPTION
将 1835 行的 manager.ts 拆分为 5 个模块，每个模块承担单一职责：

- service-registry.ts (175行): 服务注册表，管理服务实例和配置
- retry-handler.ts (214行): 重试处理，管理失败服务重试逻辑
- tool-stats.ts (223行): 工具统计，管理工具使用统计
- status-reporter.ts (218行): 状态报告，聚合状态信息
- manager.ts (1543行): 核心协调器，委托给子模块

重构原则：
- 采用组合模式，manager 通过组合子模块实现功能
- 保持所有现有 API 不变，内部委托给新模块
- 遵循单一职责原则，每个模块职责明确
- 避免过度设计，只拆分真正独立的职责

Fixes #1915

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1915