### PR TITLE
refactor: 创建共享 vitest 配置以消除重复代码

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -1,51 +1,17 @@
+/**
+ * Apps Backend Vitest 配置
+ *
+ * 使用共享基础配置，添加 backend 特定的配置项。
+ */
+
 import { resolve } from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { createSharedVitestConfig } from "../../vitest.config.base";
 
-// ESM 兼容的 __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-export default defineConfig({
-  plugins: [
-    // 添加 tsconfig 路径解析插件
-    tsconfigPaths(),
-  ],
-  test: {
-    globals: true,
-    environment: "node",
-    testTimeout: 10000, // 减少默认测试超时时间
-    hookTimeout: 10000, // 减少默认 hook 超时时间
-    include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    exclude: ["**/node_modules", "dist", "templates/**/*"],
-    // 分组配置，将超时测试分离
-    // 超时测试：包含"timeout"字样的测试文件
-    // 普通测试：其他所有测试
-    coverage: {
-      enabled: true,
-      provider: "v8",
-      reporter: ["text", "json", "html", "lcov"],
-      reportsDirectory: resolve(__dirname, "../coverage"),
-      exclude: [
-        "node_modules/**",
-        "dist/**",
-        "templates/**",
-        "**/*.d.ts",
-        "**/*.config.{js,ts}",
-        "coverage/**",
-      ],
-      include: [resolve(__dirname, "**/*.ts")],
-      all: true,
-      thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
-    },
-  },
+export default createSharedVitestConfig({
+  // Backend 特定的排除目录
+  additionalExcludes: ["templates/**/*"],
+  // 覆盖率包含的文件
+  coverageInclude: [resolve(__dirname, "**/*.ts")],
+  // 覆盖率排除的文件
+  coverageExcludes: ["templates/**"],
 });

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -1,89 +1,50 @@
+/**
+ * CLI Vitest 配置
+ *
+ * 使用共享基础配置，添加 CLI 特定的配置项。
+ */
+
 import { resolve } from "node:path";
-import { dirname } from "node:path";
-import { fileURLToPath } from "node:url";
-import tsconfigPaths from "vite-tsconfig-paths";
-import { defineConfig } from "vitest/config";
+import { createSharedVitestConfig } from "../../vitest.config.base";
 
