### PR TITLE
docs(asr): 将音频模块文件级 JSDoc 注释中文化

### DIFF
--- a/packages/asr/src/audio/AudioProcessor.ts
+++ b/packages/asr/src/audio/AudioProcessor.ts
@@ -1,5 +1,5 @@
 /**
- * Audio processor - unified entry for audio processing
+ * 音频处理器 - 音频处理的统一入口点
  */
 
 import { Buffer } from "node:buffer";

--- a/packages/asr/src/audio/OggConverter.ts
+++ b/packages/asr/src/audio/OggConverter.ts
@@ -1,5 +1,5 @@
 /**
- * OGG to WAV/PCM converter using ffmpeg
+ * OGG 到 WAV/PCM 转换器（使用 ffmpeg）
  */
 
 import { execFileSync } from "node:child_process";

--- a/packages/asr/src/audio/WavParser.ts
+++ b/packages/asr/src/audio/WavParser.ts
@@ -1,5 +1,5 @@
 /**
- * WAV file parser
+ * WAV 文件解析器
  */
 
 import { Buffer } from "node:buffer";


### PR DESCRIPTION
将 packages/asr/src/audio/ 目录下的文件级 JSDoc 注释从英文翻译为中文，符合项目本地化规范要求。

- AudioProcessor.ts: "Audio processor..." → "音频处理器..."
- WavParser.ts: "WAV file parser" → "WAV 文件解析器"
- OggConverter.ts: "OGG to WAV/PCM converter..." → "OGG 到 WAV/PCM 转换器..."

Fixes #2009

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2009