### PR TITLE
perf(mcp): 优化 getCustomMCPStatistics 方法的性能

### DIFF
--- a/apps/backend/lib/mcp/cache.ts
+++ b/apps/backend/lib/mcp/cache.ts
@@ -647,12 +647,19 @@ export class MCPCacheManager {
 
       const entries = Object.values(cache.customMCPResults);
       const totalEntries = entries.length;
-      const pendingTasks = entries.filter((e) => e.status === "pending").length;
-      const completedTasks = entries.filter(
-        (e) => e.status === "completed"
-      ).length;
-      const failedTasks = entries.filter((e) => e.status === "failed").length;
-      const consumedEntries = entries.filter((e) => e.consumed).length;
+
+      // 单次遍历统计所有状态，优化性能从 O(4n) 到 O(n)
+      let pendingTasks = 0;
+      let completedTasks = 0;
+      let failedTasks = 0;
+      let consumedEntries = 0;
+
+      for (const entry of entries) {
+        if (entry.status === "pending") pendingTasks++;
+        if (entry.status === "completed") completedTasks++;
+        if (entry.status === "failed") failedTasks++;
+        if (entry.consumed) consumedEntries++;
+      }
 
       // 计算缓存命中率
       const cacheHitRate =


### PR DESCRIPTION
将 4 次 filter 操作优化为单次遍历，将时间复杂度从 O(4n) 降低到 O(n)。

修复问题: #2465

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2465