### PR TITLE
refactor(mcp): 添加服务生命周期、统计和配置管理器

### DIFF
--- a/apps/backend/lib/mcp/config-manager.ts
+++ b/apps/backend/lib/mcp/config-manager.ts
@@ -1,0 +1,387 @@
+/**
+ * MCP 配置管理器
+ * 负责 MCP 服务的配置管理和 ModelScope 集成
+ *
+ * @remarks
+ * 该类从 MCPServiceManager 中分离出来，专门负责服务配置管理。
+ * 包括配置增强、ModelScope 认证处理、工具配置同步等功能。
+ *
+ * @example
+ * ```typescript
+ * const configManager = new MCPConfigManager();
+ * configManager.addServiceConfig(name, config);
+ * const enhanced = configManager.enhanceServiceConfig(name, config);
+ * ```
+ */
+
+import { logger } from "@/Logger.js";
+import { isModelScopeURL } from "@xiaozhi-client/config";
+import type { configManager as ConfigManagerType } from "@xiaozhi-client/config";
+import type { MCPToolConfig } from "@xiaozhi-client/config";
+import type { MCPServiceConfig } from "@/lib/mcp/types.js";
+
+/**
+ * 配置管理器依赖接口
+ */
+export interface ConfigManagerDependencies {
+  /** 配置管理器实例 */
+  configManager: typeof ConfigManagerType;
+}
+
+/**
+ * MCP 配置管理器
+ *
+ * @remarks
+ * 负责管理 MCP 服务的配置，包括：
+ * - 配置增强（如 ModelScope 认证）
+ * - 配置的添加、更新、删除
+ * - 工具配置同步到配置文件
+ */
+export class MCPConfigManager {
+  private configs: Record<string, MCPServiceConfig>;
+  private dependencies: ConfigManagerDependencies;
+
+  /**
+   * 创建配置管理器实例
+   *
+   * @param configs 服务配置对象的引用
+   * @param dependencies 配置管理器依赖
+   */
+  constructor(
+    configs: Record<string, MCPServiceConfig>,
+    dependencies: ConfigManagerDependencies
+  ) {
+    this.configs = configs;
+    this.dependencies = dependencies;
+  }
+
+  /**
+   * 检查是否为 ModelScope 服务
+   *
+   * @param config MCP 服务配置
+   * @returns 如果是 ModelScope 服务返回 true
+   */
+  isModelScopeService(config: MCPServiceConfig): boolean {
+    return config.url ? isModelScopeURL(config.url) : false;
+  }
+
+  /**
+   * 处理 ModelScope 服务认证
+   *
+   * @remarks
+   * 智能检查现有认证信息，按优先级处理：
+   * 1. 检查是否已有 Authorization header
+   * 2. 检查全局 ModelScope API Key
+   * 3. 无法获取认证信息时抛出详细错误
+   *
+   * @param serviceName 服务名称
+   * @param originalConfig 原始配置
+   * @param enhancedConfig 增强后的配置（将被修改）
+   * @throws {Error} 如果无法获取认证信息
+   */
+  handleModelScopeAuth(
+    serviceName: string,
+    originalConfig: MCPServiceConfig,
+    enhancedConfig: MCPServiceConfig
+  ): void {
+    // 1. 检查是否已有 Authorization header
+    const existingAuthHeader = originalConfig.headers?.Authorization;
+
+    if (existingAuthHeader) {
+      // 已有认证信息，直接使用
+      logger.info(
+        `[ConfigManager] 服务 ${serviceName} 使用已有的 Authorization header`
+      );
+      return;
+    }
+
+    // 2. 检查全局 ModelScope API Key
+    const modelScopeApiKey = this.dependencies.configManager.getModelScopeApiKey();
+
+    if (modelScopeApiKey) {
+      // 注入全局 API Key
+      enhancedConfig.apiKey = modelScopeApiKey;
+      logger.info(`[ConfigManager] 为 ${serviceName} 服务添加 ModelScope API Key`);
+      return;
+    }
+
+    // 3. 无法获取认证信息，提供详细错误信息
+    const serviceUrl = originalConfig.url || "未知";
+
+    throw new Error(
+      `ModelScope 服务 "${serviceName}" 需要认证信息，但未找到有效的认证配置。服务 URL: ${serviceUrl}请选择以下任一方式配置认证：1. 在服务配置中添加 headers.Authorization2. 或者在全局配置中设置 modelscope.apiKey3. 或者设置环境变量 MODELSCOPE_API_TOKEN获取 ModelScope API Key: https://modelscope.cn/my?myInfo=true`
+    );
+  }
+
+  /**
+   * 增强服务配置
+   *
+   * @remarks
+   * 根据服务类型添加必要的全局配置，智能处理认证信息。
+   * 对于 ModelScope 服务，会自动处理认证信息。
+   *
+   * @param serviceName 服务名称
+   * @param config 原始配置
+   * @returns 增强后的配置
+   */
+  enhanceServiceConfig(
+    serviceName: string,
+    config: MCPServiceConfig
+  ): MCPServiceConfig {
+    const enhancedConfig = { ...config };
+
+    try {
+      // 处理 ModelScope 服务（智能认证检查）
+      if (this.isModelScopeService(config)) {
+        this.handleModelScopeAuth(serviceName, config, enhancedConfig);
+      }
+
+      return enhancedConfig;
+    } catch (error) {
+      logger.error(`[ConfigManager] 配置增强失败: ${serviceName}`, { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 添加服务配置
+   *
+   * @remarks
+   * 支持两种调用方式：
+   * - 两参数版本：`addServiceConfig(name, config)`
+   * - 单参数版本：`addServiceConfig({ name, ...config })`
+   *
+   * @param nameOrConfig 服务名称或内部配置对象
+   * @param config 可选的服务配置
+   */
+  addServiceConfig(
+    nameOrConfig: string | (MCPServiceConfig & { name: string }),
+    config?: MCPServiceConfig
+  ): void {
+    let finalConfig: MCPServiceConfig;
+    let serviceName: string;
+
+    if (typeof nameOrConfig === "string" && config) {
+      // 两参数版本
+      serviceName = nameOrConfig;
+      finalConfig = config;
+    } else if (typeof nameOrConfig === "object") {
+      // 单参数版本
+      const internalConfig = nameOrConfig;
+      serviceName = internalConfig.name;
+      finalConfig = internalConfig;
+    } else {
+      throw new Error("Invalid arguments for addServiceConfig");
+    }
+
+    // 增强配置
+    const enhancedConfig = this.enhanceServiceConfig(serviceName, finalConfig);
+
+    // 存储增强后的配置
+    this.configs[serviceName] = enhancedConfig;
+    logger.debug(`[ConfigManager] 已添加服务配置: ${serviceName}`);
+  }
+
+  /**
+   * 更新服务配置
+   *
+   * @param name 服务名称
+   * @param config 新的配置
+   */
+  updateServiceConfig(name: string, config: MCPServiceConfig): void {
+    // 增强配置
+    const enhancedConfig = this.enhanceServiceConfig(name, config);
+
+    // 存储增强后的配置
+    this.configs[name] = enhancedConfig;
+    logger.debug(`[ConfigManager] 已更新并增强服务配置: ${name}`);
+  }
+
+  /**
+   * 移除服务配置
+   *
+   * @param name 服务名称
+   */
+  removeServiceConfig(name: string): void {
+    delete this.configs[name];
+    logger.debug(`[ConfigManager] 已移除服务配置: ${name}`);
+  }
+
+  /**
+   * 获取服务配置
+   *
+   * @param name 服务名称
+   * @returns 服务配置或 undefined
+   */
+  getServiceConfig(name: string): MCPServiceConfig | undefined {
+    return this.configs[name];
+  }
+
+  /**
+   * 获取所有服务配置
+   *
+   * @returns 服务配置对象
+   */
+  getAllConfigs(): Record<string, MCPServiceConfig> {
+    return { ...this.configs };
+  }
+
+  /**
+   * 检查工具配置是否有变化
+   *
+   * @param currentConfig 当前配置
+   * @param newConfig 新配置
+   * @returns 如果有变化返回 true
+   */
+  private hasToolsConfigChanged(
+    currentConfig: Record<string, MCPToolConfig>,
+    newConfig: Record<string, MCPToolConfig>
+  ): boolean {
+    const currentKeys = Object.keys(currentConfig);
+    const newKeys = Object.keys(newConfig);
+
+    // 检查工具数量是否变化
+    if (currentKeys.length !== newKeys.length) {
+      return true;
+    }
+
+    // 检查是否有新增或删除的工具
+    const addedTools = newKeys.filter((key) => !currentKeys.includes(key));
+    const removedTools = currentKeys.filter((key) => !newKeys.includes(key));
+
+    if (addedTools.length > 0 || removedTools.length > 0) {
+      return true;
+    }
+
+    // 检查现有工具的描述是否有变化
+    for (const toolName of currentKeys) {
+      const currentTool = currentConfig[toolName];
+      const newTool = newConfig[toolName];
+
+      if (currentTool.description !== newTool.description) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * 同步工具配置到配置文件
+   *
+   * @remarks
+   * 实现自动同步 MCP 服务工具配置到 xiaozhi.config.json。
+   * 保留用户设置的 enable 状态，但更新描述信息。
+   *
+   * @param services 服务实例映射
+   */
+  async syncToolsConfigToFile(
+    services: Map<
+      string,
+      {
+        isConnected(): boolean;
+        getTools(): Array<{ name: string; description?: string }>;
+      }
+    >
+  ): Promise<void> {
+    try {
+      logger.debug("[ConfigManager] 开始同步工具配置到配置文件");
+
+      // 获取当前配置文件中的 mcpServerConfig
+      const currentServerConfigs =
+        this.dependencies.configManager.getMcpServerConfig();
+
+      // 遍历所有已连接的服务
+      for (const [serviceName, service] of services) {
+        if (!service.isConnected()) {
+          continue;
+        }
+
+        const tools = service.getTools();
+        if (tools.length === 0) {
+          continue;
+        }
+
+        // 获取当前服务在配置文件中的工具配置
+        const currentToolsConfig =
+          currentServerConfigs[serviceName]?.tools || {};
+
+        // 构建新的工具配置
+        const newToolsConfig: Record<string, MCPToolConfig> = {};
+
+        for (const tool of tools) {
+          const currentToolConfig = currentToolsConfig[tool.name];
+
+          // 如果工具已存在，保留用户设置的 enable 状态，但更新描述
+          if (currentToolConfig) {
+            newToolsConfig[tool.name] = {
+              ...currentToolConfig,
+              description:
+                tool.description || currentToolConfig.description || "",
+            };
+          } else {
+            // 新工具，默认启用
+            newToolsConfig[tool.name] = {
+              description: tool.description || "",
+              enable: true,
+            };
+          }
+        }
+
+        // 检查是否有工具被移除（在配置文件中存在但在当前工具列表中不存在）
+        const currentToolNames = tools.map((t) => t.name);
+        const configToolNames = Object.keys(currentToolsConfig);
+        const removedTools = configToolNames.filter(
+          (name) => !currentToolNames.includes(name)
+        );
+
+        if (removedTools.length > 0) {
+          logger.info(
+            `[ConfigManager] 检测到服务 ${serviceName} 移除了 ${
+              removedTools.length
+            } 个工具: ${removedTools.join(", ")}`
+          );
+        }
+
+        // 检查配置是否有变化
+        const hasChanges = this.hasToolsConfigChanged(
+          currentToolsConfig,
+          newToolsConfig
+        );
+
+        if (hasChanges) {
+          // 更新配置文件
+          this.dependencies.configManager.updateServerToolsConfig(
+            serviceName,
+            newToolsConfig
+          );
+
+          const addedTools = Object.keys(newToolsConfig).filter(
+            (name) => !currentToolsConfig[name]
+          );
+          const updatedTools = Object.keys(newToolsConfig).filter((name) => {
+            const current = currentToolsConfig[name];
+            const updated = newToolsConfig[name];
+            return current && current.description !== updated.description;
+          });
+
+          logger.debug(`[ConfigManager] 已同步服务 ${serviceName} 的工具配置:`);
+          if (addedTools.length > 0) {
+            logger.debug(`  - 新增工具: ${addedTools.join(", ")}`);
+          }
+          if (updatedTools.length > 0) {
+            logger.debug(`  - 更新工具: ${updatedTools.join(", ")}`);
+          }
+          if (removedTools.length > 0) {
+            logger.debug(`  - 移除工具: ${removedTools.join(", ")}`);
+          }
+        }
+      }
+
+      logger.debug("[ConfigManager] 工具配置同步完成");
+    } catch (error) {
+      logger.error("[ConfigManager] 同步工具配置到配置文件失败", { error });
+      // 不抛出错误，避免影响服务正常运行
+    }
+  }
+}

--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -4,6 +4,9 @@
  * 提供完整的 MCP（Model Context Protocol）核心功能，包括：
  * - MCPServiceManager: MCP 服务管理器，统一管理多个 MCP 服务
  * - MCPService: MCP 服务类，负责单个 MCP 服务的连接和工具管理
+ * - MCPServiceLifecycleManager: MCP 服务生命周期管理器
+ * - MCPToolStatsManager: MCP 工具统计管理器
+ * - MCPConfigManager: MCP 配置管理器
  * - MCPMessageHandler: MCP 消息处理器，处理所有 MCP 协议消息
  * - MCPCacheManager: MCP 缓存管理器，负责工具列表的缓存
  * - CustomMCPHandler: 自定义 MCP 处理器，处理 Coze 工作流等自定义工具
@@ -37,3 +40,6 @@ export * from "./message.js";
 export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+export * from "./lifecycle.js";
+export * from "./tool-stats.js";
+export * from "./config-manager.js";

--- a/apps/backend/lib/mcp/lifecycle.ts
+++ b/apps/backend/lib/mcp/lifecycle.ts
@@ -1,0 +1,610 @@
+/**
+ * MCP 服务生命周期管理器
+ * 负责管理 MCP 服务的启动、停止和重试逻辑
+ *
+ * @remarks
+ * 该类从 MCPServiceManager 中分离出来，专门负责服务生命周期管理。
+ * 这符合单一职责原则（SRP），使代码更易于维护和测试。
+ *
+ * @example
+ * ```typescript
+ * const lifecycleManager = new MCPServiceLifecycleManager(services, configs, {
+ *   onServiceStarted: async (serviceName) => { ... },
+ *   onServiceFailed: async (serviceName, error) => { ... }
+ * });
+ * await lifecycleManager.startAllServices();
+ * ```
+ */
+
+import { logger } from "@/Logger.js";
+import type { MCPService } from "@/lib/mcp/connection.js";
+import type { MCPServiceConfig } from "@/lib/mcp/types.js";
+import { getEventBus } from "@/services/event-bus.service.js";
+
+/**
+ * 服务生命周期事件回调接口
+ */
+export interface LifecycleEventCallbacks {
+  /** 服务启动成功回调 */
+  onServiceStarted?: (serviceName: string) => Promise<void>;
+  /** 服务启动失败回调 */
+  onServiceFailed?: (serviceName: string, error: Error) => Promise<void>;
+  /** 服务停止回调 */
+  onServiceStopped?: (serviceName: string) => Promise<void>;
+}
+
+/**
+ * 重试统计信息
+ */
+export interface RetryStats {
+  /** 失败的服务列表 */
+  failedServices: string[];
+  /** 活跃的重试列表 */
+  activeRetries: string[];
+  /** 总失败数 */
+  totalFailed: number;
+  /** 总活跃重试数 */
+  totalActiveRetries: number;
+}
+
+/**
+ * 服务启动结果
+ */
+interface ServiceStartResult {
+  serviceName: string;
+  success: boolean;
+  error: string | null;
+}
+
+/**
+ * MCP 服务生命周期管理器
+ *
+ * @remarks
+ * 负责管理 MCP 服务的启动、停止和重试逻辑。
+ * 不负责工具管理、配置增强等功能。
+ */
+export class MCPServiceLifecycleManager {
+  private services: Map<string, MCPService>;
+  private configs: Record<string, MCPServiceConfig>;
+  private eventBus = getEventBus();
+  private retryTimers: Map<string, NodeJS.Timeout> = new Map();
+  private failedServices: Set<string> = new Set();
+  private eventListeners: {
+    serviceConnected: (data: {
+      serviceName: string;
+      tools: unknown[];
+      connectionTime: Date;
+    }) => void;
+    serviceDisconnected: (data: {
+      serviceName: string;
+      reason?: string;
+      disconnectionTime: Date;
+    }) => void;
+    serviceConnectionFailed: (data: {
+      serviceName: string;
+      error: Error;
+      attempt: number;
+    }) => void;
+  } | null = null;
+
+  private callbacks: LifecycleEventCallbacks;
+
+  /**
+   * 创建生命周期管理器实例
+   *
+   * @param services 服务实例映射的引用
+   * @param configs 服务配置对象的引用
+   * @param callbacks 生命周期事件回调
+   */
+  constructor(
+    services: Map<string, MCPService>,
+    configs: Record<string, MCPServiceConfig>,
+    callbacks: LifecycleEventCallbacks = {}
+  ) {
+    this.services = services;
+    this.configs = configs;
+    this.callbacks = callbacks;
+  }
+
+  /**
+   * 设置事件监听器
+   */
+  setupEventListeners(): void {
+    if (this.eventListeners) {
+      return; // 已经设置过了
+    }
+
+    this.eventListeners = {
+      serviceConnected: async (data) => {
+        await this.handleServiceConnected(data);
+      },
+      serviceDisconnected: async (data) => {
+        await this.handleServiceDisconnected(data);
+      },
+      serviceConnectionFailed: async (data) => {
+        await this.handleServiceConnectionFailed(data);
+      },
+    };
+
+    // 监听 MCP 服务连接成功事件
+    this.eventBus.onEvent(
+      "mcp:service:connected",
+      this.eventListeners.serviceConnected
+    );
+
+    // 监听 MCP 服务断开连接事件
+    this.eventBus.onEvent(
+      "mcp:service:disconnected",
+      this.eventListeners.serviceDisconnected
+    );
+
+    // 监听 MCP 服务连接失败事件
+    this.eventBus.onEvent(
+      "mcp:service:connection:failed",
+      this.eventListeners.serviceConnectionFailed
+    );
+  }
+
+  /**
+   * 清理事件监听器
+   */
+  cleanupEventListeners(): void {
+    if (!this.eventListeners) {
+      return;
+    }
+
+    this.eventBus.offEvent(
+      "mcp:service:connected",
+      this.eventListeners.serviceConnected
+    );
+    this.eventBus.offEvent(
+      "mcp:service:disconnected",
+      this.eventListeners.serviceDisconnected
+    );
+    this.eventBus.offEvent(
+      "mcp:service:connection:failed",
+      this.eventListeners.serviceConnectionFailed
+    );
+
+    this.eventListeners = null;
+  }
+
+  /**
+   * 处理 MCP 服务连接成功事件
+   */
+  private async handleServiceConnected(data: {
+    serviceName: string;
+    tools: unknown[];
+    connectionTime: Date;
+  }): Promise<void> {
+    logger.debug(`服务 ${data.serviceName} 连接成功`);
+
+    // 从失败集合中移除
+    this.failedServices.delete(data.serviceName);
+
+    // 触发回调
+    if (this.callbacks.onServiceStarted) {
+      try {
+        await this.callbacks.onServiceStarted(data.serviceName);
+      } catch (error) {
+        logger.error(`服务 ${data.serviceName} 启动回调失败`, { error });
+      }
+    }
+  }
+
+  /**
+   * 处理 MCP 服务断开连接事件
+   */
+  private async handleServiceDisconnected(data: {
+    serviceName: string;
+    reason?: string;
+    disconnectionTime: Date;
+  }): Promise<void> {
+    logger.info(
+      `服务 ${data.serviceName} 断开连接，原因: ${data.reason || "未知"}`
+    );
+
+    // 触发回调
+    if (this.callbacks.onServiceStopped) {
+      try {
+        await this.callbacks.onServiceStopped(data.serviceName);
+      } catch (error) {
+        logger.error(`服务 ${data.serviceName} 停止回调失败`, { error });
+      }
+    }
+  }
+
+  /**
+   * 处理 MCP 服务连接失败事件
+   */
+  private async handleServiceConnectionFailed(data: {
+    serviceName: string;
+    error: Error;
+    attempt: number;
+  }): Promise<void> {
+    // 触发失败回调
+    if (this.callbacks.onServiceFailed) {
+      try {
+        await this.callbacks.onServiceFailed(data.serviceName, data.error);
+      } catch (error) {
+        logger.error(`服务 ${data.serviceName} 失败回调执行失败`, { error });
+      }
+    }
+  }
+
+  /**
+   * 启动所有 MCP 服务
+   *
+   * @remarks
+   * 并行启动所有服务，实现服务隔离。
+   * 启动失败的服务会被安排重试。
+   */
+  async startAllServices(
+    MCPServiceClass: new (config: { name: string } & MCPServiceConfig) => MCPService
+  ): Promise<void> {
+    logger.debug("[LifecycleManager] 正在启动所有 MCP 服务...");
+
+    const configEntries = Object.entries(this.configs);
+    if (configEntries.length === 0) {
+      logger.warn(
+        "[LifecycleManager] 没有配置任何 MCP 服务，请使用 addServiceConfig() 添加服务配置"
+      );
+      return;
+    }
+
+    // 记录启动开始
+    logger.info(
+      `[LifecycleManager] 开始并行启动 ${configEntries.length} 个 MCP 服务`
+    );
+
+    // 并行启动所有服务，实现服务隔离
+    const startPromises = configEntries.map(async ([serviceName]) => {
+      try {
+        await this.startService(serviceName, MCPServiceClass);
+        return {
+          serviceName,
+          success: true,
+          error: null,
+        } satisfies ServiceStartResult;
+      } catch (error) {
+        return {
+          serviceName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        } satisfies ServiceStartResult;
+      }
+    });
+
+    // 等待所有服务启动完成
+    const results = await Promise.allSettled(startPromises);
+
+    // 统计启动结果
+    let successCount = 0;
+    let failureCount = 0;
+    const failedServices: string[] = [];
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        if (result.value.success) {
+          successCount++;
+        } else {
+          failureCount++;
+          failedServices.push(result.value.serviceName);
+        }
+      } else {
+        failureCount++;
+      }
+    }
+
+    // 记录启动完成统计
+    logger.info(
+      `[LifecycleManager] 服务启动完成 - 成功: ${successCount}, 失败: ${failureCount}`
+    );
+
+    // 记录失败的服务列表
+    if (failedServices.length > 0) {
+      logger.warn(
+        `[LifecycleManager] 以下服务启动失败: ${failedServices.join(", ")}`
+      );
+
+      // 如果所有服务都失败了，发出警告但系统继续运行以便重试
+      if (failureCount === configEntries.length) {
+        logger.warn(
+          "[LifecycleManager] 所有 MCP 服务启动失败，但系统将继续运行以便重试"
+        );
+      }
+    }
+
+    // 启动失败服务重试机制
+    if (failedServices.length > 0) {
+      this.scheduleFailedServicesRetry(failedServices);
+    }
+  }
+
+  /**
+   * 启动单个 MCP 服务
+   *
+   * @param serviceName 服务名称
+   * @param MCPServiceClass MCP 服务类
+   * @throws {Error} 如果未找到服务配置或启动失败
+   */
+  async startService(
+    serviceName: string,
+    MCPServiceClass: new (config: { name: string } & MCPServiceConfig) => MCPService
+  ): Promise<void> {
+    const config = this.configs[serviceName];
+    if (!config) {
+      throw new Error(`未找到服务配置: ${serviceName}`);
+    }
+
+    try {
+      // 如果服务已存在，先停止它
+      if (this.services.has(serviceName)) {
+        await this.stopService(serviceName);
+      }
+
+      // 创建 MCPService 实例
+      const serviceConfig = {
+        name: serviceName,
+        ...config,
+      };
+      const service = new MCPServiceClass(serviceConfig);
+
+      // 连接到服务
+      await service.connect();
+
+      // 存储服务实例
+      this.services.set(serviceName, service);
+
+      const tools = service.getTools();
+      logger.debug(
+        `[LifecycleManager] ${serviceName} 服务启动成功，加载了 ${tools.length} 个工具:`,
+        tools.map((t) => t.name).join(", ")
+      );
+    } catch (error) {
+      logger.error(`[LifecycleManager] 启动 ${serviceName} 服务失败`, {
+        error: (error as Error).message,
+      });
+      // 清理可能的部分状态
+      this.services.delete(serviceName);
+      throw error;
+    }
+  }
+
+  /**
+   * 停止单个服务
+   *
+   * @param serviceName 服务名称
+   */
+  async stopService(serviceName: string): Promise<void> {
+    logger.info(`[LifecycleManager] 停止 MCP 服务: ${serviceName}`);
+
+    const service = this.services.get(serviceName);
+    if (!service) {
+      logger.warn(`[LifecycleManager] 服务 ${serviceName} 不存在或未启动`);
+      return;
+    }
+
+    try {
+      await service.disconnect();
+      this.services.delete(serviceName);
+      this.stopServiceRetry(serviceName);
+
+      logger.info(`[LifecycleManager] ${serviceName} 服务已停止`);
+    } catch (error) {
+      logger.error(`[LifecycleManager] 停止 ${serviceName} 服务失败`, {
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 停止所有服务
+   */
+  async stopAllServices(): Promise<void> {
+    logger.info("[LifecycleManager] 正在停止所有 MCP 服务...");
+
+    // 停止所有服务重试
+    this.stopAllServiceRetries();
+
+    // 停止所有服务实例
+    for (const [serviceName, service] of this.services) {
+      try {
+        await service.disconnect();
+        logger.info(`[LifecycleManager] ${serviceName} 服务已停止`);
+      } catch (error) {
+        logger.error(`[LifecycleManager] 停止 ${serviceName} 服务失败`, {
+          error: (error as Error).message,
+        });
+      }
+    }
+
+    this.services.clear();
+
+    logger.info("[LifecycleManager] 所有 MCP 服务已停止");
+  }
+
+  /**
+   * 安排失败服务的重试
+   *
+   * @param failedServices 失败的服务列表
+   */
+  private scheduleFailedServicesRetry(failedServices: string[]): void {
+    if (failedServices.length === 0) return;
+
+    // 记录重试安排
+    logger.info(`[LifecycleManager] 安排 ${failedServices.length} 个失败服务的重试`);
+
+    // 初始重试延迟：30秒
+    const initialDelay = 30000;
+
+    for (const serviceName of failedServices) {
+      this.failedServices.add(serviceName);
+      this.scheduleServiceRetry(serviceName, initialDelay);
+    }
+  }
+
+  /**
+   * 安排单个服务的重试
+   *
+   * @param serviceName 服务名称
+   * @param delay 延迟时间（毫秒）
+   */
+  private scheduleServiceRetry(serviceName: string, delay: number): void {
+    // 清除现有定时器
+    const existingTimer = this.retryTimers.get(serviceName);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.retryTimers.delete(serviceName);
+    }
+
+    logger.debug(`[LifecycleManager] 安排服务 ${serviceName} 在 ${delay}ms 后重试`);
+
+    const timer = setTimeout(async () => {
+      this.retryTimers.delete(serviceName);
+      await this.retryFailedService(serviceName);
+    }, delay);
+
+    this.retryTimers.set(serviceName, timer);
+  }
+
+  /**
+   * 重试失败的服务
+   *
+   * @param serviceName 服务名称
+   */
+  private async retryFailedService(
+    serviceName: string,
+    MCPServiceClass?: new (config: { name: string } & MCPServiceConfig) => MCPService
+  ): Promise<void> {
+    if (!this.failedServices.has(serviceName)) {
+      return; // 服务已经成功启动或不再需要重试
+    }
+
+    if (!MCPServiceClass) {
+      logger.warn(`[LifecycleManager] 无法重试服务 ${serviceName}，未提供 MCPServiceClass`);
+      return;
+    }
+
+    try {
+      await this.startService(serviceName, MCPServiceClass);
+
+      // 重试成功
+      this.failedServices.delete(serviceName);
+      logger.info(`[LifecycleManager] 服务 ${serviceName} 重试启动成功`);
+
+      // 触发成功回调
+      if (this.callbacks.onServiceStarted) {
+        try {
+          await this.callbacks.onServiceStarted(serviceName);
+        } catch (error) {
+          logger.error(`服务 ${serviceName} 启动回调失败`, { error });
+        }
+      }
+    } catch (error) {
+      logger.error(`[LifecycleManager] 服务 ${serviceName} 重试启动失败`, {
+        error: (error as Error).message,
+      });
+
+      // 指数退避重试策略：延迟时间翻倍，最大不超过5分钟
+      const currentDelay = this.getRetryDelay(serviceName);
+      const nextDelay = Math.min(currentDelay * 2, 300000); // 最大5分钟
+
+      logger.debug(
+        `[LifecycleManager] 服务 ${serviceName} 下次重试将在 ${nextDelay}ms 后进行`
+      );
+
+      // 安排下次重试
+      if (this.failedServices.has(serviceName)) {
+        this.scheduleServiceRetry(serviceName, nextDelay);
+      }
+    }
+  }
+
+  /**
+   * 获取当前重试延迟时间
+   *
+   * @param serviceName 服务名称
+   * @returns 当前延迟时间
+   */
+  private getRetryDelay(serviceName: string): number {
+    // 这里可以实现更复杂的状态跟踪来计算准确的延迟
+    // 简化实现：返回一个基于服务名称的哈希值的初始延迟
+    const hash = serviceName
+      .split("")
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    return 30000 + (hash % 60000); // 30-90秒之间的初始延迟
+  }
+
+  /**
+   * 停止指定服务的重试
+   *
+   * @param serviceName 服务名称
+   */
+  stopServiceRetry(serviceName: string): void {
+    const timer = this.retryTimers.get(serviceName);
+    if (timer) {
+      clearTimeout(timer);
+      this.retryTimers.delete(serviceName);
+      logger.debug(`[LifecycleManager] 已停止服务 ${serviceName} 的重试`);
+    }
+    this.failedServices.delete(serviceName);
+  }
+
+  /**
+   * 停止所有服务的重试
+   */
+  stopAllServiceRetries(): void {
+    logger.info("[LifecycleManager] 停止所有服务重试");
+
+    for (const [serviceName, timer] of this.retryTimers) {
+      clearTimeout(timer);
+      logger.debug(`[LifecycleManager] 已停止服务 ${serviceName} 的重试`);
+    }
+
+    this.retryTimers.clear();
+    this.failedServices.clear();
+  }
+
+  /**
+   * 获取失败服务列表
+   *
+   * @returns 失败的服务名称数组
+   */
+  getFailedServices(): string[] {
+    return Array.from(this.failedServices);
+  }
+
+  /**
+   * 检查服务是否失败
+   *
+   * @param serviceName 服务名称
+   * @returns 如果服务失败返回 true
+   */
+  isServiceFailed(serviceName: string): boolean {
+    return this.failedServices.has(serviceName);
+  }
+
+  /**
+   * 获取重试统计信息
+   *
+   * @returns 重试统计信息
+   */
+  getRetryStats(): RetryStats {
+    return {
+      failedServices: Array.from(this.failedServices),
+      activeRetries: Array.from(this.retryTimers.keys()),
+      totalFailed: this.failedServices.size,
+      totalActiveRetries: this.retryTimers.size,
+    };
+  }
+
+  /**
+   * 清理资源
+   */
+  cleanup(): void {
+    this.cleanupEventListeners();
+    this.stopAllServiceRetries();
+  }
+}

--- a/apps/backend/lib/mcp/tool-stats.ts
+++ b/apps/backend/lib/mcp/tool-stats.ts
@@ -1,0 +1,260 @@
+/**
+ * MCP 工具统计管理器
+ * 负责管理 MCP 工具的调用统计信息
+ *
+ * @remarks
+ * 该类从 MCPServiceManager 中分离出来，专门负责工具调用统计管理。
+ * 包括使用次数、最后使用时间等统计信息的更新。
+ *
+ * @example
+ * ```typescript
+ * const statsManager = new MCPToolStatsManager();
+ * await statsManager.updateToolStats(toolName, serviceName, originalToolName, true);
+ * ```
+ */
+
+import { logger } from "@/Logger.js";
+import { configManager } from "@xiaozhi-client/config";
+
+/**
+ * MCP 工具统计管理器
+ *
+ * @remarks
+ * 负责管理 MCP 工具的调用统计信息，包括：
+ * - 使用次数统计
+ * - 最后使用时间记录
+ * - 成功/失败调用统计
+ */
+export class MCPToolStatsManager {
+  /**
+   * 更新工具调用统计信息的通用方法
+   *
+   * @param toolName 工具名称
+   * @param serviceName 服务名称
+   * @param originalToolName 原始工具名称
+   * @param isSuccess 是否调用成功
+   */
+  async updateToolStats(
+    toolName: string,
+    serviceName: string,
+    originalToolName: string,
+    isSuccess: boolean
+  ): Promise<void> {
+    try {
+      const currentTime = new Date().toISOString();
+
+      if (isSuccess) {
+        // 成功调用：更新使用统计
+        await this.updateCustomMCPToolStats(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolStats(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug(`[StatsManager] 已更新工具 ${toolName} 的统计信息`);
+      } else {
+        // 失败调用：只更新最后使用时间
+        await this.updateCustomMCPToolLastUsedTime(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolLastUsedTime(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug("[StatsManager] 已更新工具的失败调用统计信息", {
+          toolName,
+        });
+      }
+    } catch (error) {
+      logger.error("[StatsManager] 更新工具统计信息失败", { toolName, error });
+      throw error;
+    }
+  }
+
+  /**
+   * 统一的统计更新处理方法（带错误处理）
+   *
+   * @param toolName 工具名称
+   * @param serviceName 服务名称
+   * @param originalToolName 原始工具名称
+   * @param isSuccess 是否调用成功
+   */
+  async updateToolStatsSafe(
+    toolName: string,
+    serviceName: string,
+    originalToolName: string,
+    isSuccess: boolean
+  ): Promise<void> {
+    try {
+      await this.updateToolStats(
+        toolName,
+        serviceName,
+        originalToolName,
+        isSuccess
+      );
+    } catch (error) {
+      const action = isSuccess ? "统计信息" : "失败统计信息";
+      logger.warn("[StatsManager] 更新工具统计信息失败", {
+        toolName,
+        action,
+        error,
+      });
+      // 统计更新失败不应该影响主流程，所以这里只记录警告
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具统计信息
+   *
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   */
+  async updateCustomMCPToolStats(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, true);
+      logger.debug(`[StatsManager] 已更新 customMCP 工具 ${toolName} 使用统计`);
+    } catch (error) {
+      logger.error(`[StatsManager] 更新 customMCP 工具 ${toolName} 统计失败`, {
+        error,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具最后使用时间
+   *
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   */
+  async updateCustomMCPToolLastUsedTime(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, false); // 只更新时间，不增加计数
+      logger.debug(
+        `[StatsManager] 已更新 customMCP 工具 ${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[StatsManager] 更新 customMCP 工具 ${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具统计信息
+   *
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   */
+  async updateMCPServerToolStats(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        true
+      );
+      logger.debug(
+        `[StatsManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 统计`
+      );
+    } catch (error) {
+      logger.error(
+        `[StatsManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 统计失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具最后使用时间
+   *
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   */
+  async updateMCPServerToolLastUsedTime(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        false
+      ); // 只更新时间，不增加计数
+      logger.debug(
+        `[StatsManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[StatsManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 清理统计更新锁
+   *
+   * @remarks
+   * 此方法用于在服务停止时清理所有活跃的统计更新锁，防止死锁
+   */
+  clearAllStatsUpdateLocks(): void {
+    try {
+      configManager.clearAllStatsUpdateLocks();
+      logger.info("[StatsManager] 统计更新锁已清理");
+    } catch (error) {
+      logger.error("[StatsManager] 清理统计更新锁失败", { error });
+    }
+  }
+
+  /**
+   * 获取统计更新监控信息
+   *
+   * @returns 包含活跃锁信息的对象
+   */
+  getStatsUpdateInfo(): {
+    activeLocks: string[];
+    totalLocks: number;
+  } {
+    try {
+      const activeLocks = configManager.getStatsUpdateLocks();
+      return {
+        activeLocks,
+        totalLocks: activeLocks.length,
+      };
+    } catch (error) {
+      logger.warn("[StatsManager] 获取统计更新监控信息失败", { error });
+      return {
+        activeLocks: [],
+        totalLocks: 0,
+      };
+    }
+  }
+}


### PR DESCRIPTION
创建三个新的管理器类，从 MCPServiceManager 中分离职责：

- MCPServiceLifecycleManager: 负责服务启动、停止和重试逻辑
- MCPToolStatsManager: 负责工具调用统计信息管理
- MCPConfigManager: 负责服务配置管理和 ModelScope 集成

这些类遵循单一职责原则（SRP），使代码更易于维护和测试。

相关 Issue: #2360

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2360