### PR TITLE
fix: 使用 ensureToolJSONSchema 替换 as any 进行类型验证

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -9,6 +9,7 @@ import { InternalMCPManagerAdapter } from "../internal-mcp-manager.js";
 // Mock 依赖
 vi.mock("@xiaozhi-client/mcp-core", () => ({
   MCPManager: vi.fn(),
+  ensureToolJSONSchema: vi.fn((schema) => schema),
 }));
 
 vi.mock("@xiaozhi-client/config", () => ({

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,7 +4,7 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
-import { MCPManager } from "@xiaozhi-client/mcp-core";
+import { MCPManager, ensureToolJSONSchema } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
@@ -105,7 +105,8 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        // 使用 ensureToolJSONSchema 进行运行时类型验证和转换
+        inputSchema: ensureToolJSONSchema(mcpTool.inputSchema as Record<string, unknown>),
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,


### PR DESCRIPTION
- 在 InternalMCPManagerAdapter.refreshTools() 中使用 ensureToolJSONSchema() 替换 as any
- 添加运行时类型验证，确保 inputSchema 符合 JSONSchema 类型
- 更新测试文件 mock 以包含 ensureToolJSONSchema

修复 #2248

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2248