### PR TITLE
refactor: 将测试专用事件从 EventBusEvents 接口移至测试文件

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.boundary.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.boundary.test.ts
@@ -9,13 +9,89 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import { EventBus } from "../event-bus.service.js";
+import { EventBus, type EventBusEvents } from "../event-bus.service.js";
+
+/**
+ * 测试专用事件类型扩展
+ * 这些事件仅用于测试，不应混入生产代码
+ */
+interface TestEventBusEvents extends EventBusEvents {
+  "high-frequency": {
+    id: number;
+    timestamp: number;
+  };
+  "bulk-test": {
+    id: number;
+    timestamp: number;
+  };
+  "error-test": {
+    error: string;
+    timestamp: number;
+  };
+  "large-data-test": {
+    data: unknown;
+    timestamp: number;
+  };
+  "destroy-test": {
+    message: string;
+    timestamp: number;
+  };
+  "chain-event-1": {
+    value: number;
+    timestamp: number;
+  };
+  "chain-event-2": {
+    value: number;
+    timestamp: number;
+  };
+  "chain-event-3": {
+    value: number;
+    timestamp: number;
+  };
+  "performance-test": {
+    data: unknown;
+    timestamp: number;
+  };
+  "test:performance": {
+    id: number;
+    timestamp: number;
+  };
+  "chain:start": {
+    value: number;
+    timestamp: number;
+  };
+  "chain:middle": {
+    value: number;
+    timestamp: number;
+  };
+  "chain:end": {
+    value: number;
+    timestamp: number;
+  };
+  "test:error": {
+    error: boolean;
+    timestamp: number;
+  };
+  "test:remove": {
+    id: number;
+    timestamp: number;
+  };
+}
 
 describe("事件系统边界情况测试", () => {
-  let eventBus: EventBus;
+  let eventBus: EventBus & {
+    emitEvent<K extends keyof TestEventBusEvents>(
+      eventName: K,
+      data: TestEventBusEvents[K]
+    ): boolean;
+    onEvent<K extends keyof TestEventBusEvents>(
+      eventName: K,
+      listener: (data: TestEventBusEvents[K]) => void
+    ): this;
+  };
 
   beforeEach(() => {
-    eventBus = new EventBus();
+    eventBus = new EventBus() as typeof eventBus;
   });
 
   afterEach(() => {

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -201,68 +201,6 @@ export interface EventBusEvents {
     duration: number;
     timestamp: number;
   };
-
-  // 测试相关事件（仅用于测试）
-  "high-frequency": {
-    id: number;
-    timestamp: number;
-  };
-  "bulk-test": {
-    id: number;
-    timestamp: number;
-  };
-  "error-test": {
-    error: string;
-    timestamp: number;
-  };
-  "large-data-test": {
-    data: any;
-    timestamp: number;
-  };
-  "destroy-test": {
-    message: string;
-    timestamp: number;
-  };
-  "chain-event-1": {
-    value: number;
-    timestamp: number;
-  };
-  "chain-event-2": {
-    value: number;
-    timestamp: number;
-  };
-  "chain-event-3": {
-    value: number;
-    timestamp: number;
-  };
-  "performance-test": {
-    data: any;
-    timestamp: number;
-  };
-  "test:performance": {
-    id: number;
-    timestamp: number;
-  };
-  "chain:start": {
-    value: number;
-    timestamp: number;
-  };
-  "chain:middle": {
-    value: number;
-    timestamp: number;
-  };
-  "chain:end": {
-    value: number;
-    timestamp: number;
-  };
-  "test:error": {
-    error: boolean;
-    timestamp: number;
-  };
-  "test:remove": {
-    id: number;
-    timestamp: number;
-  };
 }
 
 /**


### PR DESCRIPTION
修复 #2108

将 15 个仅用于测试的事件类型从生产代码的 EventBusEvents 接口中
移除，改为在测试文件中通过类型扩展方式定义。

变更内容：
- 移除 event-bus.service.ts 中的 15 个测试事件类型定义
- 在测试文件中新增 TestEventBusEvents 接口扩展 EventBusEvents
- 添加类型断言以支持测试中的事件类型

影响：
- 提高代码可维护性，测试事件不再混入生产接口
- 减少生产代码体积
- 遵循关注点分离原则

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2108