### PR TITLE
fix: 将 == null 替换为严格相等检查

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -1642,7 +1642,11 @@ export class MCPToolHandler {
     // 验证必需字段
     const requiredFields = ["name", "description", "inputSchema", "handler"];
     for (const field of requiredFields) {
-      if (!(field in tool) || tool[field as keyof CustomMCPTool] == null) {
+      if (
+        !(field in tool) ||
+        tool[field as keyof CustomMCPTool] === null ||
+        tool[field as keyof CustomMCPTool] === undefined
+      ) {
         throw MCPError.validationError(
           MCPErrorCode.TOOL_VALIDATION_FAILED,
           `工具配置缺少必需字段: ${field}`


### PR DESCRIPTION
修复 mcp-tool.handler.ts:1645 中使用宽松相等操作符 == 违反项目代码规范的问题。
将 == null 替换为 === null || === undefined 以保持相同行为并符合项目规范。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1966