### PR TITLE
fix(asr): 添加 @discordjs/opus 依赖解决 Opus 编码器缺失问题

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@coze/api": "^1.3.9",
+    "@discordjs/opus": "^0.9.0",
     "@hono/node-server": "^1.17.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@xiaozhi-client/asr": "workspace:*",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
   },
   "dependencies": {
     "@coze/api": "^1.3.9",
+    "@discordjs/opus": "^0.9.0",
     "@hono/node-server": "^1.17.1",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@xiaozhi-client/asr": "workspace:*",

--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -47,6 +47,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@discordjs/opus": "^0.9.0",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,9 @@ importers:
       '@coze/api':
         specifier: ^1.3.9
         version: 1.3.9(axios@1.13.5)
+      '@discordjs/opus':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@hono/node-server':
         specifier: ^1.17.1
         version: 1.19.9(hono@4.12.0)
@@ -189,6 +192,9 @@ importers:
       '@coze/api':
         specifier: ^1.3.9
         version: 1.3.9(axios@1.13.5)
+      '@discordjs/opus':
+        specifier: ^0.9.0
+        version: 0.9.0
       '@hono/node-server':
         specifier: ^1.17.1
         version: 1.19.9(hono@4.12.0)
@@ -536,6 +542,9 @@ importers:
 
   packages/asr:
     dependencies:
+      '@discordjs/opus':
+        specifier: ^0.9.0
+        version: 0.9.0
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.9.0)
@@ -8571,7 +8580,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   '@discordjs/opus@0.9.0':
     dependencies:
@@ -8580,7 +8588,6 @@ snapshots:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    optional: true
 
   '@dnd-kit/accessibility@3.1.1(react@19.2.4)':
     dependencies:
@@ -10538,8 +10545,7 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
-  abbrev@1.1.1:
-    optional: true
+  abbrev@1.1.1: {}
 
   accepts@2.0.0:
     dependencies:
@@ -10565,7 +10571,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   agora-extension-ai-denoiser@1.1.0(agora-rtc-sdk-ng@4.23.2-1):
     dependencies:
@@ -10617,14 +10622,12 @@ snapshots:
       normalize-path: 3.0.0
       picomatch: 2.3.1
 
-  aproba@2.1.0:
-    optional: true
+  aproba@2.1.0: {}
 
   are-we-there-yet@2.0.0:
     dependencies:
       delegates: 1.0.0
       readable-stream: 3.6.2
-    optional: true
 
   arg@4.1.3: {}
 
@@ -10791,7 +10794,6 @@ snapshots:
     dependencies:
       balanced-match: 1.0.2
       concat-map: 0.0.1
-    optional: true
 
   brace-expansion@2.0.2:
     dependencies:
@@ -10912,8 +10914,7 @@ snapshots:
     dependencies:
       readdirp: 4.1.2
 
-  chownr@2.0.0:
-    optional: true
+  chownr@2.0.0: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -10972,8 +10973,7 @@ snapshots:
 
   color-name@1.1.4: {}
 
-  color-support@1.1.3:
-    optional: true
+  color-support@1.1.3: {}
 
   colorette@2.0.20: {}
 
@@ -11014,8 +11014,7 @@ snapshots:
 
   compute-scroll-into-view@3.1.1: {}
 
-  concat-map@0.0.1:
-    optional: true
+  concat-map@0.0.1: {}
 
   concurrently@9.2.1:
     dependencies:
@@ -11030,8 +11029,7 @@ snapshots:
 
   consola@3.4.2: {}
 
-  console-control-strings@1.1.0:
-    optional: true
+  console-control-strings@1.1.0: {}
 
   constantinople@4.0.1:
     dependencies:
@@ -11402,8 +11400,7 @@ snapshots:
 
   delayed-stream@1.0.0: {}
 
-  delegates@1.0.0:
-    optional: true
+  delegates@1.0.0: {}
 
   depd@2.0.0: {}
 
@@ -11842,10 +11839,8 @@ snapshots:
   fs-minipass@2.1.0:
     dependencies:
       minipass: 3.3.6
-    optional: true
 
-  fs.realpath@1.0.0:
-    optional: true
+  fs.realpath@1.0.0: {}
 
   fsevents@2.3.3:
     optional: true
@@ -11863,7 +11858,6 @@ snapshots:
       string-width: 4.2.3
       strip-ansi: 6.0.1
       wide-align: 1.1.5
-    optional: true
 
   gensequence@8.0.8: {}
 
@@ -11934,7 +11928,6 @@ snapshots:
       minimatch: 3.1.2
       once: 1.4.0
       path-is-absolute: 1.0.1
