### PR TITLE
docs: add JSDoc comments to protocol types (Issue #1918)

### DIFF
--- a/packages/asr/src/protocol/types.ts
+++ b/packages/asr/src/protocol/types.ts
@@ -1,64 +1,121 @@
 /**
  * Protocol type definitions
+ *
+ * Defines core types for the ASR protocol binary format,
+ * including message types, serialization methods, compression types, and interfaces.
+ *
+ * @module types
  */
 
-// Message Type
+/**
+ * Message type enum
+ * Defines different types of messages in the ASR protocol
+ */
 export enum MessageType {
+  /** Client full request (contains audio and control info) */
   CLIENT_FULL_REQUEST = 0b0001,
+  /** Client audio-only request */
   CLIENT_AUDIO_ONLY_REQUEST = 0b0010,
+  /** Server full response */
   SERVER_FULL_RESPONSE = 0b1001,
+  /** Server acknowledgment message */
   SERVER_ACK = 0b1011,
+  /** Server error response */
   SERVER_ERROR_RESPONSE = 0b1111,
 }
 
-// Message Type Specific Flags
+/**
+ * Message type-specific flags enum
+ * Controls serialization behavior for messages
+ */
 export enum MessageTypeSpecificFlags {
+  /** No sequence number */
   NO_SEQUENCE = 0b0000,
+  /** Positive sequence number */
   POS_SEQUENCE = 0b0001,
+  /** Negative sequence number */
   NEG_SEQUENCE = 0b0010,
+  /** Negative sequence number variant */
   NEG_SEQUENCE_1 = 0b0011,
 }
 
-// Message Serialization Method
+/**
+ * Serialization method enum
+ * Defines how message payloads are serialized
+ */
 export enum SerializationMethod {
+  /** No serialization */
   NO_SERIALIZATION = 0b0000,
+  /** JSON serialization */
   JSON = 0b0001,
+  /** Thrift serialization */
   THRIFT = 0b0011,
+  /** Custom serialization */
   CUSTOM_TYPE = 0b1111,
 }
 
-// Message Compression Type
+/**
+ * Compression type enum
+ * Defines how message payloads are compressed
+ */
 export enum CompressionType {
+  /** No compression */
   NO_COMPRESSION = 0b0000,
+  /** GZIP compression */
   GZIP = 0b0001,
+  /** Custom compression */
   CUSTOM_COMPRESSION = 0b1111,
 }
 
-// Header options for generating headers
+/**
+ * Protocol header generation options interface
+ * Used to configure protocol header parameters
+ */
 export interface HeaderOptions {
+  /** Protocol version number, default is PROTOCOL_VERSION */
   version?: number;
+  /** Message type */
   messageType?: MessageType;
+  /** Message type-specific flags */
   messageTypeSpecificFlags?: MessageTypeSpecificFlags;
+  /** Serialization method */
   serialMethod?: SerializationMethod;
-  compressionType?: CompressionType;
+  /** Compression type */
+  compressionType?: CompressionType /** Reserved data, default is 0x00 */
   reservedData?: number;
+  /** Extension header data */
   extensionHeader?: Buffer;
 }
 
-// Parsed response from server
+/**
+ * Parsed server response interface
+ * Contains complete protocol header and payload information
+ */
 export interface ParsedResponse {
+  /** Protocol version number */
   protocolVersion: number;
+  /** Protocol header size (in 4-byte units) */
   headerSize: number;
+  /** Message type */
   messageType: number;
+  /** Message type-specific flags */
   messageTypeSpecificFlags: number;
+  /** Serialization method */
   serializationMethod: number;
+  /** Message compression type */
   messageCompression: number;
+  /** Reserved field */
   reserved: number;
+  /** Extension header data */
   headerExtensions: Buffer;
+  /** Message payload data */
   payload: Buffer;
-  // Parsed fields
+  /** Response status code (parsed) */
   code?: number;
+  /** Sequence number (parsed) */
   seq?: number;
+  /** Payload size (parsed) */
   payloadSize?: number;
+  /** Payload message (parsed) */
   payloadMsg?: unknown;
 }


### PR DESCRIPTION
## Description
Add detailed JSDoc comments to all public API types in packages/asr/src/protocol/types.ts

## Changes
- MessageType enum: Added descriptions for all 5 message types
- MessageTypeSpecificFlags enum: Added descriptions for all 4 flags
- SerializationMethod enum: Added descriptions for all 4 methods
- CompressionType enum: Added descriptions for all 3 types
- HeaderOptions interface: Added JSDoc for all 7 properties
- ParsedResponse interface: Added JSDoc for all 14 properties

Closes #1918

---
*Submitted by OpenClaw AI (Raven)*