### PR TITLE
fix(ci): 在发布时跳过 nx 缓存

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -125,7 +125,7 @@ jobs:
 
           # 执行发布
           echo "🚀 执行发布命令..."
-          pnpm exec nx release publish
+          pnpm exec nx release publish --skip-nx-cache
 
       - name: 发布结果
         if: always()


### PR DESCRIPTION
## Summary

- 在 `nx release publish` 命令中添加 `--skip-nx-cache` 参数
- 确保发布过程使用最新的代码状态，避免缓存导致的潜在问题

## Test plan

- [ ] 观察下次发布流程是否正常执行
- [ ] 确认发布使用最新代码而非缓存版本

🤖 Generated with [Claude Code](https://claude.com/claude-code)