### PR TITLE
fix: 移除 mcp-server-list.tsx 中的 as any 类型断言

### DIFF
--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -37,6 +37,7 @@ import type {
   CustomMCPToolWithStats,
   JSONSchema,
   MCPServerConfig,
+  MCPToolConfig,
   WorkflowParameter,
 } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon } from "lucide-react";
@@ -170,9 +171,10 @@ export function McpServerList({
           ([serverName, value]) => {
             return Object.entries(value?.tools || {}).map(
               ([toolName, tool]) => ({
+                name: toolName,
                 serverName,
                 toolName,
-                ...(tool as any),
+                ...(tool as MCPToolConfig),
               })
             );
           }


### PR DESCRIPTION
- 使用 MCPToolConfig 类型替代 as any
- 添加缺失的 name 属性以满足 ToolWithServerInfo 类型要求
- 提升类型安全性，避免运行时类型错误

Fixes #2461

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2461