### PR TITLE
fix: 修复 esp32/connection.ts 中 catch 块内 onMessage 调用缺少错误处理的问题

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -197,16 +197,23 @@ export class ESP32Connection {
             //   `解析音频包成功(协议2): type=${parsed.type}, timestamp=${parsed.timestamp}, payloadSize=${parsed.payload.length}`
             // );
             // 处理为解析后的音频消息（附加解析信息）
-            await this.config.onMessage({
-              type: "audio",
-              data: parsed.payload,
-              // 附加解析信息供服务层使用
-              _parsed: {
-                protocolVersion: parsed.protocolVersion,
-                dataType: parsed.type,
-                timestamp: parsed.timestamp,
-              },
-            } as ESP32WSMessage);
+            try {
+              await this.config.onMessage({
+                type: "audio",
+                data: parsed.payload,
+                // 附加解析信息供服务层使用
+                _parsed: {
+                  protocolVersion: parsed.protocolVersion,
+                  dataType: parsed.type,
+                  timestamp: parsed.timestamp,
+                },
+              } as ESP32WSMessage);
+            } catch (onMessageError) {
+              logger.error(
+                `处理音频消息失败(协议2): deviceId=${this.deviceId}`,
+                onMessageError
+              );
+            }
             return;
           }
           logger.info("协议2解析失败，尝试其他协议");
@@ -219,15 +226,22 @@ export class ESP32Connection {
             logger.info(
               `解析音频包成功(协议3): type=${parsed.type}, timestamp=${parsed.timestamp}, payloadSize=${parsed.payload.length}`
             );
-            await this.config.onMessage({
-              type: "audio",
-              data: parsed.payload,
-              _parsed: {
-                protocolVersion: parsed.protocolVersion,
-                dataType: parsed.type,
-                timestamp: parsed.timestamp,
-              },
-            } as ESP32WSMessage);
+            try {
+              await this.config.onMessage({
+                type: "audio",
+                data: parsed.payload,
+                _parsed: {
+                  protocolVersion: parsed.protocolVersion,
+                  dataType: parsed.type,
+                  timestamp: parsed.timestamp,
+                },
+              } as ESP32WSMessage);
+            } catch (onMessageError) {
+              logger.error(
+                `处理音频消息失败(协议3): deviceId=${this.deviceId}`,
+                onMessageError
+              );
+            }
             return;
           }
           logger.info("协议3解析失败，作为原始数据处理");
@@ -236,10 +250,17 @@ export class ESP32Connection {
         const version = data.readUInt16BE(0);
         logger.info(`音频协议解析失败，作为原始数据处理, version=${version}`);
         // 处理为原始音频消息
-        await this.config.onMessage({
-          type: "audio",
-          data: new Uint8Array(data),
-        });
+        try {
+          await this.config.onMessage({
+            type: "audio",
+            data: new Uint8Array(data),
+          });
+        } catch (onMessageError) {
+          logger.error(
+            `处理原始音频消息失败: deviceId=${this.deviceId}`,
+            onMessageError
+          );
+        }
       } else {
         logger.error(`消息解析失败: deviceId=${this.deviceId}`, error);
         await this.sendError(


### PR DESCRIPTION
为 handleMessage 方法的 catch 块内的三个 onMessage 调用添加了 try-catch 错误处理：
1. BinaryProtocol2 音频协议消息处理
2. BinaryProtocol3 音频协议消息处理
3. 原始音频数据消息处理

这防止了当 onMessage 回调（最终调用 esp32.service.ts 的 handleDeviceMessage）
在处理音频消息时抛出错误导致的未捕获 Promise rejection。

修复了 issue #2208

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2208