### PR TITLE
fix(lib/mcp): 修复 MCPCacheManager 的 cleanupInterval 定时器资源泄漏

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -659,7 +659,13 @@ export class MCPToolHandler {
 
     // 从缓存中获取工具信息
     const cacheManager = new MCPCacheManager();
-    const cachedTools = await cacheManager.getAllCachedTools();
+    let cachedTools: Tool[];
+    try {
+      cachedTools = await cacheManager.getAllCachedTools();
+    } finally {
+      // 确保清理缓存管理器，防止资源泄漏
+      cacheManager.cleanup();
+    }
 
     // 查找对应的工具
     const fullToolName = `${serviceName}__${toolName}`;

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1831,5 +1831,8 @@ export class MCPServiceManager extends EventEmitter {
       "mcp:service:connection:failed",
       this.eventListeners.serviceConnectionFailed
     );
+
+    // 清理缓存管理器，停止定时器
+    this.cacheManager?.cleanup();
   }
 }


### PR DESCRIPTION
在多个使用位置中，MCPCacheManager 的 cleanupInterval 定时器未被正确清理，
导致资源泄漏。

修复内容：
1. MCPManager.cleanup() 方法添加了 cacheManager?.cleanup() 调用
2. mcp-tool.handler.ts 中使用 try-finally 确保临时创建的 MCPCacheManager 实例被清理

修复位置：
- apps/backend/lib/mcp/manager.ts:1834
- apps/backend/handlers/mcp-tool.handler.ts:660-670

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1936