### PR TITLE
refactor: 将 jsonFormSchema 提取到共享位置

### DIFF
--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { mcpFormSchema } from "@/schemas/mcp-form";
+import { jsonFormSchema, mcpFormSchema } from "@/schemas/mcp-form";
 import { apiClient } from "@/services/api";
 import {
   formToApiConfig,
@@ -32,14 +32,6 @@ import { PlusIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
 
 export function AddMcpServerButton() {
   const [open, setOpen] = useState(false);

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -20,7 +20,7 @@ import {
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import { useNetworkServiceActions } from "@/providers/WebSocketProvider";
-import { mcpFormSchema } from "@/schemas/mcp-form";
+import { jsonFormSchema, mcpFormSchema } from "@/schemas/mcp-form";
 import { useConfig } from "@/stores/config";
 import {
   apiConfigToForm,
@@ -35,14 +35,6 @@ import { SettingsIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
 
 export function McpServerSettingButton({
   mcpServer,

--- a/apps/frontend/src/schemas/mcp-form.ts
+++ b/apps/frontend/src/schemas/mcp-form.ts
@@ -62,6 +62,16 @@ export const mcpFormSchema = z.discriminatedUnion("type", [
 ]);
 
 /**
+ * 高级模式的 JSON 表单验证 Schema
+ */
+export const jsonFormSchema = z.object({
+  config: z.string().min(2, {
+    message: "配置不能为空",
+  }),
+});
+
+/**
  * 类型推断
  */
 export type McpFormSchema = z.infer<typeof mcpFormSchema>;
+export type JsonFormSchema = z.infer<typeof jsonFormSchema>;


### PR DESCRIPTION
修复 #2293

将 jsonFormSchema 从 add-mcp-server-button.tsx 和 mcp-server-setting-button.tsx 提取到 @/schemas/mcp-form.ts，消除代码重复，遵循 DRY 原则。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2293