### PR TITLE
fix(handlers): 将 WebSocket 参数从 any 类型改为正确的 WebSocketLike 类型

### DIFF
--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -19,7 +19,7 @@ interface MockNotificationService extends Partial<NotificationService> {
 
 interface MockWebSocket {
   send: ReturnType<typeof vi.fn>;
-  readyState?: number;
+  readyState: number;
 }
 
 // 模拟依赖

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -11,6 +11,15 @@ import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
+import type WebSocket from "ws";
+
+/**
+ * WebSocket 兼容类型
+ * 支持 ws 库的 WebSocket 类型和测试 Mock 类型
+ */
+type WebSocketLike =
+  | WebSocket
+  | { send: (data: string) => void; readyState: number };
 
 /**
  * 心跳消息接口
@@ -46,7 +55,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -82,7 +91,10 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -200,7 +212,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -12,6 +12,15 @@ import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
+import type WebSocket from "ws";
+
+/**
+ * WebSocket 兼容类型
+ * 支持 ws 库的 WebSocket 类型和测试 Mock 类型
+ */
+type WebSocketLike =
+  | WebSocket
+  | { send: (data: string) => void; readyState: number };
 
 /**
  * WebSocket 消息接口
@@ -46,7 +55,7 @@ export class RealtimeNotificationHandler {
    * @deprecated 部分消息类型已废弃，建议使用 HTTP API
    */
   async handleMessage(
-    ws: any,
+    ws: WebSocketLike,
     message: WebSocketMessage,
     clientId: string
   ): Promise<void> {
@@ -103,7 +112,10 @@ export class RealtimeNotificationHandler {
    * 处理获取配置请求
    * @deprecated 使用 GET /api/config 替代
    */
-  private async handleGetConfig(ws: any, clientId: string): Promise<void> {
+  private async handleGetConfig(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     this.logDeprecationWarning("WebSocket getConfig", "GET /api/config");
 
     try {
@@ -126,7 +138,7 @@ export class RealtimeNotificationHandler {
    * @deprecated 使用 PUT /api/config 替代
    */
   private async handleUpdateConfig(
-    ws: any,
+    ws: WebSocketLike,
     configData: AppConfig,
     clientId: string
   ): Promise<void> {
@@ -173,7 +185,10 @@ export class RealtimeNotificationHandler {
    * 处理获取状态请求
    * @deprecated 使用 GET /api/status 替代
    */
-  private async handleGetStatus(ws: any, clientId: string): Promise<void> {
+  private async handleGetStatus(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     this.logDeprecationWarning("WebSocket getStatus", "GET /api/status");
 
     try {
@@ -195,7 +210,10 @@ export class RealtimeNotificationHandler {
    * 处理重启服务请求
    * @deprecated 使用 POST /api/services/restart 替代
    */
-  private async handleRestartService(ws: any, clientId: string): Promise<void> {
+  private async handleRestartService(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     this.logDeprecationWarning(
       "WebSocket restartService",
       "POST /api/services/restart"
@@ -238,7 +256,7 @@ export class RealtimeNotificationHandler {
   /**
    * 发送初始数据给新连接的客户端
    */
-  async sendInitialData(ws: any, clientId: string): Promise<void> {
+  async sendInitialData(ws: WebSocketLike, clientId: string): Promise<void> {
     try {
       this.logger.debug("发送初始数据给客户端", { clientId });
 
@@ -280,7 +298,7 @@ export class RealtimeNotificationHandler {
   /**
    * 处理客户端连接
    */
-  handleClientConnect(ws: any, clientId: string): void {
+  handleClientConnect(ws: WebSocketLike, clientId: string): void {
     this.logger.debug(`客户端连接: ${clientId}`);
     this.notificationService.registerClient(clientId, ws);
   }


### PR DESCRIPTION
修复了 heartbeat.handler.ts 和 realtime-notification.handler.ts 中的 WebSocket 参数类型，将 any 类型替换为更具类型安全性的 WebSocketLike 类型。

主要变更：
- 添加 WebSocketLike 类型定义，兼容 ws 库的 WebSocket 类型和测试 Mock 类型
- 修复 heartbeat.handler.ts 中 3 处 ws 参数类型
- 修复 realtime-notification.handler.ts 中 7 处 ws 参数类型
- 更新 heartbeat.handler.test.ts 中的 MockWebSocket 接口

这改善了 IDE 的类型提示和自动补全功能，并提高了代码的类型安全性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2033