### PR TITLE
refactor: 提取共享 Hook useMcpFormDialog 消除重复代码

### DIFF
--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -19,94 +19,36 @@ import {
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { mcpFormSchema } from "@/schemas/mcp-form";
+import { useMcpFormDialog, type jsonFormSchema } from "@/hooks/useMcpFormDialog";
+import type { mcpFormSchema } from "@/schemas/mcp-form";
 import { apiClient } from "@/services/api";
-import {
-  formToApiConfig,
-  formToJson,
-  jsonToFormData,
-} from "@/utils/mcpFormConverter";
+import { formToApiConfig } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
-import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useCallback } from "react";
+import type { z } from "zod";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
 
 export function AddMcpServerButton() {
-  const [open, setOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [inputMode, setInputMode] = useState<"form" | "json">("form");
-  const [jsonInput, setJsonInput] = useState<string>("");
-
-  // 表单模式的表单实例
-  const form = useForm<z.infer<typeof mcpFormSchema>>({
-    resolver: zodResolver(mcpFormSchema),
-    defaultValues: {
+  const {
+    open,
+    setOpen,
+    isLoading,
+    setIsLoading,
+    inputMode,
+    setJsonInput,
+    form,
+    advancedForm,
+    handleOpenChange,
+    handleModeChange,
+  } = useMcpFormDialog({
+    defaultFormValues: {
       type: "stdio",
       name: "",
       command: "",
       env: "",
     },
   });
-
-  // 高级模式的表单实例（保持原有验证逻辑）
-  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
-    resolver: zodResolver(jsonFormSchema),
-    defaultValues: {
-      config: "",
-    },
-  });
-
-  // 当弹窗关闭时重置状态
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      if (!newOpen) {
-        // 重置表单和状态
-        form.reset();
-        advancedForm.reset();
-        setJsonInput("");
-        setInputMode("form");
-      }
-      setOpen(newOpen);
-    },
-    [form, advancedForm]
-  );
-
-  // 处理模式切换
-  const handleModeChange = useCallback(
-    (newMode: string) => {
-      if (newMode !== "form" && newMode !== "json") {
-        return; // 忽略无效值
-      }
-
-      if (newMode === "json" && inputMode === "form") {
-        // 表单 → JSON
-        const formValues = form.getValues();
-        try {
-          setJsonInput(formToJson(formValues));
-        } catch {
-          setJsonInput("");
-        }
-      } else if (newMode === "form" && inputMode === "json") {
-        // JSON → 表单
-        const formData = jsonToFormData(jsonInput);
-        if (formData) {
-          form.reset(formData);
-        }
-      }
-      setInputMode(newMode);
-    },
-    [inputMode, form, jsonInput]
-  );
 
   // 表单模式提交处理
   const handleFormSubmit = useCallback(
@@ -141,7 +83,7 @@ export function AddMcpServerButton() {
         setIsLoading(false);
       }
     },
-    [form]
+    [form, setIsLoading, setOpen]
   );
 
   // 高级模式提交处理
@@ -199,7 +141,7 @@ export function AddMcpServerButton() {
         setIsLoading(false);
       }
     },
