### PR TITLE
chore(asr,tts): 添加发布配置

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -14,6 +14,14 @@
   "files": [
     "dist"
   ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shenjingnan/xiaozhi-client.git",
+    "directory": "packages/asr"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "scripts": {
     "build": "tsup",
     "dev": "tsup --watch",

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -5,6 +5,14 @@
   "type": "module",
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shenjingnan/xiaozhi-client.git",
+    "directory": "packages/tts"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
## Summary
- 为 `packages/asr` 和 `packages/tts` 添加 `repository` 字段，指向 GitHub 仓库
- 添加 `publishConfig.access: public` 配置，支持发布到 npm registry

## Test plan
- [ ] 验证 package.json 配置正确
- [ ] 确认发布流程正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)