### PR TITLE
perf(log): 将 cleanupOldRecords() 改为异步文件操作

### DIFF
--- a/apps/backend/lib/mcp/log.ts
+++ b/apps/backend/lib/mcp/log.ts
@@ -4,6 +4,7 @@
  */
 
 import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import { logger } from "@/Logger.js";
 import { PathUtils } from "@/utils/path-utils.js";
@@ -160,13 +161,16 @@ export class ToolCallLogger {
    */
   private async cleanupOldRecords(): Promise<void> {
     try {
-      // 检查日志文件是否存在
-      if (!fs.existsSync(this.logFilePath)) {
+      // 检查日志文件是否存在（使用异步方式）
+      try {
+        await fsPromises.access(this.logFilePath);
+      } catch {
+        // 文件不存在，直接返回
         return;
       }
 
-      // 读取文件内容
-      const content = fs.readFileSync(this.logFilePath, "utf8");
+      // 读取文件内容（使用异步方式）
+      const content = await fsPromises.readFile(this.logFilePath, "utf8");
       const lines = content
         .trim()
         .split("\n")
@@ -183,10 +187,10 @@ export class ToolCallLogger {
       // 删除最旧的记录（从文件开头删除）
       const linesToKeep = lines.slice(recordsToRemove);
 
-      // 重新写入文件
+      // 重新写入文件（使用异步方式）
       const newContent =
         linesToKeep.join("\n") + (linesToKeep.length > 0 ? "\n" : "");
-      fs.writeFileSync(this.logFilePath, newContent, "utf8");
+      await fsPromises.writeFile(this.logFilePath, newContent, "utf8");
 
       logger.info("已清理旧的工具调用记录", {
         recordsToRemove,


### PR DESCRIPTION
将同步文件 I/O (fs.readFileSync/fs.writeFileSync) 替换为异步
操作 (fs.promises.readFile/fs.promises.writeFile)，避免阻塞
Node.js 事件循环。

修复问题 #2187

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2187