### PR TITLE
perf(cache): 使用 fs.stat 替代 readFileSync 获取文件大小

### DIFF
--- a/apps/backend/lib/mcp/cache.ts
+++ b/apps/backend/lib/mcp/cache.ts
@@ -5,6 +5,7 @@
  */
 
 import { createHash } from "node:crypto";
+import { promises as fs } from "node:fs";
 import {
   existsSync,
   mkdirSync,
@@ -317,13 +318,14 @@ export class MCPCacheManager {
   async getStats(): Promise<CacheStats | null> {
     try {
       const cache = await this.loadExistingCache();
+      const cacheFileSize = existsSync(this.cachePath)
+        ? (await fs.stat(this.cachePath)).size
+        : 0;
       const stats: CacheStats = {
         totalWrites: cache.metadata.totalWrites,
         lastUpdate: cache.metadata.lastGlobalUpdate,
         serverCount: Object.keys(cache.mcpServers).length,
-        cacheFileSize: existsSync(this.cachePath)
-          ? readFileSync(this.cachePath, "utf8").length
-          : 0,
+        cacheFileSize,
       };
       return stats;
     } catch (error) {


### PR DESCRIPTION
修复 getStats 方法中为了获取文件大小而读取整个文件内容的性能问题：
- 使用 fs.promises.stat().size 替代 readFileSync().length
- 避免 O(n) 的内存浪费，改为 O(1) 的文件元数据读取
- 返回实际字节数而非 UTF-16 字符数，更准确

Fixes #2341

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2341