### PR TITLE
docs(frontend): 为 MCP 相关组件添加文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -1,3 +1,14 @@
+/**
+ * AddMcpServerButton 组件 - 添加 MCP 服务器
+ *
+ * 功能：
+ * - 提供表单模式和高级模式（JSON）两种输入方式
+ * - 支持 stdio、SSE、HTTP 三种通信方式配置
+ * - 支持表单与 JSON 格式之间的双向转换
+ * - 验证配置格式和检查重名
+ * - 提交后需要重启服务才会生效
+ */
+
 import { McpServerForm } from "@/components/mcp-server-form";
 import { Button } from "@/components/ui/button";
 import {

--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -1,3 +1,15 @@
+/**
+ * McpEndpointSettingButton 组件 - MCP 接入点管理
+ *
+ * 功能：
+ * - 显示和管理多个 MCP 接入点
+ * - 支持添加、删除新的接入点
+ * - 支持连接、断开接入点
+ * - 显示接入点连接状态
+ * - 支持接入点复制功能
+ * - 管理 WebSocket 事件监听
+ */
+
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -1,3 +1,15 @@
+/**
+ * McpServerSettingButton 组件 - MCP 服务器配置编辑
+ *
+ * 功能：
+ * - 编辑已配置的 MCP 服务器配置
+ * - 支持表单模式和高级模式（JSON）两种编辑方式
+ * - 支持表单与 JSON 格式之间的双向转换
+ * - 支持修改服务器名称（重命名）
+ * - 验证配置格式
+ * - 提交后需要重启服务才会生效
+ */
+
 import { McpServerForm } from "@/components/mcp-server-form";
 import { Button } from "@/components/ui/button";
 import {


### PR DESCRIPTION
为以下三个大型组件添加文件级 JSDoc 注释，提升代码可维护性：

- mcp-endpoint-setting-button.tsx (625 行)
  - MCP 接入点管理功能
  - 连接状态显示和管理
  - WebSocket 事件监听

- add-mcp-server-button.tsx (315 行)
  - 表单模式和高级模式输入
  - 支持 stdio、SSE、HTTP 通信方式
  - 配置验证和重名检查

- mcp-server-setting-button.tsx (358 行)
  - MCP 服务器配置编辑
  - 支持表单与 JSON 格式转换
  - 服务器重命名功能

参考 mcp-server-list.tsx 的 JSDoc 风格，使用中文描述组件功能。

Fixes #2311

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2311