### PR TITLE
fix(ci): 确保 nx 缓存目录存在

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -124,6 +124,8 @@ jobs:
             exit 0
           fi
 
+          mkdir -p .nx/cache/terminalOutputs
+
           # 执行发布
           echo "🚀 执行发布命令..."
           pnpm exec nx release publish --skip-nx-cache


### PR DESCRIPTION
## Summary
- 在执行发布命令前创建 `.nx/cache/terminalOutputs` 目录
- 避免因目录不存在导致的发布失败

## Test plan
- [ ] 验证 CI 发布流程能正常执行

🤖 Generated with [Claude Code](https://claude.com/claude-code)