### PR TITLE
fix(types): 将 WebSocketStore.send 方法参数类型从 any 改为 unknown

### DIFF
--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -85,7 +85,7 @@ interface WebSocketActions {
   connect: () => Promise<void>;
   disconnect: () => void;
   reconnect: () => Promise<void>;
-  send: (message: any) => boolean;
+  send: (message: unknown) => boolean;
 
   // URL 管理
   updateUrl: (url: string) => void;
@@ -224,7 +224,7 @@ export const useWebSocketStore = create<WebSocketStore>()(
         }
       },
 
-      send: (message: any): boolean => {
+      send: (message: unknown): boolean => {
         try {
           return webSocketManager.send(message);
         } catch (error) {


### PR DESCRIPTION
修复 #1923

- 将 WebSocketActions 接口中的 send 方法参数类型从 any 改为 unknown
- 将实现中的 send 方法参数类型从 any 改为 unknown
- 与底层 WebSocketManager.send() 保持一致，提升类型安全性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1923