### PR TITLE
fix(tts): 使用 @/ 路径别名替代相对路径导入

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -8,7 +8,7 @@ import type {
   AudioChunkCallback,
   PlatformConfig,
   TTSController,
-} from "../../core/index.js";
+} from "@/core/index.js";
 import {
   FullClientRequest,
   MsgType,

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -2,7 +2,7 @@
  * 字节跳动 TTS 平台模块导出
  */
 
-import { platformRegistry } from "../../core/index.js";
+import { platformRegistry } from "@/core/index.js";
 import { ByteDanceTTSPlatform } from "./TTSController.js";
 
 // 注册字节跳动平台


### PR DESCRIPTION
将 packages/tts/src/platforms/bytedance/ 目录下的文件从使用相对路径导入改为使用 @/ 路径别名，与项目代码规范保持一致。

修改文件：
- packages/tts/src/platforms/bytedance/index.ts
- packages/tts/src/platforms/bytedance/TTSController.ts

Fixes #1978

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1978