### PR TITLE
fix: 统一 ConnectionConfig 接口定义，解决字段数量不一致问题

### DIFF
--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -51,6 +51,9 @@ const DEFAULT_CONNECTION_CONFIG: Required<ConnectionConfig> = {
   heartbeatInterval: 30000, // 30秒心跳间隔
   heartbeatTimeout: 10000, // 10秒心跳超时
   reconnectInterval: 5000, // 5秒重连间隔
+  maxReconnectAttempts: 10, // 最大重连次数
+  connectionTimeout: 30000, // 30秒连接超时
+  autoReconnect: true, // 启用自动重连
 };
 
 // 配置文件接口定义
@@ -96,10 +99,22 @@ export interface MCPServerToolsConfig {
   tools: Record<string, MCPToolConfig>;
 }
 
+/**
+ * 连接配置接口
+ */
 export interface ConnectionConfig {
-  heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
-  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000
-  reconnectInterval?: number; // 重连间隔（毫秒），默认5000
+  /** 心跳间隔（毫秒） */
+  heartbeatInterval?: number;
+  /** 心跳超时时间（毫秒） */
+  heartbeatTimeout?: number;
+  /** 重连间隔（毫秒） */
+  reconnectInterval?: number;
+  /** 最大重连次数 */
+  maxReconnectAttempts?: number;
+  /** 连接超时时间（毫秒） */
+  connectionTimeout?: number;
+  /** 是否启用自动重连 */
+  autoReconnect?: boolean;
 }
 
 export interface ModelScopeConfig {
@@ -1105,6 +1120,15 @@ export class ConfigManager {
       reconnectInterval:
         connectionConfig.reconnectInterval ??
         DEFAULT_CONNECTION_CONFIG.reconnectInterval,
+      maxReconnectAttempts:
+        connectionConfig.maxReconnectAttempts ??
+        DEFAULT_CONNECTION_CONFIG.maxReconnectAttempts,
+      connectionTimeout:
+        connectionConfig.connectionTimeout ??
+        DEFAULT_CONNECTION_CONFIG.connectionTimeout,
+      autoReconnect:
+        connectionConfig.autoReconnect ??
+        DEFAULT_CONNECTION_CONFIG.autoReconnect,
     };
   }
 

--- a/packages/shared-types/src/config/app.ts
+++ b/packages/shared-types/src/config/app.ts
@@ -2,15 +2,7 @@
  * 应用配置相关类型定义
  */
 
-// 连接配置接口
-export interface ConnectionConfig {
-  heartbeatInterval?: number;
-  heartbeatTimeout?: number;
-  reconnectInterval?: number;
-  maxReconnectAttempts?: number;
-  connectionTimeout?: number;
-  autoReconnect?: boolean;
-}
+import type { ConnectionConfig } from "./connection";
 
 /**
  * 本地 MCP 服务器配置

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -19,7 +19,7 @@ export type {
 
 // 连接配置相关类型
 export type {
-  ConnectionConfig as ConfigConnectionConfig,
+  ConnectionConfig,
   EndpointConfig,
   LoadBalancingConfig,
 } from "./connection";
@@ -30,6 +30,3 @@ export type {
   ServerInfo,
   RestartStatus,
 } from "./server";
-
-// 重新导出 ConnectionConfig 以避免命名冲突，使用默认的 app.ts 中的定义
-export type { ConnectionConfig } from "./app";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -607,6 +607,9 @@ importers:
 
   packages/config:
     dependencies:
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       comment-json:
         specifier: ^4.2.5
         version: 4.5.1


### PR DESCRIPTION
- 将 config 包中的 ConnectionConfig 扩展为 6 个字段，与 shared-types 保持一致
- 删除 shared-types/app.ts 中重复的 ConnectionConfig 定义
- 更新 shared-types/index.ts 导出，统一使用 connection.ts 中的定义
- 更新 config 包的 getConnectionConfig 方法以返回完整的配置字段
- 添加默认值：maxReconnectAttempts=10, connectionTimeout=30000, autoReconnect=true

修复 #2090

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2090