### PR TITLE
fix: 将 event-bus.service.ts 中 mcp:server:added 事件的 config 类型从 any 改为 MCPServerConfig

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -15,6 +15,7 @@ import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 
 /**
  * 事件类型定义
@@ -125,7 +126,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };


### PR DESCRIPTION
修复 #2316

- 添加 MCPServerConfig 类型导入
- 将 EventBusEvents 中 mcp:server:added 事件的 config 字段类型从 any 改为 MCPServerConfig
- 提高事件总线类型安全性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2316