### PR TITLE
chore(ci): 简化 nx 缓存处理逻辑

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -96,7 +96,6 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_CONFIG_PROVENANCE: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NX_CACHE_DISABLED: true
         run: |
           VERSION="${{ steps.version-info.outputs.version }}"
           VERSION_TYPE="${{ steps.version-info.outputs.version_type }}"
@@ -123,8 +122,6 @@ jobs:
             echo "⚠️ 预演模式：跳过实际发布"
             exit 0
           fi
-
-          mkdir -p .nx/cache/terminalOutputs
 
           # 执行发布
           echo "🚀 执行发布命令..."

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xiaozhi-client": "dist/cli/index.js"
   },
   "scripts": {
-    "build": "nx reset && pnpm run clean:dist && nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false",
+    "build": "pnpm run clean:dist && nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false",
     "dev": "nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false && concurrently \"nx run backend:dev\" \"nx run cli:dev\" \"nx run frontend:dev\" --prefix \"[{name}]\" --names \"BACKEND,CLI,FRONTEND\"",
     "dev:cli": "nx run cli:dev",
     "dev:docs": "nx run docs:dev",


### PR DESCRIPTION
## Summary

- 移除构建脚本中的 `nx reset` 命令
- 移除 CI 工作流中的 `NX_CACHE_DISABLED` 环境变量
- 移除手动创建 `.nx/cache/terminalOutputs` 目录的步骤

这些变通方案是在排查 nx 缓存问题时添加的，现在问题已解决，可以恢复正常的缓存处理流程。

## Test plan

- [ ] CI 构建流程正常运行
- [ ] 发布流程不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)