### PR TITLE
chore(ci): 在发布流程中禁用 nx 缓存

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -96,6 +96,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NX_CACHE_DISABLED: true
         run: |
           VERSION="${{ steps.version-info.outputs.version }}"
           VERSION_TYPE="${{ steps.version-info.outputs.version_type }}"


### PR DESCRIPTION
## Summary

- 在 npm 发布工作流中添加 `NX_CACHE_DISABLED=true` 环境变量
- 确保发布时使用最新代码构建，避免缓存导致的潜在问题

## Test plan

- [ ] 验证工作流语法正确
- [ ] 下次发布时确认缓存已禁用

🤖 Generated with [Claude Code](claude.com/claude-code)