### PR TITLE
refactor: 统一 ToolCallResult 接口定义到单一位置

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -15,14 +15,13 @@ import type {
   InternalMCPServiceConfig,
   MCPServiceConfig,
   ManagerStatus,
-  ToolCallResult,
   ToolInfo,
   ToolStatusFilter,
   UnifiedServerConfig,
   UnifiedServerStatus,
 } from "@/lib/mcp/types";
 import { getEventBus } from "@/services/event-bus.service.js";
-import type { MCPMessage } from "@/types/mcp.js";
+import type { MCPMessage, ToolCallResult } from "@/types/mcp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { isModelScopeURL } from "@xiaozhi-client/config";
 import type { MCPToolConfig } from "@xiaozhi-client/config";

--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -113,19 +113,8 @@ export interface MCPServiceStatus {
 // 4. 工具调用相关类型
 // =========================
 
-/**
- * 工具调用结果接口
- * 使用简化的类型定义，保持向后兼容性
- * 注意：这与 @xiaozhi-client/mcp-core 中的 ToolCallResult 类型不同
- */
-export interface ToolCallResult {
-  content: Array<{
-    type: string;
-    text: string;
-  }>;
-  isError?: boolean;
-  [key: string]: unknown; // 支持其他未知字段，与 endpoint 包保持兼容
-}
+// ToolCallResult 重新导出：统一到 @/types/mcp.js 避免重复定义
+export type { ToolCallResult } from "@/types/mcp.js";
 
 /**
  * JSON Schema 类型定义


### PR DESCRIPTION
将 ToolCallResult 接口统一定义到 apps/backend/types/mcp.ts，
移除 apps/backend/lib/mcp/types.ts 中的重复定义。

修改内容：
- 移除 lib/mcp/types.ts 中的 ToolCallResult 接口定义
- 添加重新导出语句: export type { ToolCallResult } from "@/types/mcp.js"
- 更新 manager.ts 导入路径，统一使用 @/types/mcp.js

这消除了代码重复，遵循 DRY 原则，提高了代码可维护性。

修复 #2086

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2086