### PR TITLE
fix: 统一 apps/backend 中的 MCP 相关导入路径

### DIFF
--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -17,12 +17,12 @@ import { logger } from "@/Logger.js";
 import { ErrorCategory, MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { MCPService } from "@/lib/mcp";
+import { TypeFieldNormalizer } from "@/lib/mcp";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
-import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
 
 /**

--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -37,3 +37,6 @@ export * from "./message.js";
 export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+
+// 重新导出 @xiaozhi-client/mcp-core 中的类型规范化工具
+export { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";

--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -6,7 +6,7 @@
  * - 工具调用参数验证
  */
 
-import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
+import { TypeFieldNormalizer } from "@/lib/mcp/index.js";
 import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
   MCPServiceConfig,


### PR DESCRIPTION
- 在 @/lib/mcp 中重新导出 TypeFieldNormalizer
- 将 mcp-manage.handler.ts 的导入从 @xiaozhi-client/mcp-core 改为 @/lib/mcp
- 将 utils.ts 的导入从 @xiaozhi-client/mcp-core 改为 @/lib/mcp

这确保了 apps/backend 中所有 MCP 相关导入使用一致的路径，
提高代码一致性，降低维护成本。

修复 #2399

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2399