### PR TITLE
fix(frontend): 添加 API 请求超时配置防止 UI 卡死

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -168,6 +168,11 @@ interface MCPToolListResponse {
 /**
  * HTTP API 客户端类
  */
+/**
+ * 默认请求超时时间（毫秒）
+ */
+const DEFAULT_REQUEST_TIMEOUT = 30000;
+
 export class ApiClient {
   private baseUrl: string;
 
@@ -185,36 +190,55 @@ export class ApiClient {
 
   /**
    * 通用请求方法
+   * @param endpoint API 端点
+   * @param options 请求选项
+   * @param timeout 超时时间（毫秒），默认 30000ms
    */
   private async request<T>(
     endpoint: string,
-    options: RequestInit = {}
+    options: RequestInit = {},
+    timeout = DEFAULT_REQUEST_TIMEOUT
   ): Promise<T> {
     const url = `${this.baseUrl}${endpoint}`;
 
-    const defaultOptions: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-    };
+    // 创建 AbortController 用于超时控制
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeout);
 
-    const response = await fetch(url, { ...defaultOptions, ...options });
+    try {
+      const defaultOptions: RequestInit = {
+        headers: {
+          "Content-Type": "application/json",
+          ...options.headers,
+        },
+        signal: controller.signal,
+      };
 
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      const response = await fetch(url, { ...defaultOptions, ...options });
 
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+
+        try {
+          const errorData: ApiErrorResponse = await response.json();
+          errorMessage = errorData.error?.message || errorMessage;
+        } catch {
+          // 如果无法解析错误响应，使用默认错误消息
+        }
+
+        throw new Error(errorMessage);
       }
 
-      throw new Error(errorMessage);
+      return response.json();
+    } catch (error) {
+      // 处理超时错误
+      if (error instanceof Error && error.name === "AbortError") {
+        throw new Error(`请求超时 (${timeout}ms)`);
+      }
+      throw error;
+    } finally {
+      clearTimeout(timeoutId);
     }
-
-    return response.json();
   }
 
   // ==================== 配置管理 API ====================


### PR DESCRIPTION
- 使用 AbortController 实现 30 秒默认超时
- 捕获 AbortError 并提供用户友好的中文错误消息
- 防止后端服务无响应时前端 UI 无限期挂起

修复 #2335

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2335