### PR TITLE
refactor(mcp-core): 用统一 Logger 系统替换 console 方法

### DIFF
--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -53,6 +53,17 @@ export { MCPConnection } from "./connection.js";
 export { MCPManager, MCPServiceManager } from "./manager.js";
 
 // =========================
+// 日志系统导出
+// =========================
+
+export {
+  MCPLogger,
+  createLogger,
+  LogLevel,
+} from "./logger.js";
+export type { LogLevelType, LoggerLike } from "./logger.js";
+
+// =========================
 // 传输工厂导出
 // =========================
 

--- a/packages/mcp-core/src/logger.ts
+++ b/packages/mcp-core/src/logger.ts
@@ -1,0 +1,166 @@
+/**
+ * MCP 核心包日志系统
+ *
+ * 提供轻量级的日志记录功能，支持日志级别过滤和统一格式
+ *
+ * @module logger
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+}
+
+/**
+ * 日志级别类型
+ */
+export type LogLevelType = keyof typeof LogLevel;
+
+/**
+ * LoggerLike 接口 - 用于依赖注入
+ */
+export interface LoggerLike {
+  debug(message: string, ...args: unknown[]): void;
+  info(message: string, ...args: unknown[]): void;
+  warn(message: string, ...args: unknown[]): void;
+  error(message: string, ...args: unknown[]): void;
+}
+
+/**
+ * MCP 核心包 Logger 类
+ *
+ * 提供轻量级的日志记录功能，支持：
+ * - 日志级别过滤
+ * - 统一的前缀格式
+ * - 可变参数支持
+ */
+export class MCPLogger implements LoggerLike {
+  private level: LogLevel;
+  private prefix: string;
+
+  /**
+   * 创建 Logger 实例
+   * @param prefix 日志前缀
+   * @param level 日志级别，默认为 INFO
+   */
+  constructor(prefix = "", level: LogLevel = LogLevel.INFO) {
+    this.prefix = prefix;
+    this.level = level;
+  }
+
+  /**
+   * 设置日志级别
+   * @param level 新的日志级别
+   */
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+
+  /**
+   * 获取当前日志级别
+   * @returns 当前日志级别
+   */
+  getLevel(): LogLevel {
+    return this.level;
+  }
+
+  /**
+   * 记录调试级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (this.level <= LogLevel.DEBUG) {
+      this.log("debug", message, ...args);
+    }
+  }
+
+  /**
+   * 记录信息级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (this.level <= LogLevel.INFO) {
+      this.log("info", message, ...args);
+    }
+  }
+
+  /**
+   * 记录警告级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  warn(message: string, ...args: unknown[]): void {
+    if (this.level <= LogLevel.WARN) {
+      this.log("warn", message, ...args);
+    }
+  }
+
+  /**
+   * 记录错误级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  error(message: string, ...args: unknown[]): void {
+    if (this.level <= LogLevel.ERROR) {
+      this.log("error", message, ...args);
+    }
+  }
+
+  /**
+   * 内部日志方法
+   * @param level 日志级别名称
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  private log(level: string, message: string, ...args: unknown[]): void {
+    const prefix = this.prefix ? `[${this.prefix}] ` : "";
+    const fullMessage = `${prefix}${message}`;
+
+    switch (level) {
+      case "debug":
+        console.debug(fullMessage, ...args);
+        break;
+      case "info":
+        console.info(fullMessage, ...args);
+        break;
+      case "warn":
+        console.warn(fullMessage, ...args);
+        break;
+      case "error":
+        console.error(fullMessage, ...args);
+        break;
+    }
+  }
+
+  /**
+   * 创建带有新前缀的子 Logger
+   * @param newPrefix 新的前缀
+   * @returns 新的 Logger 实例
+   */
+  withPrefix(newPrefix: string): MCPLogger {
+    const combinedPrefix = this.prefix
+      ? `${this.prefix}:${newPrefix}`
+      : newPrefix;
+    return new MCPLogger(combinedPrefix, this.level);
+  }
+}
+
+/**
+ * 创建默认 Logger 实例
+ * @param prefix 日志前缀
+ * @param level 日志级别
+ * @returns Logger 实例
+ */
+export function createLogger(
+  prefix: string,
+  level: LogLevel = LogLevel.INFO
+): MCPLogger {
+  return new MCPLogger(prefix, level);
+}

--- a/packages/mcp-core/src/transport-factory.ts
+++ b/packages/mcp-core/src/transport-factory.ts
@@ -13,8 +13,12 @@ import { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js"
 import type { StreamableHTTPClientTransportOptions } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import { EventSource } from "eventsource";
+import { createLogger } from "./logger.js";
 import type { InternalMCPServiceConfig, MCPServerTransport } from "./types.js";
 import { MCPTransportType } from "./types.js";
+
+// 创建工厂日志记录器
+const factoryLogger = createLogger("TransportFactory");
 
 // 全局 polyfill EventSource（用于 SSE）
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -39,9 +43,7 @@ export interface Transport {
 export function createTransport(
   config: InternalMCPServiceConfig
 ): MCPServerTransport {
-  console.debug(
-    `[TransportFactory] 创建 ${config.type} transport for ${config.name}`
-  );
+  factoryLogger.debug(`创建 ${config.type} transport for ${config.name}`);
 
   switch (config.type) {
     case MCPTransportType.STDIO:

--- a/packages/mcp-core/src/utils/validators.ts
+++ b/packages/mcp-core/src/utils/validators.ts
@@ -9,14 +9,28 @@
  * @module validators
  */
 
-import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "../types.js";
-import { TypeFieldNormalizer } from "./type-normalizer.js";
+import { type MCPLogger, createLogger } from "../logger.js";
+import {
+  MCPTransportType,
+  ToolCallError,
+  ToolCallErrorCode,
+} from "../types.js";
 import type {
   MCPServiceConfig,
   ToolCallParams,
   ToolCallValidationOptions,
   ValidatedToolCallParams,
 } from "../types.js";
+import { TypeFieldNormalizer } from "./type-normalizer.js";
+
+/**
+ * 创建带有服务名称的 Logger 实例
+ * @param serviceName 服务名称
+ * @returns Logger 实例
+ */
+function createServiceLogger(serviceName?: string): MCPLogger {
+  return serviceName ? createLogger(`MCP-${serviceName}`) : createLogger("MCP");
+}
 
 /**
  * 根据 URL 路径推断传输类型
@@ -44,19 +58,16 @@ export function inferTransportTypeFromUrl(
       return MCPTransportType.HTTP;
     }
 
-    // 默认类型 - 使用 console 输出
+    // 默认类型 - 使用 logger 输出
     if (options?.serviceName) {
-      console.info(
-        `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
-      );
+      const logger = createServiceLogger(options.serviceName);
+      logger.info(`URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`);
     }
     return MCPTransportType.HTTP;
   } catch (error) {
     if (options?.serviceName) {
-      console.warn(
-        `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
-        error
-      );
+      const logger = createServiceLogger(options.serviceName);
+      logger.warn("URL 解析失败，默认推断为 http 类型", error);
     }
     return MCPTransportType.HTTP;
   }


### PR DESCRIPTION
- 创建 MCPLogger 类提供统一的日志记录功能
- 支持日志级别过滤 (DEBUG, INFO, WARN, ERROR)
- 替换 connection.ts 中的 ~16 处 console 调用
- 替换 transport-factory.ts 中的 console.debug 调用
- 替换 validators.ts 中的 console 调用
- 导出 LoggerLike 接口用于依赖注入

修复 #2036

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2036