### PR TITLE
fix(backend): 将 Logger 文件操作改为异步避免阻塞事件循环

### DIFF
--- a/apps/backend/Logger.ts
+++ b/apps/backend/Logger.ts
@@ -125,7 +125,7 @@
  * ```
  */
 
-import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import chalk from "chalk";
 import pino from "pino";
@@ -330,16 +330,19 @@ export class Logger {
    * 初始化日志文件
    * @param projectDir 项目目录
    */
-  initLogFile(projectDir: string): void {
+  async initLogFile(projectDir: string): Promise<void> {
     this.logFilePath = path.join(projectDir, "xiaozhi.log");
 
-    // 检查并轮转日志文件
-    this.rotateLogFileIfNeeded();
+    // 异步检查并轮转日志文件
+    await this.rotateLogFileIfNeeded();
 
-    // 确保日志文件存在
+    // 确保日志文件存在（异步操作）
     try {
-      if (!fs.existsSync(this.logFilePath)) {
-        fs.writeFileSync(this.logFilePath, "");
+      try {
+        await fsPromises.access(this.logFilePath);
+      } catch {
+        // 文件不存在，创建空文件
+        await fsPromises.writeFile(this.logFilePath, "");
       }
     } catch (error) {
       // 如果创建日志文件失败，记录警告但继续执行
@@ -502,58 +505,72 @@ export class Logger {
   /**
    * 检查并轮转日志文件（如果需要）
    */
-  private rotateLogFileIfNeeded(): void {
-    if (!this.logFilePath || !fs.existsSync(this.logFilePath)) {
-      return;
-    }
+  private async rotateLogFileIfNeeded(): Promise<void> {
+    if (!this.logFilePath) return;
 
     try {
-      const stats = fs.statSync(this.logFilePath);
+      await fsPromises.access(this.logFilePath);
+      const stats = await fsPromises.stat(this.logFilePath);
       if (stats.size > this.maxLogFileSize) {
-        this.rotateLogFile();
+        // 异步执行日志轮转，避免阻塞事件循环
+        this.rotateLogFile().catch((error) => {
+          console.warn(`[Logger] 日志轮转失败: ${error}`);
+        });
       }
-    } catch (error) {
-      // 忽略文件状态检查错误
+    } catch {
+      // 文件不存在或无法访问，忽略错误
     }
   }
 
   /**
-   * 轮转日志文件
+   * 轮转日志文件（异步执行）
    */
-  private rotateLogFile(): void {
+  private async rotateLogFile(): Promise<void> {
     if (!this.logFilePath) return;
 
     try {
       const logDir = path.dirname(this.logFilePath);
       const logName = path.basename(this.logFilePath, ".log");
 
-      // 移动现有的编号日志文件
+      // 移动现有的编号日志文件（从后往前，避免覆盖）
       for (let i = this.maxLogFiles - 1; i >= 1; i--) {
         const oldFile = path.join(logDir, `${logName}.${i}.log`);
         const newFile = path.join(logDir, `${logName}.${i + 1}.log`);
 
-        if (fs.existsSync(oldFile)) {
-          if (i === this.maxLogFiles - 1) {
-            // 删除最老的文件
-            fs.unlinkSync(oldFile);
-          } else {
-            fs.renameSync(oldFile, newFile);
+        if (i === this.maxLogFiles - 1) {
+          // 尝试删除最老的文件，如果不存在则忽略
+          try {
+            await fsPromises.unlink(oldFile);
+          } catch {
+            // 文件不存在，继续
           }
+        }
+
+        // 尝试重命名文件，如果不存在则忽略
+        try {
+          await fsPromises.rename(oldFile, newFile);
+        } catch {
+          // 文件不存在或已被移动，继续
         }
       }
 
       // 将当前日志文件重命名为 .1.log
       const firstRotatedFile = path.join(logDir, `${logName}.1.log`);
-      fs.renameSync(this.logFilePath, firstRotatedFile);
+      await fsPromises.rename(this.logFilePath, firstRotatedFile);
     } catch (error) {
-      // 轮转失败时忽略错误，继续使用当前文件
+      // 轮转失败时记录错误，继续使用当前文件
+      console.warn(
+        `[Logger] 日志轮转失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
     }
   }
 
   /**
-   * 清理旧的日志文件
+   * 清理旧的日志文件（异步执行）
    */
