### PR TITLE
fix(docs): 修正 config 命令格式错误

### DIFF
--- a/docs/content/reference/command.mdx
+++ b/docs/content/reference/command.mdx
@@ -12,6 +12,6 @@ description: "xiaozhi-client 命令行工具的常用命令参考。"
 | xiaozhi start                                 | 启动服务                    |
 | xiaozhi stop                                  | 停止服务                    |
 | xiaozhi status                                | 查看服务状态                |
-| xiaozhi config mcpEndpoint \<小智接入点地址\> | 设置小智接入点              |
+| xiaozhi config set mcpEndpoint \<小智接入点地址\> | 设置小智接入点              |
 | xiaozhi mcp list                              | 列出所有 MCP 服务           |
 | xiaozhi mcp list --tools                      | 列出所有正在使用的 MCP 工具 |


### PR DESCRIPTION
将错误的命令格式 `xiaozhi config mcpEndpoint <地址>` 修改为正确的格式
`xiaozhi config set mcpEndpoint <地址>`，以符合 ConfigCommandHandler
的实际实现。

Fixes #2374

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2374