### PR TITLE
fix: 修复 CLI 测试无法运行的问题

### DIFF
--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -51,6 +51,13 @@ export default defineConfig({
   },
   resolve: {
     alias: {
+      // 工作区包别名（指向源码目录，用于测试）
+      "@xiaozhi-client/config": resolve(__dirname, "../config/src"),
+      "@xiaozhi-client/config/*": resolve(__dirname, "../config/src/*"),
+      "@xiaozhi-client/mcp-core": resolve(__dirname, "../mcp-core/src"),
+      "@xiaozhi-client/mcp-core/*": resolve(__dirname, "../mcp-core/src/*"),
+      "@xiaozhi-client/shared-types": resolve(__dirname, "../shared-types/src"),
+      "@xiaozhi-client/shared-types/*": resolve(__dirname, "../shared-types/src/*"),
       // Backend 路径别名（从 packages/cli 向上到项目根目录）
       "@handlers": resolve(__dirname, "../../apps/backend/handlers"),
       "@handlers/*": resolve(__dirname, "../../apps/backend/handlers/*"),


### PR DESCRIPTION
在 vitest 配置中添加工作区包别名，解决测试运行时的模块解析错误。

修改内容：
- 添加 @xiaozhi-client/config 别名指向源码目录
- 添加 @xiaozhi-client/mcp-core 别名指向源码目录
- 添加 @xiaozhi-client/shared-types 别名指向源码目录

修复后测试结果：
- 18 个测试文件全部通过
- 555 个测试用例全部通过

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2172