### PR TITLE
fix(event-bus): 将 status:updated 事件的 status 字段类型从 any 改为 ClientInfo

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -4,6 +4,7 @@ import {
   destroyEventBus,
   getEventBus,
 } from "../event-bus.service.js";
+import type { ClientInfo } from "../status.service.js";
 
 // 模拟依赖
 vi.mock("../../Logger.js", () => ({
@@ -87,7 +88,12 @@ describe("EventBus", () => {
     });
 
     it("should emit status:updated event successfully", () => {
-      const eventData = { status: { connected: true }, source: "test" };
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+      const eventData = { status: mockStatus, source: "test" };
       const listener = vi.fn();
 
       eventBus.onEvent("status:updated", listener);
@@ -483,10 +489,18 @@ describe("EventBus", () => {
 
     it("should return correct event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
 
       eventBus.emitEvent("config:updated", eventData);
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
 
       const stats = eventBus.getEventStats();
 
@@ -536,8 +550,16 @@ describe("EventBus", () => {
   describe("clearEventStats", () => {
     it("should clear all event statistics", () => {
       const eventData = { type: "customMCP", timestamp: new Date() };
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
       eventBus.emitEvent("config:updated", eventData);
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
 
       let stats = eventBus.getEventStats();
       expect(Object.keys(stats)).toHaveLength(2);
@@ -554,6 +576,11 @@ describe("EventBus", () => {
     it("should return correct status information", () => {
       const listener1 = vi.fn();
       const listener2 = vi.fn();
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
 
       eventBus.onEvent("config:updated", listener1);
       eventBus.onEvent("status:updated", listener2);
@@ -562,7 +589,10 @@ describe("EventBus", () => {
         type: "customMCP",
         timestamp: new Date(),
       });
-      eventBus.emitEvent("status:updated", { status: {}, source: "test" });
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
 
       const status = eventBus.getStatus();
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -14,6 +14,7 @@
 import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
+import type { ClientInfo } from "@/services/status.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 /**
@@ -30,7 +31,7 @@ export interface EventBusEvents {
   "config:error": { error: Error; operation: string };
 
   // 状态相关事件
-  "status:updated": { status: any; source: string };
+  "status:updated": { status: ClientInfo; source: string };
   "status:error": { error: Error; operation: string };
 
   // 接入点状态变更事件


### PR DESCRIPTION
修复 issue #2358 - event-bus.service.ts 中 status:updated 事件的 status 字段使用 any 类型而非已定义的 ClientInfo 降低类型安全性

主要更改：
- 在 event-bus.service.ts 中导入 ClientInfo 类型
- 将 EventBusEvents 接口中 status:updated 事件的 status 字段类型从 any 改为 ClientInfo
- 更新相关测试用例以匹配新的类型定义

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2358