### PR TITLE
docs: 添加关键模块的 API 参考文档

### DIFF
--- a/docs/content/reference/_meta.ts
+++ b/docs/content/reference/_meta.ts
@@ -2,6 +2,13 @@ import type { MetaRecord } from "nextra";
 
 const meta: MetaRecord = {
   command: "常用命令",
+  mcp: "MCP 模块",
+  endpoint: "端点管理",
+  websocket: "WebSocket 通信",
+  config: "配置管理",
+  esp32: "ESP32 集成",
+  "event-bus": "事件总线",
+  routes: "路由系统",
 };
 
 export default meta;

--- a/docs/content/reference/config.mdx
+++ b/docs/content/reference/config.mdx
@@ -1,0 +1,387 @@
+---
+title: "配置管理 API - Xiaozhi Client"
+description: "配置管理模块的 API 参考文档"
+---
+
+# 配置管理 API
+
+## 概述
+
+配置管理模块是 xiaozhi-client 的核心配置管理组件，负责配置文件的读取和解析（支持 JSON、JSON5、JSONC 格式）、配置验证和类型检查、配置更新和持久化、配置变更事件通知等。
+
+**文件位置**: `packages/config/src/manager.ts`
+
+## 核心组件
+
+### configManager
+
+配置管理器单例，提供全局的配置访问和修改接口。
+
+#### 主要方法
+
+##### `getConfig(): AppConfig`
+
+获取当前配置对象。
+
+**返回**: 应用配置对象
+
+**示例**:
+```typescript
+import { configManager } from '@xiaozhi-client/config';
+
+const config = configManager.getConfig();
+console.log('MCP 端点:', config.mcpEndpoint);
+```
+
+##### `updateConfig(updates: Partial<AppConfig>): Promise<void>`
+
+更新配置并持久化到文件。
+
+**参数**:
+- `updates`: 部分配置更新对象
+
+**示例**:
+```typescript
+await configManager.updateConfig({
+  mcpEndpoint: 'wss://api.xiaozhi.me/mcp'
+});
+```
+
+##### `reloadConfig(): Promise<void>`
+
+重新加载配置文件。
+
+##### `getConfigPath(): string`
+
+获取配置文件路径。
+
+##### `getMcpServers(): Record<string, MCPToolConfig>`
+
+获取 MCP 服务器配置。
+
+##### `addMcpServer(name: string, config: MCPToolConfig): Promise<void>`
+
+添加 MCP 服务器配置。
+
+**参数**:
+- `name`: 服务器名称
+- `config`: 服务器配置
+
+**示例**:
+```typescript
+await configManager.addMcpServer('calculator', {
+  command: 'npx',
+  args: ['-y', '@xiaozhi-client/calculator-mcp']
+});
+```
+
+##### `removeMcpServer(name: string): Promise<void>`
+
+移除 MCP 服务器配置。
+
+**参数**:
+- `name`: 要移除的服务器名称
+
+##### `updateMcpServer(name: string, config: Partial<MCPToolConfig>): Promise<void>`
+
+更新 MCP 服务器配置。
+
+**参数**:
+- `name`: 服务器名称
+- `config`: 部分配置更新
+
+##### `getCustomMcpTools(): CustomMCPTool[]`
+
+获取自定义 MCP 工具配置。
+
+##### `addCustomMcpTool(tool: CustomMCPTool): Promise<void>`
+
+添加自定义 MCP 工具。
+
+##### `removeCustomMcpTool(toolName: string): Promise<void>`
+
+移除自定义 MCP 工具。
+
+##### `getConnectionConfig(): ConnectionConfig`
+
+获取连接配置。
+
+##### `updateConnectionConfig(config: Partial<ConnectionConfig>): Promise<void>`
+
+更新连接配置。
+
+##### `getWebUIConfig(): WebUIConfig | undefined`
+
+获取 Web UI 配置。
+
+##### `updateWebUIConfig(config: Partial<WebUIConfig>): Promise<void>`
+
+更新 Web UI 配置。
+
+#### 事件监听
+
+配置管理器继承自 EventEmitter，支持监听配置更新事件。
+
+```typescript
+// 监听配置更新事件
+configManager.on('config:updated', (payload) => {
+  console.log('配置已更新:', payload.type);
+
+  // 获取最新配置
+  const latestConfig = configManager.getConfig();
+});
+```
+
+**事件负载类型**:
+```typescript
+interface ConfigUpdatePayload {
+  type: 'endpoint' | 'customMCP' | 'config' | 'serverTools' | 'connection' | 'modelscope' | 'webui' | 'platform';
+  timestamp: Date;
+  serviceName?: string;
+  platformName?: string;
+}
+```
+
+## 配置文件格式
+
+配置文件 `xiaozhi.config.json` 支持以下格式：
+
+### JSON 格式
+
+```json
+{
+  "mcpEndpoint": "wss://api.xiaozhi.me/mcp",
+  "mcpServers": {
+    "calculator": {
+      "command": "npx",
+      "args": ["-y", "@xiaozhi-client/calculator-mcp"]
+    }
+  },
+  "connection": {
+    "heartbeatInterval": 30000,
+    "heartbeatTimeout": 10000,
+    "reconnectInterval": 5000
+  }
+}
+```
+
+### JSON5/JSONC 格式（支持注释）
+
+```json5
+{
+  // 小智接入点地址
+  "mcpEndpoint": "wss://api.xiaozhi.me/mcp",
+
+  // MCP 服务器配置
+  "mcpServers": {
+    /* 计算器服务 */
+    "calculator": {
+      "command": "npx",
+      "args": ["-y", "@xiaozhi-client/calculator-mcp"]
+    }
+  }
+}
+```
+
+## 类型定义
+
+### AppConfig
+
+应用配置接口。
+
+```typescript
+interface AppConfig {
+  // 小智接入点配置
+  mcpEndpoint?: string | string[];
+
+  // MCP 服务器配置
+  mcpServers?: Record<string, MCPToolConfig>;
+
+  // 自定义 MCP 工具
+  customMcpTools?: CustomMCPTool[];
+
+  // 连接配置
+  connection?: ConnectionConfig;
+
+  // ModelScope 配置
+  modelscope?: ModelScopeConfig;
+
+  // Web UI 配置
+  webUI?: WebUIConfig;
+
+  // 平台配置
+  platforms?: Record<string, PlatformConfig>;
+}
+```
+
+### MCPToolConfig
+
+MCP 服务器配置接口。
+
+```typescript
+interface MCPToolConfig {
+  type?: MCPTransportType;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+  customSSEOptions?: ModelScopeSSEOptions;
+}
+```
+
+### ConnectionConfig
+
+连接配置接口。
+
+```typescript
+interface ConnectionConfig {
+  heartbeatInterval?: number;  // 心跳间隔（毫秒）
+  heartbeatTimeout?: number;   // 心跳超时（毫秒）
+  reconnectInterval?: number;  // 重连间隔（毫秒）
+}
+```
+
+### ModelScopeConfig
+
+ModelScope 配置接口。
+
+```typescript
+interface ModelScopeConfig {
+  apiKey?: string;
+  baseUrl?: string;
+}
+```
+
+### WebUIConfig
+
+Web UI 配置接口。
+
+```typescript
+interface WebUIConfig {
+  enabled?: boolean;
+  port?: number;
+}
+```
+
+### PlatformConfig
+
+平台配置接口。
+
+```typescript
+interface PlatformConfig {
+  apiKey?: string;
+  baseUrl?: string;
+}
+```
+
+### CustomMCPTool
+
+自定义 MCP 工具接口。
+
+```typescript
+interface CustomMCPTool {
+  name: string;
+  description?: string;
+  inputSchema: JSONSchema;
+  handler?: {
+    type: string;
+    config?: Record<string, unknown>;
+  };
+}
+```
+
+## 使用示例
+
+### 基本使用
+
+```typescript
+import { configManager } from '@xiaozhi-client/config';
+
+// 获取配置
+const config = configManager.getConfig();
+console.log('配置:', config);
+
+// 更新端点
+await configManager.updateConfig({
+  mcpEndpoint: 'wss://api.xiaozhi.me/mcp'
+});
+```
+
+### 管理 MCP 服务器
+
+```typescript
+// 添加服务器
+await configManager.addMcpServer('calculator', {
+  command: 'npx',
+  args: ['-y', '@xiaozhi-client/calculator-mcp']
+});
+
+// 获取所有服务器
+const servers = configManager.getMcpServers();
+
+// 更新服务器
+await configManager.updateMcpServer('calculator', {
+  args: ['-y', '@xiaozhi-client/calculator-mcp', '--verbose']
+});
+
+// 移除服务器
+await configManager.removeMcpServer('calculator');
+```
+
+### 管理连接配置
+
+```typescript
+// 获取连接配置
+const connectionConfig = configManager.getConnectionConfig();
+
+// 更新连接配置
+await configManager.updateConnectionConfig({
+  heartbeatInterval: 30000,
+  reconnectInterval: 5000
+});
+```
+
+### 监听配置变更
+
+```typescript
+// 监听配置更新事件
+configManager.on('config:updated', (payload) => {
+  switch (payload.type) {
+    case 'endpoint':
+      console.log('端点配置已更新');
+      break;
+    case 'customMCP':
+      console.log('自定义 MCP 工具已更新');
+      break;
+    case 'connection':
+      console.log('连接配置已更新');
+      break;
+    default:
+      console.log('配置已更新:', payload.type);
+  }
+});
+```
+
+## 配置文件路径解析
+
+配置管理器会按以下顺序查找配置文件：
+
+1. 当前工作目录的 `xiaozhi.config.json`
+2. 用户主目录的 `.xiaozhi/config.json`
+3. 默认配置
+
+可以使用 `getConfigPath()` 获取当前使用的配置文件路径。
+
+## 注意事项
+
+1. **格式兼容**: 配置文件支持 JSON、JSON5 和 JSONC 格式，推荐使用 JSON5 以支持注释
+2. **事件监听**: 配置更新会触发 `config:updated` 事件，可用于响应配置变更
+3. **持久化**: 使用 `updateConfig` 等方法会自动持久化到文件
+4. **重载配置**: 修改配置文件后，可以调用 `reloadConfig()` 重新加载
+
+## 相关模块
+
+- [MCP 模块](./mcp) - MCP 服务器配置由配置管理模块提供
+- [事件总线](./event-bus) - 配置更新通过事件总线通知其他模块

