### PR TITLE
fix: 修复 ws.send() 错误处理问题

### DIFF
--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -83,20 +83,20 @@ export class HeartbeatHandler {
    * 发送最新配置给客户端
    */
   private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
-    try {
-      const latestConfig = configManager.getConfig();
-      const message = {
-        type: "configUpdate",
-        data: latestConfig,
-        timestamp: Date.now(),
-      };
+    const latestConfig = configManager.getConfig();
+    const message = {
+      type: "configUpdate",
+      data: latestConfig,
+      timestamp: Date.now(),
+    };
 
-      ws.send(JSON.stringify(message));
-      this.logger.debug(`最新配置已发送给客户端: ${clientId}`);
-    } catch (error) {
-      this.logger.error(`发送最新配置失败: ${clientId}`, error);
-      // 不抛出错误，避免影响心跳处理
-    }
+    ws.send(JSON.stringify(message), (error) => {
+      if (error) {
+        this.logger.error(`发送最新配置失败: ${clientId}`, error);
+      } else {
+        this.logger.debug(`最新配置已发送给客户端: ${clientId}`);
+      }
+    });
   }
 
   /**
@@ -201,20 +201,21 @@ export class HeartbeatHandler {
    * 发送心跳响应
    */
   sendHeartbeatResponse(ws: any, clientId: string): void {
-    try {
-      const response = {
-        type: "heartbeatResponse",
-        data: {
-          timestamp: Date.now(),
-          status: "ok",
-        },
-      };
+    const response = {
+      type: "heartbeatResponse",
+      data: {
+        timestamp: Date.now(),
+        status: "ok",
+      },
+    };
 
-      ws.send(JSON.stringify(response));
-      this.logger.debug(`心跳响应已发送: ${clientId}`);
-    } catch (error) {
-      this.logger.error(`发送心跳响应失败: ${clientId}`, error);
-    }
+    ws.send(JSON.stringify(response), (error) => {
+      if (error) {
+        this.logger.error(`发送心跳响应失败: ${clientId}`, error);
+      } else {
+        this.logger.debug(`心跳响应已发送: ${clientId}`);
+      }
+    });
   }
 
   /**

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -109,7 +109,11 @@ export class RealtimeNotificationHandler {
     try {
       const config = configManager.getConfig();
       this.logger.debug("WebSocket: getConfig 请求处理成功", { clientId });
-      ws.send(JSON.stringify({ type: "config", data: config }));
+      ws.send(JSON.stringify({ type: "config", data: config }), (error) => {
+        if (error) {
+          this.logger.error("WebSocket: 发送配置消息失败", { clientId, error });
+        }
+      });
     } catch (error) {
       this.logger.error("WebSocket: getConfig 请求处理失败", error);
       sendWebSocketError(
@@ -157,7 +161,17 @@ export class RealtimeNotificationHandler {
       }
 
       this.logger.debug("WebSocket: 配置更新成功", { clientId });
-      ws.send(JSON.stringify({ type: "config:updated", success: true }));
+      ws.send(
+        JSON.stringify({ type: "config:updated", success: true }),
+        (error) => {
+          if (error) {
+            this.logger.error("WebSocket: 发送配置更新消息失败", {
+              clientId,
+              error,
+            });
+          }
+        }
+      );
     } catch (error) {
       this.logger.error("WebSocket: 配置更新失败", error);
       sendWebSocketError(
@@ -178,8 +192,21 @@ export class RealtimeNotificationHandler {
 
     try {
       const status = this.statusService.getFullStatus();
-      ws.send(JSON.stringify({ type: "status", data: status.client }));
-      this.logger.debug("WebSocket: getStatus 请求处理成功", { clientId });
+      ws.send(
+        JSON.stringify({ type: "status", data: status.client }),
+        (error) => {
+          if (error) {
+            this.logger.error("WebSocket: 发送状态消息失败", {
+              clientId,
+              error,
+            });
+          } else {
+            this.logger.debug("WebSocket: getStatus 请求处理成功", {
+              clientId,
+            });
+          }
+        }
+      );
     } catch (error) {
       this.logger.error("WebSocket: getStatus 请求处理失败", error);
       sendWebSocketError(
@@ -239,34 +266,49 @@ export class RealtimeNotificationHandler {
    * 发送初始数据给新连接的客户端
    */
   async sendInitialData(ws: any, clientId: string): Promise<void> {
-    try {
-      this.logger.debug("发送初始数据给客户端", { clientId });
+    this.logger.debug("发送初始数据给客户端", { clientId });
 
-      // 发送当前配置
-      const config = configManager.getConfig();
-      ws.send(JSON.stringify({ type: "configUpdate", data: config }));
-
-      // 发送当前状态
-      const status = this.statusService.getFullStatus();
-      ws.send(JSON.stringify({ type: "statusUpdate", data: status.client }));
-
-      // 如果有重启状态，也发送
-      if (status.restart) {
-        ws.send(
-          JSON.stringify({ type: "restartStatus", data: status.restart })
-        );
+    // 发送当前配置
+    const config = configManager.getConfig();
+    ws.send(JSON.stringify({ type: "configUpdate", data: config }), (error) => {
+      if (error) {
+        this.logger.error("WebSocket: 发送配置更新消息失败", {
+          clientId,
+          error,
+        });
       }
+    });
 
-      this.logger.debug("初始数据发送完成", { clientId });
-    } catch (error) {
-      this.logger.error("发送初始数据失败:", error);
-      sendWebSocketError(
-        ws,
-        "INITIAL_DATA_ERROR",
-        error instanceof Error ? error.message : "发送初始数据失败",
-        this.logger
+    // 发送当前状态
+    const status = this.statusService.getFullStatus();
+    ws.send(
+      JSON.stringify({ type: "statusUpdate", data: status.client }),
+      (error) => {
+        if (error) {
+          this.logger.error("WebSocket: 发送状态更新消息失败", {
+            clientId,
+            error,
+          });
+        }
+      }
+    );
+
+    // 如果有重启状态，也发送
+    if (status.restart) {
+      ws.send(
+        JSON.stringify({ type: "restartStatus", data: status.restart }),
+        (error) => {
+          if (error) {
+            this.logger.error("WebSocket: 发送重启状态消息失败", {
+              clientId,
+              error,
+            });
+          }
+        }
       );
     }
+
+    this.logger.debug("初始数据发送完成", { clientId });
   }
 
   /**

--- a/apps/backend/utils/websocket-helper.ts
+++ b/apps/backend/utils/websocket-helper.ts
@@ -5,7 +5,7 @@ import type { Logger } from "@/Logger.js";
  * 描述具有 send 方法的 WebSocket 对象
  */
 export interface WebSocketLike {
-  send(data: string): void;
+  send(data: string, callback?: (error?: Error) => void): void;
 }
 
 /**
@@ -22,17 +22,17 @@ export function sendWebSocketError(
   message: string,
   logger: Logger
 ): void {
-  try {
-    const errorResponse = {
-      type: "error",
-      error: {
-        code,
-        message,
-        timestamp: Date.now(),
-      },
-    };
-    ws.send(JSON.stringify(errorResponse));
-  } catch (error) {
-    logger.error("发送错误消息失败:", error);
-  }
+  const errorResponse = {
+    type: "error",
+    error: {
+      code,
+      message,
+      timestamp: Date.now(),
+    },
+  };
+  ws.send(JSON.stringify(errorResponse), (error) => {
+    if (error) {
+      logger.error("发送错误消息失败:", error);
+    }
+  });
 }


### PR DESCRIPTION
ws.send() 是回调风格函数而非 Promise，try-catch 无法捕获其错误。
修复以下文件中的 ws.send() 调用以使用回调参数正确处理错误：

- apps/backend/utils/websocket-helper.ts
- apps/backend/handlers/heartbeat.handler.ts
- apps/backend/handlers/realtime-notification.handler.ts

参考 Issue #2107

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2107