### PR TITLE
fix: 在 esp32.service.ts 的 onMessage 回调中添加错误处理

### DIFF
--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -300,7 +300,14 @@ export class ESP32Service {
     // 创建新的连接
     const connection = new ESP32Connection(deviceId, clientId, ws, {
       onMessage: async (message) => {
-        await this.handleDeviceMessage(deviceId, message);
+        try {
+          await this.handleDeviceMessage(deviceId, message);
+        } catch (error) {
+          logger.error(
+            `[ESP32Service] 处理设备消息失败: deviceId=${deviceId}`,
+            error
+          );
+        }
       },
       onClose: () => {
         this.handleDeviceDisconnect(deviceId, clientId);


### PR DESCRIPTION
修复 #2066

在 ESP32Connection 创建时的 onMessage 回调中添加 try-catch 错误处理，
确保 handleDeviceMessage 调用失败时能够记录错误日志，避免未捕获的
Promise rejection。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2066