### PR TITLE
fix(tts): 修复 WebSocket 事件监听器内存泄漏

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -75,8 +75,8 @@ export class ByteDanceTTSController implements TTSController {
         reject(new Error("WebSocket 未创建"));
         return;
       }
-      this.ws.on("open", () => resolve());
-      this.ws.on("error", (err) => reject(err));
+      this.ws.once("open", () => resolve());
+      this.ws.once("error", (err) => reject(err));
     });
 
     const request = {
@@ -139,7 +139,13 @@ export class ByteDanceTTSController implements TTSController {
           console.log(
             `[TTSController] Calling onAudioChunk: isLast=${isLast}, sequence=${msg.sequence}`
           );
-          await onAudioChunk(msg.payload, isLast);
+          try {
+            await onAudioChunk(msg.payload, isLast);
+          } catch (error) {
+            console.error("[TTSController] onAudioChunk 回调错误:", error);
+            this.close();
+            throw error;
+          }
 
           if (isLast) {
             this.close();
@@ -177,8 +183,8 @@ export class ByteDanceTTSController implements TTSController {
         reject(new Error("WebSocket 未创建"));
         return;
       }
-      this.ws.on("open", () => resolve());
-      this.ws.on("error", (err) => reject(err));
+      this.ws.once("open", () => resolve());
+      this.ws.once("error", (err) => reject(err));
     });
 
     const request = {


### PR DESCRIPTION
将 synthesizeStream 和 synthesize 方法中的 ws.on() 改为 ws.once()，
确保事件监听器在触发后自动移除，防止内存泄漏。

同时在 onAudioChunk 回调中添加 try-catch 错误处理，确保回调
抛出异常时 WebSocket 连接能正确关闭。

修复 #2368

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2368