### PR TITLE
fix(api): 使用统一的 apiClient 替代原始 fetch 获取工具调用日志

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -34,17 +34,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { apiClient } from "@/services/api";
 import {
   formatDuration,
   formatJson,
   formatTimestamp,
   generateStableKey,
 } from "@/utils/formatUtils";
-import type {
-  ApiResponse,
-  ToolCallLogsResponse,
-  ToolCallRecord,
-} from "@xiaozhi-client/shared-types";
+import type { ToolCallRecord } from "@xiaozhi-client/shared-types";
 import {
   CheckCircle,
   CheckIcon,
@@ -79,17 +76,11 @@ export function ToolCallLogsDialog() {
       setError(null);
 
       try {
-        const response = await fetch(`/api/tool-calls/logs?limit=${limit}`);
-        const data: ApiResponse<ToolCallLogsResponse> = await response.json();
-
-        if (data.success && data.data) {
-          setLogs(data.data.records);
-          setTotal(data.data.total);
-        } else {
-          setError(data.error?.message || "获取日志失败");
-        }
+        const data = await apiClient.getToolCallLogs(limit);
+        setLogs(data.records);
+        setTotal(data.total);
       } catch (err) {
-        setError("网络请求失败");
+        setError(err instanceof Error ? err.message : "获取日志失败");
         console.error("获取工具调用日志失败:", err);
       } finally {
         if (isRefresh) {

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import type {
   MCPServerConfig,
   MCPServerListResponse,
   MCPServerStatus,
+  ToolCallLogsResponse,
 } from "@xiaozhi-client/shared-types";
 
 /**
@@ -1177,6 +1178,24 @@ export class ApiClient {
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "获取 MCP 工具列表失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 获取工具调用日志
+   * GET /api/tool-calls/logs
+   * @param limit 返回记录数量限制
+   * @returns 工具调用日志响应
+   */
+  async getToolCallLogs(limit = 50): Promise<ToolCallLogsResponse> {
+    const response: ApiResponse<ToolCallLogsResponse> = await this.request(
+      `/api/tool-calls/logs?limit=${limit}`
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取工具调用日志失败");
     }
 
     return response.data;


### PR DESCRIPTION
修复 tool-call-logs-dialog.tsx 组件使用原始 fetch() API 而非项目统一的 apiClient 服务的问题。

主要变更：
- 在 ApiClient 类中添加 getToolCallLogs 方法
- 修改 tool-call-logs-dialog.tsx 使用 apiClient.getToolCallLogs()
- 移除未使用的 ApiResponse 和 ToolCallLogsResponse 类型导入
- 修复 import 顺序

这确保了所有组件使用统一的 API 调用方式，便于维护和错误处理。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2310