### PR TITLE
fix: 统一 services 导出路径，添加 ASRService、LLMService 和 TTSService 导出

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -12,7 +12,7 @@ import {
   parseBinaryProtocol2,
   parseBinaryProtocol3,
 } from "@/lib/esp32/audio-protocol.js";
-import type { ASRService } from "@/services/asr.service.js";
+import type { ASRService } from "@/services/index.js";
 import {
   type ESP32ConnectionState,
   ESP32ErrorCode,

--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -13,10 +13,8 @@ import type {
 } from "@/types/esp32.js";
 import { camelToSnakeCase, extractDeviceInfo } from "@/utils/esp32-utils.js";
 import type WebSocket from "ws";
-import { ASRService } from "./asr.service.js";
-import type { DeviceRegistryService } from "./device-registry.service.js";
-import { LLMService } from "./llm.service.js";
-import { TTSService } from "./tts.service.js";
+import { ASRService, LLMService, TTSService } from "@/services/index.js";
+import type { DeviceRegistryService } from "@/services/index.js";
 
 /**
  * ESP32设备服务

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -5,11 +5,16 @@
  * - StatusService: 统一的状态管理服务，管理客户端连接状态、MCP 服务状态等
  * - NotificationService: 通知服务，处理系统通知和消息推送
  * - EventBus / getEventBus: 事件总线服务，提供发布-订阅模式的事件处理机制
+ * - ASRService: 语音识别服务，处理语音到文本的转换
+ * - TTSService: 语音合成服务，处理文本到语音的转换
+ * - LLMService: 大语言模型服务，提供 AI 对话能力
+ * - DeviceRegistryService: 设备注册服务，管理设备连接和状态
+ * - ESP32Service: ESP32 设备服务，处理 ESP32 硬件通信
  * - CustomMCPHandler: 自定义 MCP 处理器（重新导出，保持向后兼容性）
  *
  * @example
  * ```typescript
- * import { StatusService, NotificationService, getEventBus } from '@/services';
+ * import { StatusService, NotificationService, getEventBus, ASRService, TTSService, LLMService } from '@/services';
  *
  * // 使用状态服务
  * const statusService = new StatusService();
@@ -20,6 +25,18 @@
  * eventBus.onEvent('event-name', (data) => {
  *   console.log('Event received:', data);
  * });
+ *
+ * // 使用 ASR 服务
+ * const asrService = new ASRService();
+ * await asrService.prepare('device-001');
+ *
+ * // 使用 TTS 服务
+ * const ttsService = new TTSService();
+ * await ttsService.speak('device-001', '你好');
+ *
+ * // 使用 LLM 服务
+ * const llmService = new LLMService();
+ * const response = await llmService.chat('你好');
  * ```
  */
 export * from "./status.service.js";
@@ -27,6 +44,9 @@ export * from "./notification.service.js";
 export * from "./event-bus.service.js";
 export * from "./device-registry.service.js";
 export * from "./esp32.service.js";
+export * from "./asr.service.js";
+export * from "./tts.service.js";
+export * from "./llm.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";


### PR DESCRIPTION
- 在 services/index.ts 中添加缺失的 ASRService、LLMService 和 TTSService 导出
- 更新模块文档注释，包含所有服务的说明和使用示例
- 更新 esp32.service.ts 使用统一导入路径 @/services
- 更新 lib/esp32/connection.ts 使用统一导入路径 @/services

修复 #2405

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2405