### PR TITLE
refactor(asr): 提取公共逻辑消除 processAudioData 和 processOpusData 重复代码

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -437,73 +437,85 @@ export class ASR extends EventEmitter {
   }
 
   /**
-   * Process audio data
+   * 内部方法：处理音频数据的核心逻辑
+   * @param audioData - 音频数据
+   * @param segmentSize - 音频分段大小
+   * @returns ASR 识别结果
    */
-  private async processAudioData(wavData: Buffer): Promise<ASRResult> {
+  private async processAudioDataInternal(
+    audioData: Buffer,
+    segmentSize: number
+  ): Promise<ASRResult> {
     const reqid = uuidv4();
 
-    // Construct request
+    // 构建请求
     const requestParams = this.constructRequest(reqid);
     const payloadBytes = Buffer.from(JSON.stringify(requestParams), "utf-8");
     const compressedPayload = compressGzipSync(payloadBytes);
 
-    // Build full client request: header + payload size (4 bytes) + payload
+    // 构建完整客户端请求：头部 + 载荷大小（4 字节）+ 载荷
     const fullRequest = Buffer.alloc(compressedPayload.length + 8);
     generateFullDefaultHeader().copy(fullRequest, 0);
     fullRequest.writeUInt32BE(compressedPayload.length, 4);
     compressedPayload.copy(fullRequest, 8);
 
-    // Connect
+    // 连接
     await this._connect();
 
-    // Send full request
+    // 发送完整请求
     await this.sendMessage(fullRequest);
 
-    // Receive response
+    // 接收响应
     await this.receiveMessage();
 
-    // Process audio chunks
-    const segmentSize =
-      this.format === AudioFormat.MP3
-        ? this.mp3SegSize
-        : this.calculateSegmentSize(wavData);
-
-    for (const { chunk, last } of this.sliceData(wavData, segmentSize)) {
-      // Compress audio data
+    // 处理音频分段
+    for (const { chunk, last } of this.sliceData(audioData, segmentSize)) {
+      // 压缩音频数据
       const compressedChunk = compressGzipSync(chunk);
 
-      // Generate header
+      // 生成头部
       const header = last
         ? generateLastAudioDefaultHeader()
         : generateAudioDefaultHeader();
 
-      // Build audio-only request
+      // 构建音频请求
       const audioRequest = Buffer.alloc(compressedChunk.length + 8);
       header.copy(audioRequest, 0);
       audioRequest.writeUInt32BE(compressedChunk.length, 4);
       compressedChunk.copy(audioRequest, 8);
 
-      // Send audio
+      // 发送音频
       await this.sendMessage(audioRequest);
 
-      // Receive response
+      // 接收响应
       const result = await this.receiveMessage();
 
-      // Check for errors
+      // 检查错误
       if (result.code && result.code !== this.successCode) {
         return result;
       }
 
-      // Emit audio end event for last chunk
+      // 最后一段音频时触发事件
       if (last) {
         this.emit("audio_end");
       }
     }
 
-    // Close connection
+    // 关闭连接
     this.close();
 
     return { code: this.successCode };
+  }
+
+  /**
+   * 处理音频数据
+   */
+  private async processAudioData(wavData: Buffer): Promise<ASRResult> {
+    const segmentSize =
+      this.format === AudioFormat.MP3
+        ? this.mp3SegSize
+        : this.calculateSegmentSize(wavData);
+    return this.processAudioDataInternal(wavData, segmentSize);
   }
 
   /**
@@ -606,70 +618,12 @@ export class ASR extends EventEmitter {
   }
 
   /**
-   * Process Opus data for OGG format
+   * 处理 OGG 格式的 Opus 数据
    */
   private async processOpusData(opusData: Buffer): Promise<ASRResult> {
-    const reqid = uuidv4();
-
-    // Construct request
-    const requestParams = this.constructRequest(reqid);
-    const payloadBytes = Buffer.from(JSON.stringify(requestParams), "utf-8");
-    const compressedPayload = compressGzipSync(payloadBytes);
-
-    // Build full client request: header + payload size (4 bytes) + payload
-    const fullRequest = Buffer.alloc(compressedPayload.length + 8);
-    generateFullDefaultHeader().copy(fullRequest, 0);
-    fullRequest.writeUInt32BE(compressedPayload.length, 4);
-    compressedPayload.copy(fullRequest, 8);
-
-    // Connect
-    await this._connect();
-
-    // Send full request
-    await this.sendMessage(fullRequest);
-
-    // Receive response
-    await this.receiveMessage();
-
-    // Process audio chunks - use smaller chunk size for Opus
-    const segmentSize = 3200; // ~100ms at 16kHz
-
-    for (const { chunk, last } of this.sliceData(opusData, segmentSize)) {
-      // Compress audio data
-      const compressedChunk = compressGzipSync(chunk);
-
-      // Generate header
-      const header = last
-        ? generateLastAudioDefaultHeader()
-        : generateAudioDefaultHeader();
-
-      // Build audio-only request
-      const audioRequest = Buffer.alloc(compressedChunk.length + 8);
-      header.copy(audioRequest, 0);
-      audioRequest.writeUInt32BE(compressedChunk.length, 4);
-      compressedChunk.copy(audioRequest, 8);
-
-      // Send audio
-      await this.sendMessage(audioRequest);
-
-      // Receive response
-      const result = await this.receiveMessage();
-
-      // Check for errors
-      if (result.code && result.code !== this.successCode) {
-        return result;
-      }
-
-      // Emit audio end event for last chunk
-      if (last) {
-        this.emit("audio_end");
-      }
-    }
-
-    // Close connection
-    this.close();
-
-    return { code: this.successCode };
+    // Opus 使用更小的分段大小（约 100ms@16kHz）
+    const segmentSize = 3200;
+    return this.processAudioDataInternal(opusData, segmentSize);
   }
 
   /**


### PR DESCRIPTION
- 新增 processAudioDataInternal 私有方法封装公共逻辑
- processAudioData 和 processOpusData 现在调用内部方法
- 仅保留 segmentSize 计算的差异
- 消除约 60 行重复代码，提升可维护性

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2350