### PR TITLE
refactor: 抽取共享平台注册表包消除 ASR/TTS 代码重复

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -39,6 +39,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@xiaozhi-client/platform-registry": "workspace:*",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",

--- a/packages/asr/src/core/ASRPlatform.ts
+++ b/packages/asr/src/core/ASRPlatform.ts
@@ -2,12 +2,12 @@
  * ASR 平台抽象接口
  */
 
-import type {
-  ASRController,
-  ASRPlatform,
-  PlatformConfig,
-  PlatformRegistry,
-} from "./types.js";
+import {
+  type PlatformConfig,
+  SimplePlatformRegistry,
+  type PlatformRegistry,
+} from "@xiaozhi-client/platform-registry";
+import type { ASRController, ASRPlatform } from "./types.js";
 
 /**
  * 创建 ASR 平台实例
@@ -15,28 +15,22 @@ import type {
 export type ASRPlatformFactory = (config: PlatformConfig) => ASRPlatform;
 
 /**
- * 简单平台注册表实现
+ * ASR 平台注册表类型
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, ASRPlatform> = new Map();
+export type ASRPlatformRegistry = PlatformRegistry<ASRPlatform>;
 
-  get(platform: string): ASRPlatform | undefined {
-    return this.platforms.get(platform);
-  }
-
-  register(platform: ASRPlatform): void {
-    this.platforms.set(platform.platform, platform);
-  }
-
-  list(): string[] {
-    return Array.from(this.platforms.keys());
-  }
-}
+/**
+ * 简单平台注册表实现（ASR 特化）
+ */
+export class SimplePlatformRegistryImpl
+  extends SimplePlatformRegistry<ASRPlatform>
+  implements ASRPlatformRegistry
+{}
 
 /**
  * 全局平台注册表
  */
-export const platformRegistry = new SimplePlatformRegistry();
+export const platformRegistry = new SimplePlatformRegistryImpl();
 
 /**
  * 注册平台装饰器
@@ -48,4 +42,4 @@ export function registerPlatform(platform: ASRPlatform): ClassDecorator {
   };
 }
 
-export type { ASRPlatform, ASRController, PlatformConfig };
+export type { ASRPlatform, ASRController };

--- a/packages/asr/src/core/index.ts
+++ b/packages/asr/src/core/index.ts
@@ -7,7 +7,6 @@ export type {
   ASRController,
   PlatformConfig,
   ASRPlatform,
-  PlatformRegistry,
   CommonASROptions,
   ASREventType,
   ASREventData,
@@ -15,13 +14,13 @@ export type {
 
 // 平台接口导出
 export {
-  SimplePlatformRegistry,
+  SimplePlatformRegistryImpl,
   platformRegistry,
   registerPlatform,
 } from "./ASRPlatform.js";
 
 // 类型导出
-export type { ASRPlatformFactory } from "./ASRPlatform.js";
+export type { ASRPlatformFactory, ASRPlatformRegistry } from "./ASRPlatform.js";
 
 // 客户端导出
 export { ASRClient, type ASRClientOptions } from "./ASRClient.js";

--- a/packages/asr/src/core/types.ts
+++ b/packages/asr/src/core/types.ts
@@ -3,6 +3,9 @@
  */
 
 import type { Readable } from "node:stream";
+import type { PlatformConfig } from "@xiaozhi-client/platform-registry";
+
+export type { PlatformConfig };
 
 /**
  * 音频输入类型
@@ -54,15 +57,6 @@ export interface ASRController {
 }
 
 /**
- * 平台配置泛型接口
- */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
-
-/**
  * ASR 平台接口
  * 定义平台需要实现的抽象方法
  */
@@ -97,21 +91,6 @@ export interface ASRPlatform {
    * @returns WebSocket URL
    */
   getEndpoint(config: PlatformConfig): string;
-}
-
-/**
- * 平台注册表
- * 存储所有已注册的平台
- */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): ASRPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: ASRPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
 }
 
 /**

--- a/packages/platform-registry/package.json
+++ b/packages/platform-registry/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@xiaozhi-client/platform-registry",
+  "version": "0.0.1",
+  "description": "平台注册表共享包，用于 ASR、TTS 等服务的平台管理",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "check:type": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "clean:dist": "rimraf dist"
+  },
+  "keywords": [
+    "platform",
+    "registry",
+    "asr",
+    "tts",
+    "plugin"
+  ],
+  "author": "",
+  "license": "MIT",
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "tsup": "^8.3.5",
+    "typescript": "^5.3.0"
+  },
+  "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"
+}

--- a/packages/platform-registry/src/index.ts
+++ b/packages/platform-registry/src/index.ts
@@ -1,0 +1,8 @@
+/**
+ * 平台注册表共享包
+ *
+ * 提供通用的平台注册和管理功能，用于 ASR、TTS 等服务
+ */
+
+export type { Platform, PlatformConfig, PlatformRegistry } from "./types.js";
+export { SimplePlatformRegistry } from "./registry.js";

