### PR TITLE
refactor(cli): 删除 Container.ts 中未使用的 asyncFactories 字段

### DIFF
--- a/packages/cli/src/Container.ts
+++ b/packages/cli/src/Container.ts
@@ -18,7 +18,6 @@ import { Validation } from "./utils/Validation";
 export class DIContainer implements IDIContainer {
   private instances = new Map<string, any>();
   private factories = new Map<string, () => any>();
-  private asyncFactories = new Map<string, () => Promise<any>>();
   private singletons = new Set<string>();
 
   /**


### PR DESCRIPTION
- 删除 DIContainer 类中从未被引用的 asyncFactories 私有字段
- 减少死代码，提高代码可读性和可维护性

Fixes #2055

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2055