### PR TITLE
docs: 将 protocol 目录文件的文件级 JSDoc 注释中文化

### DIFF
--- a/packages/asr/src/platforms/bytedance/protocol/constants.ts
+++ b/packages/asr/src/platforms/bytedance/protocol/constants.ts
@@ -1,5 +1,7 @@
 /**
- * Protocol constants
+ * 协议常量
+ *
+ * 定义字节跳动 ASR 协议使用的常量值
  */
 
 export const PROTOCOL_VERSION = 0b0001;

--- a/packages/asr/src/platforms/bytedance/protocol/header.ts
+++ b/packages/asr/src/platforms/bytedance/protocol/header.ts
@@ -1,5 +1,7 @@
 /**
- * Binary protocol header generation and parsing
+ * 二进制协议头生成和解析模块
+ *
+ * 提供字节跳动 ASR 协议的二进制协议头生成和解析功能
  */
 
 import { Buffer } from "node:buffer";

--- a/packages/asr/src/platforms/bytedance/protocol/index.ts
+++ b/packages/asr/src/platforms/bytedance/protocol/index.ts
@@ -1,5 +1,7 @@
 /**
- * ByteDance Protocol module exports
+ * 字节跳动协议模块导出
+ *
+ * 统一导出协议相关的类型、常量和函数
  */
 
 export * from "./types.js";

--- a/packages/asr/src/platforms/bytedance/protocol/types.ts
+++ b/packages/asr/src/platforms/bytedance/protocol/types.ts
@@ -1,5 +1,7 @@
 /**
- * Protocol type definitions
+ * 协议类型定义
+ *
+ * 定义字节跳动 ASR 协议相关的枚举和接口类型
  */
 
 // Message Type


### PR DESCRIPTION
- header.ts: 更新为"二进制协议头生成和解析模块"
- types.ts: 更新为"协议类型定义"
- constants.ts: 更新为"协议常量"
- index.ts: 更新为"字节跳动协议模块导出"

符合 CLAUDE.md 本地化规范要求，有助于中国开发团队的持续维护和代码理解。

Fixes #2136

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2136