--- a/packages/platform-registry/src/registry.ts
+++ b/packages/platform-registry/src/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * 平台注册表实现
+ */
+
+import type { PlatformRegistry } from "./types.js";
+
+/**
+ * 简单平台注册表实现
+ * @template TPlatform - 平台类型
+ */
+export class SimplePlatformRegistry<TPlatform extends { readonly platform: string }>
+  implements PlatformRegistry<TPlatform>
+{
+  private platforms: Map<string, TPlatform> = new Map();
+
+  get(platform: string): TPlatform | undefined {
+    return this.platforms.get(platform);
+  }
+
+  register(platform: TPlatform): void {
+    this.platforms.set(platform.platform, platform);
+  }
+
+  list(): string[] {
+    return Array.from(this.platforms.keys());
+  }
+}

--- a/packages/platform-registry/src/types.ts
+++ b/packages/platform-registry/src/types.ts
@@ -1,0 +1,65 @@
+/**
+ * 平台注册表共享类型定义
+ */
+
+/**
+ * 平台配置泛型接口
+ */
+export interface PlatformConfig {
+  /** 平台类型 */
+  readonly platform: string;
+  [key: string]: unknown;
+}
+
+/**
+ * 平台接口泛型定义
+ * @template TController - 控制器类型
+ * @template TPlatform - 平台类型
+ */
+export interface Platform<TController, TPlatform extends { readonly platform: string }> {
+  /** 平台唯一标识 */
+  readonly platform: string;
+
+  /**
+   * 创建控制器
+   * @param config - 平台配置
+   * @returns 控制器实例
+   */
+  createController(config: PlatformConfig): TController;
+
+  /**
+   * 校验配置
+   * @param config - 用户配置
+   * @returns 校验后的配置
+   */
+  validateConfig(config: unknown): PlatformConfig;
+
+  /**
+   * 获取认证头
+   * @param config - 平台配置
+   * @returns 认证头
+   */
+  getAuthHeaders(config: PlatformConfig): Record<string, string>;
+
+  /**
+   * 获取服务地址
+   * @param config - 平台配置
+   * @returns 服务地址
+   */
+  getEndpoint(config: PlatformConfig): string;
+}
+
+/**
+ * 平台注册表接口
+ * @template TPlatform - 平台类型
+ */
+export interface PlatformRegistry<TPlatform> {
+  /** 获取平台 */
+  get(platform: string): TPlatform | undefined;
+
+  /** 注册平台 */
+  register(platform: TPlatform): void;
+
+  /** 获取所有已注册的平台 */
+  list(): string[];
+}

--- a/packages/platform-registry/tsconfig.json
+++ b/packages/platform-registry/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "moduleResolution": "bundler",
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true,
+    "composite": true
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "**/*.test.ts"]
+}

--- a/packages/platform-registry/tsup.config.ts
+++ b/packages/platform-registry/tsup.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm"],
+  target: "node20",
+  outDir: "./dist",
+  clean: true,
+  sourcemap: true,
+  dts: {
+    entry: ["src/index.ts"],
+    compilerOptions: {
+      composite: false,
+    },
+  },
+  bundle: true,
+  splitting: false,
+  minify: false,
+  keepNames: true,
+  platform: "node",
+  esbuildOptions: (options) => {
+    // 在生产环境移除 console 和 debugger
+    if (process.env.NODE_ENV === "production") {
+      options.drop = ["console", "debugger"];
+    }
+    options.resolveExtensions = [".ts", ".js", ".json"];
+  },
+  outExtension() {
+    return { js: ".js" };
+  },
+});

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -41,6 +41,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@xiaozhi-client/platform-registry": "workspace:*",
     "ws": "^8.16.0",
     "zod": "^3.23.8"
   },

--- a/packages/tts/src/__tests__/core/registry.test.ts
+++ b/packages/tts/src/__tests__/core/registry.test.ts
@@ -1,21 +1,21 @@
 /**
- * SimplePlatformRegistry 测试
+ * SimplePlatformRegistryImpl 测试
  */
 
-import { SimplePlatformRegistry, type TTSPlatform } from "@/core/index.js";
+import { SimplePlatformRegistryImpl, type TTSPlatform } from "@/core/index.js";
 import { describe, expect, it, vi } from "vitest";
 
