### PR TITLE
fix(tsconfig): 添加 packages/tts 到 TypeScript 项目引用

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -32,6 +32,7 @@
   "references": [
     { "path": "./apps/backend" },
     { "path": "./packages/asr" },
+    { "path": "./packages/tts" },
     { "path": "./packages/config" },
     { "path": "./packages/mcp-core" },
     { "path": "./packages/shared-types" },


### PR DESCRIPTION
在根 tsconfig.json 的 references 数组中添加 packages/tts 引用，确保 TypeScript 项目引用配置的完整性。

packages/tts 是一个 composite TypeScript 项目（在 packages/tts/tsconfig.json 中设置了 "composite": true），并且被 apps/backend 依赖，因此需要添加到项目引用中。

### 变更内容
- 添加 { "path": "./packages/tts" } 到 references 数组
- 按字母顺序放置在 packages/asr 之后、packages/config 之前

### 测试
- ✅ TypeScript 类型检查通过

### 相关 Issue
修复 #2332

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2332