--- a/docs/content/reference/endpoint.mdx
+++ b/docs/content/reference/endpoint.mdx
@@ -1,0 +1,380 @@
+---
+title: "端点管理 API - Xiaozhi Client"
+description: "小智接入点管理模块的 API 参考文档"
+---
+
+# 端点管理 API
+
+## 概述
+
+端点管理模块负责管理多个小智接入点的 WebSocket 连接，每个端点完全独立管理，无负载均衡，支持固定间隔重连策略。
+
+**文件位置**:
+- `packages/endpoint/src/endpoint.ts` - 单个端点实现
+- `packages/endpoint/src/manager.ts` - 端点管理器
+
+## 核心组件
+
+### Endpoint
+
+管理单个小智接入点的 WebSocket 连接，实现 MCP 协议通信。
+
+#### 工厂方法（推荐）
+
+##### `Endpoint.create(config: EndpointCreateConfig): Promise<Endpoint>`
+
+使用声明式配置创建 Endpoint 实例（推荐方式）。
+
+**参数**:
+```typescript
+interface EndpointCreateConfig {
+  endpointUrl: string;              // 小智接入点 URL
+  mcpServers: Record<string, MCPServerConfig>;  // MCP 服务器配置
+  reconnectDelay?: number;          // 重连延迟（毫秒），默认 2000
+}
+```
+
+**返回**: 已配置并连接的 Endpoint 实例
+
+**示例**:
+```typescript
+const endpoint = await Endpoint.create({
+  endpointUrl: "wss://api.xiaozhi.me/mcp/?token=...",
+  mcpServers: {
+    calculator: {
+      command: "npx",
+      args: ["-y", "@xiaozhi-client/calculator-mcp"]
+    }
+  },
+  reconnectDelay: 2000
+});
+```
+
+#### 构造函数
+
+```typescript
+constructor(
+  endpointUrl: string,
+  mcpManager: IMCPServiceManager,
+  reconnectDelay?: number
+)
+```
+
+#### 主要方法
+
+##### `connect(): Promise<void>`
+
+连接小智接入点。
+
+##### `disconnect(): Promise<void>`
+
+主动断开小智连接。
+
+##### `reconnect(): Promise<void>`
+
+重连小智接入点。
+
+##### `getTools(): Tool[]`
+
+获取当前所有工具列表。
+
+##### `getStatus(): EndpointConnectionStatus`
+
+获取服务器状态。
+
+**返回**:
+```typescript
+interface EndpointConnectionStatus {
+  connected: boolean;
+  initialized: boolean;
+  url: string;
+  availableTools: number;
+  connectionState: ConnectionState;
+  lastError?: string;
+}
+```
+
+##### `isConnected(): boolean`
+
+检查连接状态。
+
+##### `getUrl(): string`
+
+获取 Endpoint URL。
+
+### EndpointManager
+
+管理多个小智接入点的连接，共享外部传入的 MCPManager。
+
+#### 构造函数
+
+```typescript
+constructor(config?: EndpointManagerConfig)
+```
+
+**配置**:
+```typescript
+interface EndpointManagerConfig {
+  defaultReconnectDelay?: number;  // 默认重连延迟（毫秒）
+}
+```
+
+#### 主要方法
+
+##### `setMcpManager(mcpManager: IMCPServiceManager): void`
+
+设置 MCPManager 实例（必需）。
+
+**注意**: MCPManager 的生命周期由外部管理，EndpointManager 不负责连接和断开。
+
+**示例**:
+```typescript
+const mcpManager = new MCPManager();
+mcpManager.addServer("calculator", {
+  command: "npx",
+  args: ["-y", "calculator-mcp"]
+});
+await mcpManager.connect();
+
+const endpointManager = new EndpointManager();
+endpointManager.setMcpManager(mcpManager);
+```
+
+##### `addEndpoint(endpoint: string | Endpoint): void`
+
+添加 Endpoint（支持 URL 字符串或 Endpoint 实例）。
+
+**参数**:
+- `endpoint`: Endpoint URL 字符串或 Endpoint 实例
+
+##### `removeEndpoint(endpoint: Endpoint): Promise<void>`
+
+移除 Endpoint 实例。
+
+##### `connect(endpoint?: string): Promise<void>`
+
+连接 Endpoint。
+
+**参数**:
+- `endpoint` (可选): 指定要连接的端点 URL。如果不传入，则连接所有端点
+
+##### `disconnect(endpoint?: string): Promise<void>`
+
+断开连接。
+
+**参数**:
+- `endpoint` (可选): 指定要断开的端点 URL。如果不传入，则断开所有端点
+
+##### `reconnect(endpoint?: string, delay?: number): Promise<void>`
+
+重连。
+
+**参数**:
+- `endpoint` (可选): 指定要重连的端点 URL
+- `delay` (可选): disconnect 和 connect 之间的等待时间（毫秒），默认 1000ms
+
+##### `getEndpoints(): string[]`
+
+获取所有 Endpoint URL。
+
+##### `getEndpoint(url: string): Endpoint | undefined`
+
+获取指定 Endpoint 实例。
+
+##### `getConnectionStatus(): SimpleConnectionStatus[]`
+
+获取所有连接状态。
+
+##### `isAnyConnected(): boolean`
+
+检查是否有任何连接处于连接状态。
+
+##### `isEndpointConnected(url: string): boolean`
+
+检查指定端点是否已连接。
+
+##### `getEndpointStatus(url: string): SimpleConnectionStatus | undefined`
+
+获取指定端点的状态。
+
+##### `clearEndpoints(): Promise<void>`
+
+清除所有端点。
+
+##### `cleanup(): Promise<void>`
+
+清理资源。
+
+## 类型定义
+
+### ConnectionState
+
+连接状态枚举。
+
+```typescript
+enum ConnectionState {
+  DISCONNECTED = "disconnected",
+  CONNECTING = "connecting",
+  CONNECTED = "connected",
+  RECONNECTING = "reconnecting",
+  FAILED = "failed",
+  ERROR = "error",
+}
+```
+
+### SimpleConnectionStatus
+
+简单连接状态接口。
+
+```typescript
+interface SimpleConnectionStatus {
+  endpoint: string;
+  connected: boolean;
+  initialized: boolean;
+  lastConnected?: Date;
+  lastError?: string;
+}
+```
+
+### MCPServerConfig
+
+MCP 服务器配置接口。
+
+```typescript
+interface MCPServerConfig {
+  type?: MCPTransportType;
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+  url?: string;
+  apiKey?: string;
+  headers?: Record<string, string>;
+}
+```
+
+### 工具调用错误码
+
+```typescript
+enum ToolCallErrorCode {
+  INVALID_PARAMS = -32602,      // 无效参数
+  TOOL_NOT_FOUND = -32601,      // 工具不存在
+  SERVICE_UNAVAILABLE = -32001, // 服务不可用
+  TIMEOUT = -32002,             // 调用超时
+  TOOL_EXECUTION_ERROR = -32000,// 工具执行错误
+}
+```
+
+## 使用示例
+
+### 方式一：使用工厂方法（推荐）
+
+```typescript
+import { Endpoint } from "@xiaozhi-client/endpoint";
+
+// 使用声明式配置创建 Endpoint
+const endpoint = await Endpoint.create({
+  endpointUrl: "wss://api.xiaozhi.me/mcp/?token=xxx",
+  mcpServers: {
+    calculator: {
+      command: "npx",
+      args: ["-y", "@xiaozhi-client/calculator-mcp"]
+    },
+    weather: {
+      command: "node",
+      args: ["./weather-server.js"]
+    }
+  },
+  reconnectDelay: 2000
+});
+
+// 检查连接状态
+console.log("已连接:", endpoint.isConnected());
+
+// 获取工具列表
+const tools = endpoint.getTools();
+console.log("可用工具:", tools);
+
+// 获取状态
+const status = endpoint.getStatus();
+console.log("状态:", status);
+```
+
+### 方式二：使用 EndpointManager 管理多个端点
+
+```typescript
+import { EndpointManager } from "@xiaozhi-client/endpoint";
+import { MCPManager } from "@xiaozhi-client/mcp-core";
+
+// 1. 先创建并配置 MCPManager
+const mcpManager = new MCPManager();
+mcpManager.addServer("calculator", {
+  command: "npx",
+  args: ["-y", "calculator-mcp"]
+});
+await mcpManager.connect();
+
+// 2. 创建 EndpointManager 并设置 MCPManager
+const manager = new EndpointManager({ defaultReconnectDelay: 2000 });
+manager.setMcpManager(mcpManager);
+
+// 3. 添加接入点
+manager.addEndpoint("wss://api1.xiaozhi.me/mcp");
+manager.addEndpoint("wss://api2.xiaozhi.me/mcp");
+
+// 4. 连接所有接入点
+await manager.connect();
+
+// 5. 检查状态
+const statuses = manager.getConnectionStatus();
+console.log("连接状态:", statuses);
+
+// 6. 重连指定端点
+await manager.reconnect("wss://api1.xiaozhi.me/mcp");
+```
+
+### 监听端点事件
+
+```typescript
+import { getEventBus } from "@/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+
+// 监听端点状态变更
+eventBus.onEvent("endpoint:status:changed", (data) => {
+  console.log("端点状态变更:", data.endpoint, data.connected);
+});
+
+// 监听重连完成
+eventBus.onEvent("endpoint:reconnect:completed", (data) => {
+  console.log("重连完成:", data.endpointCount);
+});
+```
+
+## 架构特点
+
+### 独立多端点架构
+
+- **完全独立**: 每个端点拥有独立的连接和状态管理
+- **无负载均衡**: 移除所有负载均衡逻辑和算法
+- **无故障转移**: 端点失败时不自动切换到其他端点
+- **简单重连**: 固定间隔重连，避免指数退避复杂性
+- **直接访问**: 应用程序可以直接指定和访问特定端点
+
+### MCPManager 共享
+
+- EndpointManager 通过 `setMcpManager()` 方法接收外部传入的 MCPManager
+- 所有 Endpoint 实例共享同一个 MCPManager
+- MCPManager 的生命周期由外部管理，EndpointManager 不负责连接和断开
+
+## 注意事项
+
+1. **MCPManager 生命周期**: 使用 EndpointManager 时，必须先设置 MCPManager 并确保其已连接
+2. **重连延迟**: `reconnectDelay` 参数控制 Endpoint 实例的重连延迟，EndpointManager 的 `delay` 参数只控制 disconnect 和 connect 之间的等待时间
+3. **资源清理**: 使用完毕后应调用 `cleanup()` 方法清理资源
+4. **连接超时**: 默认连接超时为 10 秒
+
+## 相关模块
+
+- [MCP 模块](./mcp) - Endpoint 内部使用 MCP 模块管理工具
+- [WebSocket 通信](./websocket) - Endpoint 使用 WebSocket 进行通信
+- [事件总线](./event-bus) - 端点状态变更通过事件总线通知

