### PR TITLE
refactor(services): create unified HttpClient base class to eliminate duplication

### DIFF
--- a/apps/frontend/src/services/HttpClient.ts
+++ b/apps/frontend/src/services/HttpClient.ts
@@ -1,0 +1,153 @@
+/**
+ * 统一的 HTTP 客户端基类
+ * 提供所有前端 API 客户端的通用 HTTP 请求功能
+ */
+
+import type { ApiErrorResponse } from "@xiaozhi-client/shared-types";
+
+/**
+ * HTTP 客户端配置选项
+ */
+interface HttpClientOptions {
+  /** 基础 URL，默认从当前页面推断 */
+  baseUrl?: string;
+  /** 默认请求超时时间（毫秒），默认 30000 */
+  timeout?: number;
+  /** 默认请求头 */
+  headers?: Record<string, string>;
+}
+
+/**
+ * 统一的 HTTP 客户端基类
+ * 提供通用请求方法，子类可继承此基类以复用 HTTP 请求逻辑
+ */
+export class HttpClient {
+  protected baseUrl: string;
+  protected defaultTimeout: number;
+  protected defaultHeaders: Record<string, string>;
+
+  constructor(options: HttpClientOptions = {}) {
+    this.baseUrl = options.baseUrl ?? this.inferBaseUrl();
+    this.defaultTimeout = options.timeout ?? 30000;
+    this.defaultHeaders = {
+      "Content-Type": "application/json",
+      ...options.headers,
+    };
+  }
+
+  /**
+   * 从当前页面 URL 推断基础 URL
+   */
+  protected inferBaseUrl(): string {
+    if (typeof window === "undefined") {
+      return "";
+    }
+    const protocol = window.location.protocol;
+    const hostname = window.location.hostname;
+    const port = window.location.port;
+    return `${protocol}//${hostname}${port ? `:${port}` : ""}`;
+  }
+
+  /**
+   * 通用请求方法
+   * @param endpoint API 端点路径
+   * @param options fetch 请求选项
+   * @returns 解析后的 JSON 响应
+   */
+  protected async request<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), this.defaultTimeout);
+
+    try {
+      const response = await fetch(url, {
+        ...options,
+        headers: {
+          ...this.defaultHeaders,
+          ...options.headers,
+        },
+        signal: controller.signal,
+      });
+
+      clearTimeout(timeoutId);
+
+      if (!response.ok) {
+        await this.handleErrorResponse(response);
+      }
+
+      return response.json();
+    } catch (error) {
+      clearTimeout(timeoutId);
+      throw this.handleRequestError(error);
+    }
+  }
+
+  /**
+   * 处理错误响应
+   * @param response 非 ok 的 fetch Response 对象
+   * @throws 包含错误信息的 Error
+   */
+  protected async handleErrorResponse(response: Response): Promise<never> {
+    let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+
+    try {
+      const errorData: ApiErrorResponse = await response.json();
+      errorMessage = errorData.error?.message || errorMessage;
+    } catch {
+      // 使用默认错误消息
+    }
+
+    throw new Error(errorMessage);
+  }
+
+  /**
+   * 处理请求错误
+   * @param error 捕获的错误对象
+   * @returns 格式化的 Error 对象
+   */
+  protected handleRequestError(error: unknown): Error {
+    if (error instanceof Error) {
+      if (error.name === "AbortError") {
+        return new Error("请求超时");
+      }
+      return error;
+    }
+    return new Error(String(error));
+  }
+
+  /**
+   * 设置基础 URL
+   * @param baseUrl 新的基础 URL
+   */
+  public setBaseUrl(baseUrl: string): void {
+    this.baseUrl = baseUrl;
+  }
+
+  /**
+   * 获取基础 URL
+   * @returns 当前基础 URL
+   */
+  public getBaseUrl(): string {
+    return this.baseUrl;
+  }
+
+  /**
+   * 设置默认超时时间
+   * @param timeout 超时时间（毫秒）
+   */
+  public setTimeout(timeout: number): void {
+    this.defaultTimeout = timeout;
+  }
+
+  /**
+   * 获取默认超时时间
+   * @returns 当前超时时间（毫秒）
+   */
+  public getTimeout(): number {
+    return this.defaultTimeout;
+  }
+}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -16,6 +16,7 @@ import type {
   MCPServerStatus,
   VoicesResponse,
 } from "@xiaozhi-client/shared-types";