-  cleanupOldLogs(): void {
+  async cleanupOldLogs(): Promise<void> {
     if (!this.logFilePath) return;
 
     try {
@@ -561,12 +578,21 @@ export class Logger {
       const logName = path.basename(this.logFilePath, ".log");
 
       // 删除超过最大数量的日志文件
+      const unlinkPromises: Promise<void>[] = [];
       for (let i = this.maxLogFiles + 1; i <= this.maxLogFiles + 10; i++) {
         const oldFile = path.join(logDir, `${logName}.${i}.log`);
-        if (fs.existsSync(oldFile)) {
-          fs.unlinkSync(oldFile);
-        }
+        // 使用 promise 来尝试删除，忽略不存在的文件
+        unlinkPromises.push(
+          (async () => {
+            try {
+              await fsPromises.unlink(oldFile);
+            } catch {
+              // 文件不存在或无法删除，忽略
+            }
+          })()
+        );
       }
+      await Promise.all(unlinkPromises);
     } catch (error) {
       // 忽略清理错误
     }

--- a/apps/backend/__tests__/logger.test.ts
+++ b/apps/backend/__tests__/logger.test.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
 import * as path from "node:path";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { Logger, logger } from "../Logger.js";
@@ -10,6 +11,15 @@ vi.mock("node:fs", () => ({
   statSync: vi.fn(),
   renameSync: vi.fn(),
   unlinkSync: vi.fn(),
+}));
+
+// 模拟 fs/promises
+vi.mock("node:fs/promises", () => ({
+  access: vi.fn(),
+  writeFile: vi.fn(),
+  stat: vi.fn(),
+  rename: vi.fn(),
+  unlink: vi.fn(),
 }));
 
 vi.mock("node:path", () => ({
@@ -148,17 +158,19 @@ describe("Logger", async () => {
   });
 
   describe("initLogFile", () => {
-    it("应该在日志文件不存在时初始化", () => {
+    it("应该在日志文件不存在时初始化", async () => {
       const testLogger = new Logger();
-      mockFs.existsSync.mockReturnValue(false);
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockRejectedValue(new Error("File not found"));
+      mockFsPromises.writeFile.mockResolvedValue(undefined);
 
-      testLogger.initLogFile("/test/project");
+      await testLogger.initLogFile("/test/project");
 
       expect(mockPath.join).toHaveBeenCalledWith(
         "/test/project",
         "xiaozhi.log"
       );
-      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+      expect(mockFsPromises.writeFile).toHaveBeenCalledWith(
         "/test/project/xiaozhi.log",
         ""
       );
@@ -166,23 +178,26 @@ describe("Logger", async () => {
       expect(mockPino).toHaveBeenCalledTimes(2); // 一次构造函数，一次 initLogFile
     });
 
-    it("应该在日志文件已存在时初始化", () => {
+    it("应该在日志文件已存在时初始化", async () => {
       const testLogger = new Logger();
-      mockFs.existsSync.mockReturnValue(true);
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
 
-      testLogger.initLogFile("/test/project");
+      await testLogger.initLogFile("/test/project");
 
-      expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+      expect(mockFsPromises.writeFile).not.toHaveBeenCalled();
       // 验证 pino 实例被重新创建
       expect(mockPino).toHaveBeenCalledTimes(2); // 一次构造函数，一次 initLogFile
     });
   });
 
   describe("文件日志记录", () => {
-    it("应该在初始化日志文件时自动启用文件日志记录", () => {
+    it("应该在初始化日志文件时自动启用文件日志记录", async () => {
       const testLogger = new Logger();
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
 
-      testLogger.initLogFile("/test/project");
+      await testLogger.initLogFile("/test/project");
 
       // 验证 pino.destination 被调用来创建文件流
       expect(mockPino.destination).toHaveBeenCalledWith({
@@ -200,10 +215,13 @@ describe("Logger", async () => {
       expect(mockPino.destination).not.toHaveBeenCalled();
     });
 
-    it("应该在守护进程模式下处理文件日志记录", () => {
+    it("应该在守护进程模式下处理文件日志记录", async () => {
       process.env.XIAOZHI_DAEMON = "true";
       const testLogger = new Logger();
-      testLogger.initLogFile("/test/project");
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
+
+      await testLogger.initLogFile("/test/project");
 
       // 在守护进程模式下，应该只有文件流，没有控制台流
       expect(mockPino.multistream).toHaveBeenCalled();
@@ -221,9 +239,11 @@ describe("Logger", async () => {
   describe("日志记录方法", () => {
     let testLogger: Logger;
 
-    beforeEach(() => {
+    beforeEach(async () => {
       testLogger = new Logger();
-      testLogger.initLogFile("/test/project");
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
+      await testLogger.initLogFile("/test/project");
     });
 
     it("应该记录 info 消息", () => {
@@ -305,9 +325,11 @@ describe("Logger", async () => {
   });
 
   describe("close", () => {
-    it("应该优雅地处理 close", () => {
+    it("应该优雅地处理 close", async () => {
       const testLogger = new Logger();
-      testLogger.initLogFile("/test/project");
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
+      await testLogger.initLogFile("/test/project");
 
       // 不应该抛出错误
       expect(() => testLogger.close()).not.toThrow();
@@ -341,16 +363,21 @@ describe("Logger", async () => {
       expect(() => testLogger.setLogFileOptions(1024, 3)).not.toThrow();
     });
 
-    it("应该清理旧日志", () => {
-      testLogger.initLogFile("/test/project");
+    it("应该清理旧日志", async () => {
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
+      mockFsPromises.unlink.mockResolvedValue(undefined);
+
+      await testLogger.initLogFile("/test/project");
 
       // 不应该抛出错误
-      expect(() => testLogger.cleanupOldLogs()).not.toThrow();
+      await expect(testLogger.cleanupOldLogs()).resolves.not.toThrow();
     });
 
-    it("应该处理日志轮转", () => {
-      mockFs.existsSync.mockReturnValue(true);
-      mockFs.statSync.mockReturnValue({
+    it("应该处理日志轮转", async () => {
+      const mockFsPromises = vi.mocked(fsPromises);
+      mockFsPromises.access.mockResolvedValue(undefined);
+      mockFsPromises.stat.mockResolvedValue({
         size: BigInt(20 * 1024 * 1024),
         isFile: () => true,
         isDirectory: () => false,
@@ -377,11 +404,13 @@ describe("Logger", async () => {
         ctime: new Date(),
         birthtime: new Date(),
       } as any); // 20MB 文件
+      mockFsPromises.rename.mockResolvedValue(undefined);
+      mockFsPromises.unlink.mockResolvedValue(undefined);
 
-      testLogger.initLogFile("/test/project");
+      await testLogger.initLogFile("/test/project");
 
       // 轮转期间不应该抛出错误
-      expect(() => testLogger.initLogFile("/test/project")).not.toThrow();
+      await expect(testLogger.initLogFile("/test/project")).resolves.not.toThrow();
     });
   });
 


### PR DESCRIPTION
- 使用 fs/promises API 替代同步文件操作
- initLogFile()、rotateLogFile()、cleanupOldLogs() 改为异步方法
- 日志轮转在后台异步执行，避免阻塞主线程
- 更新相关测试以支持异步操作

修复 #2366

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2366