### PR TITLE
fix(tts): 移除 TTS.ts 中遗留的调试 console.log 语句

### DIFF
--- a/packages/tts/src/client/TTS.ts
+++ b/packages/tts/src/client/TTS.ts
@@ -104,22 +104,13 @@ export class TTS extends EventEmitter {
       chunk: Uint8Array,
       isLast: boolean
     ): Promise<void> => {
-      console.log(
-        `[TTS Client] onAudioChunk called: isLast=${isLast}, chunk.length=${chunk.length}, queue.length before=${queue.length}`
-      );
       queue.push({ chunk, isFinal: isLast });
-      console.log(
-        `[TTS Client] onAudioChunk after push: queue.length=${queue.length}, streamEnded will be set to ${isLast}`
-      );
 
       // 唤醒等待中的迭代器
       if (resolveNext) {
-        console.log("[TTS Client] Waking iterator, resolveNext exists");
         const resolve = resolveNext;
         resolveNext = null;
         resolve();
-      } else {
-        console.log("[TTS Client] No resolveNext, iterator may not be waiting");
       }
     };
 
@@ -141,9 +132,6 @@ export class TTS extends EventEmitter {
       // 如果队列中有结果，立即 yield
       while (queue.length > 0) {
         const result = queue.shift()!;
-        console.log(
-          `[TTS Iterator] Yielding result: isFinal=${result.isFinal}, queue.length after=${queue.length}`
-        );
         // 如果是最终块，yield 后退出
         if (result.isFinal) {
           streamEnded = true;


### PR DESCRIPTION
移除 packages/tts/src/client/TTS.ts 中的调试日志语句，这些日志违反了项目使用统一 Logger 的规范。

修改内容：
- 移除 onAudioChunk 函数中的 5 个 console.log
- 移除迭代器中的 1 个 console.log

Fixes #2437

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2437