### PR TITLE
fix: 移除 ASR.ts 中重复的 close 事件监听器

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -756,11 +756,6 @@ export class ASR extends EventEmitter {
         reject(error);
       });
 
-      this.ws.on("close", () => {
-        this.connected = false;
-        this.emit("close");
-      });
-
       // Register global message handler for event-driven mode
       // In streaming mode, this enables result/vad_end events via on()
       this.ws.on("message", (data: Buffer) => {


### PR DESCRIPTION
移除 _connect() 方法中重复的 close 事件监听器（第 759-762 行），
避免 WebSocket 关闭时 this.emit("close") 被调用两次。

Fixes #2428

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2428