### PR TITLE
fix: 使用 useMemo 缓存 hasNoParams 变量避免重复计算

### DIFF
--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -461,6 +461,14 @@ export function ToolDebugDialog({
     return createDefaultValues(tool.inputSchema);
   }, [tool?.inputSchema]);
 
+  // 检查是否无参数工具（使用 useMemo 避免重复计算）
+  const hasNoParams = useMemo(() => {
+    return (
+      !tool?.inputSchema?.properties ||
+      Object.keys(tool.inputSchema.properties).length === 0
+    );
+  }, [tool?.inputSchema?.properties]);
+
   // 初始化表单
   const form = useForm({
     resolver: zodResolver(formSchema as any),
@@ -560,11 +568,6 @@ export function ToolDebugDialog({
 
     let args: any;
 
-    // 检查是否无参数工具
-    const hasNoParams =
-      !tool?.inputSchema?.properties ||
-      Object.keys(tool.inputSchema.properties).length === 0;
-
     if (hasNoParams) {
       // 无参数工具使用空对象
       args = {};
@@ -605,7 +608,7 @@ export function ToolDebugDialog({
     } finally {
       setLoading(false);
     }
-  }, [tool, inputMode, form, jsonInput, validateJSON]);
+  }, [tool, inputMode, form, jsonInput, validateJSON, hasNoParams]);
 
   // 复制结果
   const handleCopy = useCallback(async () => {
@@ -822,9 +825,6 @@ export function ToolDebugDialog({
         event.preventDefault();
 
         // 检查是否无参数工具，或者是有参数工具且JSON模式时验证格式
-        const hasNoParams =
-          !tool?.inputSchema?.properties ||
-          Object.keys(tool.inputSchema.properties).length === 0;
         if (!hasNoParams && inputMode === "json" && !validateJSON(jsonInput)) {
           toast.error("输入参数不是有效的JSON格式");
           return;
@@ -841,7 +841,7 @@ export function ToolDebugDialog({
       jsonInput,
       validateJSON,
       handleCallTool,
-      tool?.inputSchema?.properties,
+      hasNoParams,
     ]
   );
 
@@ -1035,16 +1035,7 @@ export function ToolDebugDialog({
                   disabled={
                     loading ||
                     // 只有有参数工具且在JSON模式时才检查JSON格式
-                    (() => {
-                      const hasNoParams =
-                        !tool?.inputSchema?.properties ||
-                        Object.keys(tool.inputSchema.properties).length === 0;
-                      return (
-                        !hasNoParams &&
-                        inputMode === "json" &&
-                        !validateJSON(jsonInput)
-                      );
-                    })()
+                    (!hasNoParams && inputMode === "json" && !validateJSON(jsonInput))
                   }
                 >
                   {loading ? (
@@ -1055,12 +1046,7 @@ export function ToolDebugDialog({
                   ) : (
                     <>
                       <PlayIcon className="h-4 w-4" />
-                      {(() => {
-                        const hasNoParams =
-                          !tool?.inputSchema?.properties ||
-                          Object.keys(tool.inputSchema.properties).length === 0;
-                        return hasNoParams ? "直接调用" : "调用工具";
-                      })()} ({getShortcutText()})
+                      {hasNoParams ? "直接调用" : "调用工具"} ({getShortcutText()})
                     </>
                   )}
                 </Button>


### PR DESCRIPTION
修复 Issue #2226，消除 tool-debug-dialog.tsx 中 hasNoParams 变量的 4 次重复定义。

主要变更：
- 在组件顶层使用 useMemo 缓存 hasNoParams 值
- 移除 handleCallTool 函数中的本地定义
- 移除 handleKeyDown 函数中的本地定义
- 简化按钮 disabled 条件中的 IIFE
- 简化按钮文本中的 IIFE

效果：
1. 消除代码重复，提高可维护性
2. 缓存计算结果，提升性能
3. 符合 React Hooks 最佳实践

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2226