--- a/docs/content/reference/esp32.mdx
+++ b/docs/content/reference/esp32.mdx
@@ -1,0 +1,429 @@
+---
+title: "ESP32 集成 API - Xiaozhi Client"
+description: "ESP32 设备集成模块的 API 参考文档"
+---
+
+# ESP32 集成 API
+
+## 概述
+
+ESP32 集成模块负责管理 ESP32 设备的 WebSocket 连接，支持音频数据传输、设备状态管理和二进制协议通信。
+
+**文件位置**:
+- `apps/backend/lib/esp32/connection.ts` - 设备连接管理
+- `apps/backend/lib/esp32/audio-protocol.ts` - 音频协议实现
+
+## 核心组件
+
+### ESP32Connection
+
+ESP32 设备连接类，管理单个设备的 WebSocket 连接生命周期。
+
+#### 构造函数
+
+```typescript
+constructor(
+  deviceId: string,
+  clientId: string,
+  ws: WebSocket,
+  config: ESP32ConnectionConfig
+)
+```
+
+**配置接口**:
+```typescript
+interface ESP32ConnectionConfig {
+  onMessage: (message: ESP32WSMessage) => Promise<void>;
+  onClose: () => void;
+  onError: (error: Error) => void;
+  heartbeatTimeoutMs?: number;
+  getASRService: () => ASRService;
+}
+```
+
+#### 主要方法
+
+##### `send(message: ESP32WSMessage): Promise<void>`
+
+发送消息到设备。
+
+**参数**:
+```typescript
+interface ESP32WSMessage {
+  type: string;
+  [key: string]: any;
+}
+```
+
+**示例**:
+```typescript
+await connection.send({
+  type: "tts",
+  text: "你好，世界"
+});
+```
+
+##### `sendBinary(data: Uint8Array): Promise<void>`
+
+发送二进制数据到设备。
+
+##### `sendBinaryProtocol2(data: Uint8Array, timestamp?: number): Promise<void>`
+
+发送 BinaryProtocol2 格式的音频数据到设备。
+
+**参数**:
+- `data`: 音频载荷数据
+- `timestamp`: 时间戳（毫秒级累加值，用于音频播放顺序）
+
+##### `sendError(code: ESP32ErrorCode, message: string): Promise<void>`
+
+发送错误消息。
+
+##### `checkTimeout(): boolean`
+
+检查连接是否超时。
+
+##### `close(): Promise<void>`
+
+关闭连接。
+
+##### `getDeviceId(): string`
+
+获取设备ID。
+
+##### `getClientId(): string`
+
+获取客户端ID。
+
+##### `getState(): ESP32ConnectionState`
+
+获取连接状态。
+
+##### `getSessionId(): string`
+
+获取会话ID。
+
+##### `isHelloCompleted(): boolean`
+
+是否已完成Hello握手。
+
+## 音频协议
+
+### BinaryProtocol2
+
+16 字节头部的音频协议格式。
+
+**协议格式**（大端序/网络字节序）:
+```
++--------+--------+--------+--------+--------+--------+--------+--------+
+| Version (16)  |   Type (16)   |           Reserved (32)          |
++--------+--------+--------+--------+--------+--------+--------+--------+
+|                           Timestamp (32)                          |
++--------+--------+--------+--------+--------+--------+--------+--------+
+|                          Payload Size (32)                        |
++--------+--------+--------+--------+--------+--------+--------+--------+
+|                            Payload Data...                         |
++--------+--------+--------+--------+--------+--------+--------+--------+
+```
+
+**字段说明**:
+- Version: 协议版本（固定为 2）
+- Type: 0 = Opus 音频, 1 = JSON
+- Reserved: 保留字段（0）
+- Timestamp: 毫秒级累加值（每帧递增）
+- Payload Size: 负载字节数
+- Payload: 实际音频数据
+
+#### encodeBinaryProtocol2()
+
+编码为 BinaryProtocol2 格式。
+
+```typescript
+function encodeBinaryProtocol2(
+  payload: Uint8Array,
+  timestamp: number,
+  type: "opus" | "json" = "opus"
+): Buffer
+```
+
+#### parseBinaryProtocol2()
+
+解析 BinaryProtocol2 数据。
+
+```typescript
+function parseBinaryProtocol2(
+  data: Buffer
+): BinaryProtocol2Parsed | null
+```
+
+#### isBinaryProtocol2()
+
+检查是否为 BinaryProtocol2 格式。
+
+```typescript
+function isBinaryProtocol2(data: Buffer): boolean
+```
+
+### BinaryProtocol3
+
+4 字节头部的精简音频协议格式。
+
+**协议格式**（大端序/网络字节序）:
+```
++--------+--------+--------+--------+
+|  Type  | Reserved|   Payload Size   |
++--------+--------+--------+--------+
+|          Payload Data...             |
++--------+--------+--------+--------+
+```
+
+**字段说明**:
+- Type: 0 = Opus 音频, 1 = JSON
+- Reserved: 保留字段（0）
+- Payload Size: 负载字节数（16位，无符号）
+- Payload: 实际音频数据
+
+#### parseBinaryProtocol3()
+
+解析 BinaryProtocol3 数据。
+
+```typescript
+function parseBinaryProtocol3(
+  data: Buffer
+): BinaryProtocol3Parsed | null
+```
+
+#### isBinaryProtocol3()
+
+检查是否为 BinaryProtocol3 格式。
+
+```typescript
+function isBinaryProtocol3(data: Buffer): boolean
+```
+
+### 协议检测
+
+#### detectAudioProtocol()
+
+自动检测协议版本。
+
+```typescript
+function detectAudioProtocol(data: Buffer): AudioProtocolType
+```
+
+**返回**: `"protocol1"` | `"protocol2"` | `"protocol3"` | `"unknown"`
+
+## 类型定义
+
+### ESP32ConnectionState
+
+连接状态枚举。
+
+```typescript
+type ESP32ConnectionState = "connecting" | "connected" | "disconnected";
+```
+
+### ESP32ErrorCode
+
+错误代码枚举。
+
+```typescript
+enum ESP32ErrorCode {
+  INVALID_MESSAGE_FORMAT = "INVALID_MESSAGE_FORMAT",
+  UNSUPPORTED_MESSAGE_TYPE = "UNSUPPORTED_MESSAGE_TYPE",
+  ASR_SERVICE_ERROR = "ASR_SERVICE_ERROR",
+  TTS_SERVICE_ERROR = "TTS_SERVICE_ERROR",
+}
+```
+
+### ESP32HelloMessage
+
+Hello 消息接口。
+
+```typescript
+interface ESP32HelloMessage {
+  type: "hello";
+  version: number;
+  transport: string;
+  audioParams?: {
+    format: string;
+    sampleRate: number;
+    channels: number;
+    frameDuration: number;
+  };
+  features?: {
+    mcp: boolean;
+  };
+}
+```
+
+### ESP32ServerHelloMessage
+
+服务端 Hello 响应接口。
+
+```typescript
+interface ESP32ServerHelloMessage {
+  type: "hello";
+  version: number;
+  transport: string;
+  sessionId: string;
+  audioParams: {
+    format: string;
+    sampleRate: number;
+    channels: number;
+    frameDuration: number;
+  };
+}
+```
+
+## 消息类型
+
+### 支持的消息类型
+
+| 类型 | 描述 | 方向 |
+|------|------|------|
+| `hello` | 握手消息 | 双向 |
+| `audio` | 音频数据 | 设备 → 服务端 |
+| `tts` | 语音合成请求 | 服务端 → 设备 |
+| `start` | 开始交互 | 设备 → 服务端 |
+| `stop` | 停止交互 | 设备 → 服务端 |
+| `error` | 错误消息 | 双向 |
+
+### Hello 握手流程
+
+1. 设备发送 Hello 消息
+2. 服务端响应 ServerHello 消息
+3. 握手完成后，设备可以发送其他消息
+
+**设备 Hello 消息示例**:
+```json
+{
+  "type": "hello",
+  "version": 1,
+  "transport": "websocket",
+  "audio_params": {
+    "format": "opus",
+    "sample_rate": 24000,
+    "channels": 1,
+    "frame_duration": 60
+  },
+  "features": {
+    "mcp": true
+  }
+}
+```
+
+**服务端 Hello 响应示例**:
+```json
+{
+  "type": "hello",
+  "version": 1,
+  "transport": "websocket",
+  "session_id": "device-123-456-abc",
+  "audio_params": {
+    "format": "opus",
+    "sample_rate": 24000,
+    "channels": 1,
+    "frame_duration": 60
+  }
+}
+```
+
+## 使用示例
+
+### 创建连接
+
+```typescript
+import { ESP32Connection } from "@/lib/esp32/connection.js";
+
+const connection = new ESP32Connection(
+  "device-123",           // 设备ID
+  "client-456",           // 客户端ID
+  ws,                     // WebSocket 实例
+  {
+    onMessage: async (message) => {
+      console.log("收到消息:", message);
+      // 处理消息...
+    },
+    onClose: () => {
+      console.log("连接关闭");
+    },
+    onError: (error) => {
+      console.error("连接错误:", error);
+    },
+    heartbeatTimeoutMs: 30000,
+    getASRService: () => asrService
+  }
+);
+```
+
+### 发送 TTS 消息
+
+```typescript
+await connection.send({
+  type: "tts",
+  text: "你好，我是小智助手",
+  format: "opus",
+  sampleRate: 24000
+});
+```
+
+### 发送 BinaryProtocol2 音频数据
+
+```typescript
+// Opus 编码的音频数据
+const opusData = new Uint8Array([...]);
+
+// 累加时间戳（每帧递增）
+const timestamp = frameIndex * 60; // 60ms 每帧
+
+await connection.sendBinaryProtocol2(opusData, timestamp);
+```
+
+### 检查连接状态
+
+```typescript
+// 获取连接状态
+const state = connection.getState();
+console.log("连接状态:", state); // "connecting" | "connected" | "disconnected"
+
+// 检查是否完成 Hello 握手
+const helloCompleted = connection.isHelloCompleted();
+
+// 检查是否超时
+const isTimeout = connection.checkTimeout();
+```
+
+### 解析音频数据
+
+```typescript
+import { parseBinaryProtocol2, isBinaryProtocol2, detectAudioProtocol } from "@/lib/esp32/audio-protocol.js";
+
+// 检测协议类型
+const protocolType = detectAudioProtocol(data);
+console.log("协议类型:", protocolType);
+
+// 解析 BinaryProtocol2 数据
+if (isBinaryProtocol2(data)) {
+  const parsed = parseBinaryProtocol2(data);
+  if (parsed) {
+    console.log("协议版本:", parsed.protocolVersion);
+    console.log("数据类型:", parsed.type);
+    console.log("时间戳:", parsed.timestamp);
+    console.log("载荷大小:", parsed.payload.length);
+  }
+}
+```
+
+## 注意事项
+
+1. **Hello 握手**: 设备必须先完成 Hello 握手才能发送其他消息
+2. **时间戳累加**: BinaryProtocol2 的时间戳是累加值，每帧递增，用于音频播放顺序
+3. **超时检测**: 默认心跳超时为 30 秒，可在配置中自定义
+4. **协议兼容**: 模块支持协议1（纯Opus）、协议2（16字节头）和协议3（4字节头）
+5. **命名约定**: 发送到设备的消息使用 camelCase，内部会自动转换为 snake_case
+
+## 相关模块
+
+- [WebSocket 通信](./websocket) - ESP32 使用 WebSocket 连接
+- [事件总线](./event-bus) - 设备状态变更通过事件总线通知

