### PR TITLE
refactor: 移除未使用的 LoadBalancingConfig 接口

### DIFF
--- a/packages/shared-types/src/config/connection.ts
+++ b/packages/shared-types/src/config/connection.ts
@@ -38,14 +38,3 @@ export interface EndpointConfig {
   priority?: number;
 }
 
-/**
- * 负载均衡配置
- */
-export interface LoadBalancingConfig {
-  /** 负载均衡策略 */
-  strategy: "round-robin" | "random" | "least-connections" | "weighted";
-  /** 健康检查间隔（毫秒） */
-  healthCheckInterval?: number;
-  /** 健康检查超时时间（毫秒） */
-  healthCheckTimeout?: number;
-}

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -21,7 +21,6 @@ export type {
 export type {
   ConnectionConfig as ConfigConnectionConfig,
   EndpointConfig,
-  LoadBalancingConfig,
 } from "./connection";
 
 // 服务器配置相关类型


### PR DESCRIPTION
遵循务实开发理念"如无必要勿增实体"，删除项目中未使用的
LoadBalancingConfig 接口定义。项目已采用独立多端点架构，
不再需要负载均衡配置。

Fixes #2166

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2166