### PR TITLE
fix: 将 inputSchema 类型从 any 改为 JSONSchema 提升类型安全性

### DIFF
--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -29,6 +29,7 @@ import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
 import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -48,7 +49,7 @@ export interface ToolRowData {
   enabled: boolean;
   usageCount: number;
   lastUsedTime: string;
-  inputSchema: any;
+  inputSchema?: JSONSchema;
 }
 
 interface McpToolTableProps {
@@ -109,7 +110,7 @@ export function McpToolTable({
       serverName: string;
       toolName: string;
       description?: string;
-      inputSchema?: any;
+      inputSchema?: JSONSchema;
     };
   }>({ open: false });
 

--- a/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
@@ -14,7 +14,6 @@ describe("useToolPagination", () => {
       enabled: i % 2 === 0,
       usageCount: i * 10,
       lastUsedTime: `2024-01-${(i % 28) + 1}T00:00:00Z`,
-      inputSchema: null,
     }));
   };
 

--- a/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
@@ -13,7 +13,6 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 10,
       lastUsedTime: "2024-01-01T00:00:00Z",
-      inputSchema: null,
     },
     {
       name: "tool2",
@@ -23,7 +22,6 @@ describe("useToolSearch", () => {
       enabled: false,
       usageCount: 5,
       lastUsedTime: "2024-01-02T00:00:00Z",
-      inputSchema: null,
     },
     {
       name: "tool3",
@@ -33,7 +31,6 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 3,
       lastUsedTime: "2024-01-03T00:00:00Z",
-      inputSchema: null,
     },
   ];
 
@@ -176,7 +173,6 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
         },
       ];
 
@@ -206,7 +202,6 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
         },
         {
           name: "tool2",
@@ -216,7 +211,6 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
         },
       ] as ToolRowData[];
 


### PR DESCRIPTION
- 在 mcp-tool-table.tsx 中导入 JSONSchema 类型
- 将 ToolRowData 接口中的 inputSchema 字段类型从 any 改为 JSONSchema | undefined
- 将 debugDialog 状态中的 inputSchema 字段类型从 any 改为 JSONSchema | undefined
- 更新相关测试文件，移除 inputSchema: null 赋值（使用默认 undefined）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2304