### PR TITLE
fix(cli): 将 CLI 包标记为私有包并启用类型声明生成

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,14 +1,11 @@
 {
   "name": "@xiaozhi-client/cli",
   "version": "1.10.9",
-  "private": false,
+  "private": true,
   "repository": {
     "type": "git",
     "url": "https://github.com/shenjingnan/xiaozhi-client.git",
     "directory": "packages/cli"
-  },
-  "publishConfig": {
-    "access": "public"
   },
   "type": "module",
   "main": "../../dist/cli/index.js",

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -15,7 +15,12 @@ export default defineConfig({
   outDir: "../../dist/cli",
   clean: true,
   sourcemap: true,
-  dts: false,
+  dts: {
+    entry: ["src/index.ts"],
+    compilerOptions: {
+      composite: false,
+    },
+  },
   minify: process.env.NODE_ENV === "production",
   splitting: false,
   bundle: true,


### PR DESCRIPTION
- 将 `private: false` 改为 `private: true`，因为 CLI 包不应独立发布
- 移除 `publishConfig` 配置（私有包不需要）
- 启用 DTS 类型声明生成，使用正确的配置格式修复 Issue #1826

相关 Issues:
- #1946: CLI 包 main 字段使用相对路径导致 npm 发布后无法解析
- #1826: CLI 包 tsup.config.ts 中 dts:false 导致类型声明文件未生成

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1946