### PR TITLE
fix: 重命名 MCP tools 中的 TimeoutResponse 为 ToolTimeoutResponse 以避免类型混淆

### DIFF
--- a/packages/shared-types/src/mcp/index.ts
+++ b/packages/shared-types/src/mcp/index.ts
@@ -33,12 +33,12 @@ export { ConnectionState } from "./message";
 // 工具相关类型
 export type {
   ToolCallResponse,
-  TimeoutResponse,
+  ToolTimeoutResponse,
 } from "./tools";
 
 export {
   isToolCallResult,
-  isTimeoutResponse,
+  isToolTimeoutResponse,
 } from "./tools";
 
 // 传输层相关类型

--- a/packages/shared-types/src/mcp/tools.ts
+++ b/packages/shared-types/src/mcp/tools.ts
@@ -6,14 +6,14 @@ import type { ToolCallResult } from "./cache";
 
 /**
  * 工具调用结果联合类型
- * 包含正常结果和超时响应
+ * 包含正常结果和工具超时响应
  */
-export type ToolCallResponse = ToolCallResult | TimeoutResponse;
+export type ToolCallResponse = ToolCallResult | ToolTimeoutResponse;
 
 /**
- * 超时响应接口
+ * 工具超时响应接口
  */
-export interface TimeoutResponse {
+export interface ToolTimeoutResponse {
   /** 是否为超时响应 */
   isTimeout: true;
   /** 超时时间（毫秒） */
@@ -40,9 +40,9 @@ export function isToolCallResult(response: any): response is ToolCallResult {
 }
 
 /**
- * 验证是否为超时响应
+ * 验证是否为工具超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
+export function isToolTimeoutResponse(response: any): response is ToolTimeoutResponse {
   return (
     response &&
     typeof response === "object" &&


### PR DESCRIPTION
将 packages/shared-types/src/mcp/tools.ts 中的 TimeoutResponse 接口重命名为
ToolTimeoutResponse，避免与 packages/shared-types/src/utils/timeout.ts 中
的 TimeoutResponse 接口冲突。

两个接口具有不同的字段结构：
- ToolTimeoutResponse: 用于 MCP 工具调用的超时响应
  包含 isTimeout, timeoutMs, message, taskId, backgroundProcessing
- TimeoutResponse (utils): 通用超时响应
  包含 content, isError, taskId, status, message, nextAction

同时重命名了类型守卫函数 isTimeoutResponse 为 isToolTimeoutResponse。

修复 #2468

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2468