### PR TITLE
perf(backend): 缓存 Object.values(ToolType) 避免重复数组创建

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -53,6 +53,7 @@ interface LegacyAddCustomToolRequest {
 export class MCPToolHandler {
   private logger: Logger;
   private ajv: Ajv;
+  private static readonly TOOL_TYPE_VALUES = Object.values(ToolType);
 
   constructor() {
     this.logger = logger;
@@ -535,10 +536,10 @@ export class MCPToolHandler {
     c.get("logger").info(`处理新格式工具添加请求，类型: ${type}`);
 
     // 验证工具类型
-    if (!Object.values(ToolType).includes(type)) {
+    if (!MCPToolHandler.TOOL_TYPE_VALUES.includes(type)) {
       return c.fail(
         "INVALID_TOOL_TYPE",
-        `不支持的工具类型: ${type}。支持的类型: ${Object.values(ToolType).join(", ")}`,
+        `不支持的工具类型: ${type}。支持的类型: ${MCPToolHandler.TOOL_TYPE_VALUES.join(", ")}`,
         undefined,
         400
       );
@@ -860,10 +861,10 @@ export class MCPToolHandler {
     c.get("logger").info(`处理新格式工具更新请求，类型: ${type}`);
 
     // 验证工具类型
-    if (!Object.values(ToolType).includes(type)) {
+    if (!MCPToolHandler.TOOL_TYPE_VALUES.includes(type)) {
       return c.fail(
         "INVALID_TOOL_TYPE",
-        `不支持的工具类型: ${type}。支持的类型: ${Object.values(ToolType).join(", ")}`,
+        `不支持的工具类型: ${type}。支持的类型: ${MCPToolHandler.TOOL_TYPE_VALUES.join(", ")}`,
         undefined,
         400
       );


### PR DESCRIPTION
在 MCPToolHandler 类中添加静态常量 TOOL_TYPE_VALUES 缓存 ToolType 枚举值，避免在 addTool 和 updateTool 方法中重复调用 Object.values(ToolType) 造成不必要的性能开销。

修改位置:
- apps/backend/handlers/mcp-tool.handler.ts:56 (添加静态常量)
- apps/backend/handlers/mcp-tool.handler.ts:539-542 (addTool 方法)
- apps/backend/handlers/mcp-tool.handler.ts:864-867 (updateTool 方法)

Fixes #1970

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1970