### PR TITLE
refactor: 消除 SimplePlatformRegistry 类的重复代码

### DIFF
--- a/packages/asr/src/core/ASRPlatform.ts
+++ b/packages/asr/src/core/ASRPlatform.ts
@@ -15,21 +15,46 @@ import type {
 export type ASRPlatformFactory = (config: PlatformConfig) => ASRPlatform;
 
 /**
- * 简单平台注册表实现
+ * 泛型平台注册表基础类
+ * 提供通用的平台注册逻辑
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, ASRPlatform> = new Map();
+class GenericPlatformRegistry<T extends { platform: string }> {
+  private platforms: Map<string, T> = new Map();
 
-  get(platform: string): ASRPlatform | undefined {
+  get(platform: string): T | undefined {
     return this.platforms.get(platform);
   }
 
-  register(platform: ASRPlatform): void {
+  register(platform: T): void {
     this.platforms.set(platform.platform, platform);
   }
 
   list(): string[] {
     return Array.from(this.platforms.keys());
+  }
+}
+
+/**
+ * 简单平台注册表实现
+ * 基于 GenericPlatformRegistry 的类型化封装
+ */
+export class SimplePlatformRegistry implements PlatformRegistry {
+  private registry: GenericPlatformRegistry<ASRPlatform>;
+
+  constructor() {
+    this.registry = new GenericPlatformRegistry<ASRPlatform>();
+  }
+
+  get(platform: string): ASRPlatform | undefined {
+    return this.registry.get(platform);
+  }
+
+  register(platform: ASRPlatform): void {
+    this.registry.register(platform);
+  }
+
+  list(): string[] {
+    return this.registry.list();
   }
 }
 

--- a/packages/tts/src/core/TTSPlatform.ts
+++ b/packages/tts/src/core/TTSPlatform.ts
@@ -15,21 +15,46 @@ import type {
 export type TTSPlatformFactory = (config: PlatformConfig) => TTSPlatform;
 
 /**
- * 简单平台注册表实现
+ * 泛型平台注册表基础类
+ * 提供通用的平台注册逻辑
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, TTSPlatform> = new Map();
+class GenericPlatformRegistry<T extends { platform: string }> {
+  private platforms: Map<string, T> = new Map();
 
-  get(platform: string): TTSPlatform | undefined {
+  get(platform: string): T | undefined {
     return this.platforms.get(platform);
   }
 
-  register(platform: TTSPlatform): void {
+  register(platform: T): void {
     this.platforms.set(platform.platform, platform);
   }
 
   list(): string[] {
     return Array.from(this.platforms.keys());
+  }
+}
+
+/**
+ * 简单平台注册表实现
+ * 基于 GenericPlatformRegistry 的类型化封装
+ */
+export class SimplePlatformRegistry implements PlatformRegistry {
+  private registry: GenericPlatformRegistry<TTSPlatform>;
+
+  constructor() {
+    this.registry = new GenericPlatformRegistry<TTSPlatform>();
+  }
+
+  get(platform: string): TTSPlatform | undefined {
+    return this.registry.get(platform);
+  }
+
+  register(platform: TTSPlatform): void {
+    this.registry.register(platform);
+  }
+
+  list(): string[] {
+    return this.registry.list();
   }
 }
 


### PR DESCRIPTION
通过引入 GenericPlatformRegistry 泛型基类，消除了 ASR 和 TTS 包中
SimplePlatformRegistry 类的 18 行重复代码。

- 在 ASRPlatform.ts 中新增 GenericPlatformRegistry<T> 泛型基类
- 在 TTSPlatform.ts 中新增 GenericPlatformRegistry<T> 泛型基类
- SimplePlatformRegistry 现在使用泛型基类，减少了代码重复
- 保持了相同的 API 接口，不影响现有功能

Fixes #2407

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2407