### PR TITLE
fix(tts): 修复 protocols.ts 中 WebSocket 事件监听器未移除导致的内存泄漏

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/protocols.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/protocols.ts
@@ -581,7 +581,7 @@ function setupMessageHandler(ws: WebSocket) {
     messageQueues.set(ws, []);
     messageCallbacks.set(ws, []);
 
-    ws.on("message", (data: WebSocket.RawData) => {
+    const messageHandler = (data: WebSocket.RawData) => {
       try {
         let uint8Data: Uint8Array;
         if (Buffer.isBuffer(data)) {
@@ -609,12 +609,20 @@ function setupMessageHandler(ws: WebSocket) {
       } catch (error) {
         throw new Error(`Error processing message: ${error}`);
       }
-    });
+    };
 
-    ws.on("close", () => {
+    const closeHandler = () => {
+      // 移除所有事件监听器，防止内存泄漏
+      ws.off("message", messageHandler);
+      ws.off("close", closeHandler);
+
+      // 清理数据
       messageQueues.delete(ws);
       messageCallbacks.delete(ws);
-    });
+    };
+
+    ws.on("message", messageHandler);
+    ws.on("close", closeHandler);
   }
 }
 


### PR DESCRIPTION
在 setupMessageHandler 函数中，WebSocket 的 message 和 close 事件监听器
在连接关闭时未被移除，导致内存泄漏。

修复方案：
- 将 messageHandler 和 closeHandler 声明为命名函数以保存引用
- 在 closeHandler 中使用 ws.off() 移除所有事件监听器
- 确保闭包引用被正确清理，防止内存泄漏

Fixes #2324

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2324