### PR TITLE
docs(frontend): add file-level JSDoc for VersionDisplay

### DIFF
--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -1,3 +1,12 @@
+/**
+ * VersionDisplay 组件 - 版本信息显示和更新检查
+ *
+ * 功能：
+ * - 显示当前应用版本信息
+ * - 自动检查是否有新版本可用
+ * - 支持一键复制当前版本号
+ * - 提供版本升级对话框入口
+ */
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {


### PR DESCRIPTION
## Summary
- add a file-level JSDoc block to `apps/frontend/src/components/version-display.tsx`
- describe the component responsibilities to align with neighboring business component docs
- keep implementation unchanged (documentation-only update)

## Validation
- `git diff --check`
- attempted `corepack pnpm dlx @biomejs/biome check apps/frontend/src/components/version-display.tsx` (blocked by repo Biome config version mismatch in ephemeral CLI)

Closes #2205
