### PR TITLE
fix(deps): 统一 zod 版本到 4.3.6 修复 monorepo 依赖不一致

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -42,7 +42,7 @@
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",

--- a/packages/asr/src/platforms/bytedance/config/v3.ts
+++ b/packages/asr/src/platforms/bytedance/config/v3.ts
@@ -29,7 +29,7 @@ export const ByteDanceV3AudioSchema = z.object({
   /** 编解码器 */
   codec: z.string().optional(),
   /** 编解码器选项 */
-  codec_options: z.record(z.unknown()).optional(),
+  codec_options: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**
@@ -75,7 +75,7 @@ export const ByteDanceV3RequestSchema = z.object({
   /** 首字加速分数 */
   accelerate_score: z.number().optional(),
   /** 额外参数 */
-  extra: z.record(z.unknown()).optional(),
+  extra: z.record(z.string(), z.unknown()).optional(),
 });
 
 /**

--- a/packages/asr/src/platforms/bytedance/schemas/api-v3.ts
+++ b/packages/asr/src/platforms/bytedance/schemas/api-v3.ts
@@ -43,7 +43,7 @@ export const ByteDanceV3AudioSchema = z.object({
     .string()
     .optional()
     .describe("音频编码格式：raw / opus，默认为 raw(表示pcm)"),
-  codec_options: z.record(z.unknown()).optional().describe("编码选项"),
+  codec_options: z.record(z.string(), z.unknown()).optional().describe("编码选项"),
 });
 
 export type ByteDanceV3Audio = z.infer<typeof ByteDanceV3AudioSchema>;
@@ -90,7 +90,7 @@ export const ByteDanceV3RequestSchema = z.object({
     .optional()
     .describe("是否启动首字返回加速"),
   accelerate_score: z.number().optional().describe("首字返回加速率"),
-  extra: z.record(z.unknown()).optional().describe("额外参数"),
+  extra: z.record(z.string(), z.unknown()).optional().describe("额外参数"),
 });
 
 export type ByteDanceV3Request = z.infer<typeof ByteDanceV3RequestSchema>;

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -42,7 +42,7 @@
   "license": "MIT",
   "dependencies": {
     "ws": "^8.16.0",
-    "zod": "^3.23.8"
+    "zod": "^4.3.6"
   },
   "devDependencies": {
     "@types/node": "^24.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -546,8 +546,8 @@ importers:
         specifier: ^8.16.0
         version: 8.19.0
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^20.10.0
@@ -707,8 +707,8 @@ importers:
         specifier: ^8.16.0
         version: 8.19.0
       zod:
-        specifier: ^3.23.8
-        version: 3.25.76
+        specifier: ^4.3.6
+        version: 4.3.6
     devDependencies:
       '@types/node':
         specifier: ^24.3.0
@@ -7466,9 +7466,6 @@ packages:
     resolution: {integrity: sha512-pM/SU9d3YAggzi6MtR4h7ruuQlqKtad8e9S0fmxcMi+ueAK5Korys/aWcV9LIIHTVbj01NdzxcnXSN+O74ZIVA==}
     peerDependencies:
       zod: ^3.25 || ^4
-
-  zod@3.25.76:
-    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zod@4.3.6:
     resolution: {integrity: sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==}
@@ -15285,8 +15282,6 @@ snapshots:
   zod-to-json-schema@3.25.1(zod@4.3.6):
     dependencies:
       zod: 4.3.6
-
-  zod@3.25.76: {}
 
   zod@4.3.6: {}
 


### PR DESCRIPTION
- 升级 packages/asr 和 packages/tts 的 zod 从 ^3.23.8 到 ^4.3.6
- 修复 zod 4.x 破坏性变更：z.record(z.unknown()) 需要改为 z.record(z.string(), z.unknown())
- 所有类型检查和测试通过

修复 #2042

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2042