### PR TITLE
fix(tsconfig): 添加 packages/tts 到 TypeScript 项目引用

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
   "references": [
     { "path": "./apps/backend" },
     { "path": "./packages/asr" },
+    { "path": "./packages/tts" },
     { "path": "./packages/config" },
     { "path": "./packages/mcp-core" },
     { "path": "./packages/shared-types" },


### PR DESCRIPTION
在根 tsconfig.json 的 references 数组中添加 packages/tts 引用，
确保 TypeScript 项目引用配置的完整性。

修复 #2332

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2332