### PR TITLE
chore(templates): 清理配置模板中的占位符值

### DIFF
--- a/docker/templates/xiaozhi.config.json
+++ b/docker/templates/xiaozhi.config.json
@@ -12,19 +12,19 @@
   },
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
   "connection": {

--- a/templates/default/xiaozhi.config.json
+++ b/templates/default/xiaozhi.config.json
@@ -12,19 +12,19 @@
   },
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
   "connection": {

--- a/templates/hello-world/xiaozhi.config.json
+++ b/templates/hello-world/xiaozhi.config.json
@@ -12,19 +12,19 @@
   },
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
   "connection": {

--- a/templates/json5/xiaozhi.config.json5
+++ b/templates/json5/xiaozhi.config.json5
@@ -23,19 +23,19 @@
 
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
 

--- a/templates/jsonc/xiaozhi.config.jsonc
+++ b/templates/jsonc/xiaozhi.config.jsonc
@@ -23,19 +23,19 @@
 
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
 

--- a/templates/modelscope/xiaozhi.config.json
+++ b/templates/modelscope/xiaozhi.config.json
@@ -11,19 +11,19 @@
   },
   "asr": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token"
+    "appid": "",
+    "accessToken": ""
   },
   "llm": {
     "prompt": "./prompts/default.md",
-    "model": "your-model-name",
-    "apiKey": "your-api-key",
-    "baseURL": "your-base-url"
+    "model": "",
+    "apiKey": "",
+    "baseURL": ""
   },
   "tts": {
     "model": "doubao",
-    "appid": "your-appid",
-    "accessToken": "your-access-token",
+    "appid": "",
+    "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts"
   },
   "connection": {


### PR DESCRIPTION
## Summary
- 将配置模板中的占位符字符串（如 `your-appid`、`your-api-key` 等）替换为空字符串
- 涉及的配置项：asr、llm、tts 的 appid、accessToken、model、apiKey、baseURL
- 避免用户误以为这些是可用的示例值

## Test plan
- [ ] 确认配置文件格式正确
- [ ] 验证模板文件可以正常被复制和使用

🤖 Generated with [Claude Code](https://claude.com/claude-code)