### PR TITLE
fix(tts): 修复 synthesizeSpeechStream 中 WebSocket 资源泄漏

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/binary.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/binary.ts
@@ -177,39 +177,47 @@ export async function synthesizeSpeechStream(
     skipUTF8Validation: true,
   });
 
-  await new Promise((resolve, reject) => {
-    ws.on("open", resolve);
-    ws.on("error", reject);
-  });
+  try {
+    await new Promise((resolve, reject) => {
+      ws.on("open", resolve);
+      ws.on("error", reject);
+    });
 
-  const request = createTTSRequest(options);
+    const request = createTTSRequest(options);
 
-  await FullClientRequest(
-    ws,
-    new TextEncoder().encode(JSON.stringify(request))
-  );
+    await FullClientRequest(
+      ws,
+      new TextEncoder().encode(JSON.stringify(request))
+    );
 
-  while (true) {
-    const msg = await ReceiveMessage(ws);
+    while (true) {
+      const msg = await ReceiveMessage(ws);
 
-    switch (msg.type) {
-      case MsgType.FrontEndResultServer:
-        break;
-      case MsgType.AudioOnlyServer: {
-        // 每收到一个音频块立即调用回调处理
-        const isLast = msg.sequence !== undefined && msg.sequence < 0;
-        await onAudioChunk(msg.payload, isLast);
+      switch (msg.type) {
+        case MsgType.FrontEndResultServer:
+          break;
+        case MsgType.AudioOnlyServer: {
+          // 每收到一个音频块立即调用回调处理
+          const isLast = msg.sequence !== undefined && msg.sequence < 0;
+          await onAudioChunk(msg.payload, isLast);
 
-        if (isLast) {
-          // 最后一块，结束循环
-          ws.close();
-          return;
+          if (isLast) {
+            // 最后一块，结束循环
+            return;
+          }
+          break;
         }
-        break;
+        default:
+          throw new Error(`${msg.toString()}`);
       }
-      default:
-        ws.close();
-        throw new Error(`${msg.toString()}`);
+    }
+  } finally {
+    // 确保 WebSocket 在任何情况下都被关闭
+    if (
+      ws.readyState === WebSocket.OPEN ||
+      ws.readyState === WebSocket.CONNECTING
+    ) {
+      ws.close();
     }
   }
 }


### PR DESCRIPTION
在 onAudioChunk 回调抛出错误时，WebSocket 连接未能正确关闭，
导致资源泄漏。通过添加 try-finally 块确保 WebSocket 在任何情况下
都会被关闭。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2364