### PR TITLE
fix: 将 NPMManager 中的 console.log 替换为统一的 logger.error

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -71,7 +71,7 @@ export class NPMManager {
       // 监听进程启动失败事件
       npmProcess.on("error", (error) => {
         const errorMessage = `进程启动失败: ${error.message}`;
-        console.log(errorMessage, { error });
+        logger.error(errorMessage, error);
 
         // 清理资源
         cleanup();


### PR DESCRIPTION
- 修复 apps/backend/lib/npm/manager.ts:74 使用 console.log 的问题
- 改为使用 logger.error 以保持日志系统一致性
- 文件已导入 logger，无需额外依赖

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2081