### PR TITLE
fix: 统一 WebSocketLike 接口定义，消除重复定义问题

### DIFF
--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -25,17 +25,9 @@ import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
+import type { WebSocketLike } from "@/utils/websocket-helper.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
-
-/**
- * WebSocket 类接口
- * 定义了 WebSocket 实例需要具备的基本属性和方法
- */
-export interface WebSocketLike {
-  readyState: number;
-  send(data: string): void;
-}
 
 /**
  * WebSocket 客户端接口

--- a/apps/backend/utils/websocket-helper.ts
+++ b/apps/backend/utils/websocket-helper.ts
@@ -5,6 +5,7 @@ import type { Logger } from "@/Logger.js";
  * 描述具有 send 方法的 WebSocket 对象
  */
 export interface WebSocketLike {
+  readyState: number;
   send(data: string): void;
 }
 


### PR DESCRIPTION
- 在 utils/websocket-helper.ts 中添加 readyState 属性
- 更新 services/notification.service.ts 从 utils 导入 WebSocketLike
- 移除 notification.service.ts 中的本地 WebSocketLike 定义
- 修复导入顺序以符合 lint 规则

此修复解决了 Issue #2120 中报告的类型不一致问题：
- 两个位置定义了不同的 WebSocketLike 接口结构
- utils 中的定义缺少 readyState 属性
- 现在统一使用 utils 中的定义

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2120