### PR TITLE
fix: 修复 InternalMCPManagerAdapter 中事件监听器未移除导致的内存泄漏

### DIFF
--- a/packages/endpoint/src/__tests__/endpoint.test.ts
+++ b/packages/endpoint/src/__tests__/endpoint.test.ts
@@ -68,7 +68,10 @@ vi.mock("../internal-mcp-manager.js", () => ({
       return this.tools;
     }
 
-    async callTool(toolName: string, args: Record<string, unknown>): Promise<any> {
+    async callTool(
+      toolName: string,
+      args: Record<string, unknown>
+    ): Promise<any> {
       if (toolName === "not-found-tool") {
         throw new Error("未找到工具");
       }
@@ -89,9 +92,11 @@ const createMockMCPManager = (
   callToolFn?: (name: string, args: Record<string, unknown>) => Promise<any>
 ): IMCPServiceManager => ({
   getAllTools: vi.fn(() => []),
-  callTool: callToolFn || vi.fn(async () => ({
-    content: [{ type: "text", text: "调用成功" }],
-  })),
+  callTool:
+    callToolFn ||
+    vi.fn(async () => ({
+      content: [{ type: "text", text: "调用成功" }],
+    })),
   initialize: vi.fn(async () => {}),
   cleanup: vi.fn(async () => {}),
 });
@@ -342,13 +347,19 @@ describe("Endpoint", () => {
 
   describe("连接状态管理", () => {
     it("应该正确跟踪连接状态变化", async () => {
-      expect(endpoint.getStatus().connectionState).toBe(ConnectionState.DISCONNECTED);
+      expect(endpoint.getStatus().connectionState).toBe(
+        ConnectionState.DISCONNECTED
+      );
 
       await endpoint.connect();
-      expect(endpoint.getStatus().connectionState).toBe(ConnectionState.CONNECTED);
+      expect(endpoint.getStatus().connectionState).toBe(
+        ConnectionState.CONNECTED
+      );
 
       await endpoint.disconnect();
-      expect(endpoint.getStatus().connectionState).toBe(ConnectionState.DISCONNECTED);
+      expect(endpoint.getStatus().connectionState).toBe(
+        ConnectionState.DISCONNECTED
+      );
     });
 
     it("应该记录最后错误信息", async () => {
@@ -436,15 +447,11 @@ describe("Endpoint", () => {
       const consoleDebugSpy = vi.spyOn(console, "debug");
 
       // 创建一个会抛出错误的 MCP 管理器
-      const errorMCPManager = createMockMCPManager(
-        async () => {
-          throw new ToolCallErrorClass(
-            -32601,
-            "工具不存在",
-            { toolName: "test-tool" }
-          );
-        }
-      );
+      const errorMCPManager = createMockMCPManager(async () => {
+        throw new ToolCallErrorClass(-32601, "工具不存在", {
+          toolName: "test-tool",
+        });
+      });
 
       const errorEndpoint = new Endpoint(testUrl, errorMCPManager, 1000);
       await errorEndpoint.connect();
@@ -480,11 +487,9 @@ describe("Endpoint", () => {
       const consoleErrorSpy = vi.spyOn(console, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
-      const errorMCPManager = createMockMCPManager(
-        async () => {
-          throw new ToolCallErrorClass(-32603, "工具执行失败");
-        }
-      );
+      const errorMCPManager = createMockMCPManager(async () => {
+        throw new ToolCallErrorClass(-32603, "工具执行失败");
+      });
 
       const errorEndpoint = new Endpoint(testUrl, errorMCPManager, 1000);
       await errorEndpoint.connect();
@@ -537,11 +542,9 @@ describe("Endpoint", () => {
       const consoleErrorSpy = vi.spyOn(console, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
-      const errorMCPManager = createMockMCPManager(
-        async () => {
-          throw new ToolCallErrorClass(-32601, "工具不存在");
-        }
-      );
+      const errorMCPManager = createMockMCPManager(async () => {
+        throw new ToolCallErrorClass(-32601, "工具不存在");
+      });
 
       const errorEndpoint = new Endpoint(testUrl, errorMCPManager, 1000);
       // 不连接，直接触发错误
@@ -579,11 +582,9 @@ describe("Endpoint", () => {
       const consoleErrorSpy = vi.spyOn(console, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
-      const errorMCPManager = createMockMCPManager(
-        async () => {
-          throw new ToolCallErrorClass(-32601, "工具不存在");
-        }
-      );
+      const errorMCPManager = createMockMCPManager(async () => {
+        throw new ToolCallErrorClass(-32601, "工具不存在");
+      });
 
       const errorEndpoint = new Endpoint(testUrl, errorMCPManager, 1000);
       await errorEndpoint.connect();
@@ -649,7 +650,9 @@ describe("Endpoint", () => {
 
     it("应该在 initialize 失败时清理资源", async () => {
       // Mock InternalMCPManagerAdapter.initialize() to throw
-      const { InternalMCPManagerAdapter } = await import("../internal-mcp-manager.js");
+      const { InternalMCPManagerAdapter } = await import(
+        "../internal-mcp-manager.js"
+      );
       const cleanupSpy = vi.spyOn(
         InternalMCPManagerAdapter.prototype,
         "cleanup"

--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { EnhancedToolInfo, ToolCallResult } from "../types.js";
 import { InternalMCPManagerAdapter } from "../internal-mcp-manager.js";
+import type { EnhancedToolInfo, ToolCallResult } from "../types.js";
 
 // Mock 依赖
 vi.mock("@xiaozhi-client/mcp-core", () => ({
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      removeListener: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);
@@ -69,16 +70,22 @@ describe("InternalMCPManagerAdapter", () => {
     it("应该为每个 MCP 服务调用 MCPManager.addServer", () => {
       const config = {
         mcpServers: {
-          "service1": { command: "node", args: ["s1.js"] },
-          "service2": { url: "https://example.com/sse" },
+          service1: { command: "node", args: ["s1.js"] },
+          service2: { url: "https://example.com/sse" },
         },
       };
 
       new InternalMCPManagerAdapter(config);
 
       expect(mockMCPManager.addServer).toHaveBeenCalledTimes(2);
-      expect(mockMCPManager.addServer).toHaveBeenCalledWith("service1", expect.any(Object));
-      expect(mockMCPManager.addServer).toHaveBeenCalledWith("service2", expect.any(Object));
+      expect(mockMCPManager.addServer).toHaveBeenCalledWith(
+        "service1",
+        expect.any(Object)
+      );
+      expect(mockMCPManager.addServer).toHaveBeenCalledWith(
+        "service2",
+        expect.any(Object)
+      );
     });
 
     it("应该设置事件监听器", () => {
@@ -90,8 +97,14 @@ describe("InternalMCPManagerAdapter", () => {
 
       new InternalMCPManagerAdapter(config);
 
-      expect(mockMCPManager.on).toHaveBeenCalledWith("connected", expect.any(Function));
-      expect(mockMCPManager.on).toHaveBeenCalledWith("error", expect.any(Function));
+      expect(mockMCPManager.on).toHaveBeenCalledWith(
+        "connected",
+        expect.any(Function)
+      );
+      expect(mockMCPManager.on).toHaveBeenCalledWith(
+        "error",
+        expect.any(Function)
+      );
     });
 
     it("应该正确转换配置", () => {
@@ -262,7 +275,9 @@ describe("InternalMCPManagerAdapter", () => {
         },
       });
 
-      const result = await adapter.callTool("test-service__tool1", { param: "value" });
+      const result = await adapter.callTool("test-service__tool1", {
+        param: "value",
+      });
 
       expect(mockMCPManager.callTool).toHaveBeenCalledWith(
         "test-service",
@@ -405,8 +420,14 @@ describe("InternalMCPManagerAdapter", () => {
         },
       });
 
-      expect(mockMCPManager.on).toHaveBeenCalledWith("connected", expect.any(Function));
-      expect(mockMCPManager.on).toHaveBeenCalledWith("error", expect.any(Function));
+      expect(mockMCPManager.on).toHaveBeenCalledWith(
+        "connected",
+        expect.any(Function)
+      );
+      expect(mockMCPManager.on).toHaveBeenCalledWith(
+        "error",
+        expect.any(Function)
+      );
     });
 
     it("connected 事件应该正确记录", () => {
@@ -419,7 +440,9 @@ describe("InternalMCPManagerAdapter", () => {
       });
 
       const onCalls = mockMCPManager.on.mock.calls;
-      const connectedCallback = onCalls.find((call) => call[0] === "connected")?.[1];
+      const connectedCallback = onCalls.find(
+        (call) => call[0] === "connected"
+      )?.[1];
 
       if (connectedCallback) {
         connectedCallback({ serverName: "test-service", tools: [] });
@@ -432,7 +455,9 @@ describe("InternalMCPManagerAdapter", () => {
     });
 
     it("error 事件应该正确记录", () => {
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const consoleSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
 
       new InternalMCPManagerAdapter({
         mcpServers: {
@@ -444,7 +469,10 @@ describe("InternalMCPManagerAdapter", () => {
       const errorCallback = onCalls.find((call) => call[0] === "error")?.[1];
 
       if (errorCallback) {
-        errorCallback({ serverName: "test-service", error: new Error("测试错误") });
+        errorCallback({
+          serverName: "test-service",
+          error: new Error("测试错误"),
+        });
         expect(consoleSpy).toHaveBeenCalledWith(
           expect.stringContaining("MCP 服务 test-service 出错"),
           expect.any(Error)
@@ -469,7 +497,11 @@ describe("InternalMCPManagerAdapter", () => {
 
       await adapter.callTool("test-service__tool1", {});
 
-      expect(mockMCPManager.callTool).toHaveBeenCalledWith("test-service", "tool1", {});
+      expect(mockMCPManager.callTool).toHaveBeenCalledWith(
+        "test-service",
+        "tool1",
+        {}
+      );
     });
 
     it("应该正确解析包含 __ 的工具名", async () => {
@@ -519,8 +551,18 @@ describe("InternalMCPManagerAdapter", () => {
 
     it("应该处理多个服务", async () => {
       mockMCPManager.listTools.mockReturnValue([
-        { serverName: "service1", name: "tool1", description: "工具1", inputSchema: {} },
-        { serverName: "service2", name: "tool2", description: "工具2", inputSchema: {} },
+        {
+          serverName: "service1",
+          name: "tool1",
+          description: "工具1",
+          inputSchema: {},
+        },
+        {
+          serverName: "service2",
+          name: "tool2",
+          description: "工具2",
+          inputSchema: {},
+        },
       ]);
 
       const adapter = new InternalMCPManagerAdapter({

--- a/packages/endpoint/src/__tests__/manager.test.ts
+++ b/packages/endpoint/src/__tests__/manager.test.ts
@@ -3,8 +3,8 @@
  */
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { EndpointManager } from "../manager.js";
 import { Endpoint } from "../endpoint.js";
+import { EndpointManager } from "../manager.js";
 
 // Mock Endpoint 类，内联定义到 vi.mock() 中以符合 Vitest 规范
 vi.mock("../endpoint.js", () => ({
@@ -188,7 +188,9 @@ describe("EndpointManager", () => {
     it("应该处理连接失败", async () => {
       // 创建一个会失败的端点
       const failingEndpoint = new Endpoint("ws://failing.com");
-      vi.spyOn(failingEndpoint, "connect").mockRejectedValue(new Error("连接失败"));
+      vi.spyOn(failingEndpoint, "connect").mockRejectedValue(
+        new Error("连接失败")
+      );
 
       manager.addEndpoint(failingEndpoint);
 
@@ -353,13 +355,17 @@ describe("EndpointManager", () => {
     });
 
     it("未连接时应该返回 false", () => {
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(false);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        false
+      );
     });
 
     it("连接后应该返回 true", async () => {
       await manager.connect();
 
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(true);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        true
+      );
     });
 
     it("不存在的端点应该返回 false", () => {
@@ -421,7 +427,9 @@ describe("EndpointManager", () => {
 
     it("应该处理部分重连失败", async () => {
       // Mock 一个端点重连失败
-      vi.spyOn(mockEndpoints[0], "reconnect").mockRejectedValue(new Error("重连失败"));
+      vi.spyOn(mockEndpoints[0], "reconnect").mockRejectedValue(
+        new Error("重连失败")
+      );
 
       await expect(manager.reconnectAll()).resolves.toBeUndefined();
 
@@ -441,7 +449,9 @@ describe("EndpointManager", () => {
     it("应该重连指定的端点", async () => {
       await manager.reconnectEndpoint("ws://endpoint1.example.com");
 
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(true);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        true
+      );
     });
 
     it("重连不存在的端点应该抛出错误", async () => {
@@ -457,7 +467,9 @@ describe("EndpointManager", () => {
       // 重连
       await manager.reconnectEndpoint("ws://endpoint1.example.com");
 
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(true);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        true
+      );
     });
   });
 
@@ -481,7 +493,9 @@ describe("EndpointManager", () => {
     it("应该重连单个端点（传入 endpoint 参数）", async () => {
       await manager.reconnect("ws://endpoint1.example.com");
 
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(true);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        true
+      );
     });
 
     it("应该支持自定义延迟参数", async () => {
@@ -491,7 +505,9 @@ describe("EndpointManager", () => {
 
       const elapsed = Date.now() - startTime;
       expect(elapsed).toBeGreaterThanOrEqual(100);
-      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(true);
+      expect(manager.isEndpointConnected("ws://endpoint1.example.com")).toBe(
+        true
+      );
     });
 
     it("重连不存在的端点应该抛出错误", async () => {
@@ -590,7 +606,7 @@ describe("EndpointManager", () => {
 
       manager.setMcpManager(mockMcpManager);
 
-      expect(manager["sharedMCPAdapter"]).toBeDefined();
+      expect(manager.sharedMCPAdapter).toBeDefined();
     });
 
     it("重复设置应该抛出错误", () => {

--- a/packages/endpoint/src/__tests__/types.test.ts
+++ b/packages/endpoint/src/__tests__/types.test.ts
@@ -5,9 +5,9 @@
 import { describe, expect, it } from "vitest";
 import {
   ConnectionState,
-  ensureToolJSONSchema,
   ToolCallError,
   ToolCallErrorCode,
+  ensureToolJSONSchema,
 } from "../types.js";
 
 describe("类型和枚举测试", () => {
@@ -39,7 +39,10 @@ describe("类型和枚举测试", () => {
 
   describe("ToolCallError 错误类", () => {
     it("应该创建带有错误码和消息的错误", () => {
-      const error = new ToolCallError(ToolCallErrorCode.INVALID_PARAMS, "无效参数");
+      const error = new ToolCallError(
+        ToolCallErrorCode.INVALID_PARAMS,
+        "无效参数"
+      );
       expect(error).toBeInstanceOf(Error);
       expect(error.name).toBe("ToolCallError");
       expect(error.code).toBe(ToolCallErrorCode.INVALID_PARAMS);
@@ -62,7 +65,10 @@ describe("类型和枚举测试", () => {
     });
 
     it("应该正确捕获堆栈信息", () => {
-      const error = new ToolCallError(ToolCallErrorCode.TOOL_NOT_FOUND, "工具不存在");
+      const error = new ToolCallError(
+        ToolCallErrorCode.TOOL_NOT_FOUND,
+        "工具不存在"
+      );
       expect(error.stack).toBeDefined();
       expect(typeof error.stack).toBe("string");
     });

--- a/packages/endpoint/src/__tests__/utils.test.ts
+++ b/packages/endpoint/src/__tests__/utils.test.ts
@@ -4,8 +4,8 @@
 
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import {
-  deepMerge,
   decodeJWTToken,
+  deepMerge,
   extractTokenFromUrl,
   formatErrorMessage,
   isValidEndpointUrl,
@@ -90,18 +90,26 @@ describe("工具函数测试", () => {
     });
 
     it("应该拒绝 null 参数", () => {
-      expect(() => validateToolCallParams(null)).toThrow("工具调用参数必须是对象");
+      expect(() => validateToolCallParams(null)).toThrow(
+        "工具调用参数必须是对象"
+      );
     });
 
     it("应该拒绝 undefined 参数", () => {
-      expect(() => validateToolCallParams(undefined)).toThrow("工具调用参数必须是对象");
+      expect(() => validateToolCallParams(undefined)).toThrow(
+        "工具调用参数必须是对象"
+      );
     });
 
     it("应该拒绝非对象参数", () => {
       // 字符串不是对象
-      expect(() => validateToolCallParams("string")).toThrow("工具调用参数必须是对象");
+      expect(() => validateToolCallParams("string")).toThrow(
+        "工具调用参数必须是对象"
+      );
       // 数字不是对象
-      expect(() => validateToolCallParams(123)).toThrow("工具调用参数必须是对象");
+      expect(() => validateToolCallParams(123)).toThrow(
+        "工具调用参数必须是对象"
+      );
       // 数组虽然 typeof 是 'object'，但没有 name 属性，会抛出"工具名称必须是字符串"
       expect(() => validateToolCallParams([])).toThrow("工具名称必须是字符串");
     });
@@ -110,16 +118,18 @@ describe("工具函数测试", () => {
       const params = {
         arguments: { foo: "bar" },
       };
-      expect(() => validateToolCallParams(params)).toThrow("工具名称必须是字符串");
+      expect(() => validateToolCallParams(params)).toThrow(
+        "工具名称必须是字符串"
+      );
     });
 
     it("应该拒绝非字符串的 name", () => {
-      expect(() =>
-        validateToolCallParams({ name: 123 })
-      ).toThrow("工具名称必须是字符串");
-      expect(() =>
-        validateToolCallParams({ name: null })
-      ).toThrow("工具名称必须是字符串");
+      expect(() => validateToolCallParams({ name: 123 })).toThrow(
+        "工具名称必须是字符串"
+      );
+      expect(() => validateToolCallParams({ name: null })).toThrow(
+        "工具名称必须是字符串"
+      );
     });
 
     it("应该拒绝非对象的 arguments", () => {
@@ -149,7 +159,9 @@ describe("工具函数测试", () => {
     });
 
     it("应该接受有效的 wss:// URL", () => {
-      expect(isValidEndpointUrl("wss://secure.example.com/endpoint")).toBe(true);
+      expect(isValidEndpointUrl("wss://secure.example.com/endpoint")).toBe(
+        true
+      );
       expect(isValidEndpointUrl("wss://api.example.com:443/path")).toBe(true);
     });
 
@@ -178,10 +190,14 @@ describe("工具函数测试", () => {
     });
 
     it("应该接受带路径和查询参数的 WebSocket URL", () => {
-      expect(isValidEndpointUrl("ws://example.com/path?query=value")).toBe(true);
-      expect(isValidEndpointUrl("wss://example.com/path/to/endpoint?id=123&token=abc")).toBe(
+      expect(isValidEndpointUrl("ws://example.com/path?query=value")).toBe(
         true
       );
+      expect(
+        isValidEndpointUrl(
+          "wss://example.com/path/to/endpoint?id=123&token=abc"
+        )
+      ).toBe(true);
     });
   });
 
@@ -511,13 +527,15 @@ describe("工具函数测试", () => {
 
     describe("extractTokenFromUrl", () => {
       it("应该从 URL 中提取 token 参数", () => {
-        const url = "wss://api.xiaozhi.me/mcp/?token=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.test";
+        const url =
+          "wss://api.xiaozhi.me/mcp/?token=eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.test";
         const result = extractTokenFromUrl(url);
         expect(result).toBe("eyJhbGciOiJFUzI1NiIsInR5cCI6IkpXVCJ9.test");
       });
 
       it("应该处理包含多个查询参数的 URL", () => {
-        const url = "wss://api.example.com/mcp/?id=123&token=my_token&other=value";
+        const url =
+          "wss://api.example.com/mcp/?id=123&token=my_token&other=value";
         const result = extractTokenFromUrl(url);
         expect(result).toBe("my_token");
       });

--- a/packages/endpoint/src/endpoint.ts
+++ b/packages/endpoint/src/endpoint.ts
@@ -15,8 +15,8 @@ import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import WebSocket from "ws";
 import type { ExtendedMCPMessage, MCPMessage } from "./mcp.js";
 import type {
-  IMCPServiceManager,
   EndpointConnectionStatus,
+  IMCPServiceManager,
   ToolCallResult,
 } from "./types.js";
 import {
@@ -134,7 +134,9 @@ export class Endpoint {
    */
   static async create(config: EndpointCreateConfig): Promise<Endpoint> {
     // 动态导入相关模块
-    const { InternalMCPManagerAdapter } = await import("./internal-mcp-manager.js");
+    const { InternalMCPManagerAdapter } = await import(
+      "./internal-mcp-manager.js"
+    );
 
     // 创建内部 MCP 管理器适配器配置
     const endpointConfig = {
@@ -624,9 +626,10 @@ export class Endpoint {
         console.error("发送错误响应失败:", {
           id,
           errorResponse: error,
-          sendError: sendError instanceof Error
-            ? { message: sendError.message, stack: sendError.stack }
-            : sendError,
+          sendError:
+            sendError instanceof Error
+              ? { message: sendError.message, stack: sendError.stack }
+              : sendError,
         });
       }
     } else {

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,11 +4,11 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { MCPManager } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -18,6 +18,12 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
   private mcpManager: MCPManager;
   private tools: Map<string, EnhancedToolInfo> = new Map();
   private isInitialized = false;
+  // 存储事件监听器引用以便清理时移除
+  private connectedHandler?: (data: {
+    serverName: string;
+    tools: unknown[];
+  }) => void;
+  private errorHandler?: (data: { serverName: string; error: Error }) => void;
 
   constructor(private config: EndpointConfig) {
     this.mcpManager = new MCPManager();
@@ -30,16 +36,19 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       this.mcpManager.addServer(serviceName, mcpConfig);
     }
 
-    // 设置事件监听
-    this.mcpManager.on("connected", (data) => {
+    // 设置事件监听 - 保存引用以便清理
+    this.connectedHandler = (data) => {
       console.info(
         `MCP 服务 ${data.serverName} 已连接，工具数: ${data.tools.length}`
       );
-    });
+    };
 
-    this.mcpManager.on("error", (data) => {
+    this.errorHandler = (data) => {
       console.error(`MCP 服务 ${data.serverName} 出错:`, data.error);
-    });
+    };
+
+    this.mcpManager.on("connected", this.connectedHandler);
+    this.mcpManager.on("error", this.errorHandler);
   }
 
   /**
@@ -88,6 +97,16 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
    * 清理资源
    */
   async cleanup(): Promise<void> {
+    // 移除事件监听器以防止内存泄漏
+    if (this.connectedHandler) {
+      this.mcpManager.removeListener("connected", this.connectedHandler);
+      this.connectedHandler = undefined;
+    }
+    if (this.errorHandler) {
+      this.mcpManager.removeListener("error", this.errorHandler);
+      this.errorHandler = undefined;
+    }
+
     await this.mcpManager.disconnect();
     this.tools.clear();
     this.isInitialized = false;

--- a/packages/endpoint/src/shared-mcp-adapter.ts
+++ b/packages/endpoint/src/shared-mcp-adapter.ts
@@ -15,8 +15,8 @@
  */
 
 import type {
-  IMCPServiceManager,
   EnhancedToolInfo,
+  IMCPServiceManager,
   ToolCallResult,
 } from "./types.js";
 


### PR DESCRIPTION
- 添加 connectedHandler 和 errorHandler 私有属性存储监听器引用
- 在 cleanup() 方法中移除事件监听器，防止内存泄漏
- 更新测试文件中的 mock MCPManager，添加 removeListener 方法
- 应用代码格式修复（biome）

修复 issue #2150

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2150