-    [advancedForm]
+    [advancedForm, setIsLoading, setOpen]
   );
 
   return (

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -19,30 +19,20 @@ import {
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
+import { useMcpFormDialog, type jsonFormSchema } from "@/hooks/useMcpFormDialog";
 import { useNetworkServiceActions } from "@/providers/WebSocketProvider";
-import { mcpFormSchema } from "@/schemas/mcp-form";
+import type { mcpFormSchema } from "@/schemas/mcp-form";
 import { useConfig } from "@/stores/config";
 import {
   apiConfigToForm,
   formToApiConfig,
-  formToJson,
-  jsonToFormData,
 } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
-import { zodResolver } from "@hookform/resolvers/zod";
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 import { SettingsIcon } from "lucide-react";
-import { useCallback, useState } from "react";
-import { useForm } from "react-hook-form";
+import { useCallback } from "react";
+import type { z } from "zod";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
 
 export function McpServerSettingButton({
   mcpServer,
@@ -51,75 +41,34 @@ export function McpServerSettingButton({
   mcpServer: MCPServerConfig;
   mcpServerName: string;
 }) {
-  const [open, setOpen] = useState(false);
-  const [isLoading, setIsLoading] = useState(false);
-  const [inputMode, setInputMode] = useState<"form" | "json">("form");
-  const [jsonInput, setJsonInput] = useState<string>("");
   const config = useConfig();
   const { updateConfig } = useNetworkServiceActions();
 
   // 将现有配置转换为表单数据
   const defaultFormValues = apiConfigToForm(mcpServerName, mcpServer);
 
-  // 表单模式的表单实例
-  const form = useForm<z.infer<typeof mcpFormSchema>>({
-    resolver: zodResolver(mcpFormSchema),
-    defaultValues: defaultFormValues,
-  });
-
-  // 高级模式的表单实例（保持原有验证逻辑）
-  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
-    resolver: zodResolver(jsonFormSchema),
-    defaultValues: {
-      config: JSON.stringify(
-        { mcpServers: { [mcpServerName]: mcpServer } },
-        null,
-        2
-      ),
-    },
-  });
-
-  // 当弹窗关闭时重置状态
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      if (!newOpen) {
-        // 重置表单和状态
-        form.reset(defaultFormValues);
-        advancedForm.reset();
-        setJsonInput("");
-        setInputMode("form");
-      }
-      setOpen(newOpen);
-    },
-    [form, advancedForm, defaultFormValues]
+  // 高级模式的默认 JSON 配置
+  const defaultJsonConfig = JSON.stringify(
+    { mcpServers: { [mcpServerName]: mcpServer } },
+    null,
+    2
   );
 
-  // 处理模式切换
-  const handleModeChange = useCallback(
-    (newMode: string) => {
-      if (newMode !== "form" && newMode !== "json") {
-        return; // 忽略无效值
-      }
-
-      if (newMode === "json" && inputMode === "form") {
-        // 表单 → JSON
-        const formValues = form.getValues();
-        try {
-          setJsonInput(formToJson(formValues));
-        } catch {
-          setJsonInput("");
-        }
-      } else if (newMode === "form" && inputMode === "json") {
-        // JSON → 表单
-        const formData = jsonToFormData(jsonInput);
-        if (formData) {
-          form.reset(formData);
-        }
-      }
-      setInputMode(newMode);
-    },
-    [inputMode, form, jsonInput]
-  );
+  const {
+    open,
+    setOpen,
+    isLoading,
+    setIsLoading,
+    inputMode,
+    setJsonInput,
+    form,
+    advancedForm,
+    handleOpenChange,
+    handleModeChange,
+  } = useMcpFormDialog({
+    defaultFormValues,
+    defaultJsonConfig,
+  });
 
   // 表单模式提交处理
   const handleFormSubmit = useCallback(
@@ -170,7 +119,7 @@ export function McpServerSettingButton({
         setIsLoading(false);
       }
     },
-    [config, mcpServerName, updateConfig]
+    [config, mcpServerName, updateConfig, setIsLoading, setOpen]
   );
 
   // 高级模式提交处理
@@ -241,7 +190,7 @@ export function McpServerSettingButton({
         setIsLoading(false);
       }
     },
-    [config, mcpServerName, updateConfig]
+    [config, mcpServerName, updateConfig, setIsLoading, setOpen]
   );
 
   return (

--- a/apps/frontend/src/hooks/useMcpFormDialog.ts
+++ b/apps/frontend/src/hooks/useMcpFormDialog.ts
@@ -1,0 +1,123 @@
+/**
+ * MCP 表单对话框 Hook
+ *
+ * 封装 MCP 服务器添加/编辑对话框的共享逻辑
+ * 包括表单/JSON 模式切换、状态管理、表单验证等功能
+ */
+
+import { mcpFormSchema } from "@/schemas/mcp-form";
+import {
+  formToJson,
+  jsonToFormData,
+} from "@/utils/mcpFormConverter";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { useCallback, useState } from "react";
+import { useForm } from "react-hook-form";
+
+// 高级模式的 JSON 表单 schema
+export const jsonFormSchema = z.object({
+  config: z.string().min(2, {
+    message: "配置不能为空",
+  }),
+});
+
+export interface UseMcpFormDialogOptions {
+  /** 表单模式的默认值 */
+  defaultFormValues: z.infer<typeof mcpFormSchema>;
+  /** 高级模式的默认 JSON 配置（可选） */
+  defaultJsonConfig?: string;
+  /** 对话框关闭时的回调（可选） */
+  onDialogClose?: () => void;
+}
+
+export function useMcpFormDialog({
+  defaultFormValues,
+  defaultJsonConfig = "",
+  onDialogClose,
+}: UseMcpFormDialogOptions) {
+  const [open, setOpen] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+  const [inputMode, setInputMode] = useState<"form" | "json">("form");
+  const [jsonInput, setJsonInput] = useState<string>(defaultJsonConfig);
+
+  // 表单模式的表单实例
+  const form = useForm<z.infer<typeof mcpFormSchema>>({
+    resolver: zodResolver(mcpFormSchema),
+    defaultValues: defaultFormValues,
+  });
+
+  // 高级模式的表单实例
+  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
+    resolver: zodResolver(jsonFormSchema),
+    defaultValues: {
+      config: defaultJsonConfig,
+    },
+  });
+
+  // 当弹窗关闭时重置状态
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        // 重置表单和状态
+        form.reset(defaultFormValues);
+        advancedForm.reset();
+        setJsonInput(defaultJsonConfig);
+        setInputMode("form");
+        onDialogClose?.();
+      }
+      setOpen(newOpen);
+    },
+    [form, advancedForm, defaultFormValues, defaultJsonConfig, onDialogClose]
+  );
+
+  // 处理模式切换
+  const handleModeChange = useCallback(
+    (newMode: string) => {
+      if (newMode !== "form" && newMode !== "json") {
+        return; // 忽略无效值
+      }
+
+      if (newMode === "json" && inputMode === "form") {
+        // 表单 → JSON
+        const formValues = form.getValues();
+        try {
+          setJsonInput(formToJson(formValues));
+        } catch {
+          setJsonInput("");
+        }
+      } else if (newMode === "form" && inputMode === "json") {
+        // JSON → 表单
+        const formData = jsonToFormData(jsonInput);
+        if (formData) {
+          form.reset(formData);
+        }
+      }
+      setInputMode(newMode);
+    },
+    [inputMode, form, jsonInput]
+  );
+
+  return {
+    // 对话框状态
+    open,
+    setOpen,
+    isLoading,
+    setIsLoading,
+    // 模式切换状态
+    inputMode,
+    setInputMode,
+    jsonInput,
+    setJsonInput,
+    // 表单实例
+    form,
+    advancedForm,
+    // 事件处理器
+    handleOpenChange,
+    handleModeChange,
+    // Schema（供组件使用）
+    jsonFormSchema,
+  };
+}
+
+export type UseMcpFormDialogReturn = ReturnType<typeof useMcpFormDialog>;


### PR DESCRIPTION
- 创建 useMcpFormDialog Hook 封装 MCP 表单对话框的共享逻辑
- 重构 add-mcp-server-button.tsx 使用共享 Hook
- 重构 mcp-server-setting-button.tsx 使用共享 Hook
- 消除约 30 行重复代码（jsonFormSchema、handleModeChange、状态管理）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2426