### PR TITLE
chore: 升级 @biomejs/biome 从 1.9.4 到 2.4.4

### DIFF
--- a/apps/backend/Logger.ts
+++ b/apps/backend/Logger.ts
@@ -128,8 +128,8 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import chalk from "chalk";
-import pino from "pino";
 import type { Logger as PinoLogger } from "pino";
+import pino from "pino";
 import { z } from "zod";
 
 const LogLevelSchema = z.enum([

--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -18,10 +18,20 @@
  * ```
  */
 
-import { createServer } from "node:http";
 import type { IncomingMessage, Server, ServerResponse } from "node:http";
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
+import { createServer } from "node:http";
+import type { ServerType } from "@hono/node-server";
+import { serve } from "@hono/node-server";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
+import { configManager, normalizeServiceConfig } from "@xiaozhi-client/config";
+import type { SimpleConnectionStatus } from "@xiaozhi-client/endpoint";
+import { EndpointManager } from "@xiaozhi-client/endpoint";
+import type { Hono } from "hono";
+import type WebSocket from "ws";
+import { WebSocketServer } from "ws";
+import { HTTP_SERVER_CONFIG } from "@/constants/index.js";
+import { MCPServiceManagerNotInitializedError } from "@/errors/mcp-errors.middleware.js";
 import {
   ConfigApiHandler,
   CozeHandler,
@@ -39,6 +49,8 @@ import {
   UpdateApiHandler,
   VersionApiHandler,
 } from "@/handlers/index.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
@@ -55,40 +67,26 @@ import {
 import type { EventBus, EventBusEvents } from "@/services/index.js";
 import {
   DeviceRegistryService,
+  destroyEventBus,
   ESP32Service,
+  getEventBus,
   NotificationService,
   StatusService,
-  destroyEventBus,
-  getEventBus,
 } from "@/services/index.js";
 import type { AppContext } from "@/types/index.js";
 import { createApp } from "@/types/index.js";
-import type { ServerType } from "@hono/node-server";
-import { serve } from "@hono/node-server";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
-import { configManager } from "@xiaozhi-client/config";
-import type { MCPServerConfig } from "@xiaozhi-client/config";
-import { EndpointManager } from "@xiaozhi-client/endpoint";
-import type { SimpleConnectionStatus } from "@xiaozhi-client/endpoint";
-import type { Hono } from "hono";
-import { WebSocketServer } from "ws";
-import type WebSocket from "ws";
-
-import { HTTP_SERVER_CONFIG } from "@/constants/index.js";
-import { MCPServiceManagerNotInitializedError } from "@/errors/mcp-errors.middleware.js";
 // 路由系统导入
 import {
-  type HandlerDependencies,
-  RouteManager,
   // 导入所有路由配置
   configRoutes,
   cozeRoutes,
   endpointRoutes,
   esp32Routes,
+  type HandlerDependencies,
   mcpRoutes,
   mcpserverRoutes,
   miscRoutes,
+  RouteManager,
   servicesRoutes,
   staticRoutes,
   statusRoutes,

--- a/apps/backend/__tests__/config-sync-integration.test.ts
+++ b/apps/backend/__tests__/config-sync-integration.test.ts
@@ -62,7 +62,7 @@ describe("配置同步集成测试", () => {
     vi.clearAllMocks();
 
     // 重置单例实例
-    // @ts-ignore - accessing private static property for testing
+    // @ts-expect-error - accessing private static property for testing
     ConfigManager.instance = undefined;
 
     configManager = ConfigManager.getInstance();

--- a/apps/backend/__tests__/index.ts
+++ b/apps/backend/__tests__/index.ts
@@ -3,12 +3,12 @@
  */
 
 export {
-  DEFAULT_TEST_CONFIG,
   createMockConfigManager,
   createMockLogger,
+  DEFAULT_TEST_CONFIG,
   mockConfigManager,
   mockLogger,
+  setupCommonMocks,
   setupConfigManagerMock,
   setupLoggerMock,
-  setupCommonMocks,
 } from "./utils/index.js";

--- a/apps/backend/__tests__/utils/index.ts
+++ b/apps/backend/__tests__/utils/index.ts
@@ -3,12 +3,12 @@
  */
 
 export {
-  DEFAULT_TEST_CONFIG,
   createMockConfigManager,
   createMockLogger,
+  DEFAULT_TEST_CONFIG,
   mockConfigManager,
   mockLogger,
+  setupCommonMocks,
   setupConfigManagerMock,
   setupLoggerMock,
-  setupCommonMocks,
 } from "./testMocks.js";

--- a/apps/backend/__tests__/webserver/webserver.cleanup.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.cleanup.test.ts
@@ -301,7 +301,7 @@ describe("WebServer 配置清理功能", () => {
 
       // 模拟启动过程中的配置加载
       try {
-        // @ts-ignore - 调用私有方法用于测试
+        // @ts-expect-error - 调用私有方法用于测试
         await webServer.loadConfiguration();
       } catch (error) {
         // 忽略其他初始化错误，我们只关心配置清理是否被调用
@@ -320,7 +320,7 @@ describe("WebServer 配置清理功能", () => {
 
       // 应该抛出错误
       await expect(async () => {
-        // @ts-ignore - 调用私有方法用于测试
+        // @ts-expect-error - 调用私有方法用于测试
         await webServer.loadConfiguration();
       }).rejects.toThrow("配置文件不存在");
 
@@ -343,7 +343,7 @@ describe("WebServer 配置清理功能", () => {
 
       webServer = new WebServer(currentPort);
 
-      // @ts-ignore - 调用私有方法用于测试
+      // @ts-expect-error - 调用私有方法用于测试
       const config = await webServer.loadConfiguration();
 
       // 验证配置清理方法被调用

--- a/apps/backend/__tests__/webserver/webserver.unit.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.unit.test.ts
@@ -1,5 +1,5 @@
-import { MCPServiceManager } from "@/lib/mcp";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServiceManager } from "@/lib/mcp";
 import { WebServer } from "../../WebServer";
 
 // Mock configManager to avoid triggering real config loading

--- a/apps/backend/constants/index.ts
+++ b/apps/backend/constants/index.ts
@@ -15,18 +15,13 @@
 
 // API 相关常量
 export * from "./api.constants.js";
-
-// HTTP 协议常量
-export * from "./http.constants.js";
-
-// MCP 协议常量
-export * from "./mcp.constants.js";
-
-// 事件名称常量
-export * from "./event.constants.js";
-
-// 超时和延迟常量
-export * from "./timeout.constants.js";
-
 // 缓存相关常量
 export * from "./cache.constants.js";
+// 事件名称常量
+export * from "./event.constants.js";
+// HTTP 协议常量
+export * from "./http.constants.js";
+// MCP 协议常量
+export * from "./mcp.constants.js";
+// 超时和延迟常量
+export * from "./timeout.constants.js";

--- a/apps/backend/errors/__tests__/error-helper.integration.test.ts
+++ b/apps/backend/errors/__tests__/error-helper.integration.test.ts
@@ -1,15 +1,15 @@
 import { existsSync, unlinkSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { InternalMCPServiceConfig } from "@/lib/mcp";
 import { MCPTransportType } from "@/lib/mcp";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../../Logger.js";
 import type { MCPError } from "../error-helper.js";
 import {
-  ErrorCategory,
   categorizeError,
   clearErrorHistory,
+  ErrorCategory,
   getErrorStatistics,
   shouldAlert,
 } from "../error-helper.js";

--- a/apps/backend/errors/__tests__/error-helper.test.ts
+++ b/apps/backend/errors/__tests__/error-helper.test.ts
@@ -2,12 +2,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger } from "../../Logger.js";
 import type { MCPError } from "../error-helper.js";
 import {
-  ErrorCategory,
-  RecoveryStrategy,
   categorizeError,
   clearErrorHistory,
+  ErrorCategory,
   formatUserFriendlyMessage,
   getErrorStatistics,
+  RecoveryStrategy,
   shouldAlert,
 } from "../error-helper.js";
 

--- a/apps/backend/errors/index.ts
+++ b/apps/backend/errors/index.ts
@@ -1,4 +1,3 @@
-export * from "./mcp-errors.js";
-
 // ErrorHelper 使用命名空间导出以避免与 mcp-errors 中的类型冲突
 export * as ErrorHelper from "./error-helper.js";
+export * from "./mcp-errors.js";

--- a/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
+++ b/apps/backend/handlers/__tests__/heartbeat.handler.test.ts
@@ -1,6 +1,6 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { HeartbeatHandler } from "../heartbeat.handler.js";
 
 /**

--- a/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
@@ -1,11 +1,10 @@
 import path from "node:path";
+import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPErrorCode } from "@/errors/mcp-errors.js";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { EventBus } from "@/services/event-bus.service.js";
-import type { ConfigManager } from "@xiaozhi-client/config";
-import type { MCPServerConfig } from "@xiaozhi-client/config";
-import type { Context } from "hono";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPHandler, MCPServerConfigValidator } from "../mcp-manage.handler.js";
 
 // 创建模拟对象

--- a/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
@@ -3,8 +3,8 @@
  * 专注于基本功能验证
  */
 
-import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
 import { describe, expect, it } from "vitest";
+import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
 import { MCPToolLogHandler } from "../mcp-tool-log.handler.js";
 
 describe("MCPToolLogHandler - 基本功能测试", () => {

--- a/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
@@ -3,10 +3,10 @@
  * 测试核心业务逻辑和边界条件处理
  */
 
-import { ToolType } from "@/types/toolApi.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolType } from "@/types/toolApi.js";
 import { MCPToolHandler } from "../mcp-tool.handler.js";
 
 // 模拟 configManager

--- a/apps/backend/handlers/__tests__/mcp-tool.parameter-config.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.parameter-config.test.ts
@@ -3,10 +3,10 @@
  * 测试第二阶段新增的参数配置功能
  */
 
-import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
 import { MCPToolHandler } from "../mcp-tool.handler.js";
 
 // 模拟 configManager

--- a/apps/backend/handlers/__tests__/service.handler.test.ts
+++ b/apps/backend/handlers/__tests__/service.handler.test.ts
@@ -1,5 +1,5 @@
-import type { StatusService } from "@/services/status.service.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatusService } from "@/services/status.service.js";
 import { ServiceApiHandler } from "../service.handler.js";
 
 // 模拟依赖

--- a/apps/backend/handlers/__tests__/status.handler.test.ts
+++ b/apps/backend/handlers/__tests__/status.handler.test.ts
@@ -1,5 +1,5 @@
-import type { StatusService } from "@/services/status.service.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatusService } from "@/services/status.service.js";
 import { StatusApiHandler } from "../status.handler.js";
 
 // 模拟依赖

--- a/apps/backend/handlers/__tests__/update.handler.test.ts
+++ b/apps/backend/handlers/__tests__/update.handler.test.ts
@@ -1,6 +1,6 @@
-import { NPMManager } from "@/lib/npm";
 import type { Context } from "hono";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { NPMManager } from "@/lib/npm";
 import { logger } from "../../Logger.js";
 import { UpdateApiHandler } from "../update.handler.js";
 

--- a/apps/backend/handlers/base.handler.ts
+++ b/apps/backend/handlers/base.handler.ts
@@ -3,8 +3,9 @@
  * 提供便捷的辅助方法
  * logger 通过 c.get("logger") 访问（Hono 推荐做法）
  */
-import type { AppContext } from "@/types/hono.context.js";
+
 import type { Context } from "hono";
+import type { AppContext } from "@/types/hono.context.js";
 
 export abstract class BaseHandler {
   /**

--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -2,10 +2,11 @@
  * 配置 API HTTP 路由处理器
  * 提供配置读取、配置更新等配置相关的 RESTful API 接口
  */
-import type { AppContext } from "@/types/hono.context.js";
+
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
+import type { AppContext } from "@/types/hono.context.js";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -3,11 +3,11 @@
  * 提供扣子工作空间和工作流相关的 RESTful API 接口
  */
 
+import { configManager } from "@xiaozhi-client/config";
+import type { Context } from "hono";
 import { CozeApiService } from "@/lib/coze";
 import type { CozeWorkflowsParams } from "@/types/coze";
 import type { AppContext } from "@/types/hono.context.js";
-import { configManager } from "@xiaozhi-client/config";
-import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/endpoint.handler.ts
+++ b/apps/backend/handlers/endpoint.handler.ts
@@ -10,17 +10,18 @@
  *
  * @see @xiaozhi-client/endpoint - EndpointManager 实现
  */
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
-import type { EventBus } from "@/services/event-bus.service.js";
-import { getEventBus } from "@/services/event-bus.service.js";
-import type { AppContext } from "@/types/hono.context.js";
+
 import type { ConfigManager } from "@xiaozhi-client/config";
 import type {
   ConnectionStatus,
   EndpointManager,
 } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
+import type { AppContext } from "@/types/hono.context.js";
 
 /**
  * 验证结果类型定义

--- a/apps/backend/handlers/esp32.handler.ts
+++ b/apps/backend/handlers/esp32.handler.ts
@@ -3,11 +3,11 @@
  * 处理ESP32设备相关的HTTP请求
  */
 
+import type { Context } from "hono";
 import type { ESP32Service } from "@/services/esp32.service.js";
 import type { ESP32DeviceReport } from "@/types/esp32.js";
 import { ESP32ErrorCode } from "@/types/esp32.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -4,13 +4,14 @@
  * 负责处理客户端心跳消息，维护客户端连接状态，
  * 并监控 MCP 端点的连接状态。
  */
+
+import { configManager } from "@xiaozhi-client/config";
+import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
-import { configManager } from "@xiaozhi-client/config";
 
 /**
  * 心跳消息接口

--- a/apps/backend/handlers/index.ts
+++ b/apps/backend/handlers/index.ts
@@ -33,17 +33,17 @@
  */
 export * from "./config.handler.js";
 export { CozeHandler } from "./coze.handler.js";
-export * from "./heartbeat.handler.js";
 export { EndpointHandler } from "./endpoint.handler.js";
+export { ESP32Handler } from "./esp32.handler.js";
+export * from "./heartbeat.handler.js";
 export * from "./mcp.handler.js";
 export { MCPHandler } from "./mcp-manage.handler.js";
+export * from "./mcp-tool.handler.js";
+export * from "./mcp-tool-log.handler.js";
 export * from "./realtime-notification.handler.js";
 export * from "./service.handler.js";
 export { StaticFileHandler } from "./static-file.handler.js";
 export * from "./status.handler.js";
-export * from "./mcp-tool.handler.js";
-export * from "./mcp-tool-log.handler.js";
+export { TTSApiHandler } from "./tts.handler.js";
 export * from "./update.handler.js";
 export * from "./version.handler.js";
-export { TTSApiHandler } from "./tts.handler.js";
-export { ESP32Handler } from "./esp32.handler.js";

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -12,18 +12,17 @@
  * 并通过 EventBus 发布（发射）服务状态变化事件。
  */
 
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
-import { ErrorCategory, MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
-import type { MCPServiceManager } from "@/lib/mcp";
-import type { MCPService } from "@/lib/mcp";
-import { getEventBus } from "@/services/event-bus.service.js";
-import type { AppContext } from "@/types/hono.context.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
+import { ErrorCategory, MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import type { MCPService, MCPServiceManager } from "@/lib/mcp";
+import { getEventBus } from "@/services/event-bus.service.js";
+import type { AppContext } from "@/types/hono.context.js";
 
 /**
  * MCPServiceManager 扩展接口，用于访问私有属性

--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -3,12 +3,12 @@
  * 负责处理工具调用日志相关的 HTTP API 请求
  */
 
+import type { Context } from "hono";
+import { z } from "zod";
 import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
 import type { ToolCallQuery } from "@/lib/mcp/log.js";
 import { ToolCallLogService } from "@/lib/mcp/log.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
-import { z } from "zod";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -3,12 +3,17 @@
  * 处理通过 HTTP API 调用 MCP 工具的请求
  */
 
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
+import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
+import Ajv from "ajv";
+import dayjs from "dayjs";
+import type { Context } from "hono";
 import { HTTP_TIMEOUTS } from "@/constants/timeout.constants.js";
 import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
-import { MCPCacheManager } from "@/lib/mcp";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import type { MCPServiceManager } from "@/lib/mcp";
+import { MCPCacheManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
 import type { AppContext } from "@/types/hono.context.js";
@@ -16,16 +21,12 @@ import type {
   AddCustomToolRequest,
   AddToolResponse,
   CozeWorkflowData,
+  CustomMCPToolWithStats,
+  JSONSchema,
   MCPToolData,
 } from "@/types/toolApi.js";
 import { ToolType } from "@/types/toolApi.js";
-import type { CustomMCPToolWithStats, JSONSchema } from "@/types/toolApi.js";
-import { type ToolSortField, sortTools } from "@/utils/toolSorters";
-import { configManager } from "@xiaozhi-client/config";
-import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
-import Ajv from "ajv";
-import dayjs from "dayjs";
-import type { Context } from "hono";
+import { sortTools, type ToolSortField } from "@/utils/toolSorters";
 
 /**
  * 工具调用请求接口

--- a/apps/backend/handlers/mcp.handler.ts
+++ b/apps/backend/handlers/mcp.handler.ts
@@ -4,8 +4,7 @@
  * 支持 POST 请求（JSON-RPC 消息）
  */
 
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
+import type { Context } from "hono";
 import {
   HTTP_CONTENT_TYPES,
   HTTP_ERROR_MESSAGES,
@@ -16,11 +15,12 @@ import {
   MCP_SUPPORTED_PROTOCOL_VERSIONS,
   MESSAGE_SIZE_LIMITS,
 } from "@/constants/index.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import type { MCPServiceManager } from "@/lib/mcp";
 import { MCPMessageHandler } from "@/lib/mcp";
 import type { AppContext } from "@/types/hono.context.js";
 import type { MCPMessage } from "@/types/mcp.js";
-import type { Context } from "hono";
 
 /**
  * MCP 路由处理器配置接口

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -3,6 +3,8 @@
  * 提供 WebSocket 实时通知相关的消息处理接口，处理配置更新、状态变化和服务重启等实时通知
  */
 
+import type { AppConfig } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
@@ -10,8 +12,6 @@ import { getEventBus } from "@/services/event-bus.service.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
-import type { AppConfig } from "@xiaozhi-client/config";
-import { configManager } from "@xiaozhi-client/config";
 
 /**
  * WebSocket 消息接口

--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -2,18 +2,19 @@
  * 服务 API HTTP 路由处理器
  * 提供服务启动、停止、重启等相关的 RESTful API 接口
  */
-import { spawn } from "node:child_process";
+
 import type { ChildProcess } from "node:child_process";
-import { logger } from "@/Logger.js";
-import type { Logger } from "@/Logger.js";
+import { spawn } from "node:child_process";
+import type { Context } from "hono";
 import { SERVICE_RESTART_DELAYS } from "@/constants/timeout.constants.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { requireMCPServiceManager } from "@/types/hono.context.js";
-import type { Context } from "hono";
 
 /**
  * 服务 API 处理器

--- a/apps/backend/handlers/static-file.handler.ts
+++ b/apps/backend/handlers/static-file.handler.ts
@@ -6,10 +6,10 @@ import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { dirname, join } from "node:path";
 import { fileURLToPath } from "node:url";
+import type { Context } from "hono";
+import { HTTP_CONTENT_TYPES, HTTP_STATUS_CODES } from "@/constants/index.js";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import { HTTP_CONTENT_TYPES, HTTP_STATUS_CODES } from "@/constants/index.js";
-import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/status.handler.ts
+++ b/apps/backend/handlers/status.handler.ts
@@ -2,9 +2,10 @@
  * 状态 API HTTP 路由处理器
  * 提供客户端状态、服务状态、心跳等状态相关的 RESTful API 接口
  */
+
+import type { Context } from "hono";
 import type { StatusService } from "@/services/status.service.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/tts.handler.ts
+++ b/apps/backend/handlers/tts.handler.ts
@@ -4,10 +4,10 @@
  */
 
 import fs from "node:fs";
-import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
 import { TTS } from "@xiaozhi-client/tts";
 import type { Context } from "hono";
+import type { AppContext } from "@/types/hono.context.js";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/handlers/update.handler.ts
+++ b/apps/backend/handlers/update.handler.ts
@@ -2,11 +2,12 @@
  * 更新 API HTTP 路由处理器
  * 提供版本更新和 NPM 包安装相关的 RESTful API 接口
  */
+
+import type { Context } from "hono";
+import { z } from "zod";
 import { NPMManager } from "@/lib/npm";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
-import { z } from "zod";
 import { BaseHandler } from "./base.handler.js";
 
 // 版本号请求格式验证

--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -2,10 +2,11 @@
  * 版本 API HTTP 路由处理器
  * 提供版本信息查询、可用版本列表获取、版本检查等相关的 RESTful API 接口
  */
-import { NPMManager } from "@/lib/npm";
-import type { AppContext } from "@/types/hono.context.js";
+
 import { VersionUtils } from "@xiaozhi-client/version";
 import type { Context } from "hono";
+import { NPMManager } from "@/lib/npm";
+import type { AppContext } from "@/types/hono.context.js";
 import { BaseHandler } from "./base.handler.js";
 
 /**

--- a/apps/backend/lib/coze/index.ts
+++ b/apps/backend/lib/coze/index.ts
@@ -18,7 +18,8 @@
  * const client = createCozeClient('your-token', 'zh');
  * ```
  */
-export { default as config } from "./config";
+
 export * from "@coze/api";
 export { createCozeClient } from "./client";
+export { default as config } from "./config";
 export { CozeApiService } from "./service";

--- a/apps/backend/lib/coze/service.ts
+++ b/apps/backend/lib/coze/service.ts
@@ -3,13 +3,13 @@
  * 负责与扣子 API 的交互，包括工作空间和工作流的获取
  */
 
+import NodeCache from "node-cache";
 import type { RunWorkflowData, WorkSpace } from "@/lib/coze";
 import type {
   CozeWorkflowsData,
   CozeWorkflowsParams,
   CozeWorkflowsResponse,
 } from "@/types/coze";
-import NodeCache from "node-cache";
 import { createCozeClient } from "./client";
 
 /**

--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -4,6 +4,7 @@
  */
 
 import { randomBytes } from "node:crypto";
+import type WebSocket from "ws";
 import { logger } from "@/Logger.js";
 import {
   encodeBinaryProtocol2,
@@ -21,7 +22,6 @@ import {
   type ESP32WSMessage,
 } from "@/types/esp32.js";
 import { camelToSnakeCase } from "@/utils/esp32-utils.js";
-import type WebSocket from "ws";
 
 /**
  * 连接配置

--- a/apps/backend/lib/mcp/__tests__/config-adapter.integration.test.ts
+++ b/apps/backend/lib/mcp/__tests__/config-adapter.integration.test.ts
@@ -3,12 +3,6 @@
  * 验证两个组件的协同工作和类型推断一致性
  */
 
-import { MCPService, MCPTransportType } from "@/lib/mcp";
-import {
-  getConfigTypeDescription,
-  normalizeServiceConfig,
-  normalizeServiceConfigBatch,
-} from "@xiaozhi-client/config";
 import type {
   HTTPMCPServerConfig,
   LocalMCPServerConfig,
@@ -16,7 +10,13 @@ import type {
   SSEMCPServerConfig,
   StreamableHTTPMCPServerConfig,
 } from "@xiaozhi-client/config";
+import {
+  getConfigTypeDescription,
+  normalizeServiceConfig,
+  normalizeServiceConfigBatch,
+} from "@xiaozhi-client/config";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPService, MCPTransportType } from "@/lib/mcp";
 
 // 统一的mockLogger定义
 let mockLogger: any;

--- a/apps/backend/lib/mcp/__tests__/custom.basic.test.ts
+++ b/apps/backend/lib/mcp/__tests__/custom.basic.test.ts
@@ -3,10 +3,10 @@
  * 专门测试 Coze 工作流功能
  */
 
-import type { EventBus } from "@/services/event-bus.service.js";
-import { getEventBus } from "@/services/event-bus.service.js";
 import type { CustomMCPTool } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { EventBus } from "@/services/event-bus.service.js";
+import { getEventBus } from "@/services/event-bus.service.js";
 import { CustomMCPHandler } from "../custom.js";
 
 // Mock logger

--- a/apps/backend/lib/mcp/__tests__/environment-variables.integration.test.ts
+++ b/apps/backend/lib/mcp/__tests__/environment-variables.integration.test.ts
@@ -3,10 +3,10 @@
  * 验证 MCP 服务环境变量传递修复是否正确工作
  */
 
-import { MCPTransportType } from "@/lib/mcp";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import type { LocalMCPServerConfig } from "@xiaozhi-client/config";
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { describe, expect, it } from "vitest";
+import { MCPTransportType } from "@/lib/mcp";
 
 describe("环境变量传递集成测试", () => {
   describe("配置转换", () => {

--- a/apps/backend/lib/mcp/__tests__/inference-consistency.test.ts
+++ b/apps/backend/lib/mcp/__tests__/inference-consistency.test.ts
@@ -1,6 +1,6 @@
-import { MCPService, MCPTransportType } from "@/lib/mcp";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { describe, expect, it } from "vitest";
+import { MCPService, MCPTransportType } from "@/lib/mcp";
 
 describe("MCPService 和 ConfigAdapter 推断逻辑一致性测试", () => {
   const testCases = [

--- a/apps/backend/lib/mcp/__tests__/log.test.ts
+++ b/apps/backend/lib/mcp/__tests__/log.test.ts
@@ -13,12 +13,12 @@ import {
 import * as fs from "node:fs/promises";
 import * as os from "node:os";
 import * as path from "node:path";
-import { PathUtils } from "@/utils/path-utils.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PathUtils } from "@/utils/path-utils.js";
 import {
   type ToolCallLogConfig,
-  ToolCallLogService,
   ToolCallLogger,
+  ToolCallLogService,
   type ToolCallRecord,
 } from "../log.js";
 

--- a/apps/backend/lib/mcp/__tests__/manager.test.ts
+++ b/apps/backend/lib/mcp/__tests__/manager.test.ts
@@ -3,9 +3,9 @@
  * 测试新增的 hasCustomMCPTool 和 getCustomMCPTools 方法
  */
 
-import { MCPServiceManager } from "@/lib/mcp";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServiceManager } from "@/lib/mcp";
 import type { CustomMCPHandler } from "../custom.js";
 
 // Mock dependencies

--- a/apps/backend/lib/mcp/__tests__/mcp-service-manager-events.test.ts
+++ b/apps/backend/lib/mcp/__tests__/mcp-service-manager-events.test.ts
@@ -1,7 +1,7 @@
-import { MCPServiceManager } from "@/lib/mcp";
-import { getEventBus } from "@/services/event-bus.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServiceManager } from "@/lib/mcp";
+import { getEventBus } from "@/services/event-bus.service.js";
 
 // Mock dependencies
 vi.mock("@/utils/Logger.js", () => ({

--- a/apps/backend/lib/mcp/__tests__/message.prompts.test.ts
+++ b/apps/backend/lib/mcp/__tests__/message.prompts.test.ts
@@ -2,9 +2,9 @@
  * MCPMessageHandler prompts/list 功能测试
  */
 
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MCPServiceManager } from "@/lib/mcp";
 import { MCPMessageHandler } from "@/lib/mcp";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock MCPServiceManager
 const mockServiceManager = {

--- a/apps/backend/lib/mcp/__tests__/message.resources.test.ts
+++ b/apps/backend/lib/mcp/__tests__/message.resources.test.ts
@@ -2,9 +2,9 @@
  * MCPMessageHandler resources/list 功能测试
  */
 
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MCPServiceManager } from "@/lib/mcp";
 import { MCPMessageHandler } from "@/lib/mcp";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // Mock MCPServiceManager
 const mockServiceManager = {

--- a/apps/backend/lib/mcp/__tests__/tool-sync-integration.test.ts
+++ b/apps/backend/lib/mcp/__tests__/tool-sync-integration.test.ts
@@ -1,6 +1,6 @@
-import type { MCPServiceConfig } from "@/lib/mcp/types.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServiceConfig } from "@/lib/mcp/types.js";
 
 // Mock CustomMCPHandler - 需要在其他 mock 之前定义
 let mockCustomMCPTools: any[] = [];

--- a/apps/backend/lib/mcp/__tests__/utils.test.ts
+++ b/apps/backend/lib/mcp/__tests__/utils.test.ts
@@ -1,7 +1,7 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
-import { MCPTransportType } from "../types.js";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { MCPServiceConfig } from "../types.js";
+import { MCPTransportType } from "../types.js";
 import {
   inferTransportTypeFromConfig,
   inferTransportTypeFromUrl,

--- a/apps/backend/lib/mcp/cache.ts
+++ b/apps/backend/lib/mcp/cache.ts
@@ -13,14 +13,16 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, resolve } from "node:path";
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import dayjs from "dayjs";
 import {
   CACHE_FILE_CONFIG,
   CACHE_TIMEOUTS,
   MCP_CACHE_VERSIONS,
   TOOL_NAME_SEPARATORS,
 } from "@/constants/index.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import type { MCPServiceConfig } from "@/lib/mcp/types";
 import type {
   CacheStatistics,
@@ -30,8 +32,6 @@ import type {
   ToolCallResult,
 } from "@/types/index.js";
 import { generateCacheKey, shouldCleanupCache } from "@/types/index.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import dayjs from "dayjs";
 
 // 缓存条目接口
 export interface MCPToolsCacheEntry {

--- a/apps/backend/lib/mcp/connection.ts
+++ b/apps/backend/lib/mcp/connection.ts
@@ -3,10 +3,10 @@
  * 包装 @xiaozhi-client/mcp-core 的 MCPConnection，使用 EventBus 发射事件
  */
 
-import { MCP_SERVICE_EVENTS } from "@/constants/index.js";
-import { getEventBus } from "@/services/event-bus.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { MCPConnection } from "@xiaozhi-client/mcp-core";
+import { MCP_SERVICE_EVENTS } from "@/constants/index.js";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { InternalMCPServiceConfig } from "./types.js";
 
 /**

--- a/apps/backend/lib/mcp/custom.ts
+++ b/apps/backend/lib/mcp/custom.ts
@@ -1,4 +1,11 @@
 #!/usr/bin/env node
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CustomMCPTool,
+  HandlerConfig,
+  ProxyHandlerConfig,
+} from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 /**
  * 自定义 MCP 工具处理器模块
  *
@@ -22,8 +29,8 @@
  */
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import { CozeApiService } from "@/lib/coze";
 import type { RunWorkflowData } from "@/lib/coze";
+import { CozeApiService } from "@/lib/coze";
 import type { MCPServiceManager } from "@/lib/mcp";
 import { MCPCacheManager } from "@/lib/mcp";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
@@ -40,14 +47,7 @@ import {
   isCacheExpired,
   shouldCleanupCache,
 } from "@/types/mcp.js";
-import { TimeoutError, createTimeoutResponse } from "@/types/timeout.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import type {
-  CustomMCPTool,
-  HandlerConfig,
-  ProxyHandlerConfig,
-} from "@xiaozhi-client/config";
-import { configManager } from "@xiaozhi-client/config";
+import { createTimeoutResponse, TimeoutError } from "@/types/timeout.js";
 
 // 工具调用参数类型
 type ToolArguments = Record<string, unknown>;

--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -29,11 +29,12 @@
  * const result = await manager.callTool('tool-name', { param: 'value' });
  * ```
  */
-export * from "@/lib/mcp/manager.js";
+
+export * from "@/lib/mcp/cache.js";
 export * from "@/lib/mcp/connection.js";
+export * from "@/lib/mcp/manager.js";
 export * from "@/lib/mcp/types.js";
 export * from "@/lib/mcp/utils.js";
-export * from "./message.js";
-export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+export * from "./message.js";

--- a/apps/backend/lib/mcp/log.ts
+++ b/apps/backend/lib/mcp/log.ts
@@ -5,10 +5,10 @@
 
 import * as fs from "node:fs";
 import * as path from "node:path";
+import type { Logger as PinoLogger } from "pino";
+import pino from "pino";
 import { logger } from "@/Logger.js";
 import { PathUtils } from "@/utils/path-utils.js";
-import pino from "pino";
-import type { Logger as PinoLogger } from "pino";
 
 // ==================== 类型定义 ====================
 

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -5,28 +5,26 @@
  */
 
 import { EventEmitter } from "node:events";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPToolConfig } from "@xiaozhi-client/config";
+import { configManager, isModelScopeURL } from "@xiaozhi-client/config";
 import { logger } from "@/Logger.js";
-import { MCPService } from "@/lib/mcp";
-import { MCPCacheManager } from "@/lib/mcp";
-import { ConnectionState } from "@/lib/mcp/types";
+import { MCPCacheManager, MCPService } from "@/lib/mcp";
 import type {
   CustomMCPTool,
   EnhancedToolInfo,
   InternalMCPServiceConfig,
-  MCPServiceConfig,
   ManagerStatus,
+  MCPServiceConfig,
   ToolCallResult,
   ToolInfo,
   ToolStatusFilter,
   UnifiedServerConfig,
   UnifiedServerStatus,
 } from "@/lib/mcp/types";
+import { ConnectionState } from "@/lib/mcp/types";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { MCPMessage } from "@/types/mcp.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { isModelScopeURL } from "@xiaozhi-client/config";
-import type { MCPToolConfig } from "@xiaozhi-client/config";
-import { configManager } from "@xiaozhi-client/config";
 import { CustomMCPHandler } from "./custom.js";
 import { ToolCallLogger } from "./log.js";
 import { MCPMessageHandler } from "./message.js";

--- a/apps/backend/lib/mcp/message.ts
+++ b/apps/backend/lib/mcp/message.ts
@@ -4,8 +4,10 @@
  * 这是阶段一重构的核心组件，用于消除双层代理架构
  */
 
-import type { Logger } from "@/Logger.js";
-import { logger } from "@/Logger.js";
+import type {
+  ClientCapabilities,
+  InitializedNotification,
+} from "@modelcontextprotocol/sdk/types.js";
 import {
   JSONRPC_VERSION,
   MCP_METHODS,
@@ -13,13 +15,11 @@ import {
   MCP_SERVER_INFO,
   MCP_SUPPORTED_PROTOCOL_VERSIONS,
 } from "@/constants/index.js";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
 import type { EnhancedToolInfo, MCPServiceManager } from "@/lib/mcp";
 import { validateToolCallParams } from "@/lib/mcp";
 import type { MCPMessage, MCPResponse } from "@/types/mcp.js";
-import type {
-  ClientCapabilities,
-  InitializedNotification,
-} from "@modelcontextprotocol/sdk/types.js";
 
 // 初始化参数接口
 interface InitializeParams {

--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -7,13 +7,13 @@
  */
 
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
-import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
   MCPServiceConfig,
   ToolCallParams,
   ToolCallValidationOptions,
   ValidatedToolCallParams,
 } from "./types.js";
+import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 
 /**
  * 根据 URL 路径推断传输类型

--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -17,10 +17,10 @@
 
 import { exec, spawn } from "node:child_process";
 import { promisify } from "node:util";
+import semver from "semver";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
-import semver from "semver";
 
 const execAsync = promisify(exec);
 

--- a/apps/backend/middlewares/endpointManager.middleware.ts
+++ b/apps/backend/middlewares/endpointManager.middleware.ts
@@ -3,8 +3,8 @@
  * 负责将 endpointManager 注入到请求上下文中
  */
 
-import type { AppContext } from "@/types/hono.context.js";
 import type { MiddlewareHandler } from "hono";
+import type { AppContext } from "@/types/hono.context.js";
 
 /**
  * 小智连接管理器中间件

--- a/apps/backend/middlewares/endpoints.middleware.ts
+++ b/apps/backend/middlewares/endpoints.middleware.ts
@@ -3,11 +3,11 @@
  * 负责创建和管理 EndpointHandler 实例
  */
 
-import { EndpointHandler } from "@/handlers/endpoint.handler.js";
-import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { MiddlewareHandler } from "hono";
+import { EndpointHandler } from "@/handlers/endpoint.handler.js";
+import type { AppContext } from "@/types/hono.context.js";
 
 /**
  * 小智端点处理器中间件
@@ -16,7 +16,7 @@ import type { MiddlewareHandler } from "hono";
 export const endpointsMiddleware = (): MiddlewareHandler<AppContext> => {
   // 使用闭包缓存 handler 实例和 manager
   let endpointHandler: EndpointHandler | null = null;
-  let lastManager: EndpointManager | null | undefined = undefined;
+  let lastManager: EndpointManager | null | undefined;
 
   return async (c, next) => {
     const endpointManager = c.get("endpointManager");

--- a/apps/backend/middlewares/index.ts
+++ b/apps/backend/middlewares/index.ts
@@ -45,26 +45,25 @@
  * ```
  */
 
-export { loggerMiddleware } from "./logger.middleware.js";
-export { corsMiddleware } from "./cors.middleware.js";
-export {
-  errorHandlerMiddleware,
-  notFoundHandlerMiddleware,
-  createErrorResponse,
-  createSuccessResponse,
-  ApiErrorResponse,
-  ApiSuccessResponse,
-} from "./error.middleware.js";
-export { responseEnhancerMiddleware } from "./response-enhancer.middleware.js";
-export {
-  mcpServiceManagerMiddleware,
-  hasMCPServiceManager,
-} from "./mcpServiceManager.middleware.js";
-export { endpointManagerMiddleware } from "./endpointManager.middleware.js";
-export { endpointsMiddleware } from "./endpoints.middleware.js";
-
 // 重新导出 context 相关函数
 export {
   getMCPServiceManager,
   requireMCPServiceManager,
 } from "@/types/hono.context.js";
+export { corsMiddleware } from "./cors.middleware.js";
+export { endpointManagerMiddleware } from "./endpointManager.middleware.js";
+export { endpointsMiddleware } from "./endpoints.middleware.js";
+export {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+  createErrorResponse,
+  createSuccessResponse,
+  errorHandlerMiddleware,
+  notFoundHandlerMiddleware,
+} from "./error.middleware.js";
+export { loggerMiddleware } from "./logger.middleware.js";
+export {
+  hasMCPServiceManager,
+  mcpServiceManagerMiddleware,
+} from "./mcpServiceManager.middleware.js";
+export { responseEnhancerMiddleware } from "./response-enhancer.middleware.js";

--- a/apps/backend/middlewares/logger.middleware.ts
+++ b/apps/backend/middlewares/logger.middleware.ts
@@ -8,10 +8,10 @@
  * @module middlewares/logger.middleware
  */
 
-import { logger } from "@/Logger.js";
-import type { Logger } from "@/Logger.js";
-import type { AppContext } from "@/types/hono.context.js";
 import type { Context, Next } from "hono";
+import type { Logger } from "@/Logger.js";
+import { logger } from "@/Logger.js";
+import type { AppContext } from "@/types/hono.context.js";
 
 /**
  * 扩展 Hono Context 接口

--- a/apps/backend/middlewares/mcpServiceManager.middleware.ts
+++ b/apps/backend/middlewares/mcpServiceManager.middleware.ts
@@ -4,12 +4,12 @@
  * 提供统一的依赖注入模式，从 WebServer 获取实例而非 Singleton
  */
 
+import type { Context, Next } from "hono";
 import {
   MCPServiceManagerNotInitializedError,
   WebServerNotAvailableError,
 } from "@/errors/mcp-errors.middleware.js";
 import type { AppContextVariables } from "@/types/hono.context.js";
-import type { Context, Next } from "hono";
 
 /**
  * MCP Service Manager 中间件

--- a/apps/backend/middlewares/response-enhancer.middleware.ts
+++ b/apps/backend/middlewares/response-enhancer.middleware.ts
@@ -3,8 +3,8 @@
  * 为 Hono Context 添加便捷的响应方法：c.success、c.fail、c.paginate
  */
 
-import type { PaginationInfo } from "@/types/api.response.js";
 import type { MiddlewareHandler } from "hono";
+import type { PaginationInfo } from "@/types/api.response.js";
 
 /**
  * 扩展 Hono Context 接口

--- a/apps/backend/routes/RouteManager.ts
+++ b/apps/backend/routes/RouteManager.ts
@@ -3,13 +3,13 @@
  * 提供直接、高效的路由注册和管理功能
  */
 
+import type { Context, Hono, Next } from "hono";
 import type { Logger } from "@/Logger.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context, Hono, Next } from "hono";
 import {
+  normalizeRoutes,
   type RouteDefinition,
   type RouteRegistry,
-  normalizeRoutes,
 } from "./types.js";
 
 /**

--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,9 +4,9 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import type { Context } from "hono";
 import type { RouteDefinition } from "@/routes/types.js";
 import type { AppContext } from "@/types/hono.context.js";
-import type { Context } from "hono";
 
 /**
  * 端点处理器方法名类型

--- a/apps/backend/routes/domains/esp32.route.ts
+++ b/apps/backend/routes/domains/esp32.route.ts
@@ -10,9 +10,9 @@
  * 注意：设备采用自动激活模式，无需管理API
  */
 
-import type { RouteDefinition } from "@/routes/types.js";
-import { type HandlerDependencies, createHandler } from "@/routes/types.js";
 import type { Context } from "hono";
+import type { RouteDefinition } from "@/routes/types.js";
+import { createHandler, type HandlerDependencies } from "@/routes/types.js";
 
 const h = createHandler("esp32Handler");
 

--- a/apps/backend/routes/domains/index.ts
+++ b/apps/backend/routes/domains/index.ts
@@ -6,20 +6,20 @@
 
 // 导入所有可用的路由配置
 export { configRoutes } from "./config.route.js";
-export { statusRoutes } from "./status.route.js";
-export { toolsRoutes } from "./tools.route.js";
-export { mcpRoutes } from "./mcp.route.js";
-export { versionRoutes } from "./version.route.js";
-export { servicesRoutes } from "./services.route.js";
-export { updateRoutes } from "./update.route.js";
-export { staticRoutes } from "./static.route.js";
 export { cozeRoutes } from "./coze.route.js";
-export { toolLogsRoutes } from "./tool-logs.route.js";
-export { mcpserverRoutes } from "./mcpserver.route.js";
 export { endpointRoutes } from "./endpoint.route.js";
-export { miscRoutes } from "./misc.route.js";
-export { ttsRoutes } from "./tts.route.js";
 export { esp32Routes } from "./esp32.route.js";
+export { mcpRoutes } from "./mcp.route.js";
+export { mcpserverRoutes } from "./mcpserver.route.js";
+export { miscRoutes } from "./misc.route.js";
+export { servicesRoutes } from "./services.route.js";
+export { staticRoutes } from "./static.route.js";
+export { statusRoutes } from "./status.route.js";
+export { toolLogsRoutes } from "./tool-logs.route.js";
+export { toolsRoutes } from "./tools.route.js";
+export { ttsRoutes } from "./tts.route.js";
+export { updateRoutes } from "./update.route.js";
+export { versionRoutes } from "./version.route.js";
 
 /**
  * 路由域名列表

--- a/apps/backend/routes/domains/mcpserver.route.ts
+++ b/apps/backend/routes/domains/mcpserver.route.ts
@@ -3,8 +3,8 @@
  * 处理 MCP 服务器管理相关的 API 路由
  */
 
-import type { HandlerDependencies, RouteDefinition } from "@/routes/types.js";
 import type { Context } from "hono";
+import type { HandlerDependencies, RouteDefinition } from "@/routes/types.js";
 
 /**
  * MCP 服务器处理器包装函数

--- a/apps/backend/routes/index.ts
+++ b/apps/backend/routes/index.ts
@@ -7,24 +7,20 @@
  * @packageDocumentation
  */
 
+// 重新导出 Hono 相关类型以方便使用
+export type { Context } from "hono";
+// 重新导出处理器类型
+export type { EndpointHandler, TTSApiHandler } from "@/handlers/index.js";
+export type { AppContext } from "@/types/hono.context.js";
+// 路由域导出
+export * from "./domains/index.js";
+// 核心类
+export { RouteManager } from "./RouteManager.js";
 // 类型定义
 export type {
   HandlerDependencies,
-  RouteRegistryOptions,
-  RouteStatistics,
   HTTPMethod,
   RouteDefinition,
+  RouteRegistryOptions,
+  RouteStatistics,
 } from "./types.js";
-
-// 核心类
-export { RouteManager } from "./RouteManager.js";
-
-// 路由域导出
-export * from "./domains/index.js";
-
-// 重新导出 Hono 相关类型以方便使用
-export type { Context } from "hono";
-export type { AppContext } from "@/types/hono.context.js";
-
-// 重新导出处理器类型
-export type { EndpointHandler, TTSApiHandler } from "@/handlers/index.js";

--- a/apps/backend/routes/types.ts
+++ b/apps/backend/routes/types.ts
@@ -3,11 +3,12 @@
  * 提供类型安全的路由配置和依赖注入
  */
 
+import type { Context, MiddlewareHandler } from "hono";
 import type {
   ConfigApiHandler,
   CozeHandler,
-  ESP32Handler,
   EndpointHandler,
+  ESP32Handler,
   MCPHandler,
   MCPRouteHandler,
   MCPToolHandler,
@@ -19,7 +20,6 @@ import type {
   UpdateApiHandler,
   VersionApiHandler,
 } from "@/handlers/index.js";
-import type { Context, MiddlewareHandler } from "hono";
 
 /**
  * 处理器依赖接口

--- a/apps/backend/services/__tests__/esp32.service.test.ts
+++ b/apps/backend/services/__tests__/esp32.service.test.ts
@@ -3,8 +3,8 @@
  * 测试设备连接、Token简化后的行为等
  */
 
-import type { ESP32DeviceReport } from "@/types/esp32.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ESP32DeviceReport } from "@/types/esp32.js";
 import { DeviceRegistryService } from "../device-registry.service.js";
 import { ESP32Service } from "../esp32.service.js";
 

--- a/apps/backend/services/__tests__/event-bus.service.boundary.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.boundary.test.ts
@@ -7,8 +7,8 @@
  * 确保系统在极端情况下仍能稳定运行。
  */
 
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { EventBus } from "../event-bus.service.js";
 
 describe("事件系统边界情况测试", () => {

--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  EventBus,
   destroyEventBus,
+  EventBus,
   getEventBus,
 } from "../event-bus.service.js";
 

--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -1,7 +1,7 @@
 import type { AppConfig } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { NotificationService } from "../notification.service.js";
 import type { WebSocketClient } from "../notification.service.js";
+import { NotificationService } from "../notification.service.js";
 import type { ClientInfo } from "../status.service.js";
 
 // 模拟 EventBus

--- a/apps/backend/services/asr.service.ts
+++ b/apps/backend/services/asr.service.ts
@@ -3,9 +3,9 @@
  * 处理语音识别功能
  */
 
-import { logger } from "@/Logger.js";
 import { ASR, AudioFormat, AuthMethod, OpusDecoder } from "@xiaozhi-client/asr";
 import { configManager } from "@xiaozhi-client/config";
+import { logger } from "@/Logger.js";
 import type {
   ASRServiceEvents,
   ASRServiceOptions,

--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -3,6 +3,7 @@
  * 负责ESP32设备的连接管理和消息路由
  */
 
+import type WebSocket from "ws";
 import { logger } from "@/Logger.js";
 import { ESP32Connection } from "@/lib/esp32/connection.js";
 import type {
@@ -12,7 +13,6 @@ import type {
   ESP32WSMessage,
 } from "@/types/esp32.js";
 import { camelToSnakeCase, extractDeviceInfo } from "@/utils/esp32-utils.js";
-import type WebSocket from "ws";
 import { ASRService } from "./asr.service.js";
 import type { DeviceRegistryService } from "./device-registry.service.js";
 import { LLMService } from "./llm.service.js";

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -12,9 +12,9 @@
  */
 
 import { EventEmitter } from "node:events";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 /**
  * 事件类型定义

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -22,11 +22,11 @@
  * });
  * ```
  */
-export * from "./status.service.js";
-export * from "./notification.service.js";
-export * from "./event-bus.service.js";
-export * from "./device-registry.service.js";
-export * from "./esp32.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";
+export * from "./device-registry.service.js";
+export * from "./esp32.service.js";
+export * from "./event-bus.service.js";
+export * from "./notification.service.js";
+export * from "./status.service.js";

--- a/apps/backend/services/llm.service.ts
+++ b/apps/backend/services/llm.service.ts
@@ -3,10 +3,10 @@
  * 提供基于 OpenAI SDK 的大语言模型调用封装
  */
 
-import { logger } from "@/Logger.js";
-import { resolvePrompt } from "@/utils/prompt-utils.js";
 import { configManager } from "@xiaozhi-client/config";
 import OpenAI from "openai";
+import { logger } from "@/Logger.js";
+import { resolvePrompt } from "@/utils/prompt-utils.js";
 
 function removeThinkTags(content: string): string {
   // 移除 <think>...</think> 及其内容

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -20,13 +20,13 @@
  * - 与 EventBus 紧密集成，监听系统事件并广播
  */
 
+import type { AppConfig } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
-import type { AppConfig } from "@xiaozhi-client/config";
-import { configManager } from "@xiaozhi-client/config";
 
 /**
  * WebSocket 类接口

--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -4,11 +4,11 @@
  */
 
 import { Readable } from "node:stream";
-import { logger } from "@/Logger.js";
-import type { ESP32Connection } from "@/lib/esp32/connection.js";
 import { configManager } from "@xiaozhi-client/config";
 import { TTS } from "@xiaozhi-client/tts";
 import * as prism from "prism-media";
+import { logger } from "@/Logger.js";
+import type { ESP32Connection } from "@/lib/esp32/connection.js";
 import type { ITTSService, TTSServiceOptions } from "./tts.interface.js";
 
 /**

--- a/apps/backend/types/hono.context.ts
+++ b/apps/backend/types/hono.context.ts
@@ -3,21 +3,21 @@
  * 为 Hono Context 添加项目特定的变量类型定义
  */
 
-import type { Logger } from "@/Logger.js";
-import type { EndpointHandler } from "@/handlers/index.js";
-import type { MCPServiceManager } from "@/lib/mcp";
-import type { HandlerDependencies } from "@/routes/types.js";
 import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
 import { Hono } from "hono";
+import type { EndpointHandler } from "@/handlers/index.js";
+import type { Logger } from "@/Logger.js";
+import type { MCPServiceManager } from "@/lib/mcp";
+import type { HandlerDependencies } from "@/routes/types.js";
 
 // 导出 API 响应类型供其他模块使用
 export type {
   ApiErrorResponse,
   ApiPaginatedResponse,
+  ApiResponse,
   ApiSuccessResponse,
   PaginationInfo,
-  ApiResponse,
 } from "./api.response.js";
 
 /**

--- a/apps/backend/types/index.ts
+++ b/apps/backend/types/index.ts
@@ -57,33 +57,34 @@
  *
  * @module apps/backend/types
  */
+
+export * from "./coze.js";
+export * from "./esp32.js";
+export * from "./hono.context.js";
 export type {
+  CacheConfig,
+  CacheStateTransition,
+  CacheStatistics,
+  EnhancedToolResultCache,
+  ExtendedMCPToolsCache,
+  MCPError,
   MCPMessage,
   MCPResponse,
-  MCPError,
-  ExtendedMCPToolsCache,
-  EnhancedToolResultCache,
-  TaskStatus,
-  CacheStatistics,
-  CacheStateTransition,
-  ToolCallOptions,
-  CacheConfig,
-  TimeoutConfig,
   TaskInfo,
+  TaskStatus,
+  TimeoutConfig,
+  ToolCallOptions,
   ToolCallResponse,
   ToolCallResult,
 } from "./mcp.js";
 export {
-  generateCacheKey,
+  DEFAULT_CONFIG,
   formatTimestamp,
+  generateCacheKey,
   isCacheExpired,
-  shouldCleanupCache,
-  isToolCallResult,
   isEnhancedToolResultCache,
   isExtendedMCPToolsCache,
-  DEFAULT_CONFIG,
+  isToolCallResult,
+  shouldCleanupCache,
 } from "./mcp.js";
-export * from "./coze.js";
 export * from "./timeout.js";
-export * from "./hono.context.js";
-export * from "./esp32.js";

--- a/apps/backend/utils/index.ts
+++ b/apps/backend/utils/index.ts
@@ -3,16 +3,16 @@
  * 提供 utils 目录下所有工具类的统一导出接口
  */
 
-export { PathUtils } from "./path-utils.js";
 // 重新导出 @xiaozhi-client/version 以保持向后兼容
 export { VersionUtils } from "@xiaozhi-client/version";
-// WebSocket 辅助工具
-export { sendWebSocketError } from "./websocket-helper.js";
-export type { WebSocketLike } from "./websocket-helper.js";
 // ESP32 设备信息提取工具
 export {
-  extractDeviceInfo,
   camelToSnakeCase,
   type DeviceInfoFromHeaders,
   type ExtractedDeviceInfo,
+  extractDeviceInfo,
 } from "./esp32-utils.js";
+export { PathUtils } from "./path-utils.js";
+export type { WebSocketLike } from "./websocket-helper.js";
+// WebSocket 辅助工具
+export { sendWebSocketError } from "./websocket-helper.js";

--- a/apps/backend/utils/tool-sorters.test.ts
+++ b/apps/backend/utils/tool-sorters.test.ts
@@ -2,8 +2,8 @@
  * toolSorters 工具函数测试
  */
 
-import type { EnhancedToolInfo } from "@/lib/mcp";
 import { describe, expect, it } from "vitest";
+import type { EnhancedToolInfo } from "@/lib/mcp";
 import { sortTools, toolSorters } from "./toolSorters";
 
 // 创建模拟工具数据

--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,5 +1,4 @@
-import { resolve } from "node:path";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";

--- a/apps/frontend/biome.json
+++ b/apps/frontend/biome.json
@@ -1,9 +1,17 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "root": false,
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "extends": ["../../biome.json"],
   "files": {
-    "include": ["src/**/*.ts", "src/**/*.tsx", "*.ts", "*.js"],
-    "ignore": ["node_modules/**", "dist/**", "coverage/**"]
+    "includes": [
+      "**/src/**/*.ts",
+      "**/src/**/*.tsx",
+      "**/*.ts",
+      "**/*.js",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/coverage/**"
+    ]
   },
   "linter": {
     "rules": {

--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,8 +1,8 @@
+import { Navigate, Route, Routes } from "react-router-dom";
 import { Toaster } from "@/components/ui/sonner";
 import { RestartNotificationProvider } from "@/hooks/useRestartNotifications";
 import DashboardPage from "@/pages/DashboardPage";
 import { WebSocketProvider } from "@/providers/WebSocketProvider";
-import { Navigate, Route, Routes } from "react-router-dom";
 
 function App() {
   return (

--- a/apps/frontend/src/components/__tests__/McpEndpointSettingButton.test.tsx
+++ b/apps/frontend/src/components/__tests__/McpEndpointSettingButton.test.tsx
@@ -1,7 +1,3 @@
-import { McpEndpointSettingButton } from "@/components/mcp-endpoint-setting-button";
-import * as api from "@/services/api";
-import * as websocket from "@/services/websocket";
-import * as stores from "@/stores/config";
 import {
   act,
   fireEvent,
@@ -12,6 +8,10 @@ import {
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { McpEndpointSettingButton } from "@/components/mcp-endpoint-setting-button";
+import * as api from "@/services/api";
+import * as websocket from "@/services/websocket";
+import * as stores from "@/stores/config";
 
 // Mock modules
 vi.mock("@/stores/config");

--- a/apps/frontend/src/components/__tests__/McpServerList.test.tsx
+++ b/apps/frontend/src/components/__tests__/McpServerList.test.tsx
@@ -1,7 +1,7 @@
-import { McpServerList } from "@/components/mcp-server-list";
 import { render, screen } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";
+import { McpServerList } from "@/components/mcp-server-list";
 
 // 模拟 sonner toast
 vi.mock("sonner", () => ({

--- a/apps/frontend/src/components/__tests__/RemoveMcpServerButton.test.tsx
+++ b/apps/frontend/src/components/__tests__/RemoveMcpServerButton.test.tsx
@@ -1,7 +1,7 @@
-import { RemoveMcpServerButton } from "@/components/remove-mcp-server-button";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { act } from "react";
 import { vi } from "vitest";
+import { RemoveMcpServerButton } from "@/components/remove-mcp-server-button";
 
 // Mock lucide-react to avoid icon loading issues
 vi.mock("lucide-react", () => ({

--- a/apps/frontend/src/components/__tests__/VersionManager.test.tsx
+++ b/apps/frontend/src/components/__tests__/VersionManager.test.tsx
@@ -2,9 +2,9 @@
  * VersionManager 组件测试
  */
 
-import { VersionManager } from "@/components/version-manager";
 import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { VersionManager } from "@/components/version-manager";
 
 // Mock API client
 vi.mock("../../services/api", () => ({

--- a/apps/frontend/src/components/add-mcp-server-button.test.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.test.tsx
@@ -1,8 +1,8 @@
-import { apiClient } from "@/services/api";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { toast } from "sonner";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/services/api";
 import { AddMcpServerButton } from "./add-mcp-server-button";
 
 // Mock dependencies

--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -1,3 +1,9 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { PlusIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import z from "zod";
 import { McpServerForm } from "@/components/mcp-server-form";
 import { Button } from "@/components/ui/button";
 import {
@@ -27,12 +33,6 @@ import {
   jsonToFormData,
 } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { PlusIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import z from "zod";
 
 // 高级模式的 JSON 表单 schema
 const jsonFormSchema = z.object({

--- a/apps/frontend/src/components/common/collapsible-text.tsx
+++ b/apps/frontend/src/components/common/collapsible-text.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { cn } from "@/lib/utils";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+import { cn } from "@/lib/utils";
 
 /**
  * CollapsibleText 组件属性

--- a/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
+++ b/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
@@ -1,3 +1,12 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import type {
+  CozeWorkflow,
+  WorkflowParameter,
+} from "@xiaozhi-client/shared-types";
+import { Plus, Trash2 } from "lucide-react";
+import { useEffect } from "react";
+import { useFieldArray, useForm } from "react-hook-form";
+import { z } from "zod";
 import { Button } from "@/components/ui/button";
 import { Checkbox } from "@/components/ui/checkbox";
 import {
@@ -24,15 +33,6 @@ import {
   SelectTrigger,
   SelectValue,
 } from "@/components/ui/select";
-import { zodResolver } from "@hookform/resolvers/zod";
-import type {
-  CozeWorkflow,
-  WorkflowParameter,
-} from "@xiaozhi-client/shared-types";
-import { Plus, Trash2 } from "lucide-react";
-import { useEffect } from "react";
-import { useFieldArray, useForm } from "react-hook-form";
-import { z } from "zod";
 
 /**
  * 参数验证Schema

--- a/apps/frontend/src/components/connection-settings.tsx
+++ b/apps/frontend/src/components/connection-settings.tsx
@@ -1,7 +1,7 @@
-import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { AlertCircle, CheckCircle2, Settings } from "lucide-react";
 import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 
 interface ConnectionSettingsProps {
   wsUrl: string;

--- a/apps/frontend/src/components/coze-workflow-integration.tsx
+++ b/apps/frontend/src/components/coze-workflow-integration.tsx
@@ -1,3 +1,18 @@
+import type {
+  CozeWorkflow,
+  WorkflowParameter,
+} from "@xiaozhi-client/shared-types";
+import {
+  AlertCircle,
+  ChevronLeft,
+  ChevronRight,
+  Loader2,
+  Plus,
+  RefreshCw,
+  Workflow,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+import { toast } from "sonner";
 import { WorkflowParameterConfigDialog } from "@/components/common/workflow-parameter-config-dialog";
 import {
   AlertDialog,
@@ -28,21 +43,6 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
 import { apiClient } from "@/services/api";
-import type {
-  CozeWorkflow,
-  WorkflowParameter,
-} from "@xiaozhi-client/shared-types";
-import {
-  AlertCircle,
-  ChevronLeft,
-  ChevronRight,
-  Loader2,
-  Plus,
-  RefreshCw,
-  Workflow,
-} from "lucide-react";
-import { useEffect, useState } from "react";
-import { toast } from "sonner";
 
 interface CozeWorkflowIntegrationProps {
   onToolAdded?: () => void;

--- a/apps/frontend/src/components/form-fields.tsx
+++ b/apps/frontend/src/components/form-fields.tsx
@@ -3,6 +3,8 @@
  * 根据配置自动渲染不同类型的表单字段
  */
 
+import type { UseFormReturn } from "react-hook-form";
+import type { z } from "zod";
 import {
   FormControl,
   FormDescription,
@@ -21,8 +23,6 @@ import {
 } from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 import type { FieldConfig } from "@/types/form-config";
-import type { UseFormReturn } from "react-hook-form";
-import type { z } from "zod";
 
 /**
  * 渲染单个表单字段

--- a/apps/frontend/src/components/icons/index.ts
+++ b/apps/frontend/src/components/icons/index.ts
@@ -1,2 +1,2 @@
-export * from "./QQ";
 export * from "./Github";
+export * from "./QQ";

--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -8,6 +8,16 @@
  * - 安装完成后提供操作选项
  */
 
+import {
+  CheckCircleIcon,
+  ChevronDownIcon,
+  ChevronUpIcon,
+  TerminalIcon,
+  XCircleIcon,
+} from "lucide-react";
+import type React from "react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -21,16 +31,6 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNPMInstall } from "@/hooks/useNPMInstall";
-import {
-  CheckCircleIcon,
-  ChevronDownIcon,
-  ChevronUpIcon,
-  TerminalIcon,
-  XCircleIcon,
-} from "lucide-react";
-import type React from "react";
-import { useEffect, useRef, useState } from "react";
-import { toast } from "sonner";
 
 // 单个正则表达式匹配所有 ANSI 颜色转义序列，避免每次渲染时创建多个正则表达式
 const ANSI_PATTERN = /\[(0|31|32|33|34|35|36|37|90|91|92|93|94|95|96|97)m/g;

--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -1,30 +1,3 @@
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-
-import {
-  AlertDialog,
-  AlertDialogAction,
-  AlertDialogCancel,
-  AlertDialogContent,
-  AlertDialogDescription,
-  AlertDialogFooter,
-  AlertDialogHeader,
-  AlertDialogTitle,
-} from "@/components/ui/alert-dialog";
-import {
-  Dialog,
-  DialogClose,
-  DialogContent,
-  DialogDescription,
-  DialogFooter,
-  DialogHeader,
-  DialogTitle,
-  DialogTrigger,
-} from "@/components/ui/dialog";
-import { Input } from "@/components/ui/input";
-import { type EndpointStatusResponse, apiClient } from "@/services/api";
-import { webSocketManager } from "@/services/websocket";
-import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
 import {
   BadgeInfoIcon,
   CopyIcon,
@@ -37,6 +10,32 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { apiClient, type EndpointStatusResponse } from "@/services/api";
+import { webSocketManager } from "@/services/websocket";
+import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
 
 // 接入点状态接口
 interface EndpointState {

--- a/apps/frontend/src/components/mcp-server-form.tsx
+++ b/apps/frontend/src/components/mcp-server-form.tsx
@@ -4,6 +4,9 @@
  * 采用配置驱动的方式自动生成表单字段
  */
 
+import { zodResolver } from "@hookform/resolvers/zod";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import type { z } from "zod";
 import {
   renderFormField,
   renderSelectFieldWithHandler,
@@ -12,9 +15,6 @@ import { Button } from "@/components/ui/button";
 import { Form } from "@/components/ui/form";
 import { mcpFormFields } from "@/config/mcp-form-fields";
 import { mcpFormSchema } from "@/schemas/mcp-form";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { type UseFormReturn, useForm } from "react-hook-form";
-import type { z } from "zod";
 
 interface McpServerFormProps {
   /** 表单实例（可选，如果不提供则内部创建） */

--- a/apps/frontend/src/components/mcp-server-list.test.tsx
+++ b/apps/frontend/src/components/mcp-server-list.test.tsx
@@ -1,8 +1,8 @@
-import type { BadgeProps } from "@/components/ui/badge";
-import type { ButtonProps } from "@/components/ui/button";
 import { render, screen, waitFor } from "@testing-library/react";
 import type * as React from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { BadgeProps } from "@/components/ui/badge";
+import type { ButtonProps } from "@/components/ui/button";
 import { McpServerList } from "./mcp-server-list";
 
 // 模拟 hooks

--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -1,3 +1,14 @@
+import type {
+  AppConfig,
+  CozeWorkflow,
+  CustomMCPToolWithStats,
+  JSONSchema,
+  MCPServerConfig,
+  WorkflowParameter,
+} from "@xiaozhi-client/shared-types";
+import { CoffeeIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { WorkflowParameterConfigDialog } from "@/components/common/workflow-parameter-config-dialog";
 import {
   AlertDialog,
@@ -18,17 +29,6 @@ import {
   useMcpServers,
 } from "@/stores/config";
 import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
-import type {
-  AppConfig,
-  CozeWorkflow,
-  CustomMCPToolWithStats,
-  JSONSchema,
-  MCPServerConfig,
-  WorkflowParameter,
-} from "@xiaozhi-client/shared-types";
-import { CoffeeIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
 import { AddMcpServerButton } from "./add-mcp-server-button";
 import { CozeWorkflowIntegration } from "./coze-workflow-integration";
 import { McpServerSettingButton } from "./mcp-server-setting-button";

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -1,3 +1,10 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
+import { SettingsIcon } from "lucide-react";
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import z from "zod";
 import { McpServerForm } from "@/components/mcp-server-form";
 import { Button } from "@/components/ui/button";
 import {
@@ -29,13 +36,6 @@ import {
   jsonToFormData,
 } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
-import { SettingsIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import z from "zod";
 
 // 高级模式的 JSON 表单 schema
 const jsonFormSchema = z.object({

--- a/apps/frontend/src/components/mcp-server/mcp-server-table-dialog.tsx
+++ b/apps/frontend/src/components/mcp-server/mcp-server-table-dialog.tsx
@@ -6,6 +6,8 @@
 
 "use client";
 
+import { Server } from "lucide-react";
+import { useState } from "react";
 import { McpServerTable } from "@/components/mcp-server/mcp-server-table";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,8 +17,6 @@ import {
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import { Server } from "lucide-react";
-import { useState } from "react";
 
 /**
  * MCP 服务器表格对话框组件

--- a/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
+++ b/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
+import { CoffeeIcon } from "lucide-react";
+import { useCallback, useEffect, useMemo } from "react";
+import { toast } from "sonner";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -15,10 +19,6 @@ import { useServerSortPersistence } from "@/hooks/useServerSortPersistence";
 import { useToolPagination } from "@/hooks/useToolPagination";
 import { cn } from "@/lib/utils";
 import { useMcpServersWithStatus } from "@/stores/config";
-import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
-import { CoffeeIcon } from "lucide-react";
-import { useCallback, useEffect, useMemo } from "react";
-import { toast } from "sonner";
 import { McpServerSettingButton } from "../mcp-server-setting-button";
 import { RemoveMcpServerButton } from "../remove-mcp-server-button";
 import { ServerPagination } from "./server-pagination";

--- a/apps/frontend/src/components/mcp-server/server-pagination.tsx
+++ b/apps/frontend/src/components/mcp-server/server-pagination.tsx
@@ -3,5 +3,5 @@
  * 重新导出 ToolPagination 组件用于服务器表格
  */
 
-export { ToolPagination as ServerPagination } from "@/components/mcp-tool/tool-pagination";
 export type { ToolPaginationProps as ServerPaginationProps } from "@/components/mcp-tool/tool-pagination";
+export { ToolPagination as ServerPagination } from "@/components/mcp-tool/tool-pagination";

--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -1,5 +1,9 @@
 "use client";
 
+import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
 import { CollapsibleText } from "@/components/common/collapsible-text";
 import { ToolDebugDialog } from "@/components/tool-debug-dialog";
 import {
@@ -28,10 +32,6 @@ import { useToolSearch } from "@/hooks/useToolSearch";
 import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
-import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
-import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import { toast } from "sonner";
 import { ToolPagination } from "./tool-pagination";
 import { ToolSearchInput } from "./tool-search-input";
 import { ToolSortSelector } from "./tool-sort-selector";

--- a/apps/frontend/src/components/mcp-tool/tool-search-input.tsx
+++ b/apps/frontend/src/components/mcp-tool/tool-search-input.tsx
@@ -1,9 +1,9 @@
 "use client";
 
-import { Input } from "@/components/ui/input";
-import { cn } from "@/lib/utils";
 import { Search, X } from "lucide-react";
 import * as React from "react";
+import { Input } from "@/components/ui/input";
+import { cn } from "@/lib/utils";
 
 interface ToolSearchInputProps {
   /** 搜索框的值 */

--- a/apps/frontend/src/components/remove-mcp-server-button.tsx
+++ b/apps/frontend/src/components/remove-mcp-server-button.tsx
@@ -1,3 +1,6 @@
+import { TrashIcon } from "lucide-react";
+import { useState } from "react";
+import { toast } from "sonner";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -11,9 +14,6 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
-import { TrashIcon } from "lucide-react";
-import { useState } from "react";
-import { toast } from "sonner";
 
 export function RemoveMcpServerButton({
   mcpServerName,

--- a/apps/frontend/src/components/restart-button.tsx
+++ b/apps/frontend/src/components/restart-button.tsx
@@ -1,7 +1,7 @@
-import { Button } from "@/components/ui/button";
-import { useRestartPollingStatus, useStatusStore } from "@/stores/status";
 import clsx from "clsx";
 import { LoaderCircleIcon, PowerIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useRestartPollingStatus, useStatusStore } from "@/stores/status";
 
 /**
  * RestartButton 组件属性接口

--- a/apps/frontend/src/components/status-cards/index.ts
+++ b/apps/frontend/src/components/status-cards/index.ts
@@ -4,12 +4,11 @@
  * 包含拆分后的所有状态卡片组件和类型定义。
  */
 
-// 组件导出
-export { MiniCircularProgress } from "./mini-circular-progress";
-export { EndpointStatusCard } from "./endpoint-status-card";
 export { ClientStatusCard } from "./client-status-card";
-export { ServerStatusCard } from "./server-status-card";
-export { SystemStatusCard } from "./system-status-card";
-
+export { EndpointStatusCard } from "./endpoint-status-card";
 // 类型导出
 export type { MiniCircularProgressProps } from "./mini-circular-progress";
+// 组件导出
+export { MiniCircularProgress } from "./mini-circular-progress";
+export { ServerStatusCard } from "./server-status-card";
+export { SystemStatusCard } from "./system-status-card";

--- a/apps/frontend/src/components/status-cards/system-status-card.tsx
+++ b/apps/frontend/src/components/status-cards/system-status-card.tsx
@@ -4,6 +4,7 @@
  * 显示系统配置完成度和快速打开设置对话框的入口。
  */
 
+import { useMemo } from "react";
 import { RestartButton } from "@/components/restart-button";
 import { SystemSettingDialog } from "@/components/system-setting-dialog";
 import {
@@ -14,7 +15,6 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { useConfig } from "@/stores/config";
-import { useMemo } from "react";
 import { MiniCircularProgress } from "./mini-circular-progress";
 
 /**

--- a/apps/frontend/src/components/system-setting-dialog.tsx
+++ b/apps/frontend/src/components/system-setting-dialog.tsx
@@ -4,6 +4,13 @@
  * 在对话框中展示和编辑系统配置，包括平台认证和连接参数。
  */
 
+import { zodResolver } from "@hookform/resolvers/zod";
+import type { AppConfig } from "@xiaozhi-client/shared-types";
+import { SettingsIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import z from "zod";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -26,13 +33,6 @@ import {
 import { Input } from "@/components/ui/input";
 import { useWebSocketActions } from "@/providers/WebSocketProvider";
 import { useConfig } from "@/stores/config";
-import { zodResolver } from "@hookform/resolvers/zod";
-import type { AppConfig } from "@xiaozhi-client/shared-types";
-import { SettingsIcon } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import z from "zod";
 
 const formSchema = z.object({
   modelscope: z.object({

--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -1,5 +1,22 @@
 "use client";
 
+import type {
+  ApiResponse,
+  ToolCallLogsResponse,
+  ToolCallRecord,
+} from "@xiaozhi-client/shared-types";
+import {
+  CheckCircle,
+  CheckIcon,
+  Code,
+  CopyIcon,
+  FileText,
+  Loader2,
+  RefreshCw,
+  RotateCwIcon,
+  XCircle,
+} from "lucide-react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -27,23 +44,6 @@ import {
   formatTimestamp,
   generateStableKey,
 } from "@/utils/formatUtils";
-import type {
-  ApiResponse,
-  ToolCallLogsResponse,
-  ToolCallRecord,
-} from "@xiaozhi-client/shared-types";
-import {
-  CheckCircle,
-  CheckIcon,
-  Code,
-  CopyIcon,
-  FileText,
-  Loader2,
-  RefreshCw,
-  RotateCwIcon,
-  XCircle,
-} from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
 
 export function ToolCallLogsDialog() {
   const [open, setOpen] = useState(false);

--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -1,5 +1,24 @@
 "use client";
 
+import { zodResolver } from "@hookform/resolvers/zod";
+import {
+  AlertCircle,
+  BrushCleaningIcon,
+  CheckIcon,
+  Code,
+  CopyIcon,
+  InfoIcon,
+  Loader2,
+  PlayIcon,
+  Plus,
+  Trash2,
+  Zap,
+} from "lucide-react";
+import type React from "react";
+import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { toast } from "sonner";
+import { z } from "zod";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -41,25 +60,6 @@ import {
   createZodSchemaFromJsonSchema,
 } from "@/lib/schema-utils";
 import { apiClient } from "@/services/api";
-import { zodResolver } from "@hookform/resolvers/zod";
-import {
-  AlertCircle,
-  BrushCleaningIcon,
-  CheckIcon,
-  Code,
-  CopyIcon,
-  InfoIcon,
-  Loader2,
-  PlayIcon,
-  Plus,
-  Trash2,
-  Zap,
-} from "lucide-react";
-import type React from "react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
-import { toast } from "sonner";
-import { z } from "zod";
 
 /**
  * 数组字段渲染器组件

--- a/apps/frontend/src/components/ui/alert.tsx
+++ b/apps/frontend/src/components/ui/alert.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/apps/frontend/src/components/ui/badge.tsx
+++ b/apps/frontend/src/components/ui/badge.tsx
@@ -1,4 +1,4 @@
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import type * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/apps/frontend/src/components/ui/button.tsx
+++ b/apps/frontend/src/components/ui/button.tsx
@@ -1,5 +1,5 @@
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/apps/frontend/src/components/ui/label.tsx
+++ b/apps/frontend/src/components/ui/label.tsx
@@ -1,5 +1,5 @@
 import * as LabelPrimitive from "@radix-ui/react-label";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/apps/frontend/src/components/ui/progress.tsx
+++ b/apps/frontend/src/components/ui/progress.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
 import * as React from "react";
+import { cn } from "@/lib/utils";
 
 interface ProgressProps extends React.HTMLAttributes<HTMLDivElement> {
   value?: number;

--- a/apps/frontend/src/components/ui/scroll-area.tsx
+++ b/apps/frontend/src/components/ui/scroll-area.tsx
@@ -1,5 +1,5 @@
-import { cn } from "@/lib/utils";
 import * as React from "react";
+import { cn } from "@/lib/utils";
 
 interface ScrollAreaProps extends React.HTMLAttributes<HTMLDivElement> {
   children: React.ReactNode;

--- a/apps/frontend/src/components/ui/sheet.tsx
+++ b/apps/frontend/src/components/ui/sheet.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { X } from "lucide-react";
 import * as React from "react";
 

--- a/apps/frontend/src/components/ui/sidebar.tsx
+++ b/apps/frontend/src/components/ui/sidebar.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { Slot } from "@radix-ui/react-slot";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import { PanelLeft } from "lucide-react";
 import * as React from "react";
 

--- a/apps/frontend/src/components/ui/table.tsx
+++ b/apps/frontend/src/components/ui/table.tsx
@@ -1,7 +1,6 @@
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
-
 import { cn } from "@/lib/utils";
-import { type VariantProps, cva } from "class-variance-authority";
 
 // Context 类型定义
 interface TableSizeContextValue {

--- a/apps/frontend/src/components/ui/toggle.tsx
+++ b/apps/frontend/src/components/ui/toggle.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import * as TogglePrimitive from "@radix-ui/react-toggle";
-import { type VariantProps, cva } from "class-variance-authority";
+import { cva, type VariantProps } from "class-variance-authority";
 import * as React from "react";
 
 import { cn } from "@/lib/utils";

--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -1,3 +1,5 @@
+import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -8,8 +10,6 @@ import {
 } from "@/components/ui/tooltip";
 import type { VersionInfo } from "@/services/api";
 import { apiClient } from "@/services/api";
-import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";
 
 interface VersionDisplayProps {

--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -8,16 +8,6 @@
  * - 显示实时安装日志
  */
 
-import { Badge } from "@/components/ui/badge";
-import { Button } from "@/components/ui/button";
-import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
-import { apiClient } from "@/services/api";
 import {
   AlertCircle,
   Calendar,
@@ -28,6 +18,16 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
+import { apiClient } from "@/services/api";
 import { InstallLogDialog } from "./install-log-dialog";
 import { VersionDisplay } from "./version-display";
 

--- a/apps/frontend/src/components/version-upgrade-dialog.tsx
+++ b/apps/frontend/src/components/version-upgrade-dialog.tsx
@@ -7,6 +7,9 @@
  * - 集成安装日志显示
  */
 
+import { DownloadIcon, ShieldAlertIcon } from "lucide-react";
+import { useCallback, useEffect, useState } from "react";
+import semver from "semver";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { Button } from "@/components/ui/button";
 import {
@@ -26,9 +29,6 @@ import {
 } from "@/components/ui/select";
 import { useNPMInstall } from "@/hooks/useNPMInstall";
 import { apiClient } from "@/services/api";
-import { DownloadIcon, ShieldAlertIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
-import semver from "semver";
 import { InstallLogDialog } from "./install-log-dialog";
 
 interface VersionUpgradeDialogProps {

--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -1,3 +1,9 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { SettingsIcon } from "lucide-react";
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { toast } from "sonner";
+import z from "zod";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
@@ -23,12 +29,6 @@ import {
   useWebSocketConnected,
   useWebSocketPortChangeStatus,
 } from "@/stores/websocket";
-import { zodResolver } from "@hookform/resolvers/zod";
-import { SettingsIcon } from "lucide-react";
-import { useEffect, useState } from "react";
-import { useForm } from "react-hook-form";
-import { toast } from "sonner";
-import z from "zod";
 
 const formSchema = z.object({
   port: z

--- a/apps/frontend/src/config/mcp-form-fields.ts
+++ b/apps/frontend/src/config/mcp-form-fields.ts
@@ -3,10 +3,10 @@
  * 定义所有表单字段的 UI 属性和验证规则
  */
 
-import type { mcpFormSchema } from "@/schemas/mcp-form";
-import type { FieldConfig } from "@/types/form-config";
 import type { UseFormReturn } from "react-hook-form";
 import type { z } from "zod";
+import type { mcpFormSchema } from "@/schemas/mcp-form";
+import type { FieldConfig } from "@/types/form-config";
 
 /**
  * MCP 服务表单字段配置数组

--- a/apps/frontend/src/hooks/__tests__/use-network-service.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-network-service.test.ts
@@ -2,9 +2,9 @@
  * useNetworkService Hook 测试
  */
 
-import { ConnectionState, networkService } from "@/services/index";
 import { renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ConnectionState, networkService } from "@/services/index";
 import { useNetworkService } from "../useNetworkService";
 
 // Mock 依赖

--- a/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
@@ -1,6 +1,6 @@
-import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useToolPagination } from "../useToolPagination";
 
 describe("useToolPagination", () => {

--- a/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
@@ -1,6 +1,6 @@
-import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { act, renderHook } from "@testing-library/react";
 import { describe, expect, it } from "vitest";
+import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useToolSearch } from "../useToolSearch";
 
 describe("useToolSearch", () => {

--- a/apps/frontend/src/hooks/__tests__/useRestartNotifications.test.tsx
+++ b/apps/frontend/src/hooks/__tests__/useRestartNotifications.test.tsx
@@ -2,12 +2,12 @@
  * 重启通知系统测试
  */
 
+import { render, waitFor } from "@testing-library/react";
+import { vi } from "vitest";
 import {
   RestartNotificationProvider,
   useRestartNotifications,
 } from "@/hooks/useRestartNotifications";
-import { render, waitFor } from "@testing-library/react";
-import { vi } from "vitest";
 
 // Mock sonner toast
 vi.mock("sonner", () => ({

--- a/apps/frontend/src/hooks/useConfigData.ts
+++ b/apps/frontend/src/hooks/useConfigData.ts
@@ -5,6 +5,14 @@
  * 返回配置数据、加载状态、更新方法
  */
 
+import type {
+  AppConfig,
+  ConnectionConfig,
+  MCPServerConfig,
+  ModelScopeConfig,
+  WebUIConfig,
+} from "@xiaozhi-client/shared-types";
+import { useCallback } from "react";
 import {
   useConfig,
   useConfigActions,
@@ -23,14 +31,6 @@ import {
   useSystemConfig,
   useWebUIConfig,
 } from "@/stores/config";
-import type {
-  AppConfig,
-  ConnectionConfig,
-  MCPServerConfig,
-  ModelScopeConfig,
-  WebUIConfig,
-} from "@xiaozhi-client/shared-types";
-import { useCallback } from "react";
 
 /**
  * 配置数据相关的 hook

--- a/apps/frontend/src/hooks/useCozeWorkflows.ts
+++ b/apps/frontend/src/hooks/useCozeWorkflows.ts
@@ -3,7 +3,6 @@
  * 提供工作空间和工作流数据的状态管理
  */
 
-import { cozeApiClient } from "@/services/cozeApi";
 import type {
   CozeUIState,
   CozeWorkflow,
@@ -11,6 +10,7 @@ import type {
   CozeWorkspace,
 } from "@xiaozhi-client/shared-types";
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { cozeApiClient } from "@/services/cozeApi";
 
 /**
  * Hook 返回值类型

--- a/apps/frontend/src/hooks/useEndpointStatus.ts
+++ b/apps/frontend/src/hooks/useEndpointStatus.ts
@@ -1,12 +1,12 @@
-import {
-  type EndpointStatusChangedEvent,
-  webSocketManager,
-} from "@/services/websocket";
 /**
  * 端点状态变更 Hook
  * 用于订阅和处理端点连接状态的实时变更
  */
 import { useCallback, useEffect, useState } from "react";
+import {
+  type EndpointStatusChangedEvent,
+  webSocketManager,
+} from "@/services/websocket";
 
 /**
  * 端点状态回调函数类型

--- a/apps/frontend/src/hooks/useNPMInstall.ts
+++ b/apps/frontend/src/hooks/useNPMInstall.ts
@@ -8,8 +8,8 @@
  * - 支持安装操作触发
  */
 
-import { webSocketManager } from "@/services/websocket";
 import { useCallback, useEffect, useState } from "react";
+import { webSocketManager } from "@/services/websocket";
 
 /**
  * 安装日志接口

--- a/apps/frontend/src/hooks/useNetworkService.ts
+++ b/apps/frontend/src/hooks/useNetworkService.ts
@@ -3,13 +3,13 @@
  * 使用统一的网络服务管理器，实现 HTTP 和 WebSocket 的协调使用
  */
 
+import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import { useCallback, useEffect, useRef } from "react";
 import { ConnectionState, networkService } from "@/services/index";
 import type { RestartStatus } from "@/services/websocket";
 import { useConfigStore } from "@/stores/config";
 import { useStatusStore } from "@/stores/status";
 import { useWebSocketActions } from "@/stores/websocket";
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
-import { useCallback, useEffect, useRef } from "react";
 
 /**
  * 网络服务 Hook

--- a/apps/frontend/src/hooks/useRestartNotifications.ts
+++ b/apps/frontend/src/hooks/useRestartNotifications.ts
@@ -8,9 +8,9 @@
  * - 提供一致的用户体验
  */
 
-import { useRestartPollingStatus, useRestartStatus } from "@/stores/status";
 import { useEffect, useRef } from "react";
 import { toast } from "sonner";
+import { useRestartPollingStatus, useRestartStatus } from "@/stores/status";
 
 /**
  * 重启通知管理 Hook

--- a/apps/frontend/src/hooks/useServerSearch.ts
+++ b/apps/frontend/src/hooks/useServerSearch.ts
@@ -4,8 +4,8 @@
  * 提供服务器列表搜索和筛选功能，支持根据通信类型和关键词进行筛选
  */
 
-import type { ServerRowData } from "@/components/mcp-server/mcp-server-table";
 import { useCallback, useMemo, useState } from "react";
+import type { ServerRowData } from "@/components/mcp-server/mcp-server-table";
 
 interface UseServerSearchResult {
   /** 搜索关键词 */

--- a/apps/frontend/src/hooks/useStatusData.ts
+++ b/apps/frontend/src/hooks/useStatusData.ts
@@ -5,6 +5,7 @@
  * 返回状态数据、轮询控制、重启方法
  */
 
+import { useCallback } from "react";
 import {
   useActiveMcpServers,
   useClientStatus,
@@ -27,7 +28,6 @@ import {
   useStatusMcpEndpoint,
   useStatusWithLoading,
 } from "@/stores/status";
-import { useCallback } from "react";
 
 /**
  * 状态数据相关的 hook

--- a/apps/frontend/src/hooks/useToolPagination.ts
+++ b/apps/frontend/src/hooks/useToolPagination.ts
@@ -4,8 +4,8 @@
  * 提供工具列表的分页功能，自动计算分页状态和当前页数据
  */
 
-import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useCallback, useMemo, useState } from "react";
+import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 
 interface UseToolPaginationResult {
   /** 当前页码 */

--- a/apps/frontend/src/hooks/useToolSearch.ts
+++ b/apps/frontend/src/hooks/useToolSearch.ts
@@ -4,8 +4,8 @@
  * 提供工具列表搜索和筛选功能，支持根据服务名、工具名、描述进行筛选
  */
 
-import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 import { useCallback, useMemo, useState } from "react";
+import type { ToolRowData } from "@/components/mcp-tool/mcp-tool-table";
 
 interface UseToolSearchResult {
   /** 搜索关键词 */

--- a/apps/frontend/src/hooks/useToolSortPersistence.ts
+++ b/apps/frontend/src/hooks/useToolSortPersistence.ts
@@ -6,8 +6,10 @@
  * 自动将用户选择的工具排序方式保存到 localStorage，支持按名称、启用状态、使用次数、最后使用时间等字段排序
  */
 
-import type { ToolSortConfig } from "@/components/mcp-tool/tool-sort-selector";
-import type { ToolSortField } from "@/components/mcp-tool/tool-sort-selector";
+import type {
+  ToolSortConfig,
+  ToolSortField,
+} from "@/components/mcp-tool/tool-sort-selector";
 import { useSortPersistence } from "@/hooks/useSortPersistence";
 
 /** 有效的排序字段列表 */

--- a/apps/frontend/src/hooks/useWebSocketConnection.ts
+++ b/apps/frontend/src/hooks/useWebSocketConnection.ts
@@ -5,6 +5,7 @@
  * 返回连接状态、错误信息、连接控制方法
  */
 
+import { useCallback } from "react";
 import { ConnectionState, webSocketManager } from "@/services/websocket";
 import {
   useWebSocketActions,
@@ -14,7 +15,6 @@ import {
   useWebSocketLastError,
   useWebSocketUrl,
 } from "@/stores/websocket";
-import { useCallback } from "react";
 
 /**
  * WebSocket 连接相关的 hook

--- a/apps/frontend/src/index.css
+++ b/apps/frontend/src/index.css
@@ -99,7 +99,9 @@
   [role="link"]:focus-visible {
     background-color: hsl(var(--accent)) !important;
     color: hsl(var(--accent-foreground)) !important;
-    transition: background-color 0.2s ease, color 0.2s ease;
+    transition:
+      background-color 0.2s ease,
+      color 0.2s ease;
   }
 
   /* input、textarea、select 保留原始焦点样式，包括 Tailwind 的 ring 样式 */

--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -1,13 +1,13 @@
-import { useNetworkService } from "@/hooks/useNetworkService";
-import { initializeStores } from "@/stores/index";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import {
-  type ReactNode,
   createContext,
+  type ReactNode,
   useContext,
   useEffect,
   useState,
 } from "react";
+import { useNetworkService } from "@/hooks/useNetworkService";
+import { initializeStores } from "@/stores/index";
 
 interface NetworkServiceContextType {
   // HTTP API 方法

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -361,8 +361,8 @@ export const networkService = new NetworkService();
 
 // 导出其他服务
 export { apiClient, webSocketManager };
+export { CozeApiClient, cozeApiClient } from "./cozeApi";
 export { ConnectionState } from "./websocket";
-export { cozeApiClient, CozeApiClient } from "./cozeApi";
 
 // 导出类型
 export type { ApiClient, WebSocketManager };

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -7,8 +7,8 @@
  * - 支持多个 store 订阅 WebSocket 事件
  */
 
-import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
 
 /**
  * WebSocket 消息类型

--- a/apps/frontend/src/stores/__tests__/config.test.ts
+++ b/apps/frontend/src/stores/__tests__/config.test.ts
@@ -1,6 +1,6 @@
-import { apiClient } from "@/services/api";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { apiClient } from "@/services/api";
 import { useConfigStore } from "../config";
 
 // Mock API client

--- a/apps/frontend/src/stores/__tests__/status.test.ts
+++ b/apps/frontend/src/stores/__tests__/status.test.ts
@@ -1,10 +1,9 @@
-import { apiClient } from "@/services/api";
 import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { useStatusStore } from "../status";
-
 // 导入 API 中的 FullStatus 类型
 import type { FullStatus } from "@/services/api";
+import { apiClient } from "@/services/api";
+import { useStatusStore } from "../status";
 
 // Mock API client
 vi.mock("@/services/api", () => ({

--- a/apps/frontend/src/stores/__tests__/websocket.test.ts
+++ b/apps/frontend/src/stores/__tests__/websocket.test.ts
@@ -1,5 +1,5 @@
-import { ConnectionState } from "@/services/websocket";
 import { beforeEach, describe, expect, it } from "vitest";
+import { ConnectionState } from "@/services/websocket";
 import { useWebSocketStore } from "../websocket";
 
 describe("WebSocket Store - 连接状态管理", () => {

--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -9,8 +9,6 @@
  * - 集成 WebSocket 事件监听
  */
 
-import { apiClient } from "@/services/api";
-import { webSocketManager } from "@/services/websocket";
 import type {
   AppConfig,
   ConnectionConfig,
@@ -22,6 +20,8 @@ import type {
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { apiClient } from "@/services/api";
+import { webSocketManager } from "@/services/websocket";
 
 /**
  * 配置加载状态

--- a/apps/frontend/src/stores/index.ts
+++ b/apps/frontend/src/stores/index.ts
@@ -95,80 +95,76 @@ export function getStoresStatus() {
   };
 }
 
-// 导出所有 stores 以便统一访问
-export { useWebSocketStore } from "./websocket";
-export { useConfigStore } from "./config";
-export { useStatusStore } from "./status";
-
-// 导出废弃的兼容性选择器（从 websocket-compat.ts 直接导入以避免循环依赖）
-export {
-  useWebSocketConfig,
-  useWebSocketStatus,
-  useWebSocketMcpEndpoint,
-  useWebSocketMcpServers,
-  useWebSocketMcpServerConfig,
-  useWebSocketRestartStatus,
-} from "./websocket-compat";
-
-// 导出所有选择器 hooks（避免命名冲突）
-export {
-  // WebSocket store exports
-  useWebSocketConnectionState,
-  useWebSocketConnected,
-  useWebSocketUrl,
-  useWebSocketConnectionStats,
-  useWebSocketPortChangeStatus,
-  useWebSocketLastError,
-  useWebSocketConnectionTimes,
-  useWebSocketConnectionInfo,
-  useWebSocketPortInfo,
-  useWebSocketActions,
-  useWebSocketControls,
-  useWebSocketData,
-} from "./websocket";
-
 export {
   // Config store exports
   useConfig,
-  useConfigLoading,
+  useConfigActions,
+  useConfigError,
   useConfigIsLoading,
   useConfigIsUpdating,
-  useConfigError,
-  useMcpEndpoint,
-  useMcpServers,
-  useMcpServerConfig,
-  useConnectionConfig,
-  useModelScopeConfig,
-  useWebUIConfig,
+  useConfigLoading,
   useConfigSource,
-  useConfigWithLoading,
-  useMcpConfig,
-  useSystemConfig,
-  useConfigActions,
+  useConfigStore,
   useConfigUpdaters,
+  useConfigWithLoading,
+  useConnectionConfig,
+  useMcpConfig,
+  useMcpEndpoint,
+  useMcpServerConfig,
+  useMcpServers,
+  useModelScopeConfig,
+  useSystemConfig,
+  useWebUIConfig,
 } from "./config";
-
 export {
+  useActiveMcpServers,
   // Status store exports
   useClientStatus,
-  useRestartStatus,
-  useServiceStatus,
-  useServiceHealth,
+  useConnectionInfo,
+  useConnectionStatus,
   useFullStatus,
-  useStatusLoading,
-  useStatusIsLoading,
-  useStatusIsRestarting,
-  useStatusError,
+  useLastHeartbeat,
+  usePollingActions,
   usePollingConfig,
   usePollingEnabled,
-  useStatusSource,
-  useConnectionStatus,
-  useStatusMcpEndpoint,
-  useActiveMcpServers,
-  useLastHeartbeat,
-  useStatusWithLoading,
+  useRestartStatus,
+  useServiceHealth,
   useServiceInfo,
-  useConnectionInfo,
+  useServiceStatus,
   useStatusActions,
-  usePollingActions,
+  useStatusError,
+  useStatusIsLoading,
+  useStatusIsRestarting,
+  useStatusLoading,
+  useStatusMcpEndpoint,
+  useStatusSource,
+  useStatusStore,
+  useStatusWithLoading,
 } from "./status";
+// 导出所有 stores 以便统一访问
+// 导出所有选择器 hooks（避免命名冲突）
+export {
+  useWebSocketActions,
+  useWebSocketConnected,
+  useWebSocketConnectionInfo,
+  // WebSocket store exports
+  useWebSocketConnectionState,
+  useWebSocketConnectionStats,
+  useWebSocketConnectionTimes,
+  useWebSocketControls,
+  useWebSocketData,
+  useWebSocketLastError,
+  useWebSocketPortChangeStatus,
+  useWebSocketPortInfo,
+  useWebSocketStore,
+  useWebSocketUrl,
+} from "./websocket";
+// 导出废弃的兼容性选择器（从 websocket-compat.ts 直接导入以避免循环依赖）
+export {
+  useWebSocketConfig,
+  useWebSocketMcpEndpoint,
+  useWebSocketMcpServerConfig,
+  useWebSocketMcpServers,
+  useWebSocketRestartStatus,
+  useWebSocketStatus,
+} from "./websocket-compat";

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -10,12 +10,12 @@
  * - 集成 WebSocket 事件监听
  */
 
-import { apiClient } from "@/services/api";
-import { webSocketManager } from "@/services/websocket";
 import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { apiClient } from "@/services/api";
+import { webSocketManager } from "@/services/websocket";
 
 /**
  * 重启状态接口

--- a/apps/frontend/src/stores/websocket-compat.ts
+++ b/apps/frontend/src/stores/websocket-compat.ts
@@ -5,8 +5,8 @@
  * 这些选择器将数据从新的专门 stores 中获取并以旧格式返回
  */
 
-import { ConnectionState } from "@/services/websocket";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import { ConnectionState } from "@/services/websocket";
 import { useConfigStore } from "./config";
 import { useStatusStore } from "./status";
 import { useWebSocketStore } from "./websocket";

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -12,11 +12,11 @@
  * - 状态数据管理已迁移到 stores/status.ts
  */
 
-import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
-import { ConnectionState, webSocketManager } from "@/services/websocket";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
+import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
+import { ConnectionState, webSocketManager } from "@/services/websocket";
 
 /**
  * 端口变更状态接口（保留用于端口切换功能）

--- a/apps/frontend/src/test/App.test.tsx
+++ b/apps/frontend/src/test/App.test.tsx
@@ -1,7 +1,7 @@
-import App from "@/App";
 import { render, screen, waitFor } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import App from "@/App";
 
 // Mock WebSocket
 class MockWebSocket {

--- a/apps/frontend/src/test/CozeWorkflowIntegration.integration.test.tsx
+++ b/apps/frontend/src/test/CozeWorkflowIntegration.integration.test.tsx
@@ -3,12 +3,12 @@
  * 测试工作流添加功能的完整流程和API集成
  */
 
-import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
-import { apiClient } from "@/services/api";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { CozeWorkflow } from "@xiaozhi-client/shared-types";
 import { toast } from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
+import { apiClient } from "@/services/api";
 
 // Mock dependencies
 vi.mock("sonner", () => ({

--- a/apps/frontend/src/test/CozeWorkflowIntegration.parameterConfig.test.tsx
+++ b/apps/frontend/src/test/CozeWorkflowIntegration.parameterConfig.test.tsx
@@ -3,12 +3,12 @@
  * 测试第三阶段新增的参数配置功能集成
  */
 
-import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
-import * as toolsApiModule from "@/services/api";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import * as sonner from "sonner";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
+import * as toolsApiModule from "@/services/api";
 
 // Mock dependencies
 vi.mock("sonner", () => ({

--- a/apps/frontend/src/test/CozeWorkflowIntegration.test.tsx
+++ b/apps/frontend/src/test/CozeWorkflowIntegration.test.tsx
@@ -2,13 +2,13 @@
  * CozeWorkflowIntegration 组件测试
  */
 
-import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
-import * as useCozeWorkflowsModule from "@/hooks/useCozeWorkflows";
-import * as toolsApiModule from "@/services/api";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import type { CozeWorkflow, CozeWorkspace } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { CozeWorkflowIntegration } from "@/components/coze-workflow-integration";
+import * as useCozeWorkflowsModule from "@/hooks/useCozeWorkflows";
+import * as toolsApiModule from "@/services/api";
 
 // Mock toast
 vi.mock("sonner", () => ({

--- a/apps/frontend/src/test/DashboardStatusCard.test.tsx
+++ b/apps/frontend/src/test/DashboardStatusCard.test.tsx
@@ -1,6 +1,6 @@
-import { DashboardStatusCard } from "@/components/dashboard-status-card";
 import { render, screen } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { DashboardStatusCard } from "@/components/dashboard-status-card";
 
 // Mock stores with hoisted mocks
 const mockUseMcpEndpoint = vi.hoisted(() =>

--- a/apps/frontend/src/test/ToolCallLogsDialog.test.tsx
+++ b/apps/frontend/src/test/ToolCallLogsDialog.test.tsx
@@ -1,7 +1,7 @@
-import { ToolCallLogsDialog } from "@/components/tool-call-logs-dialog";
 import { fireEvent, render, screen, waitFor } from "@testing-library/react";
 import type { ToolCallRecord } from "@xiaozhi-client/shared-types";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { ToolCallLogsDialog } from "@/components/tool-call-logs-dialog";
 
 // Mock fetch
 global.fetch = vi.fn();

--- a/apps/frontend/src/test/compatibility.test.tsx
+++ b/apps/frontend/src/test/compatibility.test.tsx
@@ -2,6 +2,9 @@
  * 兼容性测试 - 验证废弃选择器仍然正常工作
  */
 
+import { render } from "@testing-library/react";
+import type React from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { useConfigStore } from "@/stores/config";
 import { useStatusStore } from "@/stores/status";
 import {
@@ -12,9 +15,6 @@ import {
   useWebSocketRestartStatus,
   useWebSocketStatus,
 } from "@/stores/websocket-compat";
-import { render } from "@testing-library/react";
-import type React from "react";
-import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 // 测试组件 - 使用废弃的选择器
 const LegacyComponent: React.FC = () => {

--- a/apps/frontend/src/test/coze-api.test.ts
+++ b/apps/frontend/src/test/coze-api.test.ts
@@ -2,12 +2,12 @@
  * 扣子 API 前端服务层集成测试
  */
 
-import { CozeApiClient } from "@/services/cozeApi";
 import type {
   CozeWorkflowsResult,
   CozeWorkspace,
 } from "@xiaozhi-client/shared-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { CozeApiClient } from "@/services/cozeApi";
 
 // Mock fetch
 const mockFetch = vi.fn();

--- a/apps/frontend/src/test/format-utils.test.ts
+++ b/apps/frontend/src/test/format-utils.test.ts
@@ -1,3 +1,5 @@
+import type { ToolCallRecord } from "@xiaozhi-client/shared-types";
+import { describe, expect, it } from "vitest";
 import {
   formatDuration,
   formatError,
@@ -5,8 +7,6 @@ import {
   formatTimestamp,
   generateStableKey,
 } from "@/utils/formatUtils";
-import type { ToolCallRecord } from "@xiaozhi-client/shared-types";
-import { describe, expect, it } from "vitest";
 
 describe("formatUtils", () => {
   describe("formatTimestamp", () => {

--- a/apps/frontend/src/test/integration.test.ts
+++ b/apps/frontend/src/test/integration.test.ts
@@ -2,11 +2,11 @@
  * 集成测试 - 验证 WebSocket 架构重构后的功能
  */
 
+import { beforeEach, describe, expect, it } from "vitest";
 import { ConnectionState, webSocketManager } from "@/services/websocket";
 import { useConfigStore } from "@/stores/config";
 import { useStatusStore } from "@/stores/status";
 import { useWebSocketStore } from "@/stores/websocket";
-import { beforeEach, describe, expect, it } from "vitest";
 
 describe("WebSocket 架构集成测试", () => {
   beforeEach(() => {

--- a/apps/frontend/src/test/performance.test.tsx
+++ b/apps/frontend/src/test/performance.test.tsx
@@ -2,6 +2,10 @@
  * 性能测试 - 验证重构后的性能优化效果
  */
 
+import { act, render } from "@testing-library/react";
+import type React from "react";
+import { useEffect } from "react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
   useConfig,
   useConfigStore,
@@ -18,10 +22,6 @@ import {
   useWebSocketStore,
   useWebSocketUrl,
 } from "@/stores/websocket";
-import { act, render } from "@testing-library/react";
-import type React from "react";
-import { useEffect } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
 
 // 性能监控组件
 const PerformanceMonitor: React.FC<{

--- a/apps/frontend/src/test/use-coze-workflows.test.ts
+++ b/apps/frontend/src/test/use-coze-workflows.test.ts
@@ -2,14 +2,14 @@
  * useCozeWorkflows Hook 测试
  */
 
-import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
-import { cozeApiClient } from "@/services/cozeApi";
 import { act, renderHook, waitFor } from "@testing-library/react";
 import type {
   CozeWorkflowsResult,
   CozeWorkspace,
 } from "@xiaozhi-client/shared-types";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
+import { cozeApiClient } from "@/services/cozeApi";
 
 // Mock cozeApiClient
 vi.mock("@/services/cozeApi", () => {

--- a/apps/frontend/src/utils/mcp-form-converter.test.ts
+++ b/apps/frontend/src/utils/mcp-form-converter.test.ts
@@ -3,6 +3,7 @@
  * 测试命令解析、键值对解析、表单与 API 配置的双向转换等功能
  */
 
+import { describe, expect, it } from "vitest";
 import {
   apiConfigToForm,
   formToApiConfig,
@@ -12,7 +13,6 @@ import {
   parseCommandString,
   parseKeyValuePairs,
 } from "@/utils/mcpFormConverter";
-import { describe, expect, it } from "vitest";
 
 describe("parseCommandString", () => {
   it("应该正确解析简单命令", () => {

--- a/apps/frontend/src/utils/mcpFormConverter.ts
+++ b/apps/frontend/src/utils/mcpFormConverter.ts
@@ -2,6 +2,7 @@
  * MCP 服务表单数据与 API 配置的双向转换工具
  */
 
+import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 import type {
   HttpFormData,
   McpServerFormData,
@@ -9,7 +10,6 @@ import type {
   SseFormData,
   StdioFormData,
 } from "@/types/mcp-form";
-import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 
 // ============ 表单 → API 配置 ============
 

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.4/schema.json",
   "vcs": {
     "enabled": true,
     "clientKind": "git",
@@ -7,16 +7,17 @@
   },
   "files": {
     "ignoreUnknown": false,
-    "ignore": [
-      "node_modules/**",
-      "dist/**",
-      "*.cjs",
-      "*.d.ts",
-      "pnpm-lock.yaml",
-      "templates/**/*.js",
-      "apps/backend/tsup.config.ts",
-      "package.json",
-      "worktrees/**"
+    "includes": [
+      "**",
+      "!**/node_modules/**",
+      "!**/dist/**",
+      "!**/*.cjs",
+      "!**/*.d.ts",
+      "!**/pnpm-lock.yaml",
+      "!**/templates/**/*.js",
+      "!**/apps/backend/tsup.config.ts",
+      "!**/package.json",
+      "!**/worktrees/**"
     ]
   },
   "formatter": {
@@ -25,18 +26,13 @@
     "indentWidth": 2,
     "lineEnding": "lf"
   },
-  "organizeImports": {
-    "enabled": true
-  },
+  "assist": { "actions": { "source": { "organizeImports": "on" } } },
   "linter": {
     "enabled": true,
     "rules": {
       "recommended": true,
       "correctness": {
         "noUnusedImports": "error"
-      },
-      "nursery": {
-        "useImportRestrictions": "error"
       },
       "complexity": {
         "noStaticOnlyClass": "off",
@@ -58,14 +54,7 @@
   },
   "overrides": [
     {
-      "include": ["packages/cli/**"],
-      "linter": {
-        "rules": {
-          "nursery": {
-            "useImportRestrictions": "off"
-          }
-        }
-      }
+      "includes": ["**/packages/cli/**"]
     }
   ],
   "javascript": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
-    "@biomejs/biome": "1.9.4",
+    "@biomejs/biome": "2.4.4",
     "@nx/vite": "^22.5.1",
     "@nx/vitest": "^22.5.1",
     "@nx/workspace": "^22.5.1",

--- a/packages/asr/src/__tests__/audio/WavParser.test.ts
+++ b/packages/asr/src/__tests__/audio/WavParser.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { Buffer } from "node:buffer";
-import { createWavFile, readWavData, readWavInfo } from "@/audio/index.js";
 import { describe, expect, it } from "vitest";
+import { createWavFile, readWavData, readWavInfo } from "@/audio/index.js";
 
 describe("WavParser", () => {
   /**

--- a/packages/asr/src/__tests__/auth/SignatureAuth.test.ts
+++ b/packages/asr/src/__tests__/auth/SignatureAuth.test.ts
@@ -2,8 +2,8 @@
  * HMAC256 签名认证测试
  */
 
-import { SignatureAuth } from "@/auth/index.js";
 import { describe, expect, it } from "vitest";
+import { SignatureAuth } from "@/auth/index.js";
 
 describe("SignatureAuth", () => {
   const token = "test_token";

--- a/packages/asr/src/__tests__/auth/TokenAuth.test.ts
+++ b/packages/asr/src/__tests__/auth/TokenAuth.test.ts
@@ -2,8 +2,8 @@
  * Token 认证测试
  */
 
-import { TokenAuth } from "@/auth/index.js";
 import { describe, expect, it } from "vitest";
+import { TokenAuth } from "@/auth/index.js";
 
 describe("TokenAuth", () => {
   it("应正确生成认证头", () => {

--- a/packages/asr/src/__tests__/client/asr.test.ts
+++ b/packages/asr/src/__tests__/client/asr.test.ts
@@ -2,10 +2,10 @@
  * ASR 客户端测试
  */
 
+import { describe, expect, it, vi } from "vitest";
 import { AudioFormat } from "@/audio/index.js";
 import { AuthMethod } from "@/auth/index.js";
 import { ASR, executeOne } from "@/client/index.js";
-import { describe, expect, it, vi } from "vitest";
 
 describe("ASR 客户端", () => {
   describe("构造函数", () => {

--- a/packages/asr/src/__tests__/protocol/header.test.ts
+++ b/packages/asr/src/__tests__/protocol/header.test.ts
@@ -2,20 +2,20 @@
  * 协议头测试
  */
 
+import { describe, expect, it } from "vitest";
 import {
   CompressionType,
-  MessageType,
-  MessageTypeSpecificFlags,
-  PROTOCOL_VERSION,
-  SerializationMethod,
   compressGzipSync,
   generateAudioDefaultHeader,
   generateFullDefaultHeader,
   generateHeader,
   generateLastAudioDefaultHeader,
+  MessageType,
+  MessageTypeSpecificFlags,
+  PROTOCOL_VERSION,
   parseResponse,
+  SerializationMethod,
 } from "@/platforms/index.js";
-import { describe, expect, it } from "vitest";
 
 describe("协议头生成", () => {
   it("应生成默认完整请求头", () => {

--- a/packages/asr/src/__tests__/utils/logger.test.ts
+++ b/packages/asr/src/__tests__/utils/logger.test.ts
@@ -2,8 +2,8 @@
  * Logger 工具测试
  */
 
-import { LogLevel, Logger, logger } from "@/utils/index.js";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Logger, LogLevel, logger } from "@/utils/index.js";
 
 describe("Logger", () => {
   beforeEach(() => {

--- a/packages/asr/src/__tests__/utils/uuid.test.ts
+++ b/packages/asr/src/__tests__/utils/uuid.test.ts
@@ -2,8 +2,8 @@
  * UUID 工具测试
  */
 
-import { generateReqId, generateShortId } from "@/utils/index.js";
 import { describe, expect, it } from "vitest";
+import { generateReqId, generateShortId } from "@/utils/index.js";
 
 describe("UUID 工具", () => {
   describe("generateReqId", () => {

--- a/packages/asr/src/audio/AudioProcessor.ts
+++ b/packages/asr/src/audio/AudioProcessor.ts
@@ -9,9 +9,9 @@ import {
   convertMp3ToWav,
   convertOggToWav,
 } from "@/audio/OggConverter.js";
-import { createWavFile, readWavInfo } from "@/audio/WavParser.js";
 import type { AudioConfig, WavInfo } from "@/audio/types.js";
 import { AudioFormat } from "@/audio/types.js";
+import { createWavFile, readWavInfo } from "@/audio/WavParser.js";
 
 /**
  * Process audio file and return WAV format data

--- a/packages/asr/src/audio/index.ts
+++ b/packages/asr/src/audio/index.ts
@@ -2,9 +2,9 @@
  * Audio module exports
  */
 
+export * from "./AudioBuffer.js";
+export * from "./AudioProcessor.js";
+export * from "./OggConverter.js";
+export * from "./OpusDecoder.js";
 export * from "./types.js";
 export * from "./WavParser.js";
-export * from "./OggConverter.js";
-export * from "./AudioProcessor.js";
-export * from "./OpusDecoder.js";
-export * from "./AudioBuffer.js";

--- a/packages/asr/src/auth/index.ts
+++ b/packages/asr/src/auth/index.ts
@@ -2,6 +2,6 @@
  * Auth module exports
  */
 
-export * from "./types.js";
-export * from "./TokenAuth.js";
 export * from "./SignatureAuth.js";
+export * from "./TokenAuth.js";
+export * from "./types.js";

--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -4,6 +4,8 @@
 
 import { Buffer } from "node:buffer";
 import { EventEmitter } from "node:events";
+import { v4 as uuidv4 } from "uuid";
+import WebSocket from "ws";
 import { AudioFormat } from "@/audio";
 import { AudioProcessor } from "@/audio/index.js";
 import { AuthMethod, SignatureAuth, TokenAuth } from "@/auth";
@@ -11,25 +13,19 @@ import type { ASROption, ASRRequestConfig, ASRResult } from "@/client/types.js";
 import {
   BYTEDANCE_V2_DEFAULT_CLUSTER,
   type ByteDanceV2Config,
-  type ByteDanceV3Config,
-  isV2Config,
-  parseByteDanceConfig,
-} from "@/platforms/index.js";
-import {
   ByteDanceV2Controller,
   ByteDanceV2RequestBuilder,
+  type ByteDanceV3Config,
   ByteDanceV3Controller,
-} from "@/platforms/index.js";
-import {
-  MessageType,
   compressGzipSync,
   generateAudioDefaultHeader,
   generateFullDefaultHeader,
   generateLastAudioDefaultHeader,
+  isV2Config,
+  MessageType,
+  parseByteDanceConfig,
   parseResponse,
 } from "@/platforms/index.js";
-import { v4 as uuidv4 } from "uuid";
-import WebSocket from "ws";
 
 /**
  * Streaming ASR WebSocket Client

--- a/packages/asr/src/client/index.ts
+++ b/packages/asr/src/client/index.ts
@@ -2,5 +2,5 @@
  * Client module exports
  */
 
-export * from "./types.js";
 export * from "./ASR.js";
+export * from "./types.js";

--- a/packages/asr/src/core/index.ts
+++ b/packages/asr/src/core/index.ts
@@ -2,29 +2,25 @@
  * 核心模块导出
  */
 
+// 客户端导出
+export { ASRClient, type ASRClientOptions } from "./ASRClient.js";
+// 类型导出
+export type { ASRPlatformFactory } from "./ASRPlatform.js";
+// 平台接口导出
+export {
+  platformRegistry,
+  registerPlatform,
+  SimplePlatformRegistry,
+} from "./ASRPlatform.js";
+// 工厂函数导出
+export { getPlatform, listPlatforms } from "./factories.js";
 // 类型导出（排除与 types/ 重复的类型）
 export type {
   ASRController,
-  PlatformConfig,
-  ASRPlatform,
-  PlatformRegistry,
-  CommonASROptions,
-  ASREventType,
   ASREventData,
+  ASREventType,
+  ASRPlatform,
+  CommonASROptions,
+  PlatformConfig,
+  PlatformRegistry,
 } from "./types.js";
-
-// 平台接口导出
-export {
-  SimplePlatformRegistry,
-  platformRegistry,
-  registerPlatform,
-} from "./ASRPlatform.js";
-
-// 类型导出
-export type { ASRPlatformFactory } from "./ASRPlatform.js";
-
-// 客户端导出
-export { ASRClient, type ASRClientOptions } from "./ASRClient.js";
-
-// 工厂函数导出
-export { getPlatform, listPlatforms } from "./factories.js";

--- a/packages/asr/src/index.ts
+++ b/packages/asr/src/index.ts
@@ -2,37 +2,31 @@
  * ByteDance Streaming ASR WebSocket Client for Node.js
  */
 
-// Core exports - 核心抽象层
-export * from "./core/index.js";
-
-// Platforms exports - 平台实现
-export * from "./platforms/index.js";
-
-// Protocol exports (ByteDance 二进制协议)
-export * from "./platforms/index.js";
-
 // Audio exports
 export * from "./audio/index.js";
-
 // Auth exports
 export * from "./auth/index.js";
+// Core exports - 核心抽象层
+export * from "./core/index.js";
+// Platforms exports - 平台实现
+export * from "./platforms/index.js";
+// Protocol exports (ByteDance 二进制协议)
+export * from "./platforms/index.js";
 
 // Types exports
 export * from "./types/index.js";
 
 // Controllers exports (ByteDance 控制器) - 已通过 platforms/bytedance/index.js 导出
 
-// Client exports
-export * from "./client/index.js";
-
-// Utils exports
-export * from "./utils/index.js";
-
-// Main client
-export { ASR, executeOne } from "./client";
 export type {
+  ASREventData,
+  ASREventType,
   ASROption,
   ASRResult,
-  ASREventType,
-  ASREventData,
 } from "./client";
+// Main client
+export { ASR, executeOne } from "./client";
+// Client exports
+export * from "./client/index.js";
+// Utils exports
+export * from "./utils/index.js";

--- a/packages/asr/src/platforms/bytedance/config/index.ts
+++ b/packages/asr/src/platforms/bytedance/config/index.ts
@@ -4,29 +4,29 @@
 
 // V2 Schema
 export {
-  ByteDanceV2ConfigSchema,
-  ByteDanceV2AppSchema,
-  ByteDanceV2UserSchema,
-  ByteDanceV2AudioSchema,
-  ByteDanceV2RequestSchema,
   BYTEDANCE_V2_DEFAULT_CLUSTER,
-  type ByteDanceV2Config,
   type ByteDanceV2App,
-  type ByteDanceV2User,
+  ByteDanceV2AppSchema,
   type ByteDanceV2Audio,
+  ByteDanceV2AudioSchema,
+  type ByteDanceV2Config,
+  ByteDanceV2ConfigSchema,
   type ByteDanceV2Request,
+  ByteDanceV2RequestSchema,
+  type ByteDanceV2User,
+  ByteDanceV2UserSchema,
 } from "./v2.js";
 
 // V3 Schema
 export {
-  ByteDanceV3ConfigSchema,
-  ByteDanceV3AppSchema,
-  ByteDanceV3UserSchema,
-  ByteDanceV3AudioSchema,
-  ByteDanceV3RequestSchema,
-  type ByteDanceV3Config,
   type ByteDanceV3App,
-  type ByteDanceV3User,
+  ByteDanceV3AppSchema,
   type ByteDanceV3Audio,
+  ByteDanceV3AudioSchema,
+  type ByteDanceV3Config,
+  ByteDanceV3ConfigSchema,
   type ByteDanceV3Request,
+  ByteDanceV3RequestSchema,
+  type ByteDanceV3User,
+  ByteDanceV3UserSchema,
 } from "./v3.js";

--- a/packages/asr/src/platforms/bytedance/protocol/index.ts
+++ b/packages/asr/src/platforms/bytedance/protocol/index.ts
@@ -2,6 +2,6 @@
  * ByteDance Protocol module exports
  */
 
-export * from "./types.js";
 export * from "./constants.js";
 export * from "./header.js";
+export * from "./types.js";

--- a/packages/asr/src/platforms/bytedance/schemas/index.ts
+++ b/packages/asr/src/platforms/bytedance/schemas/index.ts
@@ -4,43 +4,43 @@
 
 // V2 Schema
 export {
-  ByteDanceV2ConfigSchema,
-  ByteDanceV2AppSchema,
-  ByteDanceV2UserSchema,
-  ByteDanceV2AudioSchema,
-  ByteDanceV2RequestSchema,
   BYTEDANCE_V2_DEFAULT_CLUSTER,
-  type ByteDanceV2Config,
   type ByteDanceV2App,
-  type ByteDanceV2User,
+  ByteDanceV2AppSchema,
   type ByteDanceV2Audio,
+  ByteDanceV2AudioSchema,
+  type ByteDanceV2Config,
+  ByteDanceV2ConfigSchema,
   type ByteDanceV2Request,
+  ByteDanceV2RequestSchema,
+  type ByteDanceV2User,
+  ByteDanceV2UserSchema,
 } from "./api-v2.js";
 
 // V3 Schema
 export {
-  ByteDanceV3ConfigSchema,
-  ByteDanceV3AppSchema,
-  ByteDanceV3UserSchema,
-  ByteDanceV3AudioSchema,
-  ByteDanceV3RequestSchema,
-  type ByteDanceV3Config,
   type ByteDanceV3App,
-  type ByteDanceV3User,
+  ByteDanceV3AppSchema,
   type ByteDanceV3Audio,
+  ByteDanceV3AudioSchema,
+  type ByteDanceV3Config,
+  ByteDanceV3ConfigSchema,
   type ByteDanceV3Request,
+  ByteDanceV3RequestSchema,
+  type ByteDanceV3User,
+  ByteDanceV3UserSchema,
 } from "./api-v3.js";
 
 // 统一 Schema
 export {
+  type ByteDanceOption,
   ByteDanceOptionSchema,
+  type ByteDanceV2Option,
   ByteDanceV2OptionSchema,
+  type ByteDanceV3Option,
   ByteDanceV3OptionSchema,
+  getApiVersion,
   isV2Config,
   isV3Config,
   parseByteDanceConfig,
-  getApiVersion,
-  type ByteDanceOption,
-  type ByteDanceV2Option,
-  type ByteDanceV3Option,
 } from "./option.js";

--- a/packages/asr/src/platforms/bytedance/schemas/option.ts
+++ b/packages/asr/src/platforms/bytedance/schemas/option.ts
@@ -2,6 +2,7 @@
  * 统一配置校验 Schema
  */
 
+import { z } from "zod";
 import {
   type ByteDanceV2Config,
   ByteDanceV2ConfigSchema,
@@ -10,7 +11,6 @@ import {
   type ByteDanceV3Config,
   ByteDanceV3ConfigSchema,
 } from "@/platforms/bytedance/schemas/api-v3.js";
-import { z } from "zod";
 
 /**
  * 字节跳动 V2 配置

--- a/packages/asr/src/platforms/index.ts
+++ b/packages/asr/src/platforms/index.ts
@@ -10,11 +10,8 @@ platformRegistry.register(
   new ByteDancePlatform({ platform: "bytedance", version: "v2" })
 );
 
-// 导出平台
-export {
-  ByteDancePlatform,
-  createByteDancePlatform,
-} from "@/platforms/bytedance/index.js";
+// 导出平台注册表
+export { platformRegistry } from "@/core/index.js";
 
 // 导出平台类型（从 bytedance/index.js 重新导出）
 export type {
@@ -22,9 +19,10 @@ export type {
   ByteDanceV2Config,
   ByteDanceV3Config,
 } from "@/platforms/bytedance/index.js";
-
-// 导出平台注册表
-export { platformRegistry } from "@/core/index.js";
-
 // 导出协议、控制器和 Schema（ByteDance）- 通过 bytedance/index.js 统一重新导出
 export * from "@/platforms/bytedance/index.js";
+// 导出平台
+export {
+  ByteDancePlatform,
+  createByteDancePlatform,
+} from "@/platforms/bytedance/index.js";

--- a/packages/cli/src/commands/__tests__/mcp-command-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp-command-handler.test.ts
@@ -1,9 +1,9 @@
-import { configManager } from "@xiaozhi-client/config";
 import type {
   MCPServerConfig,
   MCPServerToolsConfig,
   MCPToolConfig,
 } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 import ora from "ora";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { IDIContainer } from "../../interfaces/Config.js";

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -5,8 +5,8 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import type { WebServer } from "@/WebServer";
 import consola from "consola";
+import type { WebServer } from "@/WebServer";
 import { RETRY_CONSTANTS } from "../Constants";
 import { ProcessError, ServiceError } from "../errors/index";
 import type {

--- a/packages/cli/src/utils/FileUtils.ts
+++ b/packages/cli/src/utils/FileUtils.ts
@@ -5,8 +5,8 @@
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { FileOperationOptions } from "../Types";
 import { FileError } from "../errors/index";
+import type { FileOperationOptions } from "../Types";
 
 /**
  * 文件工具类

--- a/packages/cli/src/utils/PlatformUtils.ts
+++ b/packages/cli/src/utils/PlatformUtils.ts
@@ -4,8 +4,8 @@
 
 import { execSync } from "node:child_process";
 import { TIMEOUT_CONSTANTS } from "../Constants";
-import type { Platform } from "../Types";
 import { ProcessError } from "../errors/index";
+import type { Platform } from "../Types";
 
 /**
  * 平台工具类

--- a/packages/cli/src/utils/Validation.ts
+++ b/packages/cli/src/utils/Validation.ts
@@ -2,8 +2,8 @@
  * 输入验证工具
  */
 
-import type { ConfigFormat } from "../Types";
 import { ValidationError } from "../errors/index";
+import type { ConfigFormat } from "../Types";
 
 /**
  * 验证工具类

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,5 +1,4 @@
-import { resolve } from "node:path";
-import { dirname } from "node:path";
+import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 import tsconfigPaths from "vite-tsconfig-paths";
 import { defineConfig } from "vitest/config";

--- a/packages/tts/src/__tests__/client/convenience.test.ts
+++ b/packages/tts/src/__tests__/client/convenience.test.ts
@@ -2,13 +2,13 @@
  * TTS 便捷函数测试
  */
 
+import { describe, expect, it, vi } from "vitest";
 import {
   type SynthesizeOptions,
   synthesizeSpeech,
   synthesizeSpeechStream,
   validateConfig,
 } from "@/client/index.js";
-import { describe, expect, it, vi } from "vitest";
 
 describe("TTS 便捷函数", () => {
   describe("validateConfig", () => {

--- a/packages/tts/src/__tests__/client/tts.test.ts
+++ b/packages/tts/src/__tests__/client/tts.test.ts
@@ -2,8 +2,8 @@
  * TTS 客户端测试
  */
 
-import { TTS } from "@/client/index.js";
 import { describe, expect, it, vi } from "vitest";
+import { TTS } from "@/client/index.js";
 
 describe("TTS 客户端", () => {
   describe("构造函数", () => {

--- a/packages/tts/src/__tests__/core/registry.test.ts
+++ b/packages/tts/src/__tests__/core/registry.test.ts
@@ -2,8 +2,8 @@
  * SimplePlatformRegistry 测试
  */
 
-import { SimplePlatformRegistry, type TTSPlatform } from "@/core/index.js";
 import { describe, expect, it, vi } from "vitest";
+import { SimplePlatformRegistry, type TTSPlatform } from "@/core/index.js";
 
 describe("SimplePlatformRegistry", () => {
   describe("构造函数", () => {

--- a/packages/tts/src/__tests__/platforms/bytedance/protocol/message.test.ts
+++ b/packages/tts/src/__tests__/platforms/bytedance/protocol/message.test.ts
@@ -2,22 +2,22 @@
  * ByteDance TTS 协议消息测试
  */
 
+import { describe, expect, it } from "vitest";
 import {
   CompressionBits,
+  createMessage,
   EventType,
+  getEventTypeName,
+  getMsgTypeName,
   HeaderSizeBits,
   MsgType,
   MsgTypeFlagBits,
-  SerializationBits,
-  VersionBits,
-  createMessage,
-  getEventTypeName,
-  getMsgTypeName,
   marshalMessage,
   messageToString,
+  SerializationBits,
   unmarshalMessage,
+  VersionBits,
 } from "@/platforms/index.js";
-import { describe, expect, it } from "vitest";
 
 describe("协议消息", () => {
   describe("EventType 枚举", () => {

--- a/packages/tts/src/__tests__/platforms/bytedance/schemas/config.test.ts
+++ b/packages/tts/src/__tests__/platforms/bytedance/schemas/config.test.ts
@@ -2,6 +2,7 @@
  * ByteDance TTS 配置校验测试
  */
 
+import { describe, expect, it } from "vitest";
 import {
   ByteDanceTTSAppSchema,
   ByteDanceTTSAudioSchema,
@@ -9,7 +10,6 @@ import {
   DEFAULT_TTS_ENDPOINT,
   validateByteDanceTTSConfig,
 } from "@/platforms/index.js";
-import { describe, expect, it } from "vitest";
 
 describe("ByteDance TTS 配置校验", () => {
   describe("ByteDanceTTSAppSchema", () => {

--- a/packages/tts/src/client/TTS.ts
+++ b/packages/tts/src/client/TTS.ts
@@ -3,8 +3,8 @@
  */
 
 import { EventEmitter } from "node:events";
-import { createTTSController } from "../core/index.js";
 import type { AudioChunkCallback } from "../core/index.js";
+import { createTTSController } from "../core/index.js";
 import {
   type ByteDanceTTSConfig,
   validateByteDanceTTSConfig,

--- a/packages/tts/src/client/convenience.ts
+++ b/packages/tts/src/client/convenience.ts
@@ -2,8 +2,8 @@
  * TTS 便捷函数
  */
 
-import { createTTSController } from "../core/index.js";
 import type { AudioChunkCallback } from "../core/index.js";
+import { createTTSController } from "../core/index.js";
 import {
   type ByteDanceTTSConfig,
   validateByteDanceTTSConfig,

--- a/packages/tts/src/client/index.ts
+++ b/packages/tts/src/client/index.ts
@@ -2,6 +2,6 @@
  * 客户端模块导出
  */
 
-export * from "./TTS.js";
-export type { StreamSpeakResult } from "./TTS.js";
 export * from "./convenience.js";
+export type { StreamSpeakResult } from "./TTS.js";
+export * from "./TTS.js";

--- a/packages/tts/src/core/index.ts
+++ b/packages/tts/src/core/index.ts
@@ -2,6 +2,6 @@
  * 核心模块导出
  */
 
-export * from "./types.js";
-export * from "./TTSPlatform.js";
 export * from "./factories.js";
+export * from "./TTSPlatform.js";
+export * from "./types.js";

--- a/packages/tts/src/index.ts
+++ b/packages/tts/src/index.ts
@@ -5,18 +5,17 @@
 // 导入平台模块以注册平台
 import "./platforms/index.js";
 
-// 核心模块
-export * from "./core/index.js";
-
-// 平台模块
-export * from "./platforms/index.js";
-
 // 客户端模块（包含便捷函数）
-export { TTS, type TTSClientOptions } from "./client/index.js";
 export {
-  synthesizeSpeech,
-  synthesizeSpeechStream,
-  validateConfig,
   type SynthesizeOptions,
   type SynthesizeStreamOptions,
+  synthesizeSpeech,
+  synthesizeSpeechStream,
+  TTS,
+  type TTSClientOptions,
+  validateConfig,
 } from "./client/index.js";
+// 核心模块
+export * from "./core/index.js";
+// 平台模块
+export * from "./platforms/index.js";

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -8,7 +8,7 @@ import { ByteDanceTTSPlatform } from "./TTSController.js";
 // 注册字节跳动平台
 platformRegistry.register(ByteDanceTTSPlatform);
 
-export * from "./TTSController.js";
-export * from "./schemas/index.js";
 export * from "./protocol/index.js";
+export * from "./schemas/index.js";
+export * from "./TTSController.js";
 export { ByteDanceTTSPlatform };

--- a/packages/tts/src/platforms/bytedance/protocol/index.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/index.ts
@@ -2,5 +2,5 @@
  * 字节跳动 TTS 协议模块导出
  */
 
-export * from "./protocols.js";
 export * from "./binary.js";
+export * from "./protocols.js";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -115,8 +115,8 @@ importers:
         version: 4.3.6
     devDependencies:
       '@biomejs/biome':
-        specifier: 1.9.4
-        version: 1.9.4
+        specifier: 2.4.4
+        version: 2.4.4
       '@nx/vite':
         specifier: ^22.5.1
         version: 22.5.1(@babel/traverse@7.29.0)(nx@22.5.1)(typescript@5.9.3)(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(happy-dom@20.4.0)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
@@ -1339,8 +1339,19 @@ packages:
     engines: {node: '>=14.21.3'}
     hasBin: true
 
+  '@biomejs/biome@2.4.4':
+    resolution: {integrity: sha512-tigwWS5KfJf0cABVd52NVaXyAVv4qpUXOWJ1rxFL8xF1RVoeS2q/LK+FHgYoKMclJCuRoCWAPy1IXaN9/mS61Q==}
+    engines: {node: '>=14.21.3'}
+    hasBin: true
+
   '@biomejs/cli-darwin-arm64@1.9.4':
     resolution: {integrity: sha512-bFBsPWrNvkdKrNCYeAp+xo2HecOGPAy9WyNyB/jKnnedgzl4W4Hb9ZMzYNbf8dMCGmUdSavlYHiR01QaYR58cw==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@biomejs/cli-darwin-arm64@2.4.4':
+    resolution: {integrity: sha512-jZ+Xc6qvD6tTH5jM6eKX44dcbyNqJHssfl2nnwT6vma6B1sj7ZLTGIk6N5QwVBs5xGN52r3trk5fgd3sQ9We9A==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [darwin]
@@ -1351,8 +1362,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  '@biomejs/cli-darwin-x64@2.4.4':
+    resolution: {integrity: sha512-Dh1a/+W+SUCXhEdL7TiX3ArPTFCQKJTI1mGncZNWfO+6suk+gYA4lNyJcBB+pwvF49uw0pEbUS49BgYOY4hzUg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [darwin]
+
   '@biomejs/cli-linux-arm64-musl@1.9.4':
     resolution: {integrity: sha512-v665Ct9WCRjGa8+kTr0CzApU0+XXtRgwmzIf1SeKSGAv+2scAlW6JR5PMFo6FzqqZ64Po79cKODKf3/AAmECqA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@biomejs/cli-linux-arm64-musl@2.4.4':
+    resolution: {integrity: sha512-+sPAXq3bxmFwhVFJnSwkSF5Rw2ZAJMH3MF6C9IveAEOdSpgajPhoQhbbAK12SehN9j2QrHpk4J/cHsa/HqWaYQ==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [linux]
@@ -1363,8 +1386,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@biomejs/cli-linux-arm64@2.4.4':
+    resolution: {integrity: sha512-V/NFfbWhsUU6w+m5WYbBenlEAz8eYnSqRMDMAW3K+3v0tYVkNyZn8VU0XPxk/lOqNXLSCCrV7FmV/u3SjCBShg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [linux]
+
   '@biomejs/cli-linux-x64-musl@1.9.4':
     resolution: {integrity: sha512-gEhi/jSBhZ2m6wjV530Yy8+fNqG8PAinM3oV7CyO+6c3CEh16Eizm21uHVsyVBEB6RIM8JHIl6AGYCv6Q6Q9Tg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
+  '@biomejs/cli-linux-x64-musl@2.4.4':
+    resolution: {integrity: sha512-gGvFTGpOIQDb5CQ2VC0n9Z2UEqlP46c4aNgHmAMytYieTGEcfqhfCFnhs6xjt0S3igE6q5GLuIXtdQt3Izok+g==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [linux]
@@ -1375,14 +1410,32 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@biomejs/cli-linux-x64@2.4.4':
+    resolution: {integrity: sha512-R4+ZCDtG9kHArasyBO+UBD6jr/FcFCTH8QkNTOCu0pRJzCWyWC4EtZa2AmUZB5h3e0jD7bRV2KvrENcf8rndBg==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [linux]
+
   '@biomejs/cli-win32-arm64@1.9.4':
     resolution: {integrity: sha512-tlbhLk+WXZmgwoIKwHIHEBZUwxml7bRJgk0X2sPyNR3S93cdRq6XulAZRQJ17FYGGzWne0fgrXBKpl7l4M87Hg==}
     engines: {node: '>=14.21.3'}
     cpu: [arm64]
     os: [win32]
 
+  '@biomejs/cli-win32-arm64@2.4.4':
+    resolution: {integrity: sha512-trzCqM7x+Gn832zZHgr28JoYagQNX4CZkUZhMUac2YxvvyDRLJDrb5m9IA7CaZLlX6lTQmADVfLEKP1et1Ma4Q==}
+    engines: {node: '>=14.21.3'}
+    cpu: [arm64]
+    os: [win32]
+
   '@biomejs/cli-win32-x64@1.9.4':
     resolution: {integrity: sha512-8Y5wMhVIPaWe6jw2H+KlEm4wP/f7EW3810ZLmDlrEEy5KvBsb9ECEfu/kMWD484ijfQ8+nIi0giMgu9g1UAuuA==}
+    engines: {node: '>=14.21.3'}
+    cpu: [x64]
+    os: [win32]
+
+  '@biomejs/cli-win32-x64@2.4.4':
+    resolution: {integrity: sha512-gnOHKVPFAAPrpoPt2t+Q6FZ7RPry/FDV3GcpU53P3PtLNnQjBmKyN2Vh/JtqXet+H4pme8CC76rScwdjDcT1/A==}
     engines: {node: '>=14.21.3'}
     cpu: [x64]
     os: [win32]
@@ -8278,28 +8331,63 @@ snapshots:
       '@biomejs/cli-win32-arm64': 1.9.4
       '@biomejs/cli-win32-x64': 1.9.4
 
+  '@biomejs/biome@2.4.4':
+    optionalDependencies:
+      '@biomejs/cli-darwin-arm64': 2.4.4
+      '@biomejs/cli-darwin-x64': 2.4.4
+      '@biomejs/cli-linux-arm64': 2.4.4
+      '@biomejs/cli-linux-arm64-musl': 2.4.4
+      '@biomejs/cli-linux-x64': 2.4.4
+      '@biomejs/cli-linux-x64-musl': 2.4.4
+      '@biomejs/cli-win32-arm64': 2.4.4
+      '@biomejs/cli-win32-x64': 2.4.4
+
   '@biomejs/cli-darwin-arm64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-darwin-arm64@2.4.4':
     optional: true
 
   '@biomejs/cli-darwin-x64@1.9.4':
     optional: true
 
+  '@biomejs/cli-darwin-x64@2.4.4':
+    optional: true
+
   '@biomejs/cli-linux-arm64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-arm64-musl@2.4.4':
     optional: true
 
   '@biomejs/cli-linux-arm64@1.9.4':
     optional: true
 
+  '@biomejs/cli-linux-arm64@2.4.4':
+    optional: true
+
   '@biomejs/cli-linux-x64-musl@1.9.4':
+    optional: true
+
+  '@biomejs/cli-linux-x64-musl@2.4.4':
     optional: true
 
   '@biomejs/cli-linux-x64@1.9.4':
     optional: true
 
+  '@biomejs/cli-linux-x64@2.4.4':
+    optional: true
+
   '@biomejs/cli-win32-arm64@1.9.4':
     optional: true
 
+  '@biomejs/cli-win32-arm64@2.4.4':
+    optional: true
+
   '@biomejs/cli-win32-x64@1.9.4':
+    optional: true
+
+  '@biomejs/cli-win32-x64@2.4.4':
     optional: true
 
   '@braintree/sanitize-url@7.1.1': {}


### PR DESCRIPTION
- 升级 @biomejs/biome 依赖到 2.4.4
- 更新 biome.json schema URL 到 2.4.4
- 运行 Biome 2.x 迁移命令
- 移除已废弃的 useImportRestrictions 规则
- 自动修复导入排序（Biome 2.x 新的排序规则）

Biome 2.0 (Biotype) 主要变更：
- organizeImports 配置移至 assist.actions.source
- 文件匹配使用 includes 而非 include/ignore
- 新的导入排序逻辑（外部库优先于本地导入）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2114