### PR TITLE
refactor: 移除 McpServerList 组件中未使用的 updateConfig 属性

### DIFF
--- a/apps/frontend/src/components/__tests__/McpServerList.test.tsx
+++ b/apps/frontend/src/components/__tests__/McpServerList.test.tsx
@@ -15,14 +15,12 @@ vi.mock("sonner", () => ({
 const mockMcpServerConfig = vi.fn();
 const mockMcpServers = vi.fn();
 const mockRefreshConfig = vi.fn();
-const mockUpdateConfig = vi.fn();
 
 vi.mock("@/stores/config", () => ({
   useMcpServerConfig: () => mockMcpServerConfig(),
   useMcpServers: () => mockMcpServers(),
   useConfigActions: () => ({
     refreshConfig: mockRefreshConfig,
-    updateConfig: mockUpdateConfig,
   }),
 }));
 
@@ -128,7 +126,7 @@ describe("McpServerList 组件", () => {
 
   it("应该正确渲染MCP服务列表", async () => {
     await act(async () => {
-      render(<McpServerList updateConfig={mockUpdateConfig} />);
+      render(<McpServerList />);
     });
 
     // 等待工具加载
@@ -142,7 +140,7 @@ describe("McpServerList 组件", () => {
     mockMcpServerConfig.mockReturnValue({});
 
     await act(async () => {
-      render(<McpServerList updateConfig={mockUpdateConfig} />);
+      render(<McpServerList />);
     });
 
     expect(screen.getByText("还没有 MCP 服务")).toBeInTheDocument();
@@ -168,7 +166,7 @@ describe("McpServerList 组件", () => {
     mockMcpServerConfig.mockReturnValue(multipleServers);
 
     await act(async () => {
-      render(<McpServerList updateConfig={mockUpdateConfig} />);
+      render(<McpServerList />);
     });
 
     // 等待组件渲染
@@ -180,7 +178,7 @@ describe("McpServerList 组件", () => {
 
   it("应该正确显示刷新状态", async () => {
     await act(async () => {
-      render(<McpServerList updateConfig={mockUpdateConfig} />);
+      render(<McpServerList />);
     });
 
     // 组件应该能正常渲染

--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -19,7 +19,6 @@ import {
 } from "@/stores/config";
 import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
 import type {
-  AppConfig,
   CozeWorkflow,
   CustomMCPToolWithStats,
   JSONSchema,
@@ -58,12 +57,10 @@ type ToolWithServerInfo = {
 };
 
 interface McpServerListProps {
-  updateConfig?: (config: AppConfig) => Promise<void>;
   className?: string;
 }
 
 export function McpServerList({
-  updateConfig: _updateConfig,
   className,
 }: McpServerListProps) {
   const mcpServerConfig = useMcpServerConfig();


### PR DESCRIPTION
- 从 McpServerListProps 接口中移除 updateConfig 属性
- 从组件参数中移除 updateConfig: _updateConfig
- 移除未使用的 AppConfig 类型导入
- 同步更新测试文件，移除 updateConfig mock

符合务实开发原则"如无必要勿增实体"。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2154