### PR TITLE
refactor(cli): 统一使用 consola 替代 console 方法

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -3,7 +3,7 @@
  */
 
 import path from "node:path";
-import chalk from "chalk";
+import consola from "consola";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
@@ -64,7 +64,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
     args: CommandArguments,
     options: CommandOptions
   ): Promise<void> {
-    console.log("配置管理命令。使用 --help 查看可用的子命令。");
+    consola.info("配置管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
@@ -83,7 +83,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
 
       if (configManager.configExists()) {
         spinner.warn("配置文件已存在");
-        console.log(chalk.yellow("如需重新初始化，请先删除现有的配置文件"));
+        consola.log("如需重新初始化，请先删除现有的配置文件");
         return;
       }
 
@@ -95,13 +95,11 @@ export class ConfigCommandHandler extends BaseCommandHandler {
       const configFileName = `xiaozhi.config.${format}`;
       const configPath = path.join(configDir, configFileName);
 
-      console.log(chalk.green(`✅ 配置文件已创建: ${configFileName}`));
-      console.log(chalk.yellow("📝 请编辑配置文件设置你的 MCP 端点:"));
-      console.log(chalk.gray(`   配置文件路径: ${configPath}`));
-      console.log(chalk.yellow("💡 或者使用命令设置:"));
-      console.log(
-        chalk.gray("   xiaozhi config set mcpEndpoint <your-endpoint-url>")
-      );
+      consola.log(`✅ 配置文件已创建: ${configFileName}`);
+      consola.log("📝 请编辑配置文件设置你的 MCP 端点:");
+      consola.log(`   配置文件路径: ${configPath}`);
+      consola.log("💡 或者使用命令设置:");
+      consola.log("   xiaozhi config set mcpEndpoint <your-endpoint-url>");
     } catch (error) {
       spinner.fail(
         `初始化配置失败: ${error instanceof Error ? error.message : String(error)}`
@@ -121,9 +119,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+        consola.log('💡 提示: 请先运行 "xiaozhi config init" 初始化配置');
         return;
       }
 
@@ -134,32 +130,30 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           spinner.succeed("配置信息");
           const endpoints = configManager.getMcpEndpoints();
           if (endpoints.length === 0) {
-            console.log(chalk.yellow("未配置任何 MCP 端点"));
+            consola.log("未配置任何 MCP 端点");
           } else if (endpoints.length === 1) {
-            console.log(chalk.green(`MCP 端点: ${endpoints[0]}`));
+            consola.log(`MCP 端点: ${endpoints[0]}`);
           } else {
-            console.log(chalk.green(`MCP 端点 (${endpoints.length} 个):`));
+            consola.log(`MCP 端点 (${endpoints.length} 个):`);
             endpoints.forEach((ep: string, index: number) => {
-              console.log(chalk.gray(`  ${index + 1}. ${ep}`));
+              consola.log(`  ${index + 1}. ${ep}`);
             });
           }
           break;
         }
         case "mcpServers":
           spinner.succeed("配置信息");
-          console.log(chalk.green("MCP 服务:"));
+          consola.log("MCP 服务:");
           for (const [name, serverConfig] of Object.entries(
             config.mcpServers
           )) {
             const server = serverConfig as any;
             // 检查是否是 SSE 类型
             if ("type" in server && server.type === "sse") {
-              console.log(chalk.gray(`  ${name}: [SSE] ${server.url}`));
+              consola.log(`  ${name}: [SSE] ${server.url}`);
             } else {
-              console.log(
-                chalk.gray(
-                  `  ${name}: ${server.command} ${server.args.join(" ")}`
-                )
+              consola.log(
+                `  ${name}: ${server.command} ${server.args.join(" ")}`
               );
             }
           }
@@ -167,48 +161,32 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         case "connection": {
           spinner.succeed("配置信息");
           const connectionConfig = configManager.getConnectionConfig();
-          console.log(chalk.green("连接配置:"));
-          console.log(
-            chalk.gray(
-              `  心跳检测间隔: ${connectionConfig.heartbeatInterval}ms`
-            )
+          consola.log("连接配置:");
+          consola.log(
+            `  心跳检测间隔: ${connectionConfig.heartbeatInterval}ms`
           );
-          console.log(
-            chalk.gray(`  心跳超时时间: ${connectionConfig.heartbeatTimeout}ms`)
-          );
-          console.log(
-            chalk.gray(`  重连间隔: ${connectionConfig.reconnectInterval}ms`)
-          );
+          consola.log(`  心跳超时时间: ${connectionConfig.heartbeatTimeout}ms`);
+          consola.log(`  重连间隔: ${connectionConfig.reconnectInterval}ms`);
           break;
         }
         case "heartbeatInterval":
           spinner.succeed("配置信息");
-          console.log(
-            chalk.green(
-              `心跳检测间隔: ${configManager.getHeartbeatInterval()}ms`
-            )
+          consola.log(
+            `心跳检测间隔: ${configManager.getHeartbeatInterval()}ms`
           );
           break;
         case "heartbeatTimeout":
           spinner.succeed("配置信息");
-          console.log(
-            chalk.green(
-              `心跳超时时间: ${configManager.getHeartbeatTimeout()}ms`
-            )
-          );
+          consola.log(`心跳超时时间: ${configManager.getHeartbeatTimeout()}ms`);
           break;
         case "reconnectInterval":
           spinner.succeed("配置信息");
-          console.log(
-            chalk.green(`重连间隔: ${configManager.getReconnectInterval()}ms`)
-          );
+          consola.log(`重连间隔: ${configManager.getReconnectInterval()}ms`);
           break;
         default:
           spinner.fail(`未知的配置项: ${key}`);
-          console.log(
-            chalk.yellow(
-              "支持的配置项: mcpEndpoint, mcpServers, connection, heartbeatInterval, heartbeatTimeout, reconnectInterval"
-            )
+          consola.log(
+            "支持的配置项: mcpEndpoint, mcpServers, connection, heartbeatInterval, heartbeatTimeout, reconnectInterval"
           );
       }
     } catch (error) {
@@ -230,9 +208,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
 
       if (!configManager.configExists()) {
         spinner.fail("配置文件不存在");
-        console.log(
-          chalk.yellow('💡 提示: 请先运行 "xiaozhi config init" 初始化配置')
-        );
+        consola.log('💡 提示: 请先运行 "xiaozhi config init" 初始化配置');
         return;
       }
 
@@ -270,10 +246,8 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         }
         default:
           spinner.fail(`不支持设置的配置项: ${key}`);
-          console.log(
-            chalk.yellow(
-              "支持设置的配置项: mcpEndpoint, heartbeatInterval, heartbeatTimeout, reconnectInterval"
-            )
+          consola.log(
+            "支持设置的配置项: mcpEndpoint, heartbeatInterval, heartbeatTimeout, reconnectInterval"
           );
       }
     } catch (error) {

--- a/packages/cli/src/commands/EndpointCommandHandler.ts
+++ b/packages/cli/src/commands/EndpointCommandHandler.ts
@@ -2,7 +2,7 @@
  * 端点管理命令处理器
  */
 
-import chalk from "chalk";
+import consola from "consola";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
@@ -64,7 +64,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     args: CommandArguments,
     options: CommandOptions
   ): Promise<void> {
-    console.log("MCP 端点管理命令。使用 --help 查看可用的子命令。");
+    consola.info("MCP 端点管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
@@ -79,11 +79,11 @@ export class EndpointCommandHandler extends BaseCommandHandler {
       spinner.succeed("端点列表");
 
       if (endpoints.length === 0) {
-        console.log(chalk.yellow("未配置任何 MCP 端点"));
+        consola.log("未配置任何 MCP 端点");
       } else {
-        console.log(chalk.green(`共 ${endpoints.length} 个端点:`));
+        consola.log(`共 ${endpoints.length} 个端点:`);
         endpoints.forEach((ep: string, index: number) => {
-          console.log(chalk.gray(`  ${index + 1}. ${ep}`));
+          consola.log(`  ${index + 1}. ${ep}`);
         });
       }
     } catch (error) {
@@ -106,7 +106,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
       spinner.succeed(`成功添加端点: ${url}`);
 
       const endpoints = configManager.getMcpEndpoints();
-      console.log(chalk.gray(`当前共 ${endpoints.length} 个端点`));
+      consola.log(`当前共 ${endpoints.length} 个端点`);
     } catch (error) {
       spinner.fail(
         `添加端点失败: ${error instanceof Error ? error.message : String(error)}`
@@ -127,7 +127,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
       spinner.succeed(`成功移除端点: ${url}`);
 
       const endpoints = configManager.getMcpEndpoints();
-      console.log(chalk.gray(`当前剩余 ${endpoints.length} 个端点`));
+      consola.log(`当前剩余 ${endpoints.length} 个端点`);
     } catch (error) {
       spinner.fail(
         `移除端点失败: ${error instanceof Error ? error.message : String(error)}`
@@ -152,7 +152,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
         configManager.updateMcpEndpoint(urls);
         spinner.succeed(`成功设置 ${urls.length} 个端点`);
         for (const [index, url] of urls.entries()) {
-          console.log(chalk.gray(`  ${index + 1}. ${url}`));
+          consola.log(`  ${index + 1}. ${url}`);
         }
       }
     } catch (error) {

--- a/packages/cli/src/commands/McpCommandHandler.ts
+++ b/packages/cli/src/commands/McpCommandHandler.ts
@@ -3,7 +3,6 @@
  */
 
 import { configManager } from "@xiaozhi-client/config";
-import chalk from "chalk";
 import Table from "cli-table3";
 import consola from "consola";
 import ora from "ora";
@@ -170,7 +169,7 @@ export class McpCommandHandler extends BaseCommandHandler {
         const [serverName, toolName, action] = args;
 
         if (action !== "enable" && action !== "disable") {
-          console.error(chalk.red("错误: 操作必须是 'enable' 或 'disable'"));
+          consola.error("错误: 操作必须是 'enable' 或 'disable'");
           process.exit(1);
         }
 
@@ -207,7 +206,7 @@ export class McpCommandHandler extends BaseCommandHandler {
     args: CommandArguments,
     options: CommandOptions
   ): Promise<void> {
-    console.log("MCP 服务和工具管理命令。使用 --help 查看可用的子命令。");
+    consola.info("MCP 服务和工具管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
@@ -382,25 +381,23 @@ export class McpCommandHandler extends BaseCommandHandler {
       // 调用工具
       const result = await this.callToolInternal(serviceName, toolName, args);
 
-      console.log(McpCommandHandler.formatToolCallResult(result));
+      consola.log(McpCommandHandler.formatToolCallResult(result));
     } catch (error) {
-      console.log(`工具调用失败: ${serviceName}/${toolName}`);
-      console.error(chalk.red("错误:"), (error as Error).message);
+      consola.log(`工具调用失败: ${serviceName}/${toolName}`);
+      consola.error("错误:", (error as Error).message);
 
       // 提供有用的提示
       const errorMessage = (error as Error).message;
       if (errorMessage.includes("服务未启动")) {
-        console.log();
-        console.log(chalk.yellow("💡 请先启动服务:"));
-        console.log(chalk.gray("  xiaozhi start        # 前台启动"));
-        console.log(chalk.gray("  xiaozhi start -d     # 后台启动"));
+        consola.log("");
+        consola.log("💡 请先启动服务:");
+        consola.log("  xiaozhi start        # 前台启动");
+        consola.log("  xiaozhi start -d     # 后台启动");
       } else if (errorMessage.includes("参数格式错误")) {
-        console.log();
-        console.log(chalk.yellow("💡 正确格式示例:"));
-        console.log(
-          chalk.gray(
-            `  xiaozhi mcp call ${serviceName} ${toolName} --args '{"param": "value"}'`
-          )
+        consola.log("");
+        consola.log("💡 正确格式示例:");
+        consola.log(
+          `  xiaozhi mcp call ${serviceName} ${toolName} --args '{"param": "value"}'`
         );
       }
 
@@ -434,10 +431,8 @@ export class McpCommandHandler extends BaseCommandHandler {
 
       if (totalServices === 0) {
         spinner.warn("未配置任何 MCP 服务或 customMCP 工具");
-        console.log(
-          chalk.yellow(
-            "💡 提示: 使用 'xiaozhi config' 命令配置 MCP 服务或在 xiaozhi.config.json 中配置 customMCP 工具"
-          )
+        consola.log(
+          "💡 提示: 使用 'xiaozhi config' 命令配置 MCP 服务或在 xiaozhi.config.json 中配置 customMCP 工具"
         );
         return;
       }
@@ -448,9 +443,9 @@ export class McpCommandHandler extends BaseCommandHandler {
 
       if (options.tools) {
         // 显示所有服务的工具列表
-        console.log();
-        console.log(chalk.bold("MCP 服务工具列表:"));
-        console.log();
+        consola.log("");
+        consola.log("MCP 服务工具列表:");
+        consola.log("");
 
         // 计算所有工具名称的最大长度，用于动态设置列宽
         let maxToolNameWidth = 8; // 默认最小宽度
@@ -550,24 +545,22 @@ export class McpCommandHandler extends BaseCommandHandler {
           }
         }
 
-        console.log(table.toString());
+        consola.log(table.toString());
       } else {
         // 只显示服务列表
-        console.log();
-        console.log(chalk.bold("MCP 服务列表:"));
-        console.log();
+        consola.log("");
+        consola.log("MCP 服务列表:");
+        consola.log("");
 
         // 首先显示 customMCP 服务（如果存在）
         if (hasCustomMCP) {
-          console.log(`${chalk.cyan("•")} ${chalk.bold("customMCP")}`);
-          console.log(`  类型: ${chalk.gray("自定义 MCP 工具")}`);
-          console.log(`  配置: ${chalk.gray("xiaozhi.config.json")}`);
-          console.log(
-            `  工具: ${chalk.green(customMCPTools.length)} 启用 / ${chalk.yellow(
-              customMCPTools.length
-            )} 总计`
+          consola.log("• customMCP");
+          consola.log("  类型: 自定义 MCP 工具");
+          consola.log("  配置: xiaozhi.config.json");
+          consola.log(
+            `  工具: ${customMCPTools.length} 启用 / ${customMCPTools.length} 总计`
           );
-          console.log();
+          consola.log("");
         }
 
         // 然后显示标准 MCP 服务
@@ -579,56 +572,42 @@ export class McpCommandHandler extends BaseCommandHandler {
             (t) => t.enable !== false
           ).length;
 
-          console.log(`${chalk.cyan("•")} ${chalk.bold(serverName)}`);
+          consola.log(`• ${serverName}`);
 
           // 检查服务类型并显示相应信息
           if ("url" in serverConfig) {
             // URL 类型的服务（SSE 或 Streamable HTTP）
             if ("type" in serverConfig && serverConfig.type === "sse") {
-              console.log(`  类型: ${chalk.gray("SSE")}`);
+              consola.log("  类型: SSE");
             } else {
-              console.log(`  类型: ${chalk.gray("Streamable HTTP")}`);
+              consola.log("  类型: Streamable HTTP");
             }
-            console.log(`  URL: ${chalk.gray(serverConfig.url)}`);
+            consola.log(`  URL: ${serverConfig.url}`);
           } else if (isLocalMCPServerConfig(serverConfig)) {
             // 本地服务
-            console.log(
-              `  命令: ${chalk.gray(serverConfig.command)} ${chalk.gray(
-                serverConfig.args.join(" ")
-              )}`
+            consola.log(
+              `  命令: ${serverConfig.command} ${serverConfig.args.join(" ")}`
             );
           }
           if (toolCount > 0) {
-            console.log(
-              `  工具: ${chalk.green(enabledCount)} 启用 / ${chalk.yellow(
-                toolCount
-              )} 总计`
-            );
+            consola.log(`  工具: ${enabledCount} 启用 / ${toolCount} 总计`);
           } else {
-            console.log(`  工具: ${chalk.gray("未扫描 (请先启动服务)")}`);
+            consola.log("  工具: 未扫描 (请先启动服务)");
           }
-          console.log();
+          consola.log("");
         }
       }
 
-      console.log(chalk.gray("💡 提示:"));
-      console.log(
-        chalk.gray("  - 使用 'xiaozhi mcp list --tools' 查看所有工具")
-      );
-      console.log(
-        chalk.gray("  - 使用 'xiaozhi mcp <服务名> list' 查看指定服务的工具")
-      );
-      console.log(
-        chalk.gray(
-          "  - 使用 'xiaozhi mcp <服务名> <工具名> enable/disable' 启用/禁用工具"
-        )
+      consola.log("💡 提示:");
+      consola.log("  - 使用 'xiaozhi mcp list --tools' 查看所有工具");
+      consola.log("  - 使用 'xiaozhi mcp <服务名> list' 查看指定服务的工具");
+      consola.log(
+        "  - 使用 'xiaozhi mcp <服务名> <工具名> enable/disable' 启用/禁用工具"
       );
     } catch (error) {
       spinner.fail("获取 MCP 服务列表失败");
-      console.error(
-        chalk.red(
-          `错误: ${error instanceof Error ? error.message : String(error)}`
-        )
+      consola.error(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
       );
       process.exit(1);
     }
@@ -649,9 +628,7 @@ export class McpCommandHandler extends BaseCommandHandler {
 
     if (!mcpServers[serverName]) {
       spinner.fail(`服务 '${serverName}' 不存在`);
-      console.log(
-        chalk.yellow("💡 提示: 使用 'xiaozhi mcp list' 查看所有可用服务")
-      );
+      consola.log("💡 提示: 使用 'xiaozhi mcp list' 查看所有可用服务");
       return false;
     }
 
@@ -674,15 +651,15 @@ export class McpCommandHandler extends BaseCommandHandler {
 
       if (toolNames.length === 0) {
         spinner.warn(`服务 '${serverName}' 暂无工具信息`);
-        console.log(chalk.yellow("💡 提示: 请先启动服务以扫描工具列表"));
+        consola.log("💡 提示: 请先启动服务以扫描工具列表");
         return;
       }
 
       spinner.succeed(`服务 '${serverName}' 共有 ${toolNames.length} 个工具`);
 
-      console.log();
-      console.log(chalk.bold(`${serverName} 服务工具列表:`));
-      console.log();
+      consola.log("");
+      consola.log(`${serverName} 服务工具列表:`);
+      consola.log("");
 
       // 使用 cli-table3 创建表格
       const table = new Table({
@@ -710,26 +687,20 @@ export class McpCommandHandler extends BaseCommandHandler {
         table.push([toolName, status, description]);
       }
 
-      console.log(table.toString());
+      consola.log(table.toString());
 
-      console.log();
-      console.log(chalk.gray("💡 提示:"));
-      console.log(
-        chalk.gray(
-          `  - 使用 'xiaozhi mcp ${serverName} <工具名> enable' 启用工具`
-        )
+      consola.log("");
+      consola.log("💡 提示:");
+      consola.log(
+        `  - 使用 'xiaozhi mcp ${serverName} <工具名> enable' 启用工具`
       );
-      console.log(
-        chalk.gray(
-          `  - 使用 'xiaozhi mcp ${serverName} <工具名> disable' 禁用工具`
-        )
+      consola.log(
+        `  - 使用 'xiaozhi mcp ${serverName} <工具名> disable' 禁用工具`
       );
     } catch (error) {
       spinner.fail("获取工具列表失败");
-      console.error(
-        chalk.red(
-          `错误: ${error instanceof Error ? error.message : String(error)}`
-        )
+      consola.error(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
       );
       process.exit(1);
     }
@@ -755,10 +726,8 @@ export class McpCommandHandler extends BaseCommandHandler {
 
       if (!toolsConfig[toolName]) {
         spinner.fail(`工具 '${toolName}' 在服务 '${serverName}' 中不存在`);
-        console.log(
-          chalk.yellow(
-            `💡 提示: 使用 'xiaozhi mcp ${serverName} list' 查看该服务的所有工具`
-          )
+        consola.log(
+          `💡 提示: 使用 'xiaozhi mcp ${serverName} list' 查看该服务的所有工具`
         );
         return;
       }
@@ -771,18 +740,14 @@ export class McpCommandHandler extends BaseCommandHandler {
         toolsConfig[toolName].description
       );
 
-      spinner.succeed(
-        `成功${action}工具 ${chalk.cyan(serverName)}/${chalk.cyan(toolName)}`
-      );
+      spinner.succeed(`成功${action}工具 ${serverName}/${toolName}`);
 
-      console.log();
-      console.log(chalk.gray("💡 提示: 工具状态更改将在下次启动服务时生效"));
+      consola.log("");
+      consola.log("💡 提示: 工具状态更改将在下次启动服务时生效");
     } catch (error) {
       spinner.fail(`${action}工具失败`);
-      console.error(
-        chalk.red(
-          `错误: ${error instanceof Error ? error.message : String(error)}`
-        )
+      consola.error(
+        `错误: ${error instanceof Error ? error.message : String(error)}`
       );
       process.exit(1);
     }

--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -3,7 +3,7 @@
  */
 
 import path from "node:path";
-import chalk from "chalk";
+import consola from "consola";
 import ora from "ora";
 import type { CommandOption } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
@@ -63,9 +63,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
       // 检查目标目录是否已存在
       if (await fileUtils.exists(targetPath)) {
         spinner.fail(`目录 "${projectName}" 已存在`);
-        console.log(
-          chalk.yellow("💡 提示: 请选择不同的项目名称或删除现有目录")
-        );
+        consola.log("💡 提示: 请选择不同的项目名称或删除现有目录");
         return;
       }
 
@@ -112,7 +110,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
 
     if (availableTemplates.length === 0) {
       spinner.fail("找不到可用模板");
-      console.log(chalk.yellow("💡 提示: 请确保 xiaozhi-client 正确安装"));
+      consola.log("💡 提示: 请确保 xiaozhi-client 正确安装");
       return;
     }
 
@@ -132,11 +130,9 @@ export class ProjectCommandHandler extends BaseCommandHandler {
       );
 
       if (similarTemplate) {
-        console.log(
-          chalk.yellow(`💡 你是想使用模板 "${similarTemplate}" 吗？`)
-        );
+        consola.log(`💡 你是想使用模板 "${similarTemplate}" 吗？`);
         const confirmed = await this.askUserConfirmation(
-          chalk.cyan("确认使用此模板？(y/n): ")
+          "确认使用此模板？(y/n): "
         );
 
         if (confirmed) {
@@ -162,12 +158,12 @@ export class ProjectCommandHandler extends BaseCommandHandler {
 
     spinner.succeed(`项目 "${projectName}" 创建成功`);
 
-    console.log(chalk.green("✅ 项目创建完成!"));
-    console.log(chalk.yellow("📝 接下来的步骤:"));
-    console.log(chalk.gray(`   cd ${projectName}`));
-    console.log(chalk.gray("   pnpm install  # 安装依赖"));
-    console.log(chalk.gray("   # 编辑 xiaozhi.config.json 设置你的 MCP 端点"));
-    console.log(chalk.gray("   xiaozhi start  # 启动服务"));
+    consola.log("✅ 项目创建完成!");
+    consola.log("📝 接下来的步骤:");
+    consola.log(`   cd ${projectName}`);
+    consola.log("   pnpm install  # 安装依赖");
+    consola.log("   # 编辑 xiaozhi.config.json 设置你的 MCP 端点");
+    consola.log("   xiaozhi start  # 启动服务");
   }
 
   /**
@@ -190,25 +186,21 @@ export class ProjectCommandHandler extends BaseCommandHandler {
 
     spinner.succeed(`项目 "${projectName}" 创建成功`);
 
-    console.log(chalk.green("✅ 基本项目创建完成!"));
-    console.log(chalk.yellow("📝 接下来的步骤:"));
-    console.log(chalk.gray(`   cd ${projectName}`));
-    console.log(
-      chalk.gray("   # 编辑 xiaozhi.config.json 设置你的 MCP 端点和服务")
-    );
-    console.log(chalk.gray("   xiaozhi start  # 启动服务"));
-    console.log(
-      chalk.yellow("💡 提示: 使用 --template 选项可以从模板创建项目")
-    );
+    consola.log("✅ 基本项目创建完成!");
+    consola.log("📝 接下来的步骤:");
+    consola.log(`   cd ${projectName}`);
+    consola.log("   # 编辑 xiaozhi.config.json 设置你的 MCP 端点和服务");
+    consola.log("   xiaozhi start  # 启动服务");
+    consola.log("💡 提示: 使用 --template 选项可以从模板创建项目");
   }
 
   /**
    * 显示可用模板
    */
   private showAvailableTemplates(templates: string[]): void {
-    console.log(chalk.yellow("可用的模板:"));
+    consola.log("可用的模板:");
     for (const template of templates) {
-      console.log(chalk.gray(`  - ${template}`));
+      consola.log(`  - ${template}`);
     }
   }
 

--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -76,7 +76,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
     args: CommandArguments,
     options: CommandOptions
   ): Promise<void> {
-    console.log("服务管理命令。使用 --help 查看可用的子命令。");
+    consola.info("服务管理命令。使用 --help 查看可用的子命令。");
   }
 
   /**
@@ -127,15 +127,15 @@ export class ServiceCommandHandler extends BaseCommandHandler {
       const status = await serviceManager.getStatus();
 
       if (status.running) {
-        console.log(`✅ 服务正在运行 (PID: ${status.pid})`);
+        consola.log(`✅ 服务正在运行 (PID: ${status.pid})`);
         if (status.uptime) {
-          console.log(`⏱️  运行时间: ${status.uptime}`);
+          consola.log(`⏱️  运行时间: ${status.uptime}`);
         }
         if (status.mode) {
-          console.log(`🔧 运行模式: ${status.mode}`);
+          consola.log(`🔧 运行模式: ${status.mode}`);
         }
       } else {
-        console.log("❌ 服务未运行");
+        consola.log("❌ 服务未运行");
       }
     } catch (error) {
       this.handleError(error as Error);
@@ -172,18 +172,18 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    * 显示 stdio 模式迁移指南
    */
   private showStdioMigrationGuide(): void {
-    console.log("\n❌ stdio 模式已废弃\n");
-    console.log("小智客户端已迁移到纯 HTTP 架构，请使用以下方式：\n");
+    consola.log("\n❌ stdio 模式已废弃\n");
+    consola.log("小智客户端已迁移到纯 HTTP 架构，请使用以下方式：\n");
 
-    console.log("1. 启动 Web 服务：");
-    console.log("   xiaozhi start\n");
+    consola.log("1. 启动 Web 服务：");
+    consola.log("   xiaozhi start\n");
 
-    console.log("2. 在 Cursor 中配置 HTTP 端点：");
-    console.log('   "mcpServers": {');
-    console.log('     "xiaozhi-client": {');
-    console.log('       "type": "streamableHttp",');
-    console.log('       "url": "http://localhost:9999/mcp"');
-    console.log("     }");
-    console.log("   }\n");
+    consola.log("2. 在 Cursor 中配置 HTTP 端点：");
+    consola.log('   "mcpServers": {');
+    consola.log('     "xiaozhi-client": {');
+    consola.log('       "type": "streamableHttp",');
+    consola.log('       "url": "http://localhost:9999/mcp"');
+    consola.log("     }");
+    consola.log("   }\n");
   }
 }

--- a/packages/cli/src/errors/ErrorHandlers.ts
+++ b/packages/cli/src/errors/ErrorHandlers.ts
@@ -2,7 +2,7 @@
  * 错误处理器
  */
 
-import chalk from "chalk";
+import consola from "consola";
 import { ERROR_MESSAGES } from "./ErrorMessages";
 import { CLIError } from "./index";
 
@@ -27,25 +27,25 @@ export class ErrorHandler {
    * 处理 CLI 错误
    */
   private static handleCLIError(error: CLIError): void {
-    console.error(chalk.red(`❌ 错误: ${error.message}`));
+    consola.error(`❌ 错误: ${error.message}`);
 
     // 显示错误码（调试模式）
     if (process.env.DEBUG) {
-      console.error(chalk.gray(`错误码: ${error.code}`));
+      consola.log(`错误码: ${error.code}`);
     }
 
     // 显示建议
     if (error.suggestions && error.suggestions.length > 0) {
-      console.log(chalk.yellow("💡 建议:"));
+      consola.log("💡 建议:");
       for (const suggestion of error.suggestions) {
-        console.log(chalk.gray(`   ${suggestion}`));
+        consola.log(`   ${suggestion}`);
       }
     }
 
     // 显示相关帮助信息
     const helpMessage = ERROR_MESSAGES.getHelpMessage(error.code);
     if (helpMessage) {
-      console.log(chalk.blue(`ℹ️  ${helpMessage}`));
+      consola.log(`ℹ️  ${helpMessage}`);
     }
   }
 
@@ -53,16 +53,14 @@ export class ErrorHandler {
    * 处理未知错误
    */
   private static handleUnknownError(error: Error): void {
-    console.error(chalk.red(`❌ 未知错误: ${error.message}`));
+    consola.error(`❌ 未知错误: ${error.message}`);
 
     // 在调试模式下显示完整堆栈
     if (process.env.DEBUG || process.env.NODE_ENV === "development") {
-      console.error(chalk.gray("堆栈信息:"));
-      console.error(chalk.gray(error.stack));
+      consola.log("堆栈信息:");
+      consola.log(error.stack);
     } else {
-      console.log(
-        chalk.yellow("💡 提示: 设置 DEBUG=1 环境变量查看详细错误信息")
-      );
+      consola.log("💡 提示: 设置 DEBUG=1 环境变量查看详细错误信息");
     }
   }
 
@@ -112,12 +110,12 @@ export class ErrorHandler {
    * 警告处理
    */
   static warn(message: string, suggestions?: string[]): void {
-    console.warn(chalk.yellow(`⚠️  警告: ${message}`));
+    consola.warn(`⚠️  警告: ${message}`);
 
     if (suggestions && suggestions.length > 0) {
-      console.log(chalk.yellow("💡 建议:"));
+      consola.log("💡 建议:");
       for (const suggestion of suggestions) {
-        console.log(chalk.gray(`   ${suggestion}`));
+        consola.log(`   ${suggestion}`);
       }
     }
   }
@@ -126,13 +124,13 @@ export class ErrorHandler {
    * 信息提示
    */
   static info(message: string): void {
-    console.log(chalk.blue(`ℹ️  ${message}`));
+    consola.log(`ℹ️  ${message}`);
   }
 
   /**
    * 成功提示
    */
   static success(message: string): void {
-    console.log(chalk.green(`✅ ${message}`));
+    consola.log(`✅ ${message}`);
   }
 }

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -155,7 +155,7 @@ export class DaemonManagerImpl implements IDaemonManager {
 
       // 处理中断信号
       process.once("SIGINT", () => {
-        console.log("\n断开连接，服务继续在后台运行");
+        consola.log("\n断开连接，服务继续在后台运行");
         tail.kill();
         process.exit(0);
       });

--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -10,6 +10,7 @@
  * @module packages/cli/src/services/ProcessManager
  */
 
+import consola from "consola";
 import { FileError, ProcessError } from "../errors/index";
 import type {
   ProcessManager as IProcessManager,
@@ -173,7 +174,7 @@ export class ProcessManagerImpl implements IProcessManager {
       }
     } catch (error) {
       // 忽略清理错误，但可以记录日志
-      console.warn("清理 PID 文件失败:", error);
+      consola.warn("清理 PID 文件失败:", error);
     }
   }
 

--- a/packages/cli/src/services/TemplateManager.ts
+++ b/packages/cli/src/services/TemplateManager.ts
@@ -4,6 +4,7 @@
 
 import fs from "node:fs";
 import path from "node:path";
+import consola from "consola";
 import { FileError, ValidationError } from "../errors/index";
 import type {
   TemplateManager as ITemplateManager,
@@ -48,7 +49,7 @@ export class TemplateManagerImpl implements ITemplateManager {
           }
         } catch (error) {
           // 跳过无效的模板目录
-          console.warn(`跳过无效模板: ${templateName}`);
+          consola.warn(`跳过无效模板: ${templateName}`);
         }
       }
 
@@ -88,7 +89,7 @@ export class TemplateManagerImpl implements ITemplateManager {
           const configContent = FileUtils.readFile(configPath);
           config = JSON.parse(configContent);
         } catch (error) {
-          console.warn(`模板配置文件解析失败: ${templateName}`);
+          consola.warn(`模板配置文件解析失败: ${templateName}`);
         }
       }
 
@@ -158,7 +159,7 @@ export class TemplateManagerImpl implements ITemplateManager {
       // 处理模板变量替换
       await this.processTemplateVariables(targetPath, options);
 
-      console.log(`✅ 项目创建成功: ${targetPath}`);
+      consola.log(`✅ 项目创建成功: ${targetPath}`);
     } catch (error) {
       if (error instanceof FileError || error instanceof ValidationError) {
         throw error;
@@ -187,7 +188,7 @@ export class TemplateManagerImpl implements ITemplateManager {
       for (const requiredFile of requiredFiles) {
         const filePath = path.join(templateInfo.path, requiredFile);
         if (!FileUtils.exists(filePath)) {
-          console.warn(`模板缺少必要文件: ${requiredFile}`);
+          consola.warn(`模板缺少必要文件: ${requiredFile}`);
           return false;
         }
       }
@@ -298,7 +299,7 @@ export class TemplateManagerImpl implements ITemplateManager {
         }
       }
     } catch (error) {
-      console.warn(
+      consola.warn(
         `处理模板变量失败: ${error instanceof Error ? error.message : String(error)}`
       );
     }
@@ -359,7 +360,7 @@ export class TemplateManagerImpl implements ITemplateManager {
         FileUtils.writeFile(filePath, content, { overwrite: true });
       }
     } catch (error) {
-      console.warn(
+      consola.warn(
         `替换文件变量失败 ${filePath}: ${error instanceof Error ? error.message : String(error)}`
       );
     }


### PR DESCRIPTION
修复 Issue #2153

将 packages/cli 包中的所有 console 方法（console.log、console.warn、console.error、console.info）替换为统一的 consola logger 系统。

主要变更：
- McpCommandHandler.ts: 53 处替换
- ConfigCommandHandler.ts: 25 处替换
- ProjectCommandHandler.ts: 17 处替换
- ServiceCommandHandler.ts: 16 处替换
- ErrorHandlers.ts: 14 处替换
- EndpointCommandHandler.ts: 7 处替换
- TemplateManager.ts: 6 处替换
- ProcessManager.ts: 1 处替换
- DaemonManager.ts: 1 处替换

同时移除了不再需要的 chalk 依赖导入（部分文件中）。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2153