### PR TITLE
fix(types): 在 types/index.ts 中添加缺失的 api.response 和 toolApi 模块导出

### DIFF
--- a/apps/backend/types/index.ts
+++ b/apps/backend/types/index.ts
@@ -87,3 +87,35 @@ export * from "./coze.js";
 export * from "./timeout.js";
 export * from "./hono.context.js";
 export * from "./esp32.js";
+
+// API 响应类型
+export type {
+  ApiSuccessResponse,
+  ApiErrorResponse,
+  ApiPaginatedResponse,
+  ApiResponse,
+  PaginationInfo,
+} from "./api.response.js";
+
+// 工具 API 类型
+export type {
+  JSONSchema,
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  CustomMCPToolBase,
+  CustomMCPToolWithStats,
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  ToolValidationErrorDetail,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+} from "./toolApi.js";
+
+export { ToolType, ToolValidationError } from "./toolApi.js";


### PR DESCRIPTION
- 添加 api.response.ts 中的 5 个类型导出
  - ApiSuccessResponse, ApiErrorResponse, ApiPaginatedResponse
  - ApiResponse, PaginationInfo

- 添加 toolApi.ts 中的 17 个类型导出和 2 个枚举导出
  - JSONSchema, ToolHandlerConfig 及相关配置类型
  - CustomMCPToolBase, CustomMCPToolWithStats
  - MCPToolData, CozeWorkflowData, HttpApiToolData, FunctionToolData
  - AddCustomToolRequest, ToolValidationErrorDetail, AddToolResponse
  - ToolMetadata, ToolConfigOptions
  - ToolType, ToolValidationError (枚举)

开发者现在可以统一使用 '@/types' 导入所有类型，无需使用相对路径

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2448