### PR TITLE
fix(frontend): 修复 unsubscribe 调用异常覆盖原始错误的问题

### DIFF
--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -302,20 +302,32 @@ export class NetworkService {
         "data:configUpdate",
         () => {
           clearTimeout(timeoutId);
-          unsubscribe();
+          try {
+            unsubscribe();
+          } catch (cleanupError) {
+            console.error("[NetworkService] 清理事件监听器失败:", cleanupError);
+          }
           resolve();
         }
       );
 
       const timeoutId = setTimeout(() => {
-        unsubscribe();
+        try {
+          unsubscribe();
+        } catch (cleanupError) {
+          console.error("[NetworkService] 清理事件监听器失败:", cleanupError);
+        }
         reject(new Error("等待配置更新通知超时"));
       }, timeout);
 
       // 通过 HTTP API 更新配置
       this.updateConfig(config).catch((error) => {
         clearTimeout(timeoutId);
-        unsubscribe?.();
+        try {
+          unsubscribe?.();
+        } catch (cleanupError) {
+          console.error("[NetworkService] 清理事件监听器失败:", cleanupError);
+        }
         reject(error);
       });
     });
@@ -331,25 +343,47 @@ export class NetworkService {
         (status) => {
           if (status.status === "completed") {
             clearTimeout(timeoutId);
-            unsubscribe();
+            try {
+              unsubscribe();
+            } catch (cleanupError) {
+              console.error(
+                "[NetworkService] 清理事件监听器失败:",
+                cleanupError
+              );
+            }
             resolve();
           } else if (status.status === "failed") {
             clearTimeout(timeoutId);
-            unsubscribe();
+            try {
+              unsubscribe();
+            } catch (cleanupError) {
+              console.error(
+                "[NetworkService] 清理事件监听器失败:",
+                cleanupError
+              );
+            }
             reject(new Error(status.error || "服务重启失败"));
           }
         }
       );
 
       const timeoutId = setTimeout(() => {
-        unsubscribe();
+        try {
+          unsubscribe();
+        } catch (cleanupError) {
+          console.error("[NetworkService] 清理事件监听器失败:", cleanupError);
+        }
         reject(new Error("等待重启状态通知超时"));
       }, timeout);
 
       // 通过 HTTP API 重启服务
       this.restartService().catch((error) => {
         clearTimeout(timeoutId);
-        unsubscribe?.();
+        try {
+          unsubscribe?.();
+        } catch (cleanupError) {
+          console.error("[NetworkService] 清理事件监听器失败:", cleanupError);
+        }
         reject(error);
       });
     });


### PR DESCRIPTION
在 NetworkService 的 updateConfigWithNotification 和 restartServiceWithNotification 方法中，
使用 try-catch 包裹所有 unsubscribe() 调用，确保清理错误不会掩盖原始错误。

这有助于开发者准确获取配置更新/服务重启失败的真正原因，提升调试效率。

修复 #2302

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2302