### PR TITLE
fix: 统一使用 @/ 路径别名导入组件

### DIFF
--- a/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
+++ b/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
@@ -1,5 +1,11 @@
 "use client";
 
+import { McpServerSettingButton } from "@/components/mcp-server-setting-button";
+import { ServerPagination } from "@/components/mcp-server/server-pagination";
+import { ServerSearchInput } from "@/components/mcp-server/server-search-input";
+import { ServerSortSelector } from "@/components/mcp-server/server-sort-selector";
+import { StatusBadge } from "@/components/mcp-server/status-badge";
+import { RemoveMcpServerButton } from "@/components/remove-mcp-server-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,12 +25,6 @@ import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
-import { McpServerSettingButton } from "../mcp-server-setting-button";
-import { RemoveMcpServerButton } from "../remove-mcp-server-button";
-import { ServerPagination } from "./server-pagination";
-import { ServerSearchInput } from "./server-search-input";
-import { ServerSortSelector } from "./server-sort-selector";
-import { StatusBadge } from "./status-badge";
 
 /** 服务器行数据 */
 export interface ServerRowData {


### PR DESCRIPTION
将 mcp-server-table.tsx 中的相对路径导入替换为 @/ 路径别名，
保持与项目规范的一致性。

- ../mcp-server-setting-button → @/components/mcp-server-setting-button
- ../remove-mcp-server-button → @/components/remove-mcp-server-button
- ./server-pagination → @/components/mcp-server/server-pagination
- ./server-search-input → @/components/mcp-server/server-search-input
- ./server-sort-selector → @/components/mcp-server/server-sort-selector
- ./status-badge → @/components/mcp-server/status-badge

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2411