### PR TITLE
fix: 修复 NetworkService 中的 Promise<any> 类型安全问题

### DIFF
--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -3,8 +3,19 @@
  * 整合 HTTP API 客户端和 WebSocket 管理器
  */
 
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
-import { type ApiClient, apiClient } from "./api";
+import type {
+  AppConfig,
+  ClientStatus,
+  ConnectionConfig,
+} from "@xiaozhi-client/shared-types";
+import {
+  type ApiClient,
+  apiClient,
+  type FullStatus,
+  type RestartStatus,
+  type ServiceHealth,
+  type ServiceStatus,
+} from "./api";
 import {
   type ConnectionState,
   type WebSocketManager,
@@ -70,7 +81,7 @@ export class NetworkService {
   /**
    * 获取状态 (HTTP)
    */
-  async getStatus(): Promise<any> {
+  async getStatus(): Promise<FullStatus> {
     return this.apiClient.getStatus();
   }
 
@@ -105,14 +116,14 @@ export class NetworkService {
   /**
    * 获取服务状态 (HTTP)
    */
-  async getServiceStatus(): Promise<any> {
+  async getServiceStatus(): Promise<ServiceStatus> {
     return this.apiClient.getServiceStatus();
   }
 
   /**
    * 获取服务健康状态 (HTTP)
    */
-  async getServiceHealth(): Promise<any> {
+  async getServiceHealth(): Promise<ServiceHealth> {
     return this.apiClient.getServiceHealth();
   }
 
@@ -140,7 +151,7 @@ export class NetworkService {
   /**
    * 获取连接配置 (HTTP)
    */
-  async getConnectionConfig(): Promise<any> {
+  async getConnectionConfig(): Promise<ConnectionConfig> {
     return this.apiClient.getConnectionConfig();
   }
 
@@ -168,7 +179,7 @@ export class NetworkService {
   /**
    * 获取重启状态 (HTTP)
    */
-  async getRestartStatus(): Promise<any> {
+  async getRestartStatus(): Promise<RestartStatus | null> {
     return this.apiClient.getRestartStatus();
   }
 
@@ -274,7 +285,7 @@ export class NetworkService {
    */
   async getFullAppState(): Promise<{
     config: AppConfig;
-    status: any;
+    status: FullStatus;
     webSocketConnected: boolean;
   }> {
     const [config, status] = await Promise.all([


### PR DESCRIPTION
将以下方法的返回类型从 Promise<any> 更新为具体类型：
- getStatus(): Promise<any> → Promise<FullStatus>
- getServiceStatus(): Promise<any> → Promise<ServiceStatus>
- getServiceHealth(): Promise<any> → Promise<ServiceHealth>
- getConnectionConfig(): Promise<any> → Promise<ConnectionConfig>
- getRestartStatus(): Promise<any> → Promise<RestartStatus | null>
- getFullAppState() 的 status 字段: any → FullStatus

同时添加了缺失的类型导入，提高了代码的类型安全性。

Fixes #2238

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2238