### PR TITLE
fix: 在 MCPServiceManager.cleanup() 中添加 cacheManager 清理逻辑

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1818,6 +1818,14 @@ export class MCPServiceManager extends EventEmitter {
   async cleanup(): Promise<void> {
     await this.stopAllServices();
 
+    // 清理缓存管理器
+    try {
+      this.cacheManager.cleanup();
+      logger.info("[MCPManager] 缓存管理器已清理");
+    } catch (error) {
+      logger.error("[MCPManager] 缓存管理器清理失败", { error });
+    }
+
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(
       "mcp:service:connected",


### PR DESCRIPTION
修复了 cleanup() 方法中未清理 cacheManager 导致的资源泄漏问题。
现在会正确调用 cacheManager.cleanup() 以停止清理定时器。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2143