### PR TITLE
refactor: 创建通用 GenericSortSelector 组件消除重复代码

### DIFF
--- a/apps/frontend/src/components/common/generic-sort-selector.tsx
+++ b/apps/frontend/src/components/common/generic-sort-selector.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+/** 排序选项配置 */
+export interface SortOption {
+  /** 选项值 */
+  value: string;
+  /** 选项显示标签 */
+  label: string;
+}
+
+/** 排序配置 */
+export interface SortConfig<T extends string> {
+  field: T;
+}
+
+/** 通用排序选择器属性 */
+export interface GenericSortSelectorProps<T extends string> {
+  /** 当前排序配置 */
+  value: SortConfig<T>;
+  /** 排序配置变更回调 */
+  onChange: (config: SortConfig<T>) => void;
+  /** 排序选项列表 */
+  options: readonly SortOption[];
+  /** 排序选择器的 aria-label */
+  ariaLabel?: string;
+}
+
+/**
+ * 通用排序选择器组件
+ * 支持通过配置参数实现不同的排序场景，避免重复代码
+ */
+export function GenericSortSelector<T extends string>({
+  value,
+  onChange,
+  options,
+  ariaLabel = "sort-field",
+}: GenericSortSelectorProps<T>) {
+  return (
+    <div className="flex items-center gap-2">
+      <Select
+        value={value.field}
+        onValueChange={(field) => onChange({ field: field as T })}
+      >
+        <SelectTrigger id={ariaLabel} className="w-40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {options.map((option) => (
+            <SelectItem key={option.value} value={option.value}>
+              {option.label}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/frontend/src/components/mcp-server/server-sort-selector.tsx
+++ b/apps/frontend/src/components/mcp-server/server-sort-selector.tsx
@@ -1,32 +1,28 @@
 "use client";
 
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  GenericSortSelector,
+  type SortConfig,
+  type SortOption,
+} from "@/components/common/generic-sort-selector";
 
-/** 排序字段类型 */
+/** 服务器排序字段类型 */
 export type ServerSortField = "name" | "communicationType" | "toolCount";
 
-/** 排序配置 */
-export interface ServerSortConfig {
-  field: ServerSortField;
-}
+/** 服务器排序配置 */
+export type ServerSortConfig = SortConfig<ServerSortField>;
+
+/** 服务器排序选项配置 */
+const SERVER_SORT_OPTIONS: readonly SortOption[] = [
+  { value: "name", label: "按名称排序" },
+  { value: "communicationType", label: "按通信类型排序" },
+  { value: "toolCount", label: "按工具数量排序" },
+] as const;
 
 interface ServerSortSelectorProps {
   value: ServerSortConfig;
   onChange: (config: ServerSortConfig) => void;
 }
-
-/** 排序选项配置 */
-const SORT_OPTIONS = [
-  { value: "name", label: "按名称排序" },
-  { value: "communicationType", label: "按通信类型排序" },
-  { value: "toolCount", label: "按工具数量排序" },
-] as const;
 
 /**
  * MCP 服务器排序选择器组件
@@ -37,22 +33,11 @@ export function ServerSortSelector({
   onChange,
 }: ServerSortSelectorProps) {
   return (
-    <div className="flex items-center gap-2">
-      <Select
-        value={value.field}
-        onValueChange={(field) => onChange({ field: field as ServerSortField })}
-      >
-        <SelectTrigger id="server-sort-field" className="w-40">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {SORT_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <GenericSortSelector
+      value={value}
+      onChange={onChange}
+      options={SERVER_SORT_OPTIONS}
+      ariaLabel="server-sort-field"
+    />
   );
 }

--- a/apps/frontend/src/components/mcp-tool/tool-sort-selector.tsx
+++ b/apps/frontend/src/components/mcp-tool/tool-sort-selector.tsx
@@ -1,49 +1,44 @@
 "use client";
 
 import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
+  GenericSortSelector,
+  type SortConfig,
+  type SortOption,
+} from "@/components/common/generic-sort-selector";
 
+/** 工具排序字段类型 */
 export type ToolSortField = "name" | "enabled" | "usageCount" | "lastUsedTime";
 
-export interface ToolSortConfig {
-  field: ToolSortField;
-}
+/** 工具排序配置 */
+export type ToolSortConfig = SortConfig<ToolSortField>;
+
+/** 工具排序选项配置 */
+const TOOL_SORT_OPTIONS: readonly SortOption[] = [
+  { value: "name", label: "按名称排序" },
+  { value: "enabled", label: "按状态排序" },
+  { value: "usageCount", label: "按使用次数排序" },
+  { value: "lastUsedTime", label: "按最近使用排序" },
+] as const;
 
 interface ToolSortSelectorProps {
   value: ToolSortConfig;
   onChange: (config: ToolSortConfig) => void;
 }
 
-const SORT_OPTIONS = [
-  { value: "name", label: "按名称排序" },
-  { value: "enabled", label: "按状态排序" },
-  { value: "usageCount", label: "按使用次数排序" },
-  { value: "lastUsedTime", label: "按最近使用排序" },
-];
-
-export function ToolSortSelector({ value, onChange }: ToolSortSelectorProps) {
+/**
+ * MCP 工具排序选择器组件
+ * 提供按名称、状态、使用次数、最近使用排序功能
+ */
+export function ToolSortSelector({
+  value,
+  onChange,
+}: ToolSortSelectorProps) {
   return (
-    <div className="flex items-center gap-2">
-      <Select
-        value={value.field}
-        onValueChange={(field) => onChange({ field: field as ToolSortField })}
-      >
-        <SelectTrigger id="sort-field" className="w-40">
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          {SORT_OPTIONS.map((option) => (
-            <SelectItem key={option.value} value={option.value}>
-              {option.label}
-            </SelectItem>
-          ))}
-        </SelectContent>
-      </Select>
-    </div>
+    <GenericSortSelector
+      value={value}
+      onChange={onChange}
+      options={TOOL_SORT_OPTIONS}
+      ariaLabel="sort-field"
+    />
   );
 }


### PR DESCRIPTION
将 ToolSortSelector 和 ServerSortSelector 的重复代码提取到通用组件中，
符合 DRY 原则，降低维护成本。

Changes:
- 新增 GenericSortSelector 通用排序选择器组件
- 重构 ToolSortSelector 使用通用组件（50行 → 47行）
- 重构 ServerSortSelector 使用通用组件（59行 → 49行）

Fixes #2348

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2348