### PR TITLE
fix(backend): 将 heartbeat.handler.ts 中 ws 参数类型从 any 替换为 WebSocketLike

### DIFF
--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -10,6 +10,7 @@ import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
+import type { WebSocketLike } from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
 
 /**
@@ -46,7 +47,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -82,7 +83,7 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(ws: WebSocketLike, clientId: string): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -200,7 +201,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",


### PR DESCRIPTION
修复 heartbeat.handler.ts 文件中 ws 参数使用 any 类型的问题：
- 添加 WebSocketLike 类型导入
- handleClientStatus 方法的 ws 参数
- sendLatestConfig 方法的 ws 参数
- sendHeartbeatResponse 方法的 ws 参数

提高代码类型安全性，符合项目代码规范要求。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #1996