### PR TITLE
fix(handler): 为 spawnXiaozhiProcess 添加 error 事件监听器

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -44,6 +44,22 @@ export class ServiceApiHandler {
       },
     });
 
+    // 监听进程启动失败事件
+    child.on("error", (error) => {
+      this.logger.error(
+        `启动 xiaozhi 进程失败: xiaozhi ${args.join(" ")}`,
+        error
+      );
+
+      // 发射启动失败事件
+      this.eventBus.emitEvent("service:spawn:failed", {
+        command: "xiaozhi",
+        args,
+        error: error.message,
+        timestamp: Date.now(),
+      });
+    });
+
     child.unref();
     this.logger.info(`MCP 服务命令已发送: xiaozhi ${args.join(" ")}`);
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -97,6 +97,12 @@ export interface EventBusEvents {
     newStatus: string;
     timestamp: number;
   };
+  "service:spawn:failed": {
+    command: string;
+    args: string[];
+    error: string;
+    timestamp: number;
+  };
 
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };


### PR DESCRIPTION
修复 `spawnXiaozhiProcess` 方法缺少 spawn 错误事件监听的问题。
当 xiaozhi 命令不存在或启动失败时，现在会：
- 记录错误日志
- 发射 service:spawn:failed 事件

影响范围：
- POST /api/services/restart
- POST /api/services/stop
- POST /api/services/start

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2050