### PR TITLE
fix(cli): 移除对 backend 的错误依赖，修复 monorepo 分层架构违规

### DIFF
--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -11,7 +11,7 @@
         "cwd": "packages/cli"
       },
       "outputs": ["{workspaceRoot}/dist/cli"],
-      "dependsOn": ["backend:build", "config:build"]
+      "dependsOn": ["config:build"]
     },
     "test": {
       "executor": "nx:run-commands",
@@ -59,8 +59,7 @@
       "options": {
         "command": "tsup --watch",
         "cwd": "packages/cli"
-      },
-      "dependsOn": ["backend:build"]
+      }
     },
     "nx-release-publish": {
       "executor": "nx:run-commands",
@@ -71,5 +70,5 @@
     }
   },
   "tags": ["type:lib", "scope:cli"],
-  "implicitDependencies": ["backend", "shared-types"]
+  "implicitDependencies": ["shared-types"]
 }


### PR DESCRIPTION
- 移除 build 目标中的 backend:build 依赖（保留 config:build）
- 移除 dev 目标中的 backend:build 依赖
- 移除 implicitDependencies 中的 backend
- CLI 作为 packages 层的工具包不应依赖 apps 层的 backend

Fixes #2272

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2272