### PR TITLE
perf(mcp-tool): 优化 convertChineseToEnglish 方法性能

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -48,6 +48,60 @@ interface LegacyAddCustomToolRequest {
 }
 
 /**
+ * 中文到英文映射表（模块级常量，避免重复创建）
+ */
+const CHINESE_TO_ENGLISH_MAP: Record<string, string> = {
+  工作流: "workflow",
+  测试: "test",
+  数据: "data",
+  处理: "process",
+  分析: "analysis",
+  生成: "generate",
+  查询: "query",
+  搜索: "search",
+  转换: "convert",
+  计算: "calculate",
+  统计: "statistics",
+  报告: "report",
+  文档: "document",
+  图片: "image",
+  视频: "video",
+  音频: "audio",
+  文本: "text",
+  翻译: "translate",
+  识别: "recognize",
+  检测: "detect",
+  监控: "monitor",
+  管理: "manage",
+  配置: "config",
+  设置: "setting",
+  用户: "user",
+  系统: "system",
+  服务: "service",
+  接口: "api",
+  数据库: "database",
+  网络: "network",
+  安全: "security",
+  备份: "backup",
+  恢复: "restore",
+  同步: "sync",
+  导入: "import",
+  导出: "export",
+  上传: "upload",
+  下载: "download",
+};
+
+/**
+ * 预编译的中文正则表达式映射表（避免每次调用都创建新 RegExp 对象）
+ */
+const CHINESE_REGEX_MAP = new Map(
+  Object.entries(CHINESE_TO_ENGLISH_MAP).map(([chinese, english]) => [
+    chinese,
+    { regex: new RegExp(chinese, "g"), replacement: english },
+  ])
+);
+
+/**
  * MCP 工具调用 API 处理器
  */
 export class MCPToolHandler {
@@ -1208,53 +1262,13 @@ export class MCPToolHandler {
    * 简单的中文到英文转换（可以扩展为更复杂的拼音转换）
    */
   private convertChineseToEnglish(text: string): string {
-    // 常见中文词汇的映射
-    const chineseToEnglishMap: Record<string, string> = {
-      工作流: "workflow",
-      测试: "test",
-      数据: "data",
-      处理: "process",
-      分析: "analysis",
-      生成: "generate",
-      查询: "query",
-      搜索: "search",
-      转换: "convert",
-      计算: "calculate",
-      统计: "statistics",
-      报告: "report",
-      文档: "document",
-      图片: "image",
-      视频: "video",
-      音频: "audio",
-      文本: "text",
-      翻译: "translate",
-      识别: "recognize",
-      检测: "detect",
-      监控: "monitor",
-      管理: "manage",
-      配置: "config",
-      设置: "setting",
-      用户: "user",
-      系统: "system",
-      服务: "service",
-      接口: "api",
-      数据库: "database",
-      网络: "network",
-      安全: "security",
-      备份: "backup",
-      恢复: "restore",
-      同步: "sync",
-      导入: "import",
-      导出: "export",
-      上传: "upload",
-      下载: "download",
-    };
-
     let result = text;
 
-    // 替换常见中文词汇
-    for (const [chinese, english] of Object.entries(chineseToEnglishMap)) {
-      result = result.replace(new RegExp(chinese, "g"), english);
+    // 使用预编译的 RegExp 对象替换常见中文词汇
+    for (const { regex, replacement } of Array.from(
+      CHINESE_REGEX_MAP.values()
+    )) {
+      result = result.replace(regex, replacement);
     }
 
     // 如果还有中文字符，用拼音前缀替代


### PR DESCRIPTION
将中文到英文映射表和正则表达式对象移至模块级常量，避免每次调用时重复创建对象。

- 将 chineseToEnglishMap 移至模块级 CHINESE_TO_ENGLISH_MAP 常量
- 新增 CHINESE_REGEX_MAP 常量，预编译所有正则表达式对象
- 更新 convertChineseToEnglish 方法使用预编译的正则对象

性能改进：每次调用从创建 ~76 个对象减少至 0 个对象创建。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2062