### PR TITLE
fix(shared-types): 修复路径别名绕过 exports 导致配置不一致

### DIFF
--- a/apps/frontend/tsconfig.json
+++ b/apps/frontend/tsconfig.json
@@ -21,8 +21,7 @@
 
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
-      "@xiaozhi-client/shared-types": ["../../packages/shared-types/src"]
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -3,15 +3,15 @@ import { defineConfig } from "tsup";
 export default defineConfig({
   entry: {
     index: "src/index.ts",
-    mcp: "src/mcp/index.ts",
-    coze: "src/coze/index.ts",
-    api: "src/api/index.ts",
-    config: "src/config/index.ts",
-    utils: "src/utils/index.ts",
+    "mcp/index": "src/mcp/index.ts",
+    "coze/index": "src/coze/index.ts",
+    "api/index": "src/api/index.ts",
+    "config/index": "src/config/index.ts",
+    "utils/index": "src/utils/index.ts",
   },
   format: ["esm"],
   target: "node20",
-  outDir: "../../dist/shared-types",
+  outDir: "./dist",
   dts: {
     compilerOptions: {
       composite: false


### PR DESCRIPTION
- 将 shared-types 输出目录从 ../../dist/shared-types 改为 ./dist
- 更新入口格式以生成正确的子目录结构 (mcp/index, coze/index 等)
- 移除 frontend tsconfig 中的特殊路径别名配置
- 现在通过标准的 package.json exports 机制解析模块

Resolves #2344

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2344