### PR TITLE
fix: 修复 ESP32Connection 中 WebSocket 事件监听器内存泄漏

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -436,6 +436,12 @@ export class ESP32Connection {
 
     logger.info(`关闭连接: deviceId=${this.deviceId}`);
 
+    // 移除所有事件监听器以防止内存泄漏
+    this.ws.removeAllListeners("message");
+    this.ws.removeAllListeners("close");
+    this.ws.removeAllListeners("error");
+    this.ws.removeAllListeners("pong");
+
     // 如果连接已断开，直接返回
     if (
       this.ws.readyState !== this.ws.OPEN &&


### PR DESCRIPTION
在 close() 方法中添加移除所有事件监听器的逻辑，
解决 ESP32 设备频繁连接和断开时累积未清理监听器的问题。

Fixes #2135

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2135