### PR TITLE
fix: 移除 packages/cli/tsconfig.json 中对 apps/backend 的错误引用

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -8,7 +8,6 @@
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],
   "references": [
-    { "path": "../../apps/backend" },
     { "path": "../config" },
     { "path": "../version" }
   ]


### PR DESCRIPTION
- CLI 使用动态导入在运行时加载 backend，不需要编译时项目引用
- 类型声明已通过 packages/cli/src/types/backend.d.ts 本地提供
- 这修复了 monorepo 分层架构违规问题（packages 不应依赖 apps）

Fixes #2199

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2199