### PR TITLE
refactor(asr): 提取 ByteDance 平台音频和请求配置的公共类型

### DIFF
--- a/packages/asr/src/platforms/bytedance/types.ts
+++ b/packages/asr/src/platforms/bytedance/types.ts
@@ -6,6 +6,40 @@ import type { AudioFormat } from "@/audio";
 import type { AuthMethod } from "@/auth";
 
 /**
+ * ByteDance 平台音频配置
+ */
+export interface ByteDanceAudioConfig {
+  /** 音频格式 */
+  format?: AudioFormat;
+  /** 采样率 */
+  sampleRate?: number;
+  /** 位深 */
+  bits?: number;
+  /** 声道数 */
+  channel?: number;
+  /** 编解码器 */
+  codec?: string;
+}
+
+/**
+ * ByteDance 平台请求配置
+ */
+export interface ByteDanceRequestConfig {
+  /** 分片时长 (ms) */
+  segDuration?: number;
+  /** N-best 数量 */
+  nbest?: number;
+  /** 工作流 */
+  workflow?: string;
+  /** 显示语言 */
+  showLanguage?: boolean;
+  /** 显示分句 */
+  showUtterances?: boolean;
+  /** 结果类型 */
+  resultType?: string;
+}
+
+/**
  * ByteDance 平台配置
  */
 export interface ByteDancePlatformConfig {
@@ -36,34 +70,10 @@ export interface ByteDancePlatformConfig {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 
   /** 认证配置 */
   auth?: {
@@ -98,34 +108,10 @@ export interface ByteDanceV2Config {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 }
 
 /**
@@ -148,34 +134,10 @@ export interface ByteDanceV3Config {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 }
 
 /**


### PR DESCRIPTION
修复 #2126

- 新增 ByteDanceAudioConfig 接口，统一音频配置类型
- 新增 ByteDanceRequestConfig 接口，统一请求配置类型
- 更新 ByteDancePlatformConfig、ByteDanceV2Config 和 ByteDanceV3Config 使用新的公共类型
- 消除约 60 行重复代码，提升代码可维护性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2126