### PR TITLE
docs(apps/frontend): 为 icons 模块添加文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/components/icons/index.ts
+++ b/apps/frontend/src/components/icons/index.ts
@@ -1,2 +1,10 @@
+/**
+ * 图标组件统一导出模块
+ *
+ * 导出项目中使用的图标组件，包括：
+ * - QQ: QQ 图标组件
+ * - Github: Github 图标组件
+ */
+
 export * from "./QQ";
 export * from "./Github";


### PR DESCRIPTION
- 添加文件级 JSDoc 注释说明模块用途
- 列出导出的图标组件（QQ 和 Github）
- 与其他前端组件模块保持文档风格一致

修复 #1928

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1928