### PR TITLE
fix: 处理 WebServer 中 sendInitialData 的 Promise rejection

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -772,7 +772,11 @@ export class WebServer {
     });
 
     // 发送初始数据
-    this.realtimeNotificationHandler.sendInitialData(ws, clientId);
+    this.realtimeNotificationHandler
+      .sendInitialData(ws, clientId)
+      .catch((error) => {
+        this.logger.error(`发送初始数据失败: clientId=${clientId}`, error);
+      });
   }
 
   /**


### PR DESCRIPTION
- 添加 .catch() 错误处理以捕获未处理的 Promise rejection
- 确保 WebSocket 客户端连接时发送初始数据失败能够被记录
- 修复 #2220

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2220