### PR TITLE
fix(tts): 移除 WebSocket 事件监听器防止内存泄漏

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/protocols.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/protocols.ts
@@ -581,7 +581,7 @@ function setupMessageHandler(ws: WebSocket) {
     messageQueues.set(ws, []);
     messageCallbacks.set(ws, []);
 
-    ws.on("message", (data: WebSocket.RawData) => {
+    const messageHandler = (data: WebSocket.RawData) => {
       try {
         let uint8Data: Uint8Array;
         if (Buffer.isBuffer(data)) {
@@ -609,12 +609,19 @@ function setupMessageHandler(ws: WebSocket) {
       } catch (error) {
         throw new Error(`Error processing message: ${error}`);
       }
-    });
+    };
 
-    ws.on("close", () => {
+    const closeHandler = () => {
+      // 移除事件监听器，防止内存泄漏
+      ws.removeListener("message", messageHandler);
+      ws.removeListener("close", closeHandler);
+      // 清理数据
       messageQueues.delete(ws);
       messageCallbacks.delete(ws);
-    });
+    };
+
+    ws.on("message", messageHandler);
+    ws.on("close", closeHandler);
   }
 }
 


### PR DESCRIPTION
在 setupMessageHandler 函数中，将匿名事件监听器改为命名函数，
并在 close 事件处理中显式移除 message 和 close 事件监听器。

修复内容：
- 将 message 事件处理逻辑提取为 messageHandler 命名函数
- 将 close 事件处理逻辑提取为 closeHandler 命名函数
- 在 closeHandler 中调用 ws.removeListener() 移除两个事件监听器

此修复防止 WebSocket 对象和闭包被长时间引用，
避免在长期运行的应用中出现内存泄漏。

Fixes #2251

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2251