--- a/docs/content/reference/event-bus.mdx
+++ b/docs/content/reference/event-bus.mdx
@@ -1,0 +1,530 @@
+---
+title: "事件总线 API - Xiaozhi Client"
+description: "事件总线模块的 API 参考文档"
+---
+
+# 事件总线 API
+
+## 概述
+
+事件总线提供统一的事件发布订阅机制，用于解耦各个模块之间的通信。支持配置更新、状态变更、接入点状态、服务重启、MCP 服务、工具调用等多种事件类型。
+
+**文件位置**: `apps/backend/services/event-bus.service.ts`
+
+## 核心组件
+
+### EventBus
+
+事件总线类，基于 Node.js EventEmitter 实现。
+
+#### 构造函数
+
+```typescript
+constructor()
+```
+
+自动创建单例，测试环境下监听器限制为 200，生产环境为 50。
+
+#### 主要方法
+
+##### `emitEvent<K extends keyof EventBusEvents>(eventName: K, data: EventBusEvents[K]): boolean`
+
+发射事件（类型安全）。
+
+**参数**:
+- `eventName`: 事件名称（支持类型提示）
+- `data`: 事件数据（类型安全）
+
+**返回**: boolean - 是否有监听器处理了事件
+
+**示例**:
+```typescript
+eventBus.emitEvent("config:updated", {
+  type: "endpoint",
+  timestamp: new Date()
+});
+```
+
+##### `onEvent<K extends keyof EventBusEvents>(eventName: K, listener: (data: EventBusEvents[K]) => void): this`
+
+监听事件（类型安全）。
+
+**参数**:
+- `eventName`: 事件名称
+- `listener`: 事件监听器函数
+
+**示例**:
+```typescript
+eventBus.onEvent("config:updated", (data) => {
+  console.log("配置已更新:", data.type);
+});
+```
+
+##### `onceEvent<K extends keyof EventBusEvents>(eventName: K, listener: (data: EventBusEvents[K]) => void): this`
+
+一次性监听事件（触发后自动移除）。
+
+**参数**:
+- `eventName`: 事件名称
+- `listener`: 事件监听器函数
+
+##### `offEvent<K extends keyof EventBusEvents>(eventName: K, listener: (data: EventBusEvents[K]) => void): this`
+
+移除事件监听器（类型安全）。
+
+**参数**:
+- `eventName`: 事件名称
+- `listener`: 要移除的监听器函数
+
+##### `getStatus()`
+
+获取事件总线状态。
+
+**返回**:
+```typescript
+{
+  totalEvents: number;
+  totalListeners: number;
+  eventStats: Record<string, { count: number; lastEmitted: Date }>;
+  listenerStats: Record<string, number>;
+}
+```
+
+##### `getEventStats()`
+
+获取事件统计信息。
+
+##### `getListenerStats()`
+
+获取监听器统计信息。
+
+##### `clearEventStats()`
+
+清理事件统计。
+
+##### `destroy()`
+
+销毁事件总线，移除所有监听器。
+
+## 单例访问
+
+### getEventBus()
+
+获取事件总线单例实例。
+
+```typescript
+import { getEventBus } from "@/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+```
+
+### destroyEventBus()
+
+销毁事件总线单例。
+
+```typescript
+import { destroyEventBus } from "@/services/event-bus.service.js";
+
+destroyEventBus();
+```
+
+## 事件类型
+
+### 配置相关事件
+
+#### `config:updated`
+
+配置已更新事件。
+
+```typescript
+interface ConfigUpdatedEvent {
+  type: string;
+  serviceName?: string;
+  platformName?: string;
+  timestamp: Date;
+}
+```
+
+#### `config:error`
+
+配置错误事件。
+
+```typescript
+interface ConfigErrorEvent {
+  error: Error;
+  operation: string;
+}
+```
+
+### 状态相关事件
+
+#### `status:updated`
+
+状态已更新事件。
+
+```typescript
+interface StatusUpdatedEvent {
+  status: any;
+  source: string;
+}
+```
+
+#### `status:error`
+
+状态错误事件。
+
+```typescript
+interface StatusErrorEvent {
+  error: Error;
+  operation: string;
+}
+```
+
+### 接入点状态事件
+
+#### `endpoint:status:changed`
+
+接入点状态变更事件。
+
+```typescript
+interface EndpointStatusChangedEvent {
+  endpoint: string;
+  connected: boolean;
+  operation: "connect" | "disconnect" | "reconnect" | "add" | "remove";
+  success: boolean;
+  message?: string;
+  timestamp: number;
+  source: string;
+}
+```
+
+#### `endpoint:reconnect:completed`
+
+接入点重连完成事件。
+
+```typescript
+interface EndpointReconnectCompletedEvent {
+  trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+  serverName?: string;
+  endpointCount: number;
+  timestamp: number;
+}
+```
+
+#### `endpoint:reconnect:failed`
+
+接入点重连失败事件。
+
+```typescript
+interface EndpointReconnectFailedEvent {
+  trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+  serverName?: string;
+  error: string;
+  timestamp: number;
+}
+```
+
+### 服务相关事件
+
+#### `service:restart:requested`
+
+服务重启请求事件。
+
+```typescript
+interface ServiceRestartRequestedEvent {
+  serviceName: string;
+  reason?: string;
+  delay: number;
+  attempt: number;
+  timestamp: number;
+  source?: string;
+}
+```
+
+#### `service:restart:started`
+
+服务重启开始事件。
+
+```typescript
+interface ServiceRestartStartedEvent {
+  serviceName: string;
+  reason?: string;
+  attempt: number;
+  timestamp: number;
+}
+```
+
+#### `service:restart:completed`
+
+服务重启完成事件。
+
+```typescript
+interface ServiceRestartCompletedEvent {
+  serviceName: string;
+  reason?: string;
+  attempt: number;
+  timestamp: number;
+}
+```
+
+#### `service:restart:failed`
+
+服务重启失败事件。
+
+```typescript
+interface ServiceRestartFailedEvent {
+  serviceName: string;
+  error: Error;
+  attempt: number;
+  timestamp: number;
+}
+```
+
+#### `service:health:changed`
+
+服务健康状态变更事件。
+
+```typescript
+interface ServiceHealthChangedEvent {
+  serviceName: string;
+  oldStatus: string;
+  newStatus: string;
+  timestamp: number;
+}
+```
+
+### WebSocket 相关事件
+
+#### `websocket:client:connected`
+
+WebSocket 客户端连接事件。
+
+```typescript
+interface WebSocketClientConnectedEvent {
+  clientId: string;
+  timestamp: number;
+}
+```
+
+#### `websocket:client:disconnected`
+
+WebSocket 客户端断开事件。
+
+```typescript
+interface WebSocketClientDisconnectedEvent {
+  clientId: string;
+  timestamp: number;
+}
+```
+
+#### `websocket:message:received`
+
+WebSocket 消息接收事件。
+
+```typescript
+interface WebSocketMessageReceivedEvent {
+  type: string;
+  data: any;
+  clientId: string;
+}
+```
+
+### MCP 服务相关事件
+
+#### `mcp:service:connected`
+
+MCP 服务已连接事件。
+
+```typescript
+interface MCPServiceConnectedEvent {
+  serviceName: string;
+  tools: Tool[];
+  connectionTime: Date;
+}
+```
+
+#### `mcp:service:disconnected`
+
+MCP 服务已断开事件。
+
+```typescript
+interface MCPServiceDisconnectedEvent {
+  serviceName: string;
+  reason?: string;
+  disconnectionTime: Date;
+}
+```
+
+#### `mcp:service:connection:failed`
+
+MCP 服务连接失败事件。
+
+```typescript
+interface MCPServiceConnectionFailedEvent {
+  serviceName: string;
+  error: Error;
+  attempt: number;
+}
+```
+
+#### `mcp:server:added`
+
+MCP 服务器已添加事件。
+
+```typescript
+interface MCPServerAddedEvent {
+  serverName: string;
+  config: any;
+  tools: string[];
+  timestamp: Date;
+}
+```
+
+#### `mcp:server:removed`
+
+MCP 服务器已移除事件。
+
+```typescript
+interface MCPServerRemovedEvent {
+  serverName: string;
+  affectedTools: string[];
+  timestamp: Date;
+}
+```
+
+#### `mcp:server:status_changed`
+
+MCP 服务器状态变更事件。
+
+```typescript
+interface MCPServerStatusChangedEvent {
+  serverName: string;
+  oldStatus: "connected" | "disconnected" | "connecting" | "error";
+  newStatus: "connected" | "disconnected" | "connecting" | "error";
+  timestamp: Date;
+  reason?: string;
+}
+```
+
+### NPM 安装相关事件
+
+#### `npm:install:started`
+
+NPM 安装开始事件。
+
+#### `npm:install:log`
+
+NPM 安装日志事件。
+
+#### `npm:install:completed`
+
+NPM 安装完成事件。
+
+#### `npm:install:failed`
+
+NPM 安装失败事件。
+
+## 使用示例
+
+### 基本使用
+
+```typescript
+import { getEventBus } from "@/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+
+// 监听配置更新
+eventBus.onEvent("config:updated", (data) => {
+  console.log("配置已更新:", data.type);
+});
+
+// 发射配置更新事件
+eventBus.emitEvent("config:updated", {
+  type: "endpoint",
+  timestamp: new Date()
+});
+```
+
+### 监听 MCP 服务事件
+
+```typescript
+import { getEventBus } from "@/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+
+// 监听服务连接
+eventBus.onEvent("mcp:service:connected", (data) => {
+  console.log("服务已连接:", data.serviceName);
+  console.log("可用工具:", data.tools);
+});
+
+// 监听服务断开
+eventBus.onEvent("mcp:service:disconnected", (data) => {
+  console.log("服务已断开:", data.serviceName, data.reason);
+});
+
+// 监听服务连接失败
+eventBus.onEvent("mcp:service:connection:failed", (data) => {
+  console.error("服务连接失败:", data.serviceName, data.error);
+});
+```
+
+### 一次性监听
+
+```typescript
+// 只监听一次
+eventBus.onceEvent("service:restart:completed", (data) => {
+  console.log("服务重启完成:", data.serviceName);
+  // 监听器会在触发后自动移除
+});
+```
+
+### 移除监听器
+
+```typescript
+// 定义监听器函数
+const handler = (data: any) => {
+  console.log("处理事件:", data);
+};
+
+// 添加监听器
+eventBus.onEvent("config:updated", handler);
+
+// 移除监听器
+eventBus.offEvent("config:updated", handler);
+```
+
+### 获取统计信息
+
+```typescript
+// 获取事件总线状态
+const status = eventBus.getStatus();
+console.log("总事件数:", status.totalEvents);
+console.log("总监听器数:", status.totalListeners);
+console.log("事件统计:", status.eventStats);
+console.log("监听器统计:", status.listenerStats);
+```
+
+### 清理资源
+
+```typescript
+// 清理事件统计
+eventBus.clearEventStats();
+
+// 销毁事件总线（通常在应用关闭时）
+eventBus.destroy();
+```
+
+## 注意事项
+
+1. **类型安全**: 所有事件名称和数据都是类型安全的，TypeScript 会提供完整的类型提示
+2. **监听器限制**: 测试环境下监听器限制为 200，生产环境为 50
+3. **错误处理**: 监听器抛出的错误会被捕获并发射到 `error` 事件
+4. **内存泄漏**: 使用完毕后应及时移除监听器，避免内存泄漏
+5. **单例模式**: 使用 `getEventBus()` 获取全局单例，不要创建多个实例
+
+## 相关模块
+
+- [MCP 模块](./mcp) - MCP 模块使用事件总线发射连接状态变更
+- [端点管理](./endpoint) - 端点状态变更通过事件总线通知
+- [配置管理](./config) - 配置更新通过事件总线通知其他模块

