### PR TITLE
refactor(tts): 提取 TTSController 初始化公共方法以消除重复代码

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -50,12 +50,10 @@ export class ByteDanceTTSController implements TTSController {
   }
 
   /**
-   * 流式合成语音
+   * 初始化语音合成连接和请求
+   * @private
    */
-  async synthesizeStream(
-    text: string,
-    onAudioChunk: AudioChunkCallback
-  ): Promise<void> {
+  private async initializeSynthesis(text: string): Promise<void> {
     this.isStreamClosed = false;
 
     const endpoint = this.config.endpoint || DEFAULT_TTS_ENDPOINT;
@@ -122,6 +120,16 @@ export class ByteDanceTTSController implements TTSController {
       this.ws,
       new TextEncoder().encode(JSON.stringify(request))
     );
+  }
+
+  /**
+   * 流式合成语音
+   */
+  async synthesizeStream(
+    text: string,
+    onAudioChunk: AudioChunkCallback
+  ): Promise<void> {
+    await this.initializeSynthesis(text);
 
     while (true) {
       if (this.isStreamClosed || !this.ws) {
@@ -158,72 +166,7 @@ export class ByteDanceTTSController implements TTSController {
    * 非流式合成语音
    */
   async synthesize(text: string): Promise<Uint8Array> {
-    this.isStreamClosed = false;
-
-    const endpoint = this.config.endpoint || DEFAULT_TTS_ENDPOINT;
-    const encoding = this.config.audio.encoding || "wav";
-
-    const headers = {
-      Authorization: `Bearer;${this.config.app.accessToken}`,
-    };
-
-    this.ws = new WebSocket(endpoint, {
-      headers,
-      skipUTF8Validation: true,
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      if (!this.ws) {
-        reject(new Error("WebSocket 未创建"));
-        return;
-      }
-      this.ws.on("open", () => resolve());
-      this.ws.on("error", (err) => reject(err));
-    });
-
-    const request = {
-      app: {
-        appid: this.config.app.appid,
-        token: this.config.app.accessToken,
-        cluster:
-          this.config.cluster?.trim() ||
-          voiceToCluster(this.config.audio.voice_type),
-      },
-      user: {
-        uid: randomUUID(),
-      },
-      audio: {
-        voice_type: this.config.audio.voice_type,
-        encoding: encoding,
-        ...(this.config.audio.speed !== undefined && {
-          speed: this.config.audio.speed,
-        }),
-        ...(this.config.audio.pitch !== undefined && {
-          pitch: this.config.audio.pitch,
-        }),
-        ...(this.config.audio.volume !== undefined && {
-          volume: this.config.audio.volume,
-        }),
-      },
-      request: {
-        reqid: randomUUID(),
-        text: text,
-        operation: "submit",
-        extra_param: JSON.stringify({
-          disable_markdown_filter: false,
-        }),
-        with_timestamp: "1",
-      },
-    };
-
-    if (!this.ws) {
-      throw new Error("WebSocket 未创建");
-    }
-
-    await FullClientRequest(
-      this.ws,
-      new TextEncoder().encode(JSON.stringify(request))
-    );
+    await this.initializeSynthesis(text);
 
     const totalAudio: Uint8Array[] = [];
 


### PR DESCRIPTION
将 synthesizeStream 和 synthesize 方法中约 68 行重复代码提取为
私有方法 initializeSynthesis，符合 DRY 原则，降低维护成本。

- 添加 initializeSynthesis(text: string) 私有方法
- 两个方法现在都使用相同的初始化逻辑
- 减少约 68 行重复代码

Fixes #2237

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2237