-// ESM 兼容的 __dirname
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
-
-export default defineConfig({
-  plugins: [
-    // 添加 tsconfig 路径解析插件
-    tsconfigPaths(),
-  ],
+export default createSharedVitestConfig({
+  // CLI 特定的覆盖文件范围
+  coverageInclude: [resolve(__dirname, "src/**/*.ts")],
   // 定义构建时注入的全局变量，用于测试环境
-  define: {
+  defines: {
     __VERSION__: JSON.stringify("1.0.0-test"),
     __APP_NAME__: JSON.stringify("xiaozhi-client"),
   },
-  test: {
-    globals: true,
-    environment: "node",
-    testTimeout: 10000,
-    hookTimeout: 10000,
-    include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
-    exclude: ["node_modules", "dist"],
-    coverage: {
-      enabled: true,
-      provider: "v8",
-      reporter: ["text", "json", "html", "lcov"],
-      reportsDirectory: resolve(__dirname, "../coverage"),
-      exclude: [
-        "node_modules/**",
-        "dist/**",
-        "**/*.d.ts",
-        "**/*.config.{js,ts}",
-        "coverage/**",
-      ],
-      include: [resolve(__dirname, "src/**/*.ts")],
-      all: true,
-      thresholds: {
-        global: {
-          branches: 80,
-          functions: 80,
-          lines: 80,
-          statements: 80,
-        },
-      },
-    },
-  },
-  resolve: {
-    alias: {
-      // Backend 路径别名（从 packages/cli 向上到项目根目录）
-      "@handlers": resolve(__dirname, "../../apps/backend/handlers"),
-      "@handlers/*": resolve(__dirname, "../../apps/backend/handlers/*"),
-      "@services": resolve(__dirname, "../../apps/backend/services"),
-      "@services/*": resolve(__dirname, "../../apps/backend/services/*"),
-      "@errors": resolve(__dirname, "../../apps/backend/errors"),
-      "@errors/*": resolve(__dirname, "../../apps/backend/errors/*"),
-      "@utils": resolve(__dirname, "../../apps/backend/utils"),
-      "@utils/*": resolve(__dirname, "../../apps/backend/utils/*"),
-      "@core": resolve(__dirname, "../../apps/backend/core"),
-      "@core/*": resolve(__dirname, "../../apps/backend/core/*"),
-      "@transports": resolve(
-        __dirname,
-        "../../apps/backend/lib/mcp/transports"
-      ),
-      "@transports/*": resolve(
-        __dirname,
-        "../../apps/backend/lib/mcp/transports/*"
-      ),
-      "@adapters": resolve(__dirname, "../../apps/backend/adapters"),
-      "@adapters/*": resolve(__dirname, "../../apps/backend/adapters/*"),
-      "@managers": resolve(__dirname, "../../apps/backend/managers"),
-      "@managers/*": resolve(__dirname, "../../apps/backend/managers/*"),
-      "@types": resolve(__dirname, "../../apps/backend/types"),
-      "@types/*": resolve(__dirname, "../../apps/backend/types/*"),
-      "@/lib": resolve(__dirname, "../../apps/backend/lib"),
-      "@/lib/*": resolve(__dirname, "../../apps/backend/lib/*"),
-      "@": resolve(__dirname, "../../apps/backend"),
-      "@/*": resolve(__dirname, "../../apps/backend/*"),
-      "@routes": resolve(__dirname, "../../apps/backend/routes"),
-      "@routes/*": resolve(__dirname, "../../apps/backend/routes/*"),
-      "@constants": resolve(__dirname, "../../apps/backend/constants"),
-      "@constants/*": resolve(__dirname, "../../apps/backend/constants/*"),
-    },
+  // Backend 路径别名（从 packages/cli 向上到项目根目录）
+  resolveAliases: {
+    "@handlers": resolve(__dirname, "../../apps/backend/handlers"),
+    "@handlers/*": resolve(__dirname, "../../apps/backend/handlers/*"),
+    "@services": resolve(__dirname, "../../apps/backend/services"),
+    "@services/*": resolve(__dirname, "../../apps/backend/services/*"),
+    "@errors": resolve(__dirname, "../../apps/backend/errors"),
+    "@errors/*": resolve(__dirname, "../../apps/backend/errors/*"),
+    "@utils": resolve(__dirname, "../../apps/backend/utils"),
+    "@utils/*": resolve(__dirname, "../../apps/backend/utils/*"),
+    "@core": resolve(__dirname, "../../apps/backend/core"),
+    "@core/*": resolve(__dirname, "../../apps/backend/core/*"),
+    "@transports": resolve(__dirname, "../../apps/backend/lib/mcp/transports"),
+    "@transports/*": resolve(
+      __dirname,
+      "../../apps/backend/lib/mcp/transports/*"
+    ),
+    "@adapters": resolve(__dirname, "../../apps/backend/adapters"),
+    "@adapters/*": resolve(__dirname, "../../apps/backend/adapters/*"),
+    "@managers": resolve(__dirname, "../../apps/backend/managers"),
+    "@managers/*": resolve(__dirname, "../../apps/backend/managers/*"),
+    "@types": resolve(__dirname, "../../apps/backend/types"),
+    "@types/*": resolve(__dirname, "../../apps/backend/types/*"),
+    "@/lib": resolve(__dirname, "../../apps/backend/lib"),
+    "@/lib/*": resolve(__dirname, "../../apps/backend/lib/*"),
+    "@": resolve(__dirname, "../../apps/backend"),
+    "@/*": resolve(__dirname, "../../apps/backend/*"),
+    "@routes": resolve(__dirname, "../../apps/backend/routes"),
+    "@routes/*": resolve(__dirname, "../../apps/backend/routes/*"),
+    "@constants": resolve(__dirname, "../../apps/backend/constants"),
+    "@constants/*": resolve(__dirname, "../../apps/backend/constants/*"),
   },
 });

--- a/vitest.config.base.ts
+++ b/vitest.config.base.ts
@@ -1,0 +1,105 @@
+/**
+ * Vitest 共享配置基础
+ *
+ * 提供可复用的 Vitest 配置，避免在多个包中重复相同的配置代码。
+ * 各个包可以通过扩展此配置来添加特定的配置项。
+ */
+
+import { resolve } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { UserConfig } from "vitest/config";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+// ESM 兼容的 __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+/**
+ * 共享测试配置选项
+ */
+export interface SharedVitestOptions {
+  /** 额外的排除模式 */
+  additionalExcludes?: string[];
+  /** 额外的包含模式 */
+  additionalIncludes?: string[];
+  /** 覆盖率包含的文件模式 */
+  coverageInclude?: string[];
+  /** 覆盖率排除的文件模式 */
+  coverageExcludes?: string[];
+  /** 定义的全局变量 */
+  defines?: Record<string, string>;
+  /** 路径别名配置 */
+  resolveAliases?: Record<string, string>;
+  /** 额外的插件 */
+  additionalPlugins?: UserConfig["plugins"];
+}
+
+/**
+ * 创建 Vitest 共享配置
+ *
+ * @param options - 配置选项
+ * @returns Vitest 配置对象
+ */
+export function createSharedVitestConfig(options: SharedVitestOptions = {}) {
+  const {
+    additionalExcludes = [],
+    additionalIncludes = [],
+    coverageInclude = [resolve(__dirname, "**/*.ts")],
+    coverageExcludes = [],
+    defines,
+    resolveAliases,
+    additionalPlugins = [],
+  } = options;
+
+  return defineConfig({
+    plugins: [
+      // 添加 tsconfig 路径解析插件
+      tsconfigPaths(),
+      ...additionalPlugins,
+    ],
+    define: defines,
+    test: {
+      globals: true,
+      environment: "node",
+      testTimeout: 10000, // 减少默认测试超时时间
+      hookTimeout: 10000, // 减少默认 hook 超时时间
+      include: [
+        "**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}",
+        ...additionalIncludes,
+      ],
+      exclude: ["**/node_modules", "dist", ...additionalExcludes],
+      // 分组配置，将超时测试分离
+      // 超时测试：包含"timeout"字样的测试文件
+      // 普通测试：其他所有测试
+      coverage: {
+        enabled: true,
+        provider: "v8",
+        reporter: ["text", "json", "html", "lcov"],
+        reportsDirectory: resolve(__dirname, "coverage"),
+        exclude: [
+          "node_modules/**",
+          "dist/**",
+          "**/*.d.ts",
+          "**/*.config.{js,ts}",
+          "coverage/**",
+          ...coverageExcludes,
+        ],
+        include: coverageInclude,
+        all: true,
+        thresholds: {
+          global: {
+            branches: 80,
+            functions: 80,
+            lines: 80,
+            statements: 80,
+          },
+        },
+      },
+    },
+    resolve: {
+      alias: resolveAliases,
+    },
+  });
+}


### PR DESCRIPTION
创建 `vitest.config.base.ts` 提供可复用的 Vitest 配置，避免在多个包中重复相同的配置代码。

主要变化：
- 创建根目录共享配置文件，提供 `createSharedVitestConfig` 工厂函数
- 重构 `apps/backend/vitest.config.ts`，从 52 行减少到 16 行
- 重构 `packages/cli/vitest.config.ts`，从 90 行减少到 57 行
- 消除约 60 行重复代码

解决了 Issue #2299

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2299