--- a/docs/content/reference/mcp.mdx
+++ b/docs/content/reference/mcp.mdx
@@ -1,0 +1,302 @@
+---
+title: "MCP 模块 API - Xiaozhi Client"
+description: "MCP (Model Context Protocol) 模块的 API 参考文档"
+---
+
+# MCP 模块 API
+
+## 概述
+
+MCP (Model Context Protocol) 模块是 xiaozhi-client 的核心组件，负责管理 MCP 服务器的连接、工具调用和消息通信。该模块提供了完整的 MCP 协议实现，支持 STDIO、SSE 和 StreamableHTTP 三种传输协议。
+
+## 核心组件
+
+### MCPServiceManager
+
+MCP 服务管理器，负责管理多个 MCP 服务器的连接。
+
+**文件位置**: `apps/backend/lib/mcp/manager.ts`
+
+#### 主要方法
+
+##### `addServer(name: string, config: MCPServiceConfig): void`
+
+添加 MCP 服务器到管理器。
+
+**参数**:
+- `name` (string): 服务器名称
+- `config` (MCPServiceConfig): 服务器配置
+
+**示例**:
+```typescript
+manager.addServer("calculator", {
+  command: "node",
+  args: ["./calculator.js"]
+});
+```
+
+##### `removeServer(name: string): Promise<void>`
+
+移除指定的 MCP 服务器。
+
+**参数**:
+- `name` (string): 要移除的服务器名称
+
+##### `connect(): Promise<void>`
+
+连接所有已添加的 MCP 服务器。
+
+##### `disconnect(): Promise<void>`
+
+断开所有 MCP 服务器连接。
+
+##### `getAllTools(filter?: ToolStatusFilter): EnhancedToolInfo[]`
+
+获取所有可用工具列表。
+
+**参数**:
+- `filter` (可选): 工具状态过滤器 ("enabled" | "disabled" | "all")
+
+**返回**: 工具信息数组
+
+##### `callTool(toolName: string, args: Record<string, unknown>): Promise<ToolCallResult>`
+
+调用指定的 MCP 工具。
+
+**参数**:
+- `toolName`: 工具名称
+- `args`: 工具参数
+
+**返回**: 工具调用结果
+
+##### `getStatus(): ManagerStatus`
+
+获取管理器状态信息。
+
+### MCPService
+
+MCP 服务类，负责管理单个 MCP 服务的连接。
+
+**文件位置**: `apps/backend/lib/mcp/connection.ts`
+
+#### 主要方法
+
+##### `connect(): Promise<void>`
+
+连接到 MCP 服务。
+
+##### `disconnect(): Promise<void>`
+
+断开连接。
+
+##### `callTool(name: string, arguments_: Record<string, unknown>): Promise<ToolCallResult>`
+
+调用工具。
+
+##### `getTools(): Tool[]`
+
+获取工具列表。
+
+##### `getConfig(): InternalMCPServiceConfig`
+
+获取服务配置。
+
+##### `getStatus(): MCPServiceStatus`
+
+获取服务状态。
+
+##### `isConnected(): boolean`
+
+检查是否已连接。
+
+## 类型定义
+
+### MCPServiceConfig
+
+MCP 服务器配置接口。
+
+**文件位置**: `apps/backend/lib/mcp/types.ts`
+
+```typescript
+interface MCPServiceConfig {
+  // 传输类型（可选，支持自动推断）
+  type?: MCPTransportType;
+
+  // STDIO 配置
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>;
+
+  // 网络配置
+  url?: string;
+
+  // 认证配置
+  apiKey?: string;
+  headers?: Record<string, string>;
+
+  // ModelScope SSE 自定义选项
+  customSSEOptions?: ModelScopeSSEOptions;
+}
+```
+
+### MCPTransportType
+
+通信方式枚举。
+
+```typescript
+enum MCPTransportType {
+  STDIO = "stdio",
+  SSE = "sse",
+  HTTP = "http",
+}
+```
+
+### ConnectionState
+
+连接状态枚举。
+
+```typescript
+enum ConnectionState {
+  DISCONNECTED = "disconnected",
+  CONNECTING = "connecting",
+  CONNECTED = "connected",
+  RECONNECTING = "reconnecting",
+  FAILED = "failed",
+  ERROR = "error",
+}
+```
+
+### EnhancedToolInfo
+
+增强的工具信息接口。
+
+```typescript
+interface EnhancedToolInfo {
+  name: string;              // 工具唯一标识符
+  description: string;        // 工具描述
+  inputSchema: JSONSchema;    // 输入参数的 JSON Schema
+  serviceName: string;        // 所属服务名称
+  originalName: string;       // 原始工具名称
+  enabled: boolean;          // 是否启用
+  usageCount: number;        // 使用次数
+  lastUsedTime: string;      // 最后使用时间
+}
+```
+
+### ToolCallResult
+
+工具调用结果接口。
+
+```typescript
+interface ToolCallResult {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  isError?: boolean;
+}
+```
+
+## 工具调用错误码
+
+### ToolCallErrorCode
+
+工具调用错误码枚举。
+
+```typescript
+enum ToolCallErrorCode {
+  INVALID_PARAMS = -32602,      // 无效参数
+  TOOL_NOT_FOUND = -32601,      // 工具不存在
+  SERVICE_UNAVAILABLE = -32001, // 服务不可用
+  TIMEOUT = -32002,             // 调用超时
+  TOOL_EXECUTION_ERROR = -32000,// 工具执行错误
+}
+```
+
+## 使用示例
+
+### 基本使用
+
+```typescript
+import { MCPServiceManager } from "@/lib/mcp/manager.js";
+
+// 创建管理器实例
+const manager = new MCPServiceManager();
+
+// 添加服务器
+manager.addServer("calculator", {
+  command: "npx",
+  args: ["-y", "@xiaozhi-client/calculator-mcp"]
+});
+
+// 连接所有服务器
+await manager.connect();
+
+// 获取所有工具
+const tools = manager.getAllTools();
+console.log("可用工具:", tools);
+
+// 调用工具
+const result = await manager.callTool("calculator__add", {
+  a: 10,
+  b: 20
+});
+console.log("结果:", result);
+```
+
+### 使用自定义环境变量
+
+```typescript
+manager.addServer("my-service", {
+  command: "node",
+  args: ["./server.js"],
+  env: {
+    API_KEY: "your-api-key",
+    DEBUG: "true"
+  }
+});
+```
+
+### SSE 传输方式
+
+```typescript
+manager.addServer("sse-service", {
+  type: MCPTransportType.SSE,
+  url: "https://api.example.com/mcp",
+  headers: {
+    "Authorization": "Bearer token"
+  }
+});
+```
+
+### 监听连接事件
+
+```typescript
+import { getEventBus } from "@/services/event-bus.service.js";
+import { MCP_SERVICE_EVENTS } from "@/constants/index.js";
+
+const eventBus = getEventBus();
+
+eventBus.onEvent(MCP_SERVICE_EVENTS.CONNECTED, (data) => {
+  console.log("服务已连接:", data.serviceName);
+  console.log("可用工具:", data.tools);
+});
+
+eventBus.onEvent(MCP_SERVICE_EVENTS.DISCONNECTED, (data) => {
+  console.log("服务已断开:", data.serviceName);
+});
+```
+
+## 注意事项
+
+1. **传输类型自动推断**: 如果不指定 `type`，系统会根据配置自动推断传输类型
+2. **工具名称格式**: 工具名称格式为 `{serviceName}__{originalName}`
+3. **连接管理**: 使用 `connect()` 和 `disconnect()` 方法管理连接生命周期
+4. **错误处理**: 工具调用可能会抛出 `ToolCallError` 异常，建议使用 try-catch 处理
+5. **资源清理**: 使用完毕后应调用 `disconnect()` 清理资源
+
+## 相关模块
+
+- [事件总线](./event-bus) - MCP 模块使用事件总线发射连接状态变更
+- [端点管理](./endpoint) - Endpoint 模块内部使用 MCP 模块管理工具
+- [配置管理](./config) - MCP 服务器配置可以从配置文件读取

