### PR TITLE
refactor(asr): 消除 ByteDanceV2Controller 和 ByteDanceV3Controller 之间的重复代码

### DIFF
--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceController.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceController.ts
@@ -2,18 +2,311 @@
  * ByteDance 控制器基类
  */
 
+import { Buffer } from "node:buffer";
+import { Readable } from "node:stream";
+import type { ASR as ASRClient } from "@/client";
 import type { AudioInput, ListenResult } from "@/types";
 
 /**
  * ByteDance 流式 ASR 控制器基类
+ * 提供共享的流式识别逻辑，子类只需实现特定版本的行为
  */
 export abstract class ByteDanceController {
   /**
-   * 监听音频流并返回识别结果
-   * @param audioStream - 音频流输入，支持 AsyncIterable、Readable 或 Buffer
-   * @returns 异步生成器，持续产出识别结果
+   * 获取 ASR 客户端实例
    */
-  abstract listen(
+  protected abstract get asr(): ASRClient;
+
+  /**
+   * 监听音频流并返回识别结果（并行版本）
+   * 发送音频帧时不等待服务器响应，结果通过事件异步返回
+   * @param audioStream - 音频流输入
+   */
+  async *listen(
     audioStream: AudioInput
-  ): AsyncGenerator<ListenResult, void, unknown>;
+  ): AsyncGenerator<ListenResult, void, unknown> {
+    // 子类通过钩子方法决定何时注册事件监听器
+    // V2 在 connect() 之前注册，V3 在 connect() 之后注册
+    const { resultQueue, resolveNextRef, settledRef, endCalledRef } =
+      this.setupEventListeners();
+
+    // 连接服务器（子类决定是否在注册监听器后连接）
+    await this.connectIfNeeded();
+
+    // 处理错误事件
+    this.asr.on("error", (error) => {
+      if (!settledRef.value) {
+        settledRef.value = true;
+        // 关闭连接
+        this.asr.close();
+        throw error;
+      }
+    });
+
+    // 处理音频结束事件
+    this.asr.on("audio_end", async () => {
+      try {
+        // 如果 end() 已经被调用过了，不需要再次调用
+        if (endCalledRef.value) {
+          return;
+        }
+        endCalledRef.value = true;
+
+        // 等待最终结果
+        const finalResult = await this.asr.end();
+
+        // 发送最终结果
+        const text = finalResult.result?.[0]?.text || "";
+        const listenResult: ListenResult = {
+          text,
+          isFinal: true,
+          seq: finalResult.sequence,
+        };
+
+        resultQueue.push(listenResult);
+
+        // 如果有等待的消费者，唤醒它
+        if (resolveNextRef.value) {
+          const resolve = resolveNextRef.value;
+          resolveNextRef.value = null;
+          resolve();
+        }
+      } catch (error) {
+        if (!settledRef.value) {
+          settledRef.value = true;
+          throw error;
+        }
+      }
+    });
+
+    // 发送音频帧（并行版本）
+    try {
+      // 将输入转换为异步可迭代对象
+      const asyncIterable = this.toAsyncIterable(audioStream);
+
+      // 背压控制：最大并行发送的帧数
+      const MAX_PENDING_FRAMES = 10;
+      let pendingFrames = 0;
+
+      // 并行发送音频帧
+      for await (const chunk of asyncIterable) {
+        // 背压控制：如果正在等待的帧数过多，等待一下
+        while (pendingFrames >= MAX_PENDING_FRAMES) {
+          // 等待一小段时间
+          await new Promise((resolve) => setTimeout(resolve, 10));
+        }
+
+        // 确保是 Buffer 类型
+        const frame = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+
+        // 增加待处理计数
+        pendingFrames++;
+
+        // 异步发送帧，不等待完成
+        this.asr
+          .sendFrame(frame)
+          .then(() => {
+            // 发送成功，减少待处理计数
+            pendingFrames--;
+          })
+          .catch((error) => {
+            // 发送失败，减少待处理计数
+            pendingFrames--;
+            if (!settledRef.value) {
+              settledRef.value = true;
+              this.asr.close();
+              throw error;
+            }
+          });
+
+        // 发送帧后立即检查并 yield 可用的结果（不等待帧发送完成）
+        while (resultQueue.length > 0) {
+          yield resultQueue.shift()!;
+        }
+      }
+    } catch (error) {
+      settledRef.value = true;
+      this.asr.close();
+      throw error;
+    }
+
+    // 发送结束信号
+    endCalledRef.value = true;
+
+    // 如果发送过程没有触发 audio_end（可能是短音频），手动调用 end
+    if (!this.asr.isAudioEnded()) {
+      try {
+        await this.asr.end();
+      } catch {
+        // 可能已经结束，忽略错误
+      }
+    }
+
+    // 监听连接关闭事件
+    let connectionClosed = false;
+    this.asr.on("close", () => {
+      connectionClosed = true;
+      // 唤醒等待的消费者
+      if (resolveNextRef.value) {
+        const resolve = resolveNextRef.value;
+        resolveNextRef.value = null;
+        resolve();
+      }
+    });
+
+    // 现在持续 yield 所有结果，使用 resolveNext 等待新结果
+    // 注意：并行发送时，发送完成不代表结果处理完成，需要等待连接关闭
+    while (true) {
+      // 如果队列中有结果，立即 yield
+      while (resultQueue.length > 0) {
+        yield resultQueue.shift()!;
+      }
+
+      // 如果连接已关闭，退出
+      if (connectionClosed) {
+        break;
+      }
+
+      // 如果没有结果，等待新结果
+      await new Promise<void>((resolve) => {
+        resolveNextRef.value = resolve;
+      });
+
+      // 如果连接已关闭，退出
+      if (connectionClosed) {
+        break;
+      }
+
+      // 被唤醒后继续循环
+    }
+  }
+
+  /**
+   * 设置事件监听器
+   * 由子类在适当的时机调用（connect() 之前或之后）
+   */
+  protected setupEventListeners(): {
+    resultQueue: ListenResult[];
+    resolveNextRef: { value: (() => void) | null };
+    settledRef: { value: boolean };
+    endCalledRef: { value: boolean };
+  } {
+    const resultQueue: ListenResult[] = [];
+    const resolveNextRef = { value: null as (() => void) | null };
+    const settledRef = { value: false };
+    const endCalledRef = { value: false };
+
+    // 监听识别结果事件
+    this.asr.on("result", (data) => {
+      const result = data as {
+        code: number;
+        sequence?: number;
+        addition?: {
+          termination?: string;
+        };
+        result?: Array<{
+          text: string;
+          utterances?: Array<{ text: string; definite?: boolean }>;
+        }>;
+      };
+
+      // 提取文本
+      const text = result.result?.[0]?.text || "";
+
+      // 判断是否为最终结果
+      // sequence < 0 或 utterances 中 definite=true 或 termination=true 表示最终结果
+      const seq = result.sequence;
+      const definite = Boolean(
+        result.result?.some((r) =>
+          r.utterances?.some((u) => u.definite === true)
+        )
+      );
+      const isFinal =
+        (seq !== undefined && seq < 0) ||
+        definite ||
+        result.addition?.termination === "true";
+
+      const listenResult: ListenResult = {
+        text,
+        isFinal,
+        seq,
+      };
+
+      resultQueue.push(listenResult);
+
+      // 如果有等待的消费者，唤醒它
+      if (resolveNextRef.value) {
+        const resolve = resolveNextRef.value;
+        resolveNextRef.value = null;
+        resolve();
+      }
+    });
+
+    return { resultQueue, resolveNextRef, settledRef, endCalledRef };
+  }
+
+  /**
+   * 连接到服务器（如果需要）
+   * 由子类决定是否需要连接（V2 在事件注册后连接，V3 先连接）
+   */
+  protected abstract connectIfNeeded(): Promise<void>;
+
+  /**
+   * 将各种输入转换为异步可迭代对象
+   */
+  protected toAsyncIterable(
+    input: AudioInput
+  ): AsyncIterable<Buffer | Uint8Array> {
+    // 如果已经是 AsyncIterable，直接返回
+    if (Symbol.asyncIterator in Object(input)) {
+      return input as AsyncIterable<Buffer | Uint8Array>;
+    }
+
+    // 如果是 Readable 流
+    if (input instanceof Readable) {
+      return this.readableToAsyncIterable(input);
+    }
+
+    // 如果是 Buffer 或 Uint8Array，包装为单元素异步迭代器
+    let buffer: Buffer;
+    if (Buffer.isBuffer(input)) {
+      buffer = input;
+    } else {
+      buffer = Buffer.from(input as unknown as Uint8Array);
+    }
+    return (async function* () {
+      yield buffer;
+    })();
+  }
+
+  /**
+   * 将 Readable 流转换为异步可迭代对象
+   */
+  protected async *readableToAsyncIterable(
+    readable: Readable
+  ): AsyncGenerator<Buffer> {
+    for await (const chunk of readable) {
+      yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+    }
+  }
+
+  /**
+   * 非流式识别
+   */
+  async execute(_audioData: Buffer): Promise<ListenResult> {
+    const result = await this.asr.execute();
+    // 转换为 ListenResult 格式
+    return {
+      text: result.result?.[0]?.text || "",
+      isFinal: true,
+      seq: result.sequence,
+    };
+  }
+
+  /**
+   * 关闭连接
+   */
+  close(): void {
+    this.asr.close();
+  }
 }

