### PR TITLE
refactor(tts): 提取 sendMessage 辅助函数消除重复代码

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/protocols.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/protocols.ts
@@ -678,6 +678,22 @@ export async function WaitForEvent(
 }
 
 /**
+ * 通用的消息发送辅助函数
+ * @param ws - WebSocket 连接实例
+ * @param msg - 消息对象
+ * @returns Promise，发送成功后 resolve，失败后 reject
+ */
+async function sendMessage(ws: WebSocket, msg: Message): Promise<void> {
+  const data = marshalMessage(msg);
+  return new Promise((resolve, reject) => {
+    ws.send(data, (error?: Error) => {
+      if (error) reject(error);
+      else resolve();
+    });
+  });
+}
+
+/**
  * 发送完整的客户端请求
  * @param ws - WebSocket 连接实例
  * @param payload - 请求负载数据
@@ -689,13 +705,7 @@ export async function FullClientRequest(
 ): Promise<void> {
   const msg = createMessage(MsgType.FullClientRequest, MsgTypeFlagBits.NoSeq);
   msg.payload = payload;
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -712,13 +722,7 @@ export async function AudioOnlyClient(
 ): Promise<void> {
   const msg = createMessage(MsgType.AudioOnlyClient, flag);
   msg.payload = payload;
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -733,13 +737,7 @@ export async function StartConnection(ws: WebSocket): Promise<void> {
   );
   msg.event = EventType.StartConnection;
   msg.payload = new TextEncoder().encode("{}");
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -754,13 +752,7 @@ export async function FinishConnection(ws: WebSocket): Promise<void> {
   );
   msg.event = EventType.FinishConnection;
   msg.payload = new TextEncoder().encode("{}");
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -782,13 +774,7 @@ export async function StartSession(
   msg.event = EventType.StartSession;
   msg.sessionId = sessionId;
   msg.payload = payload;
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -808,13 +794,7 @@ export async function FinishSession(
   msg.event = EventType.FinishSession;
   msg.sessionId = sessionId;
   msg.payload = new TextEncoder().encode("{}");
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -834,13 +814,7 @@ export async function CancelSession(
   msg.event = EventType.CancelSession;
   msg.sessionId = sessionId;
   msg.payload = new TextEncoder().encode("{}");
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }
 
 /**
@@ -862,11 +836,5 @@ export async function TaskRequest(
   msg.event = EventType.TaskRequest;
   msg.sessionId = sessionId;
   msg.payload = payload;
-  const data = marshalMessage(msg);
-  return new Promise((resolve, reject) => {
-    ws.send(data, (error?: Error) => {
-      if (error) reject(error);
-      else resolve();
-    });
-  });
+  return sendMessage(ws, msg);
 }


### PR DESCRIPTION
- 新增 sendMessage 辅助函数统一处理 WebSocket 消息发送
- 重构 8 个导出函数使用新辅助函数
- 消除约 120 行重复代码，净减少约 82 行
- 修复 issue #2434

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2434