--- a/docs/content/reference/routes.mdx
+++ b/docs/content/reference/routes.mdx
@@ -1,0 +1,352 @@
+---
+title: "路由系统 API - Xiaozhi Client"
+description: "路由系统模块的 API 参考文档"
+---
+
+# 路由系统 API
+
+## 概述
+
+路由系统提供直接、高效的路由注册和管理功能，基于 Hono 框架实现，支持依赖注入和中间件。
+
+**文件位置**:
+- `apps/backend/routes/RouteManager.ts` - 路由管理器
+- `apps/backend/routes/types.ts` - 类型定义
+
+## 核心组件
+
+### RouteManager
+
+路由管理器，直接管理路由配置，提供路由注册和应用功能。
+
+#### 构造函数
+
+```typescript
+constructor(private logger: Logger)
+```
+
+通过依赖注入接收 Logger 实例，保持与项目日志系统的一致性。
+
+#### 主要方法
+
+##### `registerRoute(name: string, routeRegistry: RouteRegistry): void`
+
+注册单个路由模块。
+
+**参数**:
+- `name`: 路由组名称
+- `routeRegistry`: 路由注册配置
+
+**示例**:
+```typescript
+routeManager.registerRoute("version", {
+  method: "GET",
+  path: "/api/version",
+  handler: (c) => c.json({ version: "1.0.0" })
+});
+```
+
+##### `registerRoutes(routeRegistries: Record<string, RouteRegistry>): void`
+
+批量注册路由模块。
+
+**参数**:
+- `routeRegistries`: 路由注册配置对象
+
+**示例**:
+```typescript
+routeManager.registerRoutes({
+  version: versionRoutes,
+  config: configRoutes,
+  status: statusRoutes
+});
+```
+
+##### `getAllRoutes(): Map<string, RouteDefinition[]>`
+
+获取所有注册的路由配置。
+
+##### `getRoute(name: string): RouteDefinition[] | undefined`
+
+获取指定名称的路由配置。
+
+**参数**:
+- `name`: 路由组名称
+
+##### `applyToApp(app: Hono<AppContext>): void`
+
+将路由应用到 Hono 应用实例。
+
+**注意**: static 路由会自动排在最后应用，避免拦截其他路由。
+
+##### `clear(): void`
+
+清除所有路由配置（主要用于测试）。
+
+##### `hasRoute(name: string): boolean`
+
+检查路由是否已注册。
+
+##### `getRouteNames(): string[]`
+
+列出所有已注册的路由域名称。
+
+## 类型定义
+
+### RouteDefinition
+
+路由定义接口。
+
+```typescript
+interface RouteDefinition {
+  method: HTTPMethod;           // HTTP 方法
+  path: string;                 // 完整路由路径
+  handler: (c: Context) => Promise<Response | undefined>;  // 处理函数
+  middleware?: MiddlewareHandler[];  // 路由级别的中间件
+}
+```
+
+### HTTPMethod
+
+HTTP 方法类型。
+
+```typescript
+type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+```
+
+### RouteRegistry
+
+路由注册联合类型。
+
+```typescript
+type RouteRegistry = RouteDefinition[] | RouteGroup;
+```
+
+### RouteGroup
+
+路由组接口。
+
+```typescript
+interface RouteGroup {
+  routes: RouteDefinition[];     // 路由定义数组
+  name?: string;                 // 可选的组名称
+  description?: string;          // 可选的组描述
+  middleware?: MiddlewareHandler[];  // 组级别的中间件
+}
+```
+
+### HandlerDependencies
+
+处理器依赖接口，定义路由系统需要的所有处理器依赖。
+
+```typescript
+interface HandlerDependencies {
+  configApiHandler: ConfigApiHandler;
+  statusApiHandler: StatusApiHandler;
+  serviceApiHandler: ServiceApiHandler;
+  mcpToolHandler: MCPToolHandler;
+  mcpToolLogHandler: MCPToolLogHandler;
+  versionApiHandler: VersionApiHandler;
+  staticFileHandler: StaticFileHandler;
+  mcpRouteHandler: MCPRouteHandler;
+  mcpHandler?: MCPHandler;
+  updateApiHandler: UpdateApiHandler;
+  cozeHandler: CozeHandler;
+  ttsApiHandler: TTSApiHandler;
+  endpointHandler?: EndpointHandler;
+  esp32Handler?: ESP32Handler;
+}
+```
+
+## 辅助函数
+
+### createHandler()
+
+创建路由处理器辅助函数，自动处理依赖注入。
+
+```typescript
+function createHandler<K extends keyof HandlerDependencies>(
+  dependencyKey: K
+): (
+  method: (handler: HandlerDependencies[K], c: Context) => Promise<Response>
+) => RouteDefinition["handler"]
+```
+
+**使用示例**:
+```typescript
+import { createHandler } from "@/routes/types.js";
+
+const h = createHandler("versionApiHandler");
+
+export const routes = [
+  {
+    method: "GET",
+    path: "/api/version",
+    handler: h((handler, c) => handler.getVersion(c)),
+  }
+];
+```
+
+### isRouteGroup()
+
+判断是否为路由组。
+
+```typescript
+function isRouteGroup(route: RouteRegistry): route is RouteGroup
+```
+
+### normalizeRoutes()
+
+将路由注册转换为路由数组。
+
+```typescript
+function normalizeRoutes(route: RouteRegistry): RouteDefinition[]
+```
+
+## 使用示例
+
+### 定义路由
+
+```typescript
+import type { RouteDefinition } from "@/routes/types.js";
+
+export const versionRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/version",
+    handler: (c) => {
+      return c.json({ version: "1.0.0" });
+    }
+  },
+  {
+    method: "GET",
+    path: "/api/health",
+    handler: (c) => {
+      return c.json({ status: "ok" });
+    }
+  }
+];
+```
+
+### 使用路由组
+
+```typescript
+import type { RouteGroup } from "@/routes/types.js";
+
+export const configRoutes: RouteGroup = {
+  name: "config",
+  description: "配置管理路由",
+  middleware: [authMiddleware],  // 组级别中间件
+  routes: [
+    {
+      method: "GET",
+      path: "/api/config",
+      handler: (c) => c.json(getConfig())
+    },
+    {
+      method: "POST",
+      path: "/api/config",
+      handler: (c) => updateConfig(c)
+    }
+  ]
+};
+```
+
+### 注册路由
+
+```typescript
+import { RouteManager } from "@/routes/RouteManager.js";
+import { logger } from "@/Logger.js";
+
+// 创建路由管理器
+const routeManager = new RouteManager(logger);
+
+// 注册单个路由
+routeManager.registerRoute("version", versionRoutes);
+
+// 批量注册路由
+routeManager.registerRoutes({
+  config: configRoutes,
+  status: statusRoutes,
+  mcp: mcpRoutes
+});
+
+// 应用到 Hono 应用
+const app = new Hono();
+routeManager.applyToApp(app);
+```
+
+### 使用依赖注入
+
+```typescript
+import { createHandler } from "@/routes/types.js";
+
+const h = createHandler("configApiHandler");
+
+export const configRoutes = [
+  {
+    method: "GET",
+    path: "/api/config",
+    handler: h((handler, c) => handler.getConfig(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/config",
+    handler: h((handler, c) => handler.updateConfig(c)),
+  }
+];
+```
+
+### 使用中间件
+
+```typescript
+import { authMiddleware } from "@/middlewares/auth.js";
+
+export const protectedRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/admin/config",
+    middleware: [authMiddleware, rateLimitMiddleware],
+    handler: (c) => {
+      // 只有通过认证和速率限制的请求才能到达这里
+      return c.json({ success: true });
+    }
+  }
+];
+```
+
+## 错误处理
+
+路由管理器自动为每个路由添加错误处理：
+
+```typescript
+// 如果路由处理器抛出错误，会自动捕获并返回统一格式的错误响应
+{
+  "code": "HANDLER_ERROR",
+  "message": "处理器执行失败",
+  "details": "具体错误信息",
+  "status": 500
+}
+```
+
+## 路由应用顺序
+
+路由应用时遵循以下规则：
+
+1. **static 路由最后应用**: static 路由组永远排在最后，避免拦截其他路由
+2. **组内中间件优先**: 组级别的中间件会应用到组内所有路由
+3. **路由中间件其次**: 路由级别的中间件在组中间件之后应用
+
+## 注意事项
+
+1. **依赖注入**: 使用 `createHandler` 辅助函数可以简化依赖注入
+2. **中间件顺序**: 组中间件 → 路由中间件 → 处理器
+3. **错误处理**: 路由处理器抛出的错误会被自动捕获和处理
+4. **Static 路由**: static 路由会自动排在最后，无需手动排序
+5. **类型安全**: 使用 TypeScript 可以获得完整的类型提示
+
+## 相关模块
+
+- [配置管理](./config) - 配置相关路由
+- [MCP 模块](./mcp) - MCP 工具相关路由
+- [端点管理](./endpoint) - 端点管理相关路由

