### PR TITLE
fix: 删除 cache.constants.ts 中未使用的 PAGINATION_LIMITS 常量

### DIFF
--- a/apps/backend/constants/__tests__/constants.test.ts
+++ b/apps/backend/constants/__tests__/constants.test.ts
@@ -29,8 +29,6 @@ import {
   MCP_SUPPORTED_PROTOCOL_VERSIONS,
   MCP_TIMEOUTS,
   MESSAGE_SIZE_LIMITS,
-  PAGINATION_CONSTANTS,
-  PAGINATION_LIMITS,
   RETRY_CONFIG,
   RETRY_DELAYS,
   STATUS_EVENTS,
@@ -276,26 +274,6 @@ describe("缓存相关常量", () => {
       expect(MESSAGE_SIZE_LIMITS.MAX).toBeGreaterThan(
         MESSAGE_SIZE_LIMITS.DEFAULT
       );
-    });
-  });
-
-  describe("PAGINATION_LIMITS", () => {
-    it("应该包含正确的分页限制", () => {
-      expect(PAGINATION_LIMITS.DEFAULT_LIMIT).toBe(50);
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBe(200);
-    });
-
-    it("最大限制应该大于默认限制", () => {
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBeGreaterThan(
-        PAGINATION_LIMITS.DEFAULT_LIMIT
-      );
-    });
-
-    it("应该与 PAGINATION_CONSTANTS 兼容", () => {
-      expect(PAGINATION_LIMITS.DEFAULT_LIMIT).toBe(
-        PAGINATION_CONSTANTS.DEFAULT_LIMIT
-      );
-      expect(PAGINATION_LIMITS.MAX_LIMIT).toBe(PAGINATION_CONSTANTS.MAX_LIMIT);
     });
   });
 

--- a/apps/backend/constants/cache.constants.ts
+++ b/apps/backend/constants/cache.constants.ts
@@ -23,16 +23,6 @@ export const MESSAGE_SIZE_LIMITS = {
 } as const;
 
 /**
- * 分页限制常量
- */
-export const PAGINATION_LIMITS = {
-  /** 默认每页记录数 */
-  DEFAULT_LIMIT: 50,
-  /** 最大每页记录数 */
-  MAX_LIMIT: 200,
-} as const;
-
-/**
  * 缓存文件相关常量
  */
 export const CACHE_FILE_CONFIG = {


### PR DESCRIPTION
PAGINATION_LIMITS 与 api.constants.ts 中的 PAGINATION_CONSTANTS 重复，
且未被实际使用。删除此常量以保持代码一致性，避免混淆。

- 从 cache.constants.ts 中删除 PAGINATION_LIMITS 常量定义
- 更新测试文件，移除相关的导入和测试用例
- 保留 PAGINATION_CONSTANTS 作为唯一的分页常量来源

Fixes #2091

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2091