### PR TITLE
fix(tts): 使用路径别名替代相对路径导入

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -8,7 +8,7 @@ import type {
   AudioChunkCallback,
   PlatformConfig,
   TTSController,
-} from "../../core/index.js";
+} from "@/core/index.js";
 import {
   FullClientRequest,
   MsgType,

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -2,7 +2,7 @@
  * 字节跳动 TTS 平台模块导出
  */
 
-import { platformRegistry } from "../../core/index.js";
+import { platformRegistry } from "@/core/index.js";
 import { ByteDanceTTSPlatform } from "./TTSController.js";
 
 // 注册字节跳动平台


### PR DESCRIPTION
- 将 TTSController.ts 中的  改为
- 将 index.ts 中的  改为
- 遵循项目路径别名使用的一致性原则

Fixes #2227\n\nFixes issue: #2227