### PR TITLE
fix(shared-types): 替换 API 错误类型中的 any 为 ErrorDetail

### DIFF
--- a/packages/shared-types/src/api/errors.ts
+++ b/packages/shared-types/src/api/errors.ts
@@ -3,6 +3,22 @@
  */
 
 /**
+ * 错误详情接口
+ */
+export interface ErrorDetail {
+  /** 字段名（验证错误时使用） */
+  field?: string;
+  /** 错误值 */
+  value?: unknown;
+  /** 约束条件 */
+  constraint?: string;
+  /** 期望类型 */
+  expectedType?: string;
+  /** 实际类型 */
+  receivedType?: string;
+}
+
+/**
  * MCP 错误代码枚举
  */
 export enum MCPErrorCode {
@@ -46,7 +62,7 @@ export interface ApiError {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: ErrorDetail;
   /** 错误堆栈（开发环境） */
   stack?: string;
 }
@@ -62,7 +78,7 @@ export interface ToolValidationError {
   /** 验证字段名称 */
   field?: string;
   /** 错误详情 */
-  details?: any;
+  details?: ErrorDetail;
 }
 
 /**

--- a/packages/shared-types/src/api/toolApi.ts
+++ b/packages/shared-types/src/api/toolApi.ts
@@ -5,6 +5,7 @@
 
 import type { WorkflowParameterConfig, CozeWorkflow } from "../coze";
 import type { CustomMCPToolWithStats } from "../mcp";
+import type { ErrorDetail } from "./errors";
 
 /**
  * 工具类型枚举
@@ -140,7 +141,7 @@ export interface ToolValidationErrorDetail {
   /** 错误消息 */
   message: string;
   /** 错误详情 */
-  details?: any;
+  details?: ErrorDetail;
   /** 建议的解决方案 */
   suggestions?: string[];
 }


### PR DESCRIPTION
修复 #2450

- 新增 ErrorDetail 接口定义，包含 field、value、constraint、
  expectedType、receivedType 等字段
- 将 ApiError.details 从 any 改为 ErrorDetail
- 将 ToolValidationError.details 从 any 改为 ErrorDetail
- 将 ToolValidationErrorDetail.details 从 any 改为 ErrorDetail

这提高了 API 契约的类型安全性，使开发者能够更好地理解
和使用错误详情。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2450