### PR TITLE
fix(tts): use @/ alias instead of relative paths in bytedance platform

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -8,7 +8,7 @@ import type {
   AudioChunkCallback,
   PlatformConfig,
   TTSController,
-} from "../../core/index.js";
+} from "@/core/index.js";
 import {
   FullClientRequest,
   MsgType,

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -2,7 +2,7 @@
  * 字节跳动 TTS 平台模块导出
  */
 
-import { platformRegistry } from "../../core/index.js";
+import { platformRegistry } from "@/core/index.js";
 import { ByteDanceTTSPlatform } from "./TTSController.js";
 
 // 注册字节跳动平台


### PR DESCRIPTION
## What does this PR do, and why do we need it?

Fixes code quality issue #1978 by replacing relative path imports with path alias imports in the bytedance TTS platform module.

**Changes:**
- `packages/tts/src/platforms/bytedance/index.ts`: Changed import from `../../core/index.js` to `@/core/index.js`
- `packages/tts/src/platforms/bytedance/TTSController.ts`: Changed type import from `../../core/index.js` to `@/core/index.js`

This change ensures consistency with the project's path alias configuration (`packages/tts/tsconfig.json`) and matches the import style used in test files within the same package.

## Why this is needed?

1. **Code consistency**: The project is configured with `@/*` path aliases in `tsconfig.json`
2. **Maintainability**: Using path aliases makes directory structure refactoring easier
3. **Consistency**: Test files in the same package already use `@/core/index.js` imports

## Testing

This change should be verified with:
```bash
pnpm --filter @xiaozhi-client/tts check:type
pnpm --filter @xiaozhi-client/tts test
```

## Does this close any issues?

Fixes #1978