### PR TITLE
docs: 为 docs/content 目录下 9 个 MDX 文件添加 frontmatter

### DIFF
--- a/docs/content/index.mdx
+++ b/docs/content/index.mdx
@@ -1,3 +1,8 @@
+---
+title: "Xiaozhi Client - MCP 聚合工具"
+description: "Xiaozhi Client 是一个开源的 MCP 聚合工具，可以将多个 MCP 服务的工具聚合在一起提供给小智接入点。"
+---
+
 import { ImageZoom} from "nextra/components";
 
 ## 介绍

--- a/docs/content/quickstart.mdx
+++ b/docs/content/quickstart.mdx
@@ -1,3 +1,8 @@
+---
+title: "快速上手 - Xiaozhi Client"
+description: "快速入门指南将会向你展示最快速的安装、配置、启动方式。"
+---
+
 import { Callout, Steps, Tabs } from "nextra/components";
 
 # 快速上手

--- a/docs/content/reference/command.mdx
+++ b/docs/content/reference/command.mdx
@@ -1,3 +1,8 @@
+---
+title: "常用命令 - Xiaozhi Client"
+description: "xiaozhi-client 命令行工具的常用命令参考。"
+---
+
 # 常用命令
 
 | 命令                                          | 说明                        |

--- a/docs/content/release.mdx
+++ b/docs/content/release.mdx
@@ -1,3 +1,8 @@
+---
+title: "发布方法 - Xiaozhi Client"
+description: "面向项目维护者的发布指南，介绍如何发布 xiaozhi-client 项目到 npm。"
+---
+
 import { Callout, Steps, Tabs } from "nextra/components";
 
 # 发布方法

--- a/docs/content/usage/as-mcp.mdx
+++ b/docs/content/usage/as-mcp.mdx
@@ -1,3 +1,8 @@
+---
+title: "作为 MCP 服务使用 - Xiaozhi Client"
+description: "xiaozhi-client 不仅可以连接小智服务端接入点，还可以作为普通 MCP 服务被其他客户端集成。"
+---
+
 import { ImageZoom, Callout, Steps } from "nextra/components";
 
 # 作为 MCP 服务使用

--- a/docs/content/usage/coze-workflow.mdx
+++ b/docs/content/usage/coze-workflow.mdx
@@ -1,3 +1,8 @@
+---
+title: "集成扣子工作流 - Xiaozhi Client"
+description: "将扣子（Coze）工作流集成到 xiaozhi-client 中，扩展 AI 能力。"
+---
+
 import { ImageZoom, Callout, Steps } from "nextra/components";
 
 # 集成扣子工作流

--- a/docs/content/usage/docker.mdx
+++ b/docs/content/usage/docker.mdx
@@ -1,3 +1,8 @@
+---
+title: "使用 Docker 部署 - Xiaozhi Client"
+description: "使用 Docker 或 Docker Compose 快速部署 xiaozhi-client 服务。"
+---
+
 import { Tabs, Tab, Steps, Callout } from "nextra/components";
 
 # 使用 Docker 部署

--- a/docs/content/usage/modelscope.mdx
+++ b/docs/content/usage/modelscope.mdx
@@ -1,3 +1,8 @@
+---
+title: "使用魔搭社区 MCP - Xiaozhi Client"
+description: "使用魔搭社区托管 MCP 服务，简化 sse/http MCP 服务管理成本。"
+---
+
 import { ImageZoom, Callout, Steps } from "nextra/components";
 
 # 使用 魔搭社区 MCP

--- a/docs/content/usage/multi-endpoint.mdx
+++ b/docs/content/usage/multi-endpoint.mdx
@@ -1,3 +1,8 @@
+---
+title: "配置多个小智接入点 - Xiaozhi Client"
+description: "学习如何使用 Web 界面或配置文件为 xiaozhi-client 配置多个小智接入点。"
+---
+
 import { ImageZoom, Callout, Steps } from "nextra/components";
 
 # 配置多个小智接入点


### PR DESCRIPTION
为以下文件添加了 title 和 description frontmatter：
- index.mdx
- quickstart.mdx
- usage/as-mcp.mdx
- usage/multi-endpoint.mdx
- usage/coze-workflow.mdx
- usage/docker.mdx
- usage/modelscope.mdx
- reference/command.mdx
- release.mdx

修复了 Nextra 无法生成正确页面元数据的问题，改善 SEO 和用户体验。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2015