### PR TITLE
fix: 将 packages/asr 和 packages/tts 的 TypeScript 版本更新至 ^5.9.2

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -51,7 +51,7 @@
     "dotenv": "^16.4.0",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -50,7 +50,7 @@
     "dotenv": "^16.4.0",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"


### PR DESCRIPTION
修复 #1988

将 packages/asr 和 packages/tts 中的 TypeScript 版本从 ^5.3.0 更新到 ^5.9.2，
以与项目中其他包保持一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1988