### PR TITLE
fix(frontend): 在重试按钮中显示刷新中的加载状态

### DIFF
--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -96,7 +96,7 @@ export function McpToolTable({
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [, setRefreshing] = useState(false);
+  const [refreshing, setRefreshing] = useState(false);
 
   // Coze 工具确认对话框状态
   const [cozeToolToRemove, setCozeToolToRemove] = useState<string | null>(null);
@@ -345,8 +345,20 @@ export function McpToolTable({
         ) : error ? (
           <div className="flex flex-col items-center justify-center py-12 gap-4">
             <div className="text-red-500 text-sm">{error}</div>
-            <Button variant="outline" size="sm" onClick={handleRefresh}>
-              重试
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={handleRefresh}
+              disabled={refreshing}
+            >
+              {refreshing ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  刷新中...
+                </>
+              ) : (
+                "重试"
+              )}
             </Button>
           </div>
         ) : filteredTools.length === 0 ? (


### PR DESCRIPTION
修复 `refreshing` 状态值未使用的问题。现在当用户点击"重试"按钮时，
会显示加载旋转器和"刷新中..."文字提示，提供更好的用户体验。

- 捕获 `refreshing` 状态值（之前使用逗号跳过）
- 在重试按钮上添加禁用状态和加载指示器
- 使用 Loader2 组件显示动画效果

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2274