### PR TITLE
fix(cli): 移除 Container 和命令处理器中的 any 类型使用

### DIFF
--- a/packages/cli/src/Container.ts
+++ b/packages/cli/src/Container.ts
@@ -2,10 +2,12 @@
  * 依赖注入容器
  */
 
+import type { ConfigManager } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 import { VersionUtils } from "@xiaozhi-client/version";
 import { ErrorHandler } from "./errors/ErrorHandlers";
 import type { IDIContainer } from "./interfaces/Config";
+import type { ProcessManager } from "./interfaces/Service";
 import { FileUtils } from "./utils/FileUtils";
 import { FormatUtils } from "./utils/FormatUtils";
 import { PathUtils } from "./utils/PathUtils";
@@ -16,9 +18,9 @@ import { Validation } from "./utils/Validation";
  * 依赖注入容器实现
  */
 export class DIContainer implements IDIContainer {
-  private instances = new Map<string, any>();
-  private factories = new Map<string, () => any>();
-  private asyncFactories = new Map<string, () => Promise<any>>();
+  private instances = new Map<string, unknown>();
+  private factories = new Map<string, () => unknown>();
+  private asyncFactories = new Map<string, () => Promise<unknown>>();
   private singletons = new Set<string>();
 
   /**
@@ -146,14 +148,14 @@ export class DIContainer implements IDIContainer {
 
     container.registerSingleton("daemonManager", () => {
       const DaemonManagerModule = require("./services/DaemonManager.js");
-      const processManager = container.get("processManager") as any;
+      const processManager = container.get<ProcessManager>("processManager");
       return new DaemonManagerModule.DaemonManagerImpl(processManager);
     });
 
     container.registerSingleton("serviceManager", () => {
       const ServiceManagerModule = require("./services/ServiceManager.js");
-      const processManager = container.get("processManager") as any;
-      const configManager = container.get("configManager") as any;
+      const processManager = container.get<ProcessManager>("processManager");
+      const configManager = container.get<ConfigManager>("configManager");
       return new ServiceManagerModule.ServiceManagerImpl(
         processManager,
         configManager

--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -2,6 +2,7 @@
  * 配置管理命令处理器
  */
 
+import type { ConfigManager } from "@xiaozhi-client/config";
 import path from "node:path";
 import chalk from "chalk";
 import ora from "ora";
@@ -79,7 +80,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         throw new Error("格式必须是 json, json5 或 jsonc");
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (configManager.configExists()) {
         spinner.warn("配置文件已存在");
@@ -117,7 +118,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("读取配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");
@@ -226,7 +227,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     const spinner = ora("更新配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");

--- a/packages/cli/src/commands/EndpointCommandHandler.ts
+++ b/packages/cli/src/commands/EndpointCommandHandler.ts
@@ -2,6 +2,7 @@
  * 端点管理命令处理器
  */
 
+import type { ConfigManager } from "@xiaozhi-client/config";
 import chalk from "chalk";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
@@ -74,7 +75,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("读取端点配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       const endpoints = configManager.getMcpEndpoints();
       spinner.succeed("端点列表");
 
@@ -101,7 +102,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("添加端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       configManager.addMcpEndpoint(url);
       spinner.succeed(`成功添加端点: ${url}`);
 
@@ -122,7 +123,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("移除端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       configManager.removeMcpEndpoint(url);
       spinner.succeed(`成功移除端点: ${url}`);
 
@@ -143,7 +144,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("设置端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (urls.length === 1) {
         configManager.updateMcpEndpoint(urls[0]);

--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -12,6 +12,10 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { TemplateManager } from "../interfaces/Service";
+import { FileUtils } from "../utils/FileUtils";
+import { FormatUtils } from "../utils/FormatUtils";
+import type ora from "ora";
 
 /**
  * 项目管理命令处理器
@@ -54,8 +58,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     const spinner = ora("初始化项目...").start();
 
     try {
-      const templateManager = this.getService<any>("templateManager");
-      const fileUtils = this.getService<any>("fileUtils");
+      const templateManager = this.getService<TemplateManager>("templateManager");
+      const fileUtils = this.getService<typeof FileUtils>("fileUtils");
 
       // 确定目标目录
       const targetPath = path.join(process.cwd(), projectName);
@@ -102,8 +106,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     projectName: string,
     templateName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: ReturnType<typeof ora>,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = "检查模板...";
 
@@ -176,8 +180,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
   private async createBasicProject(
     projectName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: ReturnType<typeof ora>,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = `创建基本项目 "${projectName}"...`;
 
@@ -219,7 +223,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     input: string,
     templates: string[]
   ): string | null {
-    const formatUtils = this.getService<any>("formatUtils");
+    const formatUtils = this.getService<typeof FormatUtils>("formatUtils");
 
     let bestMatch = null;
     let bestSimilarity = 0;

--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -10,6 +10,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { DaemonManager, ServiceManager } from "../interfaces/Service";
 
 /**
  * 服务管理命令处理器
@@ -89,7 +90,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
         consola.level = 5; // debug 级别
       }
 
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
 
       if (options.stdio) {
         // stdio 模式已迁移到 HTTP 方式
@@ -111,7 +112,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStop(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       await serviceManager.stop();
     } catch (error) {
       this.handleError(error as Error);
@@ -123,7 +124,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStatus(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       const status = await serviceManager.getStatus();
 
       if (status.running) {
@@ -147,7 +148,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleRestart(options: CommandOptions): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       await serviceManager.restart({
         daemon: options.daemon || false,
       });
@@ -161,7 +162,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleAttach(): Promise<void> {
     try {
-      const daemonManager = this.getService<any>("daemonManager");
+      const daemonManager = this.getService<DaemonManager>("daemonManager");
       await daemonManager.attachToLogs();
     } catch (error) {
       this.handleError(error as Error);


### PR DESCRIPTION
- 将 Container.ts 中的 Map<string, any> 改为 Map<string, unknown>
- 移除 Container.ts 中的 as any 类型断言，改用具体类型
- 在命令处理器中为 getService() 调用添加具体类型参数
  - ConfigCommandHandler: 使用 ConfigManager 类型
  - EndpointCommandHandler: 使用 ConfigManager 类型
  - ProjectCommandHandler: 使用 TemplateManager、typeof FileUtils、typeof FormatUtils
  - ServiceCommandHandler: 使用 ServiceManager、DaemonManager

修复 #2122

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2122