### PR TITLE
fix: 将 ServerSearchInputProps 改为类型重新导出以符合 DRY 原则

### DIFF
--- a/apps/frontend/src/components/mcp-server/server-search-input.tsx
+++ b/apps/frontend/src/components/mcp-server/server-search-input.tsx
@@ -3,16 +3,7 @@
  * 重新导出 ToolSearchInput 组件用于服务器表格
  */
 
-export { ToolSearchInput as ServerSearchInput } from "@/components/mcp-tool/tool-search-input";
-
-/** 服务器搜索输入组件属性 */
-export interface ServerSearchInputProps {
-  /** 搜索框的值 */
-  value: string;
-  /** 值变化回调 */
-  onChange: (value: string) => void;
-  /** 占位符文本 */
-  placeholder?: string;
-  /** 额外的类名 */
-  className?: string;
-}
+export {
+  ToolSearchInput as ServerSearchInput,
+  type ToolSearchInputProps as ServerSearchInputProps,
+} from "@/components/mcp-tool/tool-search-input";

--- a/apps/frontend/src/components/mcp-tool/tool-search-input.tsx
+++ b/apps/frontend/src/components/mcp-tool/tool-search-input.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 import { Search, X } from "lucide-react";
 import * as React from "react";
 
-interface ToolSearchInputProps {
+export interface ToolSearchInputProps {
   /** 搜索框的值 */
   value: string;
   /** 值变化回调 */


### PR DESCRIPTION
- 在 tool-search-input.tsx 中导出 ToolSearchInputProps 接口
- 在 server-search-input.tsx 中使用类型重新导出而非重复定义
- 消除重复代码，确保类型同步

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2129