### PR TITLE
fix(shared-types): 移除 ConnectionConfig 重复定义

### DIFF
--- a/packages/shared-types/src/config/connection.ts
+++ b/packages/shared-types/src/config/connection.ts
@@ -2,23 +2,8 @@
  * 连接配置相关类型定义
  */
 
-/**
- * 连接配置接口
- */
-export interface ConnectionConfig {
-  /** 心跳间隔（毫秒） */
-  heartbeatInterval?: number;
-  /** 心跳超时时间（毫秒） */
-  heartbeatTimeout?: number;
-  /** 重连间隔（毫秒） */
-  reconnectInterval?: number;
-  /** 最大重连次数 */
-  maxReconnectAttempts?: number;
-  /** 连接超时时间（毫秒） */
-  connectionTimeout?: number;
-  /** 是否启用自动重连 */
-  autoReconnect?: boolean;
-}
+// 从 app.ts 导入 ConnectionConfig，避免重复定义
+import type { ConnectionConfig } from "./app";
 
 /**
  * 端点配置接口

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -19,7 +19,6 @@ export type {
 
 // 连接配置相关类型
 export type {
-  ConnectionConfig as ConfigConnectionConfig,
   EndpointConfig,
   LoadBalancingConfig,
 } from "./connection";


### PR DESCRIPTION
- 删除 connection.ts 中重复的 ConnectionConfig 定义
- 改为从 app.ts 导入 ConnectionConfig
- 删除 index.ts 中未使用的 ConfigConnectionConfig 导出

遵循 DRY 原则，统一使用 app.ts 中的 ConnectionConfig 定义。

Fixes #2072

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2072