### PR TITLE
fix(WebServer): 在 destroy() 方法中移除 wss 事件监听器防止内存泄漏

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -1068,6 +1068,11 @@ export class WebServer {
     // 异步销毁 ESP32 服务（fire and forget）
     this.esp32Service.destroy();
 
+    // 移除 WebSocket 服务器事件监听器，防止内存泄漏
+    if (this.wss) {
+      this.wss.removeAllListeners();
+    }
+
     // 销毁事件总线
     destroyEventBus();
 


### PR DESCRIPTION
在 destroy() 方法中添加了对 WebSocket 服务器 (wss) 事件监听器的清理。
通过调用 removeAllListeners() 移除所有事件监听器，防止在服务器关闭
过程中事件监听器仍被触发，避免潜在的内存泄漏。

修复问题 #2105

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2105