### PR TITLE
fix: 将 prompt-utils.ts 中的 console 方法替换为统一的 Logger 系统

### DIFF
--- a/apps/backend/utils/prompt-utils.ts
+++ b/apps/backend/utils/prompt-utils.ts
@@ -8,6 +8,7 @@
  */
 import { existsSync, readFileSync } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { logger } from "@/Logger.js";
 import { configManager } from "@xiaozhi-client/config";
 
 // 默认系统提示词
@@ -65,7 +66,7 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件是否存在
     if (!existsSync(resolvedPath)) {
-      console.warn(
+      logger.warn(
         `[prompt-utils] 提示词文件不存在: ${resolvedPath}，将使用默认提示词`
       );
       return null;
@@ -76,16 +77,16 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件内容是否为空
     if (!content) {
-      console.warn(
+      logger.warn(
         `[prompt-utils] 提示词文件内容为空: ${resolvedPath}，将使用默认提示词`
       );
       return null;
     }
 
-    console.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
+    logger.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
     return content;
   } catch (error) {
-    console.error(
+    logger.error(
       `[prompt-utils] 读取提示词文件失败: ${promptPath}`,
       error instanceof Error ? error.message : String(error)
     );


### PR DESCRIPTION
- 添加 logger 导入
- 将所有 console.warn 替换为 logger.warn (2处)
- 将所有 console.info 替换为 logger.info (1处)
- 将所有 console.error 替换为 logger.error (1处)
- 修复导入顺序以符合 Biome 规范

修复 #2146

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2146