### PR TITLE
fix: 为 ServiceManager cleanup 函数添加错误处理

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -282,8 +282,15 @@ export class ServiceManagerImpl implements IServiceManager {
 
       // 处理退出信号
       const cleanup = async () => {
-        await server.stop();
-        process.exit(0);
+        try {
+          await server.stop();
+        } catch (error) {
+          consola.error(
+            `停止服务器失败: ${error instanceof Error ? error.message : String(error)}`
+          );
+        } finally {
+          process.exit(0);
+        }
       };
 
       process.once("SIGINT", cleanup);
@@ -341,9 +348,16 @@ export class ServiceManagerImpl implements IServiceManager {
 
     // 处理退出信号
     const cleanup = async () => {
-      await server.stop();
-      this.processManager.cleanupPidFile();
-      process.exit(0);
+      try {
+        await server.stop();
+        this.processManager.cleanupPidFile();
+      } catch (error) {
+        consola.error(
+          `停止服务器失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        process.exit(0);
+      }
     };
 
     process.once("SIGINT", cleanup);


### PR DESCRIPTION
修复两个 cleanup 函数中缺少错误处理的问题：
- startMcpServerMode() 中的 cleanup 函数
- startWebServerInForeground() 中的 cleanup 函数

当 server.stop() 抛出错误时，现在会：
1. 捕获错误并记录到控制台
2. 使用 finally 确保 process.exit(0) 总是执行
3. 避免未捕获的 Promise rejection 导致进程无法正常退出

修复 #2422

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2422