### PR TITLE
docs: 为图标组件添加类型定义和文档注释

### DIFF
--- a/apps/frontend/src/components/icons/Github.tsx
+++ b/apps/frontend/src/components/icons/Github.tsx
@@ -1,4 +1,23 @@
-export const GithubIcon = ({ size = 24, color = "currentColor", ...props }) => (
+import type { SVGProps } from "react";
+
+/**
+ * GitHub 图标组件
+ *
+ * 用于展示 GitHub 链接的图标
+ */
+
+interface GithubIconProps extends SVGProps<SVGSVGElement> {
+  /** 图标大小（像素） */
+  size?: number;
+  /** 图标颜色 */
+  color?: string;
+}
+
+export const GithubIcon = ({
+  size = 24,
+  color = "currentColor",
+  ...props
+}: GithubIconProps) => (
   <svg
     width={size}
     height={size}

--- a/apps/frontend/src/components/icons/QQ.tsx
+++ b/apps/frontend/src/components/icons/QQ.tsx
@@ -1,4 +1,23 @@
-export const QQIcon = ({ size = 24, color = "currentColor", ...props }) => (
+import type { SVGProps } from "react";
+
+/**
+ * QQ 图标组件
+ *
+ * 用于展示 QQ 联系方式的图标
+ */
+
+interface QQIconProps extends SVGProps<SVGSVGElement> {
+  /** 图标大小（像素） */
+  size?: number;
+  /** 图标颜色 */
+  color?: string;
+}
+
+export const QQIcon = ({
+  size = 24,
+  color = "currentColor",
+  ...props
+}: QQIconProps) => (
   <svg
     width={size}
     height={size}

--- a/apps/frontend/src/components/icons/index.ts
+++ b/apps/frontend/src/components/icons/index.ts
@@ -1,2 +1,8 @@
+/**
+ * 图标组件统一导出
+ *
+ * 包含项目中使用的所有图标组件
+ */
+
 export * from "./QQ";
 export * from "./Github";


### PR DESCRIPTION
- QQIcon 和 GithubIcon 添加 TypeScript 接口定义
- 组件 Props 继承 React.SVGProps<SVGSVGElement> 以支持原生 SVG 属性
- 添加 JSDoc 文档注释说明组件用途
- index.ts 添加文件级文档说明

修复 #2119

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2119