### PR TITLE
fix: 重命名 fix-comment skill 以符合命名规范

### DIFF
--- a/.claude/skills/fix-comment/SKILL.md
+++ b/.claude/skills/fix-comment/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-comment-fixer
+name: fix-comment
 description: GitHub 评论修复技能，用于获取 PR 的 Copilot 评论并分析修复问题
 ---
 


### PR DESCRIPTION
## Summary
- 将 github-comment-fixer skill 重命名为 fix-comment，遵循项目命名规范

## Test plan
- [ ] 验证 skill 正常工作

🤖 Generated with [Claude Code](https://claude.com/claude-code)