### PR TITLE
fix(types): 将 AddToolResponse 中的 tool 字段从 any 改为具体类型

### DIFF
--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -5,6 +5,7 @@
 
 import type { JSONSchema as LibJSONSchema } from "@/lib/mcp/types.js";
 import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
+import type { CustomMCPTool } from "@xiaozhi-client/config";
 
 /**
  * JSON Schema 类型
@@ -252,7 +253,7 @@ export interface ToolValidationErrorDetail {
  */
 export interface AddToolResponse {
   /** 成功添加的工具 */
-  tool: any;
+  tool: CustomMCPTool;
   /** 工具名称 */
   toolName: string;
   /** 工具类型 */

--- a/packages/shared-types/src/api/toolApi.ts
+++ b/packages/shared-types/src/api/toolApi.ts
@@ -150,7 +150,7 @@ export interface ToolValidationErrorDetail {
  */
 export interface AddToolResponse {
   /** 成功添加的工具 */
-  tool: any;
+  tool: CustomMCPToolWithStats;
   /** 工具名称 */
   toolName: string;
   /** 工具类型 */


### PR DESCRIPTION
将 AddToolResponse 接口中的 tool 字段类型从 any 改为明确的类型定义：
- apps/backend/types/toolApi.ts: 使用 CustomMCPTool
- packages/shared-types/src/api/toolApi.ts: 使用 CustomMCPToolWithStats

这提高了代码的类型安全性，使得调用方可以获得正确的类型提示和检查。

Fixes #2322

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2322