### PR TITLE
fix: 修复 WebSocket 事件监听器内存泄漏

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/binary.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/binary.ts
@@ -104,8 +104,8 @@ export async function synthesizeSpeech(
   });
 
   await new Promise((resolve, reject) => {
-    ws.on("open", resolve);
-    ws.on("error", reject);
+    ws.once("open", resolve);
+    ws.once("error", reject);
   });
 
   const request = {
@@ -202,8 +202,8 @@ export async function synthesizeSpeechStream(
   });
 
   await new Promise((resolve, reject) => {
-    ws.on("open", resolve);
-    ws.on("error", reject);
+    ws.once("open", resolve);
+    ws.once("error", reject);
   });
 
   const request = {


### PR DESCRIPTION
将 synthesizeSpeech 和 synthesizeSpeechStream 函数中的 ws.on() 改为 ws.once()，
防止事件监听器在函数结束后未移除导致的内存泄漏。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2162