### PR TITLE
docs(errors): 添加文件级 JSDoc 注释

### DIFF
--- a/apps/backend/errors/index.ts
+++ b/apps/backend/errors/index.ts
@@ -1,3 +1,26 @@
+/**
+ * 错误处理模块
+ *
+ * 统一导出所有错误处理相关的类型和工具：
+ *
+ * - **直接导出**：从 `mcp-errors.ts` 导出错误类型定义
+ * - **命名空间导出**：从 `error-helper.ts` 导出错误辅助工具
+ *
+ * @packageDocumentation
+ *
+ * @example
+ * ```typescript
+ * // 导入错误类型
+ * import { MCPErrorCode, MCPError } from '@/errors/index.js';
+ *
+ * // 导入错误辅助工具（推荐使用命名空间导入）
+ * import * as ErrorHelper from '@/errors/index.js';
+ *
+ * // 使用错误辅助工具
+ * const categorizedError = ErrorHelper.categorizeError(error, 'service-name');
+ * ```
+ */
+
 export * from "./mcp-errors.js";
 
 // ErrorHelper 使用命名空间导出以避免与 mcp-errors 中的类型冲突


### PR DESCRIPTION
为 apps/backend/errors/index.ts 添加文件级 JSDoc 注释，与项目中其他模块导出文件的文档风格保持一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2013