### PR TITLE
fix(deps): 统一 monorepo 中的 dotenv 依赖版本至 17.2.3

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -57,7 +57,7 @@
     "@types/node": "^20.10.0",
     "@types/uuid": "^9.0.7",
     "@types/ws": "^8.5.10",
-    "dotenv": "^16.4.0",
+    "dotenv": "^17.2.3",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -55,7 +55,7 @@
   "devDependencies": {
     "@types/node": "^24.3.0",
     "@types/ws": "^8.5.10",
-    "dotenv": "^16.4.0",
+    "dotenv": "^17.2.3",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
     "typescript": "^5.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -568,8 +568,8 @@ importers:
         specifier: ^8.5.10
         version: 8.18.1
       dotenv:
-        specifier: ^16.4.0
-        version: 16.4.7
+        specifier: ^17.2.3
+        version: 17.2.3
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)
@@ -726,8 +726,8 @@ importers:
         specifier: ^8.5.10
         version: 8.18.1
       dotenv:
-        specifier: ^16.4.0
-        version: 16.4.7
+        specifier: ^17.2.3
+        version: 17.2.3
       tsup:
         specifier: ^8.3.5
         version: 8.5.1(jiti@2.6.1)(postcss@8.5.6)(tsx@4.21.0)(typescript@5.9.3)(yaml@2.8.2)


### PR DESCRIPTION
- 更新 packages/asr/package.json 中的 dotenv 从 ^16.4.0 到 ^17.2.3
- 更新 packages/tts/package.json 中的 dotenv 从 ^16.4.0 到 ^17.2.3
- 更新 pnpm-lock.yaml 以反映版本变更
- 所有测试通过，验证兼容性

修复 #2203

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2203