-    optional: true
 
   global-directory@4.0.1:
     dependencies:
@@ -11968,8 +11961,7 @@ snapshots:
     dependencies:
       has-symbols: 1.1.0
 
-  has-unicode@2.0.1:
-    optional: true
+  has-unicode@2.0.1: {}
 
   hasown@2.0.2:
     dependencies:
@@ -12142,7 +12134,6 @@ snapshots:
       debug: 4.4.3
     transitivePeerDependencies:
       - supports-color
-    optional: true
 
   human-signals@1.1.1: {}
 
@@ -12179,7 +12170,6 @@ snapshots:
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
-    optional: true
 
   inherits@2.0.4: {}
 
@@ -12546,7 +12536,6 @@ snapshots:
   make-dir@3.1.0:
     dependencies:
       semver: 6.3.1
-    optional: true
 
   make-dir@4.0.0:
     dependencies:
@@ -13125,7 +13114,6 @@ snapshots:
   minimatch@3.1.2:
     dependencies:
       brace-expansion: 1.1.12
-    optional: true
 
   minimatch@5.1.6:
     dependencies:
@@ -13140,10 +13128,8 @@ snapshots:
   minipass@3.3.6:
     dependencies:
       yallist: 4.0.0
-    optional: true
 
-  minipass@5.0.0:
-    optional: true
+  minipass@5.0.0: {}
 
   minipass@7.1.2: {}
 
@@ -13151,12 +13137,10 @@ snapshots:
     dependencies:
       minipass: 3.3.6
       yallist: 4.0.0
-    optional: true
 
   mj-context-menu@0.6.1: {}
 
-  mkdirp@1.0.4:
-    optional: true
+  mkdirp@1.0.4: {}
 
   mlly@1.8.0:
     dependencies:
@@ -13277,8 +13261,7 @@ snapshots:
     dependencies:
       '@types/nlcst': 2.0.3
 
-  node-addon-api@5.1.0:
-    optional: true
+  node-addon-api@5.1.0: {}
 
   node-addon-api@7.1.1:
     optional: true
@@ -13305,7 +13288,6 @@ snapshots:
   nopt@5.0.0:
     dependencies:
       abbrev: 1.1.1
-    optional: true
 
   normalize-path@3.0.0: {}
 
@@ -13330,7 +13312,6 @@ snapshots:
       console-control-strings: 1.1.0
       gauge: 3.0.2
       set-blocking: 2.0.0
-    optional: true
 
   nx@22.5.1:
     dependencies:
@@ -13519,8 +13500,7 @@ snapshots:
 
   path-data-parser@0.1.0: {}
 
-  path-is-absolute@1.0.1:
-    optional: true
+  path-is-absolute@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -14153,7 +14133,6 @@ snapshots:
   rimraf@3.0.2:
     dependencies:
       glob: 7.2.3
-    optional: true
 
   rimraf@6.1.2:
     dependencies:
@@ -14286,8 +14265,7 @@ snapshots:
 
   server-only@0.0.1: {}
 
-  set-blocking@2.0.0:
-    optional: true
+  set-blocking@2.0.0: {}
 
   set-cookie-parser@2.7.2: {}
 
@@ -14586,7 +14564,6 @@ snapshots:
       minizlib: 2.1.2
       mkdirp: 1.0.4
       yallist: 4.0.0
-    optional: true
 
   test-exclude@7.0.1:
     dependencies:
@@ -15234,7 +15211,6 @@ snapshots:
   wide-align@1.1.5:
     dependencies:
       string-width: 4.2.3
-    optional: true
 
   with@7.0.2:
     dependencies:
@@ -15259,8 +15235,7 @@ snapshots:
 
   yallist@3.1.1: {}
 
-  yallist@4.0.0:
-    optional: true
+  yallist@4.0.0: {}
 
   yaml@1.10.2: {}
 


### PR DESCRIPTION
## Summary

- 添加 `@discordjs/opus` 作为正式依赖，解决 prism-media Opus 编码器缺失问题
- 修改了三个 `package.json` 文件：`packages/asr`、`apps/backend` 和根目录

## 背景

prism-media 需要 Opus 编码器来处理音频数据。`@discordjs/opus` 原本作为 `optionalDependencies` 存在，但在某些环境下未被正确安装，导致 ASR 功能无法正常工作。

## Test plan

- [x] `pnpm install` 成功安装 `@discordjs/opus@0.9.0`
- [x] `pnpm build` 构建成功
- [x] `pnpm test` 所有 555 个测试用例通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)