### PR TITLE
fix: 补充 TypeScript 项目引用配置以解决 tts 和 asr 包的类型声明问题

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -13,6 +13,10 @@
     }
   },
   "include": ["./**/*.ts"],
+  "references": [
+    { "path": "../../packages/asr" },
+    { "path": "../../packages/tts" }
+  ],
   "exclude": [
     "node_modules",
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -38,6 +38,7 @@
     { "path": "./packages/cli" },
     { "path": "./packages/endpoint" },
     { "path": "./packages/version" },
+    { "path": "./packages/tts" },
     { "path": "./mcps/calculator-mcp" },
     { "path": "./mcps/datetime-mcp" }
   ]


### PR DESCRIPTION
- 在根 tsconfig.json 的 references 数组中添加缺失的 packages/tts 引用
- 在 apps/backend/tsconfig.json 中添加对 packages/asr 和 packages/tts 的项目引用

这修复了 backend 类型检查时无法找到 @xiaozhi-client/tts 和 @xiaozhi-client/asr 模块的问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2130