### PR TITLE
docs(handlers): 添加缺失的文件级 JSDoc 注释

### DIFF
--- a/apps/backend/handlers/base.handler.ts
+++ b/apps/backend/handlers/base.handler.ts
@@ -1,11 +1,11 @@
-import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
-
 /**
  * 抽象 API Handler 基类
  * 提供便捷的辅助方法
  * logger 通过 c.get("logger") 访问（Hono 推荐做法）
  */
+import type { AppContext } from "@/types/hono.context.js";
+import type { Context } from "hono";
+
 export abstract class BaseHandler {
   /**
    * 统一错误处理方法

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -1,3 +1,7 @@
+/**
+ * 服务 API HTTP 路由处理器
+ * 提供服务启动、停止、重启等相关的 RESTful API 接口
+ */
 import { spawn } from "node:child_process";
 import type { ChildProcess } from "node:child_process";
 import { logger } from "@/Logger.js";

--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -1,3 +1,7 @@
+/**
+ * 版本 API HTTP 路由处理器
+ * 提供版本信息查询、可用版本列表获取、版本检查等相关的 RESTful API 接口
+ */
 import { NPMManager } from "@/lib/npm";
 import type { AppContext } from "@/types/hono.context.js";
 import { VersionUtils } from "@xiaozhi-client/version";


### PR DESCRIPTION
为以下三个 handler 文件添加文件级 JSDoc 注释，使其与其他 handler 文件的文档风格保持一致：

- service.handler.ts: 服务 API HTTP 路由处理器
- version.handler.ts: 版本 API HTTP 路由处理器
- base.handler.ts: 抽象 API Handler 基类

Closes #2017

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2017