### PR TITLE
fix: 将 mcp-endpoint-setting-button.tsx 中事件监听器的 any 类型替换为 EndpointStatusChangedEvent

### DIFF
--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -24,6 +24,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { type EndpointStatusResponse, apiClient } from "@/services/api";
 import { webSocketManager } from "@/services/websocket";
+import type { EndpointStatusChangedEvent } from "@/services/websocket";
 import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
 import {
   BadgeInfoIcon,
@@ -386,7 +387,7 @@ export function McpEndpointSettingButton() {
     const unsubscribers = mcpEndpoints.map((endpoint) => {
       const unsubscribe = webSocketManager.subscribe(
         "data:endpointStatusChanged",
-        (event: any) => {
+        (event: EndpointStatusChangedEvent) => {
           // 只处理当前端点的事件
           if (event.endpoint === endpoint) {
             console.log(


### PR DESCRIPTION
修复了 apps/frontend/src/components/mcp-endpoint-setting-button.tsx:389 处的类型安全问题。

- 从 @/services/websocket 导入 EndpointStatusChangedEvent 类型
- 将事件监听器回调参数从 any 类型替换为 EndpointStatusChangedEvent
- 恢复类型安全，使 TypeScript 能够进行正确的类型检查

Fixes #2139

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2139