--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
@@ -2,95 +2,55 @@
  * ByteDance V3 流式 ASR 控制器
  */
 
-import { Buffer } from "node:buffer";
-import { Readable } from "node:stream";
 import type { ASR as ASRClient } from "@/client";
 import { ByteDanceController } from "@/platforms/bytedance/controllers/ByteDanceController.js";
-import type { AudioInput, ListenResult } from "@/types";
 
 /**
  * ByteDance V3 流式 ASR 控制器实现
- * V3 与 V2 使用相同的流式 API，区别在于认证方式和请求参数
+ * V3 先连接服务器，然后再注册事件监听器
  */
 export class ByteDanceV3Controller extends ByteDanceController {
-  private asr: ASRClient;
+  private _asr: ASRClient;
+  private _connected = false;
 
   constructor(asr: ASRClient) {
     super();
-    this.asr = asr;
+    this._asr = asr;
+  }
+
+  protected get asr(): ASRClient {
+    return this._asr;
+  }
+
+  /**
+   * 连接到服务器
+   * V3 先连接服务器，然后再注册事件监听器
+   */
+  protected async connectIfNeeded(): Promise<void> {
+    if (!this._connected) {
+      await this.asr.connect();
+      this._connected = true;
+    }
   }
 
   /**
    * 监听音频流并返回识别结果（并行版本）
-   * 发送音频帧时不等待服务器响应，结果通过事件异步返回
-   * @param audioStream - 音频流输入
+   * V3 先连接服务器，然后再注册事件监听器
    */
-  async *listen(
-    audioStream: AudioInput
-  ): AsyncGenerator<ListenResult, void, unknown> {
-    // 连接服务器
-    await this.asr.connect();
+  override async *listen(
+    audioStream: import("@/types").AudioInput
+  ): AsyncGenerator<import("@/types").ListenResult, void, unknown> {
+    // V3 特性：先连接服务器，然后再注册事件监听器
+    await this.connectIfNeeded();
 
-    // 设置结果事件处理
-    const resultQueue: ListenResult[] = [];
-    let resolveNext: (() => void) | null = null;
-    let settled = false;
-    let endCalled = false;
-
-    // 背压控制：最大并行发送的帧数
-    const MAX_PENDING_FRAMES = 10;
-    let pendingFrames = 0;
-
-    // 监听识别结果事件
-    this.asr.on("result", (data) => {
-      const result = data as {
-        code: number;
-        sequence?: number;
-        addition?: {
-          termination?: string;
-        };
-        result?: Array<{
-          text: string;
-          utterances?: Array<{ text: string; definite?: boolean }>;
-        }>;
-      };
-
-      // 提取文本
-      const text = result.result?.[0]?.text || "";
-
-      // 判断是否为最终结果
-      // V3: sequence < 0 或 utterances 中 definite=true 或 termination=true 表示最终结果
-      const seq = result.sequence;
-      const definite = Boolean(
-        result.result?.some((r) =>
-          r.utterances?.some((u) => u.definite === true)
-        )
-      );
-      const isFinal =
-        (seq !== undefined && seq < 0) ||
-        definite ||
-        result.addition?.termination === "true";
-
-      const listenResult: ListenResult = {
-        text,
-        isFinal,
-        seq,
-      };
-
-      resultQueue.push(listenResult);
-
-      // 如果有等待的消费者，唤醒它
-      if (resolveNext) {
-        const resolve = resolveNext;
-        resolveNext = null;
-        resolve();
-      }
-    });
+    // V3 在连接后注册事件监听器
+    const { resultQueue, resolveNextRef, settledRef, endCalledRef } =
+      this.setupEventListeners();
 
     // 处理错误事件
     this.asr.on("error", (error) => {
-      if (!settled) {
-        settled = true;
+      if (!settledRef.value) {
+        settledRef.value = true;
         // 关闭连接
         this.asr.close();
         throw error;
@@ -101,17 +61,17 @@ export class ByteDanceV3Controller extends ByteDanceController {
     this.asr.on("audio_end", async () => {
       try {
         // 如果 end() 已经被调用过了，不需要再次调用
-        if (endCalled) {
+        if (endCalledRef.value) {
           return;
         }
-        endCalled = true;
+        endCalledRef.value = true;
 
         // 等待最终结果
         const finalResult = await this.asr.end();
 
         // 发送最终结果
         const text = finalResult.result?.[0]?.text || "";
-        const listenResult: ListenResult = {
+        const listenResult: import("@/types").ListenResult = {
           text,
           isFinal: true,
           seq: finalResult.sequence,
@@ -120,14 +80,14 @@ export class ByteDanceV3Controller extends ByteDanceController {
         resultQueue.push(listenResult);
 
         // 如果有等待的消费者，唤醒它
-        if (resolveNext) {
-          const resolve = resolveNext;
-          resolveNext = null;
+        if (resolveNextRef.value) {
+          const resolve = resolveNextRef.value;
+          resolveNextRef.value = null;
           resolve();
         }
       } catch (error) {
-        if (!settled) {
-          settled = true;
+        if (!settledRef.value) {
+          settledRef.value = true;
           throw error;
         }
       }
@@ -137,6 +97,10 @@ export class ByteDanceV3Controller extends ByteDanceController {
     try {
       // 将输入转换为异步可迭代对象
       const asyncIterable = this.toAsyncIterable(audioStream);
+
+      // 背压控制：最大并行发送的帧数
+      const MAX_PENDING_FRAMES = 10;
+      let pendingFrames = 0;
 
       // 并行发送音频帧
       for await (const chunk of asyncIterable) {
@@ -162,8 +126,8 @@ export class ByteDanceV3Controller extends ByteDanceController {
           .catch((error) => {
             // 发送失败，减少待处理计数
             pendingFrames--;
-            if (!settled) {
-              settled = true;
+            if (!settledRef.value) {
+              settledRef.value = true;
               this.asr.close();
               throw error;
             }
@@ -175,13 +139,13 @@ export class ByteDanceV3Controller extends ByteDanceController {
         }
       }
     } catch (error) {
-      settled = true;
+      settledRef.value = true;
       this.asr.close();
       throw error;
     }
 
     // 发送结束信号
-    endCalled = true;
+    endCalledRef.value = true;
 
     // 如果发送过程没有触发 audio_end（可能是短音频），手动调用 end
     if (!this.asr.isAudioEnded()) {
@@ -197,9 +161,9 @@ export class ByteDanceV3Controller extends ByteDanceController {
     this.asr.on("close", () => {
       connectionClosed = true;
       // 唤醒等待的消费者
-      if (resolveNext) {
-        const resolve = resolveNext;
-        resolveNext = null;
+      if (resolveNextRef.value) {
+        const resolve = resolveNextRef.value;
+        resolveNextRef.value = null;
         resolve();
       }
     });
@@ -219,7 +183,7 @@ export class ByteDanceV3Controller extends ByteDanceController {
 
       // 如果没有结果，等待新结果
       await new Promise<void>((resolve) => {
-        resolveNext = resolve;
+        resolveNextRef.value = resolve;
       });
 
       // 如果连接已关闭，退出
@@ -229,64 +193,5 @@ export class ByteDanceV3Controller extends ByteDanceController {
 
       // 被唤醒后继续循环
     }
-  }
-
-  /**
-   * 将各种输入转换为异步可迭代对象
-   */
-  private toAsyncIterable(
-    input: AudioInput
-  ): AsyncIterable<Buffer | Uint8Array> {
-    // 如果已经是 AsyncIterable，直接返回
-    if (Symbol.asyncIterator in Object(input)) {
-      return input as AsyncIterable<Buffer | Uint8Array>;
-    }
-
-    // 如果是 Readable 流
-    if (input instanceof Readable) {
-      return this.readableToAsyncIterable(input);
-    }
-
-    // 如果是 Buffer 或 Uint8Array，包装为单元素异步迭代器
-    let buffer: Buffer;
-    if (Buffer.isBuffer(input)) {
-      buffer = input;
-    } else {
-      buffer = Buffer.from(input as unknown as Uint8Array);
-    }
-    return (async function* () {
-      yield buffer;
-    })();
-  }
-
-  /**
-   * 将 Readable 流转换为异步可迭代对象
-   */
-  private async *readableToAsyncIterable(
-    readable: Readable
-  ): AsyncGenerator<Buffer> {
-    for await (const chunk of readable) {
-      yield Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
-    }
-  }
-
-  /**
-   * 非流式识别
-   */
-  async execute(_audioData: Buffer): Promise<ListenResult> {
-    const result = await this.asr.execute();
-    // 转换为 ListenResult 格式
-    return {
-      text: result.result?.[0]?.text || "",
-      isFinal: true,
-      seq: result.sequence,
-    };
-  }
-
-  /**
-   * 关闭连接
-   */
-  close(): void {
-    this.asr.close();
   }
 }


### PR DESCRIPTION
将约 204 行重复的 listen() 方法逻辑提取到基类 ByteDanceController，
使用模板方法模式处理 V2 和 V3 之间事件监听器注册时机的差异。

主要变更：
- 在 ByteDanceController 基类中实现完整的 listen() 方法
- 提供 setupEventListeners() 钩子方法供子类调用
- 提供 connectIfNeeded() 抽象方法，由子类决定连接时机
- V2 在 connect() 前注册事件监听器（避免错过初始响应）
- V3 先 connect() 再注册事件监听器
- 将共享的 toAsyncIterable、readableToAsyncIterable、execute、close 方法移至基类

修复 issue #1950

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1950