### PR TITLE
fix: 添加错误响应 JSON 解析失败时的警告日志

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -197,8 +197,9 @@ export class ApiClient {
       try {
         const errorData: ApiErrorResponse = await response.json();
         errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+      } catch (jsonError) {
+        // 如果无法解析错误响应，记录警告并使用默认错误消息
+        console.warn("无法解析错误响应 JSON，使用默认错误消息:", jsonError);
       }
 
       throw new Error(errorMessage);

--- a/apps/frontend/src/services/cozeApi.ts
+++ b/apps/frontend/src/services/cozeApi.ts
@@ -76,8 +76,9 @@ export class CozeApiClient {
       try {
         const errorData: ApiErrorResponse = await response.json();
         errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+      } catch (jsonError) {
+        // 如果无法解析错误响应，记录警告并使用默认错误消息
+        console.warn("无法解析错误响应 JSON，使用默认错误消息:", jsonError);
       }
 
       throw new Error(errorMessage);


### PR DESCRIPTION
在 api.ts 和 cozeApi.ts 的 request 方法中，当错误响应 JSON
解析失败时，现在会记录 console.warn 警告日志，方便调试。

修复 #2064

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2064