### PR TITLE
refactor: 提取配置文件存在性检查为辅助方法以消除代码重复

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -111,21 +111,35 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   }
 
   /**
+   * 检查配置文件是否存在，如果不存在则显示错误信息并返回 true
+   * @returns 如果配置文件不存在返回 true，否则返回 false
+   */
+  private ensureConfigFileExists(spinner: ReturnType<typeof ora>): boolean {
+    const configManager = this.getService<any>("configManager");
+
+    if (!configManager.configExists()) {
+      spinner.fail("配置文件不存在");
+      console.log(
+        chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
+      );
+      return true;
+    }
+
+    return false;
+  }
+
+  /**
    * 处理获取配置命令
    */
   private async handleGet(key: string): Promise<void> {
     const spinner = ora("读取配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
-
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+      if (this.ensureConfigFileExists(spinner)) {
         return;
       }
+
+      const configManager = this.getService<any>("configManager");
 
       const config = configManager.getConfig();
 
@@ -226,15 +240,11 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("更新配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
-
-      if (!configManager.configExists()) {
-        spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+      if (this.ensureConfigFileExists(spinner)) {
         return;
       }
+
+      const configManager = this.getService<any>("configManager");
 
       switch (key) {
         case "mcpEndpoint":


### PR DESCRIPTION
将 handleGet 和 handleSet 方法中重复的配置文件存在性检查代码
提取为私有辅助方法 ensureConfigFileExists，遵循 DRY 原则。

修改内容:
- 新增 ensureConfigFileExists 私有辅助方法
- handleGet 和 handleSet 方法使用新的辅助方法

Fixes #1956

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1956