### PR TITLE
fix: 在 apps/backend/lib/mcp/ 模块中使用 MCPError 类替代通用 Error 类

### DIFF
--- a/apps/backend/lib/mcp/custom.ts
+++ b/apps/backend/lib/mcp/custom.ts
@@ -22,6 +22,7 @@
  */
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import { CozeApiService } from "@/lib/coze";
 import type { RunWorkflowData } from "@/lib/coze";
 import type { MCPServiceManager } from "@/lib/mcp";
@@ -96,7 +97,10 @@ export class CustomMCPHandler {
     const token = configManager.getConfig().platforms?.coze?.token;
 
     if (!token) {
-      throw new Error("Coze Token 配置不存在");
+      throw MCPError.configError(
+        MCPErrorCode.INVALID_CONFIG,
+        "Coze Token 配置不存在"
+      );
     }
 
     return new CozeApiService(token);
@@ -219,7 +223,11 @@ export class CustomMCPHandler {
   ): Promise<ToolCallResponse> {
     const tool = this.tools.get(toolName);
     if (!tool) {
-      throw new Error(`未找到工具: ${toolName}`);
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_NOT_FOUND,
+        `未找到工具: ${toolName}`,
+        { context: { toolName } }
+      );
     }
 
     // 首先检查是否有已完成的任务结果（一次性缓存）
@@ -373,7 +381,11 @@ export class CustomMCPHandler {
 
       // 检查 workflow_id 是否存在
       if (!config.workflow_id) {
-        throw new Error("工作流ID未配置");
+        throw MCPError.configError(
+          MCPErrorCode.INVALID_CONFIG,
+          "工作流ID未配置",
+          { context: { toolName: tool.name } }
+        );
       }
 
       // 调用 callWorkflow 方法

--- a/apps/backend/lib/mcp/log.ts
+++ b/apps/backend/lib/mcp/log.ts
@@ -6,6 +6,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import { PathUtils } from "@/utils/path-utils.js";
 import pino from "pino";
 import type { Logger as PinoLogger } from "pino";
@@ -255,7 +256,10 @@ export class ToolCallLogService {
   private checkLogFile(): void {
     const logFilePath = this.getLogFilePath();
     if (!fs.existsSync(logFilePath)) {
-      throw new Error("工具调用日志文件不存在");
+      throw MCPError.systemError(
+        MCPErrorCode.INTERNAL_ERROR,
+        "工具调用日志文件不存在"
+      );
     }
   }
 
@@ -297,7 +301,10 @@ export class ToolCallLogService {
       return records;
     } catch (error) {
       logger.error("读取日志文件失败", { error });
-      throw new Error("无法读取工具调用日志文件");
+      throw MCPError.systemError(
+        MCPErrorCode.INTERNAL_ERROR,
+        "无法读取工具调用日志文件"
+      );
     }
   }
 

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from "node:events";
 import { logger } from "@/Logger.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import { MCPService } from "@/lib/mcp";
 import { MCPCacheManager } from "@/lib/mcp";
 import { ConnectionState } from "@/lib/mcp/types";
@@ -314,7 +315,11 @@ export class MCPServiceManager extends EventEmitter {
   async startService(serviceName: string): Promise<void> {
     const config = this.configs[serviceName];
     if (!config) {
-      throw new Error(`未找到服务配置: ${serviceName}`);
+      throw MCPError.configError(
+        MCPErrorCode.SERVER_NOT_FOUND,
+        `未找到服务配置: ${serviceName}`,
+        { serverName: serviceName }
+      );
     }
 
     try {
@@ -663,7 +668,11 @@ export class MCPServiceManager extends EventEmitter {
         // 如果不是 customMCP 工具，则查找标准 MCP 工具
         const toolInfo = this.tools.get(toolName);
         if (!toolInfo) {
-          throw new Error(`未找到工具: ${toolName}`);
+          throw MCPError.validationError(
+            MCPErrorCode.TOOL_NOT_FOUND,
+            `未找到工具: ${toolName}`,
+            { context: { toolName } }
+          );
         }
 
         // 设置日志信息
@@ -672,11 +681,19 @@ export class MCPServiceManager extends EventEmitter {
 
         const service = this.services.get(toolInfo.serviceName);
         if (!service) {
-          throw new Error(`服务 ${toolInfo.serviceName} 不可用`);
+          throw MCPError.connectionError(
+            MCPErrorCode.SERVICE_UNAVAILABLE,
+            `服务 ${toolInfo.serviceName} 不可用`,
+            { serverName: toolInfo.serviceName }
+          );
         }
 
         if (!service.isConnected()) {
-          throw new Error(`服务 ${toolInfo.serviceName} 未连接`);
+          throw MCPError.connectionError(
+            MCPErrorCode.CONNECTION_FAILED,
+            `服务 ${toolInfo.serviceName} 未连接`,
+            { serverName: toolInfo.serviceName }
+          );
         }
 
         result = (await service.callTool(
@@ -968,11 +985,19 @@ export class MCPServiceManager extends EventEmitter {
 
     const service = this.services.get(serviceName);
     if (!service) {
-      throw new Error(`服务 ${serviceName} 不可用`);
+      throw MCPError.connectionError(
+        MCPErrorCode.SERVICE_UNAVAILABLE,
+        `服务 ${serviceName} 不可用`,
+        { serverName: serviceName }
+      );
     }
 
     if (!service.isConnected()) {
-      throw new Error(`服务 ${serviceName} 未连接`);
+      throw MCPError.connectionError(
+        MCPErrorCode.CONNECTION_FAILED,
+        `服务 ${serviceName} 未连接`,
+        { serverName: serviceName }
+      );
     }
 
     try {
@@ -1251,7 +1276,10 @@ export class MCPServiceManager extends EventEmitter {
       serviceName = internalConfig.name;
       finalConfig = internalConfig;
     } else {
-      throw new Error("Invalid arguments for addServiceConfig");
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "Invalid arguments for addServiceConfig"
+      );
     }
 
     // 增强配置
@@ -1592,7 +1620,10 @@ export class MCPServiceManager extends EventEmitter {
    */
   public async start(): Promise<void> {
     if (this.isRunning) {
-      throw new Error("服务器已在运行");
+      throw MCPError.configError(
+        MCPErrorCode.SERVER_ALREADY_EXISTS,
+        "服务器已在运行"
+      );
     }
 
     logger.info("启动 MCP 服务管理器");

--- a/apps/backend/lib/mcp/message.ts
+++ b/apps/backend/lib/mcp/message.ts
@@ -13,6 +13,7 @@ import {
   MCP_SERVER_INFO,
   MCP_SUPPORTED_PROTOCOL_VERSIONS,
 } from "@/constants/index.js";
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import type { EnhancedToolInfo, MCPServiceManager } from "@/lib/mcp";
 import { validateToolCallParams } from "@/lib/mcp";
 import type { MCPMessage, MCPResponse } from "@/types/mcp.js";
@@ -106,7 +107,11 @@ export class MCPMessageHandler {
             this.logger.warn(`收到未知的通知消息: ${message.method}`, message);
             return null;
           }
-          throw new Error(`未知的方法: ${message.method}`);
+          throw MCPError.validationError(
+            MCPErrorCode.TOOL_VALIDATION_FAILED,
+            `未知的方法: ${message.method}`,
+            { context: { method: message.method } }
+          );
       }
     } catch (error) {
       this.logger.error(`处理消息时出错: ${message.method}`, error);

--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -6,6 +6,7 @@
  * - 工具调用参数验证
  */
 
+import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
@@ -95,8 +96,10 @@ export function inferTransportTypeFromConfig(
     };
   }
 
-  throw new Error(
-    `无法为服务 ${serviceName} 推断传输类型。请显式指定 type 字段，或提供 command/url 配置`
+  throw MCPError.configError(
+    MCPErrorCode.INVALID_CONFIG,
+    `无法为服务 ${serviceName} 推断传输类型。请显式指定 type 字段，或提供 command/url 配置`,
+    { serverName: serviceName }
   );
 }
 


### PR DESCRIPTION
- 在 manager.ts 中替换 8 处通用 Error 为 MCPError
- 在 custom.ts 中替换 3 处通用 Error 为 MCPError
- 在 log.ts 中替换 2 处通用 Error 为 MCPError
- 在 message.ts 中替换 1 处通用 Error 为 MCPError
- 在 utils.ts 中替换 1 处通用 Error 为 MCPError
- 为每个错误添加适当的错误代码和详情

错误代码映射：
- SERVER_NOT_FOUND: 服务配置未找到
- TOOL_NOT_FOUND: 工具未找到
- SERVICE_UNAVAILABLE: 服务不可用
- CONNECTION_FAILED: 服务未连接
- SERVER_ALREADY_EXISTS: 服务器已在运行
- TOOL_VALIDATION_FAILED: 参数验证失败
- INVALID_CONFIG: 配置无效
- INTERNAL_ERROR: 系统内部错误

修复 #2443

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2443