### PR TITLE
deps: 将 comment-json 从 4.2.5 升级到 4.6.1

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -31,7 +31,7 @@
     "@xiaozhi-client/version": "workspace:*",
     "ajv": "^8.17.1",
     "chalk": "^5.6.0",
-    "comment-json": "^4.2.5",
+    "comment-json": "^4.6.1",
     "dayjs": "^1.11.13",
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -25,7 +25,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "comment-json": "^4.2.5",
+    "comment-json": "^4.6.1",
     "dayjs": "^1.11.13"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -226,8 +226,8 @@ importers:
         specifier: ^5.6.0
         version: 5.6.2
       comment-json:
-        specifier: ^4.2.5
-        version: 4.5.1
+        specifier: ^4.6.1
+        version: 4.6.1
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -617,8 +617,8 @@ importers:
   packages/config:
     dependencies:
       comment-json:
-        specifier: ^4.2.5
-        version: 4.5.1
+        specifier: ^4.6.1
+        version: 4.6.1
       dayjs:
         specifier: ^1.11.13
         version: 1.11.19
@@ -4111,6 +4111,10 @@ packages:
 
   comment-json@4.5.1:
     resolution: {integrity: sha512-taEtr3ozUmOB7it68Jll7s0Pwm+aoiHyXKrEC8SEodL4rNpdfDLqa7PfBlrgFoCNNdR8ImL+muti5IGvktJAAg==}
+    engines: {node: '>= 6'}
+
+  comment-json@4.6.1:
+    resolution: {integrity: sha512-kdBIsBGqD/sAeqvzeOhBvO/bhtpbfbIU/2lw7bp182FV1cVlY7gr1Jf3Q1I+NOsCk8e4gF5Sl9iYH5cNvVmx5w==}
     engines: {node: '>= 6'}
 
   complex.js@2.4.3:
@@ -11008,6 +11012,12 @@ snapshots:
       core-util-is: 1.0.3
       esprima: 4.0.1
 
+  comment-json@4.6.1:
+    dependencies:
+      array-timsort: 1.0.3
+      core-util-is: 1.0.3
+      esprima: 4.0.1
+
   complex.js@2.4.3: {}
 
   component-emitter@1.3.1: {}
@@ -11093,7 +11103,7 @@ snapshots:
   cspell-config-lib@9.6.2:
     dependencies:
       '@cspell/cspell-types': 9.6.2
-      comment-json: 4.5.1
+      comment-json: 4.6.1
       smol-toml: 1.6.0
       yaml: 2.8.2
 


### PR DESCRIPTION
跨越多个 minor 版本 (4.3.0 → 4.6.1) 的升级，可能包含重要的功能改进和 bug 修复。

- 更新 packages/config/package.json 中的 comment-json 版本
- 更新 apps/backend/package.json 中的 comment-json 版本
- 运行测试验证配置管理功能正常

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2158