+import { HttpClient } from "./HttpClient";
 
 /**
  * CustomMCPTool 接口定义
@@ -168,54 +169,11 @@ interface MCPToolListResponse {
 
 /**
  * HTTP API 客户端类
+ * 继承自 HttpClient，提供具体的 API 端点方法
  */
-export class ApiClient {
-  private baseUrl: string;
-
+export class ApiClient extends HttpClient {
   constructor(baseUrl?: string) {
-    // 从当前页面 URL 推断 API 基础 URL
-    if (baseUrl) {
-      this.baseUrl = baseUrl;
-    } else {
-      const protocol = window.location.protocol;
-      const hostname = window.location.hostname;
-      const port = window.location.port;
-      this.baseUrl = `${protocol}//${hostname}${port ? `:${port}` : ""}`;
-    }
-  }
-
-  /**
-   * 通用请求方法
-   */
-  private async request<T>(
-    endpoint: string,
-    options: RequestInit = {}
-  ): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
-    const defaultOptions: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-    };
-
-    const response = await fetch(url, { ...defaultOptions, ...options });
-
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
-      }
-
-      throw new Error(errorMessage);
-    }
-
-    return response.json();
+    super({ baseUrl, timeout: 30000 });
   }
 
   // ==================== 配置管理 API ====================

--- a/apps/frontend/src/services/cozeApi.ts
+++ b/apps/frontend/src/services/cozeApi.ts
@@ -8,6 +8,7 @@ import type {
   CozeWorkflowsResult,
   CozeWorkspace,
 } from "@xiaozhi-client/shared-types";
+import { HttpClient } from "./HttpClient";
 
 /**
  * API 响应格式
@@ -16,14 +17,6 @@ interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   message?: string;
-}
-
-interface ApiErrorResponse {
-  error: {
-    code: string;
-    message: string;
-    details?: Record<string, unknown>;
-  };
 }
 
 /**
@@ -36,54 +29,11 @@ interface CacheStats {
 
 /**
  * 扣子 API 客户端类
+ * 继承自 HttpClient，提供扣子相关的 API 端点方法
  */
-export class CozeApiClient {
-  private baseUrl: string;
-
+export class CozeApiClient extends HttpClient {
   constructor(baseUrl?: string) {
-    // 从当前页面 URL 推断 API 基础 URL
-    if (baseUrl) {
-      this.baseUrl = baseUrl;
-    } else {
-      const protocol = window.location.protocol;
-      const hostname = window.location.hostname;
-      const port = window.location.port;
-      this.baseUrl = `${protocol}//${hostname}${port ? `:${port}` : ""}`;
-    }
-  }
-
-  /**
-   * 通用请求方法
-   */
-  private async request<T>(
-    endpoint: string,
-    options: RequestInit = {}
-  ): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
-    const defaultOptions: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-    };
-
-    const response = await fetch(url, { ...defaultOptions, ...options });
-
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
-      }
-
-      throw new Error(errorMessage);
-    }
-
-    return response.json();
+    super({ baseUrl, timeout: 30000 });
   }
 
   /**
@@ -184,4 +134,4 @@ export class CozeApiClient {
 export const cozeApiClient = new CozeApiClient();
 
 // 导出类型
-export type { ApiResponse, ApiErrorResponse, CacheStats };
+export type { ApiResponse, CacheStats };


### PR DESCRIPTION
创建统一的 HttpClient 基类，消除 ApiClient 和 CozeApiClient 中的重复 HTTP 请求逻辑，符合 DRY 原则。

**主要变更：**

1. **新增 HttpClient.ts**
   - 提供统一的 HTTP 请求方法
   - 包含通用错误处理逻辑
   - 支持超时控制
   - 从当前页面 URL 推断基础 URL

2. **重构 ApiClient**
   - 继承 HttpClient 基类
   - 移除重复的 request 方法
   - 保留所有业务方法

3. **重构 CozeApiClient**
   - 继承 HttpClient 基类
   - 移除重复的 request 方法和 ApiErrorResponse 接口
   - 保留所有业务方法

**影响范围：**
- apps/frontend/src/services/HttpClient.ts (新增)
- apps/frontend/src/services/api.ts (修改)
- apps/frontend/src/services/cozeApi.ts (修改)

**测试结果：**
- 所有 45 个测试文件通过（547 个测试）
- TypeScript 类型检查通过

**相关 Issue：**
- #2460

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2460