-describe("SimplePlatformRegistry", () => {
+describe("SimplePlatformRegistryImpl", () => {
   describe("构造函数", () => {
     it("应创建空的平台注册表", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
       expect(registry.list()).toEqual([]);
     });
   });
 
   describe("register 方法", () => {
     it("应注册平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const mockPlatform: TTSPlatform = {
         platform: "test-platform",
@@ -31,7 +31,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应允许注册多个平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const mockPlatform1: TTSPlatform = {
         platform: "platform-1",
@@ -58,7 +58,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应覆盖已存在的平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const mockPlatform1: TTSPlatform = {
         platform: "duplicate-platform",
@@ -85,7 +85,7 @@ describe("SimplePlatformRegistry", () => {
 
   describe("get 方法", () => {
     it("应返回已注册的平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const mockPlatform: TTSPlatform = {
         platform: "test-platform",
@@ -104,7 +104,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应返回 undefined 当平台不存在时", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const result = registry.get("non-existent");
 
@@ -114,13 +114,13 @@ describe("SimplePlatformRegistry", () => {
 
   describe("list 方法", () => {
     it("应返回空数组当没有注册平台时", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       expect(registry.list()).toEqual([]);
     });
 
     it("应返回所有已注册的平台名称", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimplePlatformRegistryImpl();
 
       const mockPlatform1: TTSPlatform = {
         platform: "platform-a",

--- a/packages/tts/src/core/TTSPlatform.ts
+++ b/packages/tts/src/core/TTSPlatform.ts
@@ -2,12 +2,12 @@
  * TTS 平台抽象接口
  */
 
-import type {
-  PlatformConfig,
-  PlatformRegistry,
-  TTSController,
-  TTSPlatform,
-} from "./types.js";
+import {
+  type PlatformConfig,
+  SimplePlatformRegistry,
+  type PlatformRegistry,
+} from "@xiaozhi-client/platform-registry";
+import type { TTSController, TTSPlatform } from "./types.js";
 
 /**
  * 创建 TTS 平台实例
@@ -15,28 +15,22 @@ import type {
 export type TTSPlatformFactory = (config: PlatformConfig) => TTSPlatform;
 
 /**
- * 简单平台注册表实现
+ * TTS 平台注册表类型
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, TTSPlatform> = new Map();
+export type TTSPlatformRegistry = PlatformRegistry<TTSPlatform>;
 
-  get(platform: string): TTSPlatform | undefined {
-    return this.platforms.get(platform);
-  }
-
-  register(platform: TTSPlatform): void {
-    this.platforms.set(platform.platform, platform);
-  }
-
-  list(): string[] {
-    return Array.from(this.platforms.keys());
-  }
-}
+/**
+ * 简单平台注册表实现（TTS 特化）
+ */
+export class SimplePlatformRegistryImpl
+  extends SimplePlatformRegistry<TTSPlatform>
+  implements TTSPlatformRegistry
+{}
 
 /**
  * 全局平台注册表
  */
-export const platformRegistry = new SimplePlatformRegistry();
+export const platformRegistry = new SimplePlatformRegistryImpl();
 
 /**
  * 注册平台装饰器
@@ -48,4 +42,4 @@ export function registerPlatform(platform: TTSPlatform): ClassDecorator {
   };
 }
 
-export type { TTSController, TTSPlatform, PlatformConfig };
+export type { TTSController, TTSPlatform };

--- a/packages/tts/src/core/types.ts
+++ b/packages/tts/src/core/types.ts
@@ -2,6 +2,10 @@
  * TTS 核心类型定义
  */
 
+import type { PlatformConfig } from "@xiaozhi-client/platform-registry";
+
+export type { PlatformConfig };
+
 /**
  * 音频块回调类型
  * @param chunk - 音频数据块
@@ -53,15 +57,6 @@ export interface TTSController {
 }
 
 /**
- * 平台配置泛型接口
- */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
-
-/**
  * TTS 平台接口
  * 定义平台需要实现的抽象方法
  */
@@ -96,21 +91,6 @@ export interface TTSPlatform {
    * @returns WebSocket URL
    */
   getEndpoint(config: PlatformConfig): string;
-}
-
-/**
- * 平台注册表
- * 存储所有已注册的平台
- */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): TTSPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: TTSPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -536,6 +536,9 @@ importers:
 
   packages/asr:
     dependencies:
+      '@xiaozhi-client/platform-registry':
+        specifier: workspace:*
+        version: link:../platform-registry
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.9.0)
@@ -689,6 +692,18 @@ importers:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(happy-dom@20.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
 
+  packages/platform-registry:
+    devDependencies:
+      '@types/node':
+        specifier: ^20.10.0
+        version: 20.19.33
+      tsup:
+        specifier: ^8.3.5
+        version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
+      typescript:
+        specifier: ^5.3.0
+        version: 5.9.3
+
   packages/shared-types:
     devDependencies:
       '@types/node':
@@ -703,6 +718,9 @@ importers:
 
   packages/tts:
     dependencies:
+      '@xiaozhi-client/platform-registry':
+        specifier: workspace:*
+        version: link:../platform-registry
       ws:
         specifier: ^8.16.0
         version: 8.19.0


### PR DESCRIPTION
创建 `@xiaozhi-client/platform-registry` 共享包，包含:
- 通用 `PlatformConfig` 接口
- 泛型 `PlatformRegistry<T>` 接口
- `SimplePlatformRegistry<T>` 实现类

更新 `@xiaozhi-client/asr` 和 `@xiaozhi-client/tts` 使用共享包:
- 删除重复的 `SimplePlatformRegistry` 类实现
- 删除重复的 `PlatformConfig` 和 `PlatformRegistry` 接口定义
- 保留各包特定的 `SimplePlatformRegistryImpl` 特化类

修复了 jscpd 检测到的跨包代码重复问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2025