### PR TITLE
fix(deps): 将 asr 和 tts 包的 TypeScript 版本从 5.3.0 升级到 5.9.2

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -60,7 +60,7 @@
     "dotenv": "^16.4.0",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -58,7 +58,7 @@
     "dotenv": "^16.4.0",
     "tsup": "^8.3.5",
     "tsx": "^4.7.0",
-    "typescript": "^5.3.0",
+    "typescript": "^5.9.2",
     "vitest": "^3.2.4"
   },
   "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -577,7 +577,7 @@ importers:
         specifier: ^4.7.0
         version: 4.21.0
       typescript:
-        specifier: ^5.3.0
+        specifier: ^5.9.2
         version: 5.9.3
       vitest:
         specifier: ^3.2.4
@@ -738,7 +738,7 @@ importers:
         specifier: ^4.7.0
         version: 4.21.0
       typescript:
-        specifier: ^5.3.0
+        specifier: ^5.9.2
         version: 5.9.3
       vitest:
         specifier: ^3.2.4


### PR DESCRIPTION
修复了 monorepo 中 TypeScript 版本不一致的问题：
- packages/asr/package.json: typescript ^5.3.0 → ^5.9.2
- packages/tts/package.json: typescript ^5.3.0 → ^5.9.2

现在所有包都使用统一的 TypeScript 5.9.2 版本，确保类型检查行为一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2268