### PR TITLE
fix(types): 将 mcp-tool-table.tsx 中的 inputSchema 类型从 any 改为 JSONSchema

### DIFF
--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -28,7 +28,7 @@ import { useToolSearch } from "@/hooks/useToolSearch";
 import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
-import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import type { CustomMCPToolWithStats, JSONSchema } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -48,7 +48,7 @@ export interface ToolRowData {
   enabled: boolean;
   usageCount: number;
   lastUsedTime: string;
-  inputSchema: any;
+  inputSchema: JSONSchema;
 }
 
 interface McpToolTableProps {
@@ -109,7 +109,7 @@ export function McpToolTable({
       serverName: string;
       toolName: string;
       description?: string;
-      inputSchema?: any;
+      inputSchema?: JSONSchema;
     };
   }>({ open: false });
 

--- a/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
@@ -14,7 +14,7 @@ describe("useToolPagination", () => {
       enabled: i % 2 === 0,
       usageCount: i * 10,
       lastUsedTime: `2024-01-${(i % 28) + 1}T00:00:00Z`,
-      inputSchema: null,
+      inputSchema: {},
     }));
   };
 

--- a/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
@@ -13,7 +13,7 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 10,
       lastUsedTime: "2024-01-01T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
     {
       name: "tool2",
@@ -23,7 +23,7 @@ describe("useToolSearch", () => {
       enabled: false,
       usageCount: 5,
       lastUsedTime: "2024-01-02T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
     {
       name: "tool3",
@@ -33,7 +33,7 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 3,
       lastUsedTime: "2024-01-03T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
   ];
 
@@ -176,7 +176,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
       ];
 
@@ -206,7 +206,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
         {
           name: "tool2",
@@ -216,7 +216,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
       ] as ToolRowData[];
 


### PR DESCRIPTION
- 导入 JSONSchema 类型从 @xiaozhi-client/shared-types
- 更新 ToolRowData 接口使用 JSONSchema 类型
- 更新调试对话框状态类型使用 JSONSchema
- 修复测试文件中的 mock 数据使用空对象替代 null

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1931