### PR TITLE
chore(docker): 更新 Docker 镜像默认版本号至 2.0.0

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -7,7 +7,7 @@ FROM node:20
 # 定义 xiaozhi-client 版本号
 # 默认使用当前项目版本，可在构建时通过 --build-arg 覆盖
 # 例如: docker build --build-arg XIAOZHI_VERSION=1.6.0 .
-ARG XIAOZHI_VERSION=1.6.1
+ARG XIAOZHI_VERSION=2.0.0
 
 # 配置 npm 和 pnpm 使用国内镜像源
 # 设置 npm 注册表镜像


### PR DESCRIPTION
## Summary
- 将 Dockerfile 中的 `XIAOZHI_VERSION` 默认值从 `1.6.1` 更新到 `2.0.0`
- 与项目最新发布的版本保持同步

## Test plan
- [ ] 验证 Dockerfile 中版本号已正确更新
- [ ] 确认与 package.json 中的版本一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)