### PR TITLE
fix(types): 使用 ensureToolJSONSchema 替换 as any 类型断言

### DIFF
--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,11 +4,12 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { MCPManager } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { ensureToolJSONSchema } from "./types.js";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -105,7 +106,7 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        inputSchema: ensureToolJSONSchema(mcpTool.inputSchema),
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -3,10 +3,10 @@
  * 统一管理所有 MCP 相关的类型定义
  */
 
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 // =========================
 // 1. 基础传输类型
@@ -211,8 +211,9 @@ export function isValidToolJSONSchema(obj: unknown): obj is {
 
 /**
  * 确保对象符合 MCP Tool JSON Schema 格式
+ * 接受 unknown 类型输入，进行运行时验证后返回安全的 JSONSchema
  */
-export function ensureToolJSONSchema(schema: JSONSchema): {
+export function ensureToolJSONSchema(schema: unknown): {
   type: "object";
   properties?: Record<string, object>;
   required?: string[];
@@ -227,6 +228,7 @@ export function ensureToolJSONSchema(schema: JSONSchema): {
     };
   }
 
+  // 如果不符合 schema 格式，返回默认的空 schema
   return {
     type: "object",
     properties: {} as Record<string, object>,


### PR DESCRIPTION
- 修改 ensureToolJSONSchema 函数签名，将参数类型从 JSONSchema 改为 unknown
- 在 internal-mcp-manager.ts 中使用 ensureToolJSONSchema 进行类型安全的 schema 转换
- 移除了不安全的 as any 类型断言，提高代码的类型安全性

Fixes #2004

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2004