### PR TITLE
perf(config): 优化 getConfig() 方法性能

### DIFF
--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -559,10 +559,14 @@ export class ConfigManager {
    * 获取配置（只读）
    */
   public getConfig(): Readonly<AppConfig> {
-    this.config = this.loadConfig();
+    // 如果配置未加载，则加载配置
+    if (!this.config) {
+      this.config = this.loadConfig();
+    }
 
-    // 返回深度只读副本
-    return JSON.parse(JSON.stringify(this.config));
+    // 返回冻结的配置对象，提供运行时只读保护
+    // 避免使用 JSON.parse(JSON.stringify()) 进行深拷贝，提升性能
+    return Object.freeze(this.config) as Readonly<AppConfig>;
   }
 
   /**


### PR DESCRIPTION
- 移除每次调用都重新加载配置文件的问题，改为仅在首次调用时加载
- 使用 Object.freeze() 替代 JSON.parse(JSON.stringify()) 深拷贝，显著提升性能
- 保持运行时只读保护，防止意外修改配置对象

修复 issue #2178

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2178