### PR TITLE
fix: 将 workflow-parameter-config-dialog 中的 any 类型替换为 JSONSchema

### DIFF
--- a/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
+++ b/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
@@ -27,6 +27,7 @@ import {
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
   CozeWorkflow,
+  JSONSchema,
   WorkflowParameter,
 } from "@xiaozhi-client/shared-types";
 import { Plus, Trash2 } from "lucide-react";
@@ -91,7 +92,9 @@ export interface WorkflowParameterConfigDialogProps {
 /**
  * 从 inputSchema 提取现有参数配置
  */
-function extractParametersFromSchema(inputSchema: any): FormData["parameters"] {
+function extractParametersFromSchema(
+  inputSchema: JSONSchema | undefined
+): FormData["parameters"] {
   if (!inputSchema || !inputSchema.properties) {
     return [];
   }
@@ -100,7 +103,7 @@ function extractParametersFromSchema(inputSchema: any): FormData["parameters"] {
   const required = inputSchema.required || [];
 
   return Object.entries(properties).map(
-    ([fieldName, schema]: [string, any]) => {
+    ([fieldName, schema]: [string, JSONSchema]) => {
       let type: "string" | "number" | "boolean" = "string";
 
       if (schema.type === "integer" || schema.type === "number") {


### PR DESCRIPTION
修复 #2337

- 导入 JSONSchema 类型
- 将 inputSchema 参数类型从 any 替换为 JSONSchema | undefined
- 将 schema 变量类型从 any 替换为 JSONSchema
- 提升类型安全性，增强 IDE 类型提示

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2337