### PR TITLE
fix: 修复 packages/endpoint tsconfig.json 的 outDir 配置

### DIFF
--- a/packages/endpoint/tsconfig.json
+++ b/packages/endpoint/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "extends": "../../tsconfig.json",
   "compilerOptions": {
-    "outDir": "../../dist/endpoint",
+    "outDir": "./dist",
     "rootDir": "src",
     "composite": true,
     "downlevelIteration": true,


### PR DESCRIPTION
将 outDir 从 "../../dist/endpoint" 改为 "./dist"，使其与 tsup.config.ts
和 package.json 的 main/types 字段保持一致。

修复 Issue #1958

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1958