### PR TITLE
fix: 修复 waitForBufferDrain 方法中未处理的 Promise rejection

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -207,7 +207,12 @@ export class TTSService implements ITTSService {
 
       // 缓冲区已清空且不在处理中
       if ((!buffer || buffer.length === 0) && !isProcessing) {
-        this.sendStopAndCleanup(deviceId);
+        void this.sendStopAndCleanup(deviceId).catch((error) => {
+          logger.error(
+            `[TTSService] sendStopAndCleanup 执行失败: deviceId=${deviceId}`,
+            error
+          );
+        });
         return true;
       }
 
@@ -216,7 +221,12 @@ export class TTSService implements ITTSService {
         logger.warn(
           `[TTSService] 缓冲区排空超时，强制发送 stop: deviceId=${deviceId}`
         );
-        this.sendStopAndCleanup(deviceId);
+        void this.sendStopAndCleanup(deviceId).catch((error) => {
+          logger.error(
+            `[TTSService] sendStopAndCleanup 执行失败: deviceId=${deviceId}`,
+            error
+          );
+        });
         return true;
       }
 


### PR DESCRIPTION
在 waitForBufferDrain 方法中，sendStopAndCleanup 是异步方法但调用时未处理 Promise rejection。添加 void 关键字和 .catch() 错误处理，与文件中其他位置（如第 169-174 行）保持一致的模式。

Fixes #2000

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2000