### PR TITLE
fix: 添加 tts:build 和 asr:build 到 backend type-check 依赖

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "tts:build", "asr:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
修复 Issue #2210

apps/backend/project.json 的 type-check 目标缺少 tts:build 和 asr:build
依赖，导致在干净的仓库中运行 pnpm check:type 时类型检查失败。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2210