### PR TITLE
docs(shared-types): 添加详细的包级文档注释

### DIFF
--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -1,5 +1,72 @@
 /**
- * 小智项目共享类型定义主入口
+ * @xiaozhi-client/shared-types
+ *
+ * 小智项目的共享类型定义包，公开发布到 npm
+ *
+ * 此包提供项目中所有模块共享的类型定义，包括：
+ *
+ * - **Coze 平台类型**: 扣子平台相关类型，包括工作流、参数配置等
+ * - **MCP 相关类型**: MCP 协议相关类型，包括工具定义、消息格式、缓存等
+ * - **API 类型**: 工具 API 相关类型定义
+ * - **配置类型**: 各种服务配置类型，包括连接、服务器、平台等配置
+ * - **前端类型**: 前端专用类型定义
+ * - **工具类型**: 通用工具类和函数，如 TimeoutError 等
+ *
+ * @example
+ * ### 使用配置类型
+ * ```typescript
+ * import type { AppConfig, MCPServerConfig } from '@xiaozhi-client/shared-types';
+ *
+ * const config: AppConfig = {
+ *   mcpEndpoint: 'wss://api.example.com/mcp',
+ *   mcpServers: {
+ *     'calculator': {
+ *       type: 'stdio',
+ *       command: 'node',
+ *       args: ['calculator.js']
+ *     }
+ *   }
+ * };
+ * ```
+ *
+ * @example
+ * ### 使用 MCP 工具类型
+ * ```typescript
+ * import type { CustomMCPTool, JSONSchema } from '@xiaozhi-client/shared-types';
+ *
+ * const tool: CustomMCPTool = {
+ *   name: 'my_tool',
+ *   description: '我的工具',
+ *   inputSchema: {
+ *     type: 'object',
+ *     properties: {
+ *       param1: { type: 'string', description: '参数1' }
+ *     }
+ *   }
+ * };
+ * ```
+ *
+ * @example
+ * ### 使用 Coze 平台类型
+ * ```typescript
+ * import type { CozeWorkflow, WorkflowParameter } from '@xiaozhi-client/shared-types';
+ *
+ * const workflow: CozeWorkflow = {
+ *   workflow_id: 'workflow_123',
+ *   name: '我的工作流',
+ *   description: '工作流描述',
+ *   parameters: [
+ *     {
+ *       name: 'input',
+ *       type: 'string',
+ *       required: true,
+ *       description: '输入参数'
+ *     } as WorkflowParameter
+ *   ]
+ * };
+ * ```
+ *
+ * @packageDocumentation
  */
 
 // 扣子平台相关类型


### PR DESCRIPTION
为 @xiaozhi-client/shared-types 包的主入口文件添加完整的文档注释，包括：
- 包的详细说明和用途
- 主要导出模块的概述
- 配置类型使用示例
- MCP 工具类型使用示例
- Coze 平台类型使用示例

这有助于用户快速了解包的功能和正确用法。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2378