### PR TITLE
fix: 移除子包中冗余的 @discordjs/opus 依赖声明

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,6 @@
   },
   "dependencies": {
     "@coze/api": "^1.3.9",
-    "@discordjs/opus": "^0.10.0",
     "@hono/node-server": "^1.19.10",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "@xiaozhi-client/asr": "workspace:*",

--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -47,7 +47,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@discordjs/opus": "^0.10.0",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -198,9 +198,6 @@ importers:
       '@coze/api':
         specifier: ^1.3.9
         version: 1.3.9(axios@1.13.5)
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
       '@hono/node-server':
         specifier: ^1.19.10
         version: 1.19.11(hono@4.12.7)
@@ -551,9 +548,6 @@ importers:
 
   packages/asr:
     dependencies:
-      '@discordjs/opus':
-        specifier: ^0.10.0
-        version: 0.10.0
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)


### PR DESCRIPTION
移除 apps/backend/package.json 和 packages/asr/package.json 中冗余的 @discordjs/opus 声明，保留仅在根 package.json 中的声明。这符合 monorepo 的 DRY 原则，减少维护成本并避免版本不一致风险。

- 从 apps/backend/package.json 移除 @discordjs/opus
- 从 packages/asr/package.json 移除 @discordjs/opus
- @discordjs/opus 仍可通过根 package.json 访问
- 所有 2046 个测试通过

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2439