### PR TITLE
fix: 修复 ArrayField 组件枚举数组边界情况处理

### DIFF
--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -100,7 +100,7 @@ const ArrayField = memo(function ArrayField({
 
     switch (itemSchema.type) {
       case "string":
-        newItem = itemSchema.enum ? itemSchema.enum[0] : "";
+        newItem = itemSchema.enum?.[0] ?? "";
         break;
       case "number":
       case "integer":


### PR DESCRIPTION
在 tool-debug-dialog.tsx 的 ArrayField 组件中，addItem 方法处理
字符串类型枚举时，直接访问 itemSchema.enum[0] 未检查枚举数
组是否为空。现在使用可选链操作符 (?.) 和空值合并操作符 (??)
来安全地处理空枚举数组的情况。

修复前: newItem = itemSchema.enum ? itemSchema.enum[0] : "";
修复后: newItem = itemSchema.enum?.[0] ?? "";

Fixes #2415

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2415