### PR TITLE
fix(asr): 移除 sendFrame Promise catch 块中的 throw 语句以避免未捕获的 Promise rejection

### DIFF
--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceV2Controller.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceV2Controller.ts
@@ -164,7 +164,6 @@ export class ByteDanceV2Controller extends ByteDanceController {
             if (!settled) {
               settled = true;
               this.asr.close();
-              throw error;
             }
           });
 

--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
@@ -165,7 +165,6 @@ export class ByteDanceV3Controller extends ByteDanceController {
             if (!settled) {
               settled = true;
               this.asr.close();
-              throw error;
             }
           });
 


### PR DESCRIPTION
在 ByteDanceV2Controller 和 ByteDanceV3Controller 中，sendFrame Promise 的 catch
块包含 throw error 语句。由于 Promise 有意设计为异步发送（不 await），
throw 语句会导致未捕获的 Promise rejection 警告，可能导致进程崩溃。

错误已经在 catch 块中被正确处理（减少 pendingFrames 计数、关闭连接），
因此无需再次抛出错误。

修复 #2253

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2253