### PR TITLE
fix(release): 将 asr 和 tts 包纳入发布流程

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -39,7 +39,7 @@
     }
   },
   "release": {
-    "projects": ["cli", "config", "shared-types", "mcp-core", "endpoint", "version", "calculator-mcp", "datetime-mcp", "xiaozhi-client"],
+    "projects": ["cli", "config", "shared-types", "mcp-core", "endpoint", "version", "asr", "tts", "calculator-mcp", "datetime-mcp", "xiaozhi-client"],
     "projectsRelationship": "fixed",
     "git": {
       "commit": true,

--- a/packages/asr/project.json
+++ b/packages/asr/project.json
@@ -60,6 +60,13 @@
         "command": "pnpm --filter asr run dev",
         "cwd": "packages/asr"
       }
+    },
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "../../scripts/publish-with-tag.sh",
+        "cwd": "packages/asr"
+      }
     }
   },
   "tags": ["type:lib", "scope:asr"]

--- a/packages/tts/project.json
+++ b/packages/tts/project.json
@@ -60,6 +60,13 @@
         "command": "pnpm --filter tts run dev",
         "cwd": "packages/tts"
       }
+    },
+    "nx-release-publish": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "../../scripts/publish-with-tag.sh",
+        "cwd": "packages/tts"
+      }
     }
   },
   "tags": ["type:lib", "scope:tts"]


### PR DESCRIPTION
## Summary

- 在 `nx.json` 的 `release.projects` 中添加 `asr` 和 `tts`
- 为 `packages/asr/project.json` 添加 `nx-release-publish` target
- 为 `packages/tts/project.json` 添加 `nx-release-publish` target

## 修复问题

用户安装 `xiaozhi-client@2.0.0-beta.4` 后执行 `xiaozhi start` 报错：
```
The requested module '@xiaozhi-client/asr' does not provide an export named 'OpusDecoder'
```

**根本原因**：`@xiaozhi-client/asr` 和 `@xiaozhi-client/tts` 未被纳入 Nx 发布流程，导致发布时版本号未更新，npm 上仍是旧版本。

## Test plan

- [x] 运行 `npx nx show projects --type lib` 确认 asr 和 tts 被识别
- [x] 运行 `pnpm check:type` 类型检查通过
- [ ] 发布 `2.0.0-beta.5` 后验证 `npm view @xiaozhi-client/asr version` 版本正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)