### PR TITLE
fix(deps): 统一 packages/tts 的 @types/node 版本至 ^24.3.0

### DIFF
--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -45,7 +45,7 @@
     "zod": "^3.23.8"
   },
   "devDependencies": {
-    "@types/node": "^20.10.0",
+    "@types/node": "^24.3.0",
     "@types/ws": "^8.5.10",
     "dotenv": "^16.4.0",
     "tsup": "^8.3.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -711,8 +711,8 @@ importers:
         version: 3.25.76
     devDependencies:
       '@types/node':
-        specifier: ^20.10.0
-        version: 20.19.33
+        specifier: ^24.3.0
+        version: 24.10.9
       '@types/ws':
         specifier: ^8.5.10
         version: 8.18.1
@@ -730,7 +730,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@20.19.33)(happy-dom@20.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
+        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(happy-dom@20.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
   packages/version:
     devDependencies:


### PR DESCRIPTION
将 packages/tts 的 @types/node 从 ^20.10.0 升级至 ^24.3.0，
与其他包保持一致，避免类型定义冲突。

修复 #2019

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2019