### PR TITLE
fix: 完善 apps/backend/utils/index.ts 统一导出模块

### DIFF
--- a/apps/backend/utils/index.ts
+++ b/apps/backend/utils/index.ts
@@ -16,3 +16,8 @@ export {
   type DeviceInfoFromHeaders,
   type ExtractedDeviceInfo,
 } from "./esp32-utils.js";
+// Prompt 工具（用于 LLM 服务和配置处理器）
+export { resolvePrompt } from "./prompt-utils.js";
+// Tool 排序工具（用于 MCP 工具管理）
+export { sortTools, toolSorters } from "./toolSorters.js";
+export type { ToolSortField } from "./toolSorters.js";


### PR DESCRIPTION
添加缺失的导出：
- resolvePrompt (from prompt-utils.ts)
- sortTools, toolSorters, ToolSortField (from toolSorters.ts)

这些导出允许通过 @/utils 统一访问，提升代码一致性并符合项目路径别名系统原则。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2417