--- a/docs/content/reference/websocket.mdx
+++ b/docs/content/reference/websocket.mdx
@@ -1,0 +1,176 @@
+---
+title: "WebSocket 通信 API - Xiaozhi Client"
+description: "WebSocket 通信模块的 API 参考文档"
+---
+
+# WebSocket 通信 API
+
+## 概述
+
+WebSocket 通信模块提供 WebSocket 相关的工具函数和类型定义，用于处理小智接入点和 ESP32 设备的 WebSocket 连接。
+
+**文件位置**: `apps/backend/utils/websocket-helper.ts`
+
+## 核心组件
+
+### WebSocketLike
+
+WebSocket 接口定义，描述具有 send 方法的 WebSocket 对象。
+
+```typescript
+interface WebSocketLike {
+  send(data: string): void;
+}
+```
+
+### sendWebSocketError
+
+向 WebSocket 客户端发送错误消息的工具函数。
+
+**签名**:
+```typescript
+function sendWebSocketError(
+  ws: WebSocketLike,
+  code: string,
+  message: string,
+  logger: Logger
+): void
+```
+
+**参数**:
+- `ws` (WebSocketLike): WebSocket 客户端连接对象
+- `code` (string): 错误代码
+- `message` (string): 错误消息
+- `logger` (Logger): 日志记录器
+
+**发送的错误消息格式**:
+```typescript
+{
+  type: "error",
+  error: {
+    code: string,
+    message: string,
+    timestamp: number
+  }
+}
+```
+
+## 使用示例
+
+### 发送错误消息
+
+```typescript
+import { sendWebSocketError } from "@/utils/websocket-helper.js";
+import { logger } from "@/Logger.js";
+
+// 在 WebSocket 处理函数中使用
+ws.on("message", (data) => {
+  try {
+    // 处理消息
+    handleMessage(data);
+  } catch (error) {
+    // 发送错误响应给客户端
+    sendWebSocketError(
+      ws,
+      "PROCESSING_ERROR",
+      error instanceof Error ? error.message : "处理消息时发生错误",
+      logger
+    );
+  }
+});
+```
+
+### 自定义 WebSocketLike 实现
+
+```typescript
+// WebSocketLike 接口适用于任何具有 send 方法的对象
+class MockWebSocket implements WebSocketLike {
+  sentMessages: string[] = [];
+
+  send(data: string): void {
+    this.sentMessages.push(data);
+    console.log("发送消息:", data);
+  }
+}
+
+// 可以用于测试
+const mockWs = new MockWebSocket();
+sendWebSocketError(mockWs, "TEST_ERROR", "测试错误", logger);
+```
+
+## 错误消息格式
+
+所有通过 `sendWebSocketError` 发送的错误消息都遵循统一的格式：
+
+```typescript
+{
+  "type": "error",
+  "error": {
+    "code": "错误代码",
+    "message": "错误描述",
+    "timestamp": 1234567890
+  }
+}
+```
+
+### 常用错误代码
+
+| 错误代码 | 描述 | 使用场景 |
+|---------|------|---------|
+| `INVALID_MESSAGE_FORMAT` | 消息格式无效 | 收到无法解析的消息 |
+| `INVALID_PARAMS` | 参数无效 | 请求参数验证失败 |
+| `TOOL_NOT_FOUND` | 工具不存在 | 请求的工具不存在 |
+| `SERVICE_UNAVAILABLE` | 服务不可用 | 后端服务未就绪 |
+| `TIMEOUT` | 超时 | 请求处理超时 |
+| `INTERNAL_ERROR` | 内部错误 | 服务器内部错误 |
+
+## 使用场景
+
+### 小智接入点通信
+
+小智接入点使用 WebSocket 进行 MCP 协议通信：
+
+```typescript
+// Endpoint 类中的错误处理示例
+private handleConnectionError(error: Error): void {
+  if (this.ws) {
+    sendWebSocketError(
+      this.ws,
+      "CONNECTION_ERROR",
+      error.message,
+      this.logger
+    );
+  }
+}
+```
+
+### ESP32 设备通信
+
+ESP32 设备通过 WebSocket 连接进行通信：
+
+```typescript
+// ESP32 连接中的错误处理
+async sendError(code: ESP32ErrorCode, message: string): Promise<void> {
+  try {
+    await this.send({
+      type: "error",
+      code,
+      message,
+    });
+  } catch (error) {
+    logger.error(`发送错误消息失败: deviceId=${this.deviceId}`, error);
+  }
+}
+```
+
+## 注意事项
+
+1. **异常处理**: `sendWebSocketError` 内部已处理发送异常，不会抛出错误
+2. **日志记录**: 发送失败时会记录错误日志，便于调试
+3. **接口兼容**: `WebSocketLike` 接口兼容标准 WebSocket 对象和任何实现了 `send` 方法的对象
+
+## 相关模块
+
+- [端点管理](./endpoint) - 小智接入点使用 WebSocket 通信
+- [ESP32 集成](./esp32) - ESP32 设备使用 WebSocket 连接
+- [MCP 模块](./mcp) - MCP 协议通过 WebSocket 传输


### PR DESCRIPTION
为 docs/content/reference/ 目录添加了项目关键模块的 API 参考文档，包括：

- MCP 模块: MCP 服务管理器和 MCP 服务的 API 文档
- 端点管理: Endpoint 和 EndpointManager 的 API 文档
- WebSocket 通信: WebSocket 相关工具函数和类型定义
- 配置管理: configManager 的 API 文档
- ESP32 集成: ESP32 设备连接和音频协议的 API 文档
- 事件总线: EventBus 的 API 文档
- 路由系统: RouteManager 的 API 文档

同时更新了 _meta.ts 导航配置。

每个文档包含：
- 模块概述
- 核心组件说明
- 主要方法签名和参数
- 类型定义
- 使用示例
- 注意事项
- 相关模块引用

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2320