### PR TITLE
fix: 添加 postinstall 脚本解决 workspace 依赖未构建时类型检查失败问题

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -17,6 +17,42 @@
 - **简单直接**：避免为了工程化而工程化
 - **渐进改进**：遇到问题再优化，不过度预防
 
+## 开发前准备
+
+### 首次检出代码
+
+首次检出代码后，需要安装依赖：
+
+```bash
+# 安装依赖（postinstall 脚本会自动构建 workspace 包）
+pnpm install
+```
+
+**重要说明**：
+- 项目使用 workspace 架构，`apps/backend` 依赖于 `packages/` 中的多个包
+- 这些依赖包需要先构建才能生成类型定义文件（`dist/index.d.ts`）
+- `pnpm install` 会自动触发 `postinstall` 脚本，检测并构建缺失的 workspace 包
+- 如果构建产物已存在，`postinstall` 会跳过构建，加快安装速度
+
+### 手动构建
+
+如果需要手动重新构建所有包：
+
+```bash
+# 构建所有包
+pnpm build
+
+# 仅构建 workspace 包
+nx run-many -t build --projects=shared-types,version,config,endpoint,mcp-core,asr,tts,cli --parallel=false
+```
+
+### 类型检查
+
+```bash
+# 运行类型检查（确保 workspace 包已构建）
+pnpm check:type
+```
+
 ## 开发命令
 
 ### 构建和测试

--- a/README.md
+++ b/README.md
@@ -114,6 +114,43 @@ docker-compose logs -f
 docker-compose down
 ```
 
-## 贡献者
+## 开发者指南
+
+### 开发前准备
+
+首次检出代码后，需要安装依赖并构建项目：
+
+```bash
+# 克隆仓库
+git clone https://github.com/shenjingnan/xiaozhi-client.git
+cd xiaozhi-client
+
+# 安装依赖（postinstall 脚本会自动构建 workspace 包）
+pnpm install
+```
+
+### 开发命令
+
+```bash
+# 构建项目
+pnpm build
+
+# 开发模式（监听文件变化）
+pnpm dev
+
+# 运行测试
+pnpm test
+
+# 类型检查
+pnpm check:type
+
+# 代码检查和修复
+pnpm lint:fix
+
+# 运行所有质量检查
+pnpm check:all
+```
+
+### 贡献者
 
 ![Contributors](https://contrib.rocks/image?repo=shenjingnan/xiaozhi-client&max=100&columns=10)

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "xiaozhi-client": "dist/cli/index.js"
   },
   "scripts": {
+    "postinstall": "node scripts/postinstall.js",
     "build": "pnpm run clean:dist && nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false",
     "dev": "nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false && concurrently \"nx run backend:dev\" \"nx run cli:dev\" \"nx run frontend:dev\" --prefix \"[{name}]\" --names \"BACKEND,CLI,FRONTEND\"",
     "dev:cli": "nx run cli:dev",

--- a/scripts/postinstall.js
+++ b/scripts/postinstall.js
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * postinstall 脚本
+ *
+ * 在 pnpm install 后自动构建 workspace 依赖包（如果尚未构建）
+ * 这解决了在未构建 workspace 依赖时类型检查失败的问题
+ *
+ * @see {@link https://github.com/shenjingnan/xiaozhi-client/issues/2270}
+ */
+
+import { existsSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+// 需要构建的 workspace 包列表
+const packagesToBuild = [
+  "shared-types",
+  "version",
+  "config",
+  "endpoint",
+  "mcp-core",
+  "asr",
+  "tts",
+  "cli",
+];
+
+/**
+ * 检查是否需要构建
+ * 只有当所有包的 dist 目录都不存在时才触发构建
+ */
+function checkNeedsBuild() {
+  const rootDir = join(__dirname, "..");
+  const missingPackages = [];
+
+  for (const pkg of packagesToBuild) {
+    const distPath = join(rootDir, "packages", pkg, "dist");
+    if (!existsSync(distPath)) {
+      missingPackages.push(pkg);
+    }
+  }
+
+  return {
+    needsBuild: missingPackages.length > 0,
+    missingPackages,
+  };
+}
+
+/**
+ * 构建所有 workspace 包
+ */
+function buildWorkspacePackages() {
+  const { needsBuild, missingPackages } = checkNeedsBuild();
+
+  if (!needsBuild) {
+    console.log("✓ workspace 依赖包已存在，跳过构建");
+    return;
+  }
+
+  console.log(`⚠ 缺少以下包的构建产物: ${missingPackages.join(", ")}`);
+  console.log("正在构建 workspace 依赖包...");
+
+  try {
+    // 使用 nx 构建所有需要的包
+    const projects = packagesToBuild.join(",");
+    execSync(
+      `npx nx run-many -t build --projects=${projects} --parallel=false`,
+      {
+        stdio: "inherit",
+        cwd: join(__dirname, ".."),
+      }
+    );
+    console.log("✓ workspace 依赖包构建完成！");
+  } catch (error) {
+    console.error("✗ workspace 依赖包构建失败:", error.message);
+    throw error;
+  }
+}
+
+// 执行构建
+buildWorkspacePackages();


### PR DESCRIPTION
- 创建 scripts/postinstall.js 脚本，在 pnpm install 后自动构建缺失的 workspace 包
- 更新 package.json 添加 postinstall 钩子
- 更新 README.md 添加开发者指南
- 更新 CLAUDE.md 添加开发前准备说明

解决了 #2270 中描述的问题：当 @xiaozhi-client/asr 和 @xiaozhi-client/tts 包未构建时，
apps/backend 的类型检查会报错无法找到模块。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2270