### PR TITLE
fix(types): 从 shared-types 重新导出 TimeoutError 和 TimeoutResponse 消除重复定义

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -6,12 +6,14 @@
     "declarationMap": true,
     "outDir": "../../dist/backend",
     "rootDir": ".",
-    "baseUrl": ".",
+    "baseUrl": "../../",
     "types": ["vitest/globals"],
     "paths": {
-      "@/*": ["./*"]
+      "@/*": ["apps/backend/*"],
+      "@xiaozhi-client/shared-types/src/*": ["packages/shared-types/src/*"]
     }
   },
+  "references": [{ "path": "../../packages/shared-types" }],
   "include": ["./**/*.ts"],
   "exclude": [
     "node_modules",

--- a/apps/backend/types/timeout.ts
+++ b/apps/backend/types/timeout.ts
@@ -1,39 +1,19 @@
 /**
  * 超时错误类型
+ * 从 @xiaozhi-client/shared-types 重新导出共享类型
  */
-export class TimeoutError extends Error {
-  public override readonly name = "TimeoutError" as const;
 
-  constructor(message: string) {
-    super(message);
-    this.name = "TimeoutError";
-    Error.captureStackTrace(this, TimeoutError);
-  }
+// 从 shared-types 导入共享类型（用于本文件）
+import {
+  TimeoutError,
+  type TimeoutResponse,
+  isTimeoutError,
+  isTimeoutResponse,
+} from "packages/shared-types/src/utils/timeout";
 
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      stack: this.stack,
-    };
-  }
-}
-
-/**
- * 超时响应接口
- */
-export interface TimeoutResponse {
-  content: Array<{
-    type: "text";
-    text: string;
-  }>;
-  isError: boolean;
-  taskId: string;
-  status: "timeout";
-  message: string;
-  nextAction: string;
-  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
-}
+// 重新导出以供外部使用
+export { TimeoutError, isTimeoutError, isTimeoutResponse };
+export type { TimeoutResponse };
 
 /**
  * 创建超时响应的工具函数
@@ -70,7 +50,7 @@ function getToolSpecificTimeoutMessage(
 ): string {
   const toolMessages: Record<string, string> = {
     coze_workflow: `⏱️ 扣子工作流执行超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 工具类型: 扣子工作流
@@ -93,7 +73,7 @@ function getToolSpecificTimeoutMessage(
  */
 function getDefaultTimeoutMessage(taskId: string): string {
   return `⏱️ 工具调用超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 状态: 处理中
@@ -103,29 +83,4 @@ function getDefaultTimeoutMessage(taskId: string): string {
 1. 使用相同的参数重新调用工具
 2. 系统会自动返回已完成的任务结果
 3. 如果长时间未完成，请联系管理员`;
-}
-
-/**
- * 验证是否为超时响应
- */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
-  return !!(
-    response &&
-    response.status === "timeout" &&
-    typeof response.taskId === "string" &&
-    Array.isArray(response.content) &&
-    response.content.length > 0 &&
-    response.content[0].type === "text"
-  );
-}
-
-/**
- * 验证是否为超时错误
- */
-export function isTimeoutError(error: any): error is TimeoutError {
-  return !!(
-    error &&
-    error.name === "TimeoutError" &&
-    error instanceof TimeoutError
-  );
 }

--- a/packages/shared-types/src/utils/timeout.ts
+++ b/packages/shared-types/src/utils/timeout.ts
@@ -36,6 +36,7 @@ export interface TimeoutResponse {
   status: "timeout";
   message: string;
   nextAction: string;
+  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
 }
 
 /**

--- a/packages/shared-types/tsconfig.json
+++ b/packages/shared-types/tsconfig.json
@@ -3,7 +3,7 @@
     "target": "ES2022",
     "module": "ESNext",
     "lib": ["ES2022"],
-    "outDir": "./dist",
+    "outDir": "../../dist/shared-types",
     "rootDir": "src",
     "declaration": true,
     "declarationMap": true,


### PR DESCRIPTION
修改内容：
- packages/shared-types/src/utils/timeout.ts: 添加 [key: string]: unknown 索引签名以保持兼容性
- packages/shared-types/tsconfig.json: 更新 outDir 以匹配 tsup 输出位置
- apps/backend/types/timeout.ts: 从 shared-types 导入并重新导出共享类型，保留 backend 特定工具函数
- apps/backend/tsconfig.json: 添加对 shared-types 的项目引用和路径映射

这解决了 #1927 中提到的 DRY 原则违反问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1927