### PR TITLE
refactor: 提取 useToolList Hook 消除代码重复

### DIFF
--- a/apps/frontend/src/components/hooks/index.ts
+++ b/apps/frontend/src/components/hooks/index.ts
@@ -1,0 +1,7 @@
+/**
+ * Hooks 模块入口
+ *
+ * 统一导出所有自定义 Hooks，方便外部导入
+ */
+
+export { useToolList, type ToolWithServerInfo } from "./useToolList";

--- a/apps/frontend/src/components/hooks/useToolList.ts
+++ b/apps/frontend/src/components/hooks/useToolList.ts
@@ -1,0 +1,197 @@
+/**
+ * useToolList Hook - 工具列表状态管理
+ *
+ * 职责：
+ * - 管理已启用和未启用的工具列表状态
+ * - 提供统一的工具获取和刷新方法
+ * - 处理工具格式化逻辑
+ */
+
+import { apiClient } from "@/services/api";
+import type { CustomMCPToolWithStats, JSONSchema } from "@xiaozhi-client/shared-types";
+import { useCallback, useEffect, useState } from "react";
+import { toast } from "sonner";
+
+// 服务名称常量
+const UNKNOWN_SERVICE_NAME = "未知服务";
+const CUSTOM_SERVICE_NAME = "自定义服务";
+
+// 工具类型别名
+export type ToolWithServerInfo = {
+  name: string;
+  serverName: string;
+  toolName: string;
+  enable: boolean;
+  description?: string;
+  usageCount?: number;
+  lastUsedTime?: string;
+  inputSchema?: JSONSchema;
+  handler?: {
+    type: string;
+    platform: string;
+    config?: Record<string, unknown>;
+  };
+};
+
+interface UseToolListOptions {
+  mcpServerConfig?: Record<string, any>;
+  onError?: (error: Error) => void;
+}
+
+interface UseToolListReturn {
+  /** 已启用的工具列表 */
+  enabledTools: ToolWithServerInfo[];
+  /** 未启用的工具列表 */
+  disabledTools: ToolWithServerInfo[];
+  /** 获取工具列表（包含错误回退逻辑） */
+  fetchTools: () => Promise<void>;
+  /** 刷新工具列表（不包含错误回退） */
+  refreshToolLists: () => Promise<void>;
+}
+
+/**
+ * 工具列表管理 Hook
+ *
+ * 统一管理工具列表的状态和获取逻辑，消除代码重复
+ */
+export function useToolList({
+  mcpServerConfig,
+  onError,
+}: UseToolListOptions = {}): UseToolListReturn {
+  const [enabledTools, setEnabledTools] = useState<ToolWithServerInfo[]>([]);
+  const [disabledTools, setDisabledTools] = useState<ToolWithServerInfo[]>([]);
+
+  // 格式化工具信息的辅助函数
+  const formatTool = useCallback(
+    (tool: CustomMCPToolWithStats, enable: boolean): ToolWithServerInfo => {
+      const { serviceName, toolName } = (() => {
+        // 安全检查：确保 handler 存在
+        if (!tool || !tool.handler) {
+          return {
+            serviceName: UNKNOWN_SERVICE_NAME,
+            toolName: tool?.name || UNKNOWN_SERVICE_NAME,
+          };
+        }
+
+        if (tool.handler.type === "mcp") {
+          return {
+            serviceName:
+              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
+            toolName: tool.handler.config?.toolName || tool.name,
+          };
+        }
+        if (
+          tool.handler.type === "proxy" &&
+          tool.handler.platform === "coze"
+        ) {
+          return {
+            serviceName: "customMCP",
+            toolName: tool.name,
+          };
+        }
+        return {
+          serviceName: CUSTOM_SERVICE_NAME,
+          toolName: tool.name,
+        };
+      })();
+
+      return {
+        serverName: serviceName,
+        toolName,
+        enable,
+        name: tool.name,
+        description: tool.description,
+        usageCount: tool.usageCount,
+        lastUsedTime: tool.lastUsedTime,
+        inputSchema: tool.inputSchema,
+      };
+    },
+    []
+  );
+
+  /**
+   * 核心工具获取逻辑
+   * 统一处理工具列表的获取和格式化，避免代码重复
+   */
+  const loadTools = useCallback(
+    async ({ useFallback = false } = {}): Promise<void> => {
+      try {
+        const [enabledToolsList, disabledToolsList] = await Promise.all([
+          apiClient.getToolsList("enabled"),
+          apiClient.getToolsList("disabled"),
+        ]);
+
+        // 格式化已启用和未启用的工具
+        const formattedEnabledTools = enabledToolsList.map((tool) =>
+          formatTool(tool, true)
+        );
+        const formattedDisabledTools = disabledToolsList.map((tool) =>
+          formatTool(tool, false)
+        );
+
+        setEnabledTools(formattedEnabledTools);
+        setDisabledTools(formattedDisabledTools);
+      } catch (error) {
+        console.error("获取工具列表失败:", error);
+        const errorMessage =
+          error instanceof Error ? error.message : "获取工具列表失败";
+        toast.error(errorMessage);
+
+        // 仅在 useFallback 为 true 时使用回退逻辑
+        if (useFallback && mcpServerConfig) {
+          const fallbackTools = Object.entries(mcpServerConfig).flatMap(
+            ([serverName, value]) => {
+              return Object.entries(value?.tools || {}).map(
+                ([toolName, tool]) => ({
+                  serverName,
+                  toolName,
+                  ...(tool as any),
+                })
+              );
+            }
+          );
+
+          const enabled = fallbackTools.filter((tool) => tool.enable !== false);
+          const disabled = fallbackTools.filter((tool) => tool.enable === false);
+
+          setEnabledTools(enabled);
+          setDisabledTools(disabled);
+        }
+
+        // 调用错误回调
+        if (onError && error instanceof Error) {
+          onError(error);
+        }
+      }
+    },
+    [mcpServerConfig, formatTool, onError]
+  );
+
+  /**
+   * 获取工具列表（包含错误回退逻辑）
+   * 用于初始化时加载工具列表
+   */
+  const fetchTools = useCallback(async () => {
+    await loadTools({ useFallback: true });
+  }, [loadTools]);
+
+  /**
+   * 刷新工具列表（不包含错误回退）
+   * 用于启用/禁用工具后的刷新
+   */
+  const refreshToolLists = useCallback(async () => {
+    await loadTools({ useFallback: false });
+  }, [loadTools]);
+
+  // 组件加载时获取工具列表
+  useEffect(() => {
+    void fetchTools();
+  }, [fetchTools]);
+
+  return {
+    enabledTools,
+    disabledTools,
+    fetchTools,
+    refreshToolLists,
+  };
+}

--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -34,13 +34,12 @@ import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
 import type {
   AppConfig,
   CozeWorkflow,
-  CustomMCPToolWithStats,
   JSONSchema,
   MCPServerConfig,
   WorkflowParameter,
 } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon } from "lucide-react";
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useState } from "react";
 import { toast } from "sonner";
 import { AddMcpServerButton } from "./add-mcp-server-button";
 import { CozeWorkflowIntegration } from "./coze-workflow-integration";
@@ -48,27 +47,7 @@ import { McpServerSettingButton } from "./mcp-server-setting-button";
 import { RemoveMcpServerButton } from "./remove-mcp-server-button";
 import { RestartButton } from "./restart-button";
 import { ToolDebugDialog } from "./tool-debug-dialog";
-
-// 服务名称常量
-const UNKNOWN_SERVICE_NAME = "未知服务";
-const CUSTOM_SERVICE_NAME = "自定义服务";
-
-// 工具类型别名
-type ToolWithServerInfo = {
-  name: string;
-  serverName: string;
-  toolName: string;
-  enable: boolean;
-  description?: string;
-  usageCount?: number;
-  lastUsedTime?: string;
-  inputSchema?: JSONSchema;
-  handler?: {
-    type: string;
-    platform: string;
-    config?: Record<string, unknown>;
-  };
-};
+import { useToolList, type ToolWithServerInfo } from "./hooks";
 
 interface McpServerListProps {
   updateConfig?: (config: AppConfig) => Promise<void>;
@@ -82,110 +61,10 @@ export function McpServerList({
   const mcpServerConfig = useMcpServerConfig();
   const mcpServers = useMcpServers();
   const { refreshConfig } = useConfigActions();
-  // const config = useConfig(); // 不再使用配置更新，改为使用 API
 
-  // 添加工具列表状态管理
-  const [enabledTools, setEnabledTools] = useState<Array<ToolWithServerInfo>>(
-    []
-  );
-  const [disabledTools, setDisabledTools] = useState<Array<ToolWithServerInfo>>(
-    []
-  );
-
-  // 格式化工具信息的辅助函数
-  const formatTool = useCallback(
-    (tool: CustomMCPToolWithStats, enable: boolean) => {
-      const { serviceName, toolName } = (() => {
-        // 安全检查：确保 handler 存在
-        if (!tool || !tool.handler) {
-          return {
-            serviceName: UNKNOWN_SERVICE_NAME,
-            toolName: tool?.name || UNKNOWN_SERVICE_NAME,
-          };
-        }
-
-        if (tool.handler.type === "mcp") {
-          return {
-            serviceName:
-              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
-            toolName: tool.handler.config?.toolName || tool.name,
-          };
-        }
-        if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
-          return {
-            serviceName: "customMCP",
-            toolName: tool.name,
-          };
-        }
-        return {
-          serviceName: CUSTOM_SERVICE_NAME,
-          toolName: tool.name,
-        };
-      })();
-
-      return {
-        serverName: serviceName,
-        toolName,
-        enable,
-        name: tool.name,
-        description: tool.description,
-        usageCount: tool.usageCount,
-        lastUsedTime: tool.lastUsedTime,
-        inputSchema: tool.inputSchema,
-      };
-    },
-    []
-  );
-
-  // 获取工具列表
-  const fetchTools = useCallback(async () => {
-    try {
-      // 并行获取已启用和未启用的工具列表
-      const [enabledToolsList, disabledToolsList] = await Promise.all([
-        apiClient.getToolsList("enabled"),
-        apiClient.getToolsList("disabled"),
-      ]);
-
-      // 格式化已启用的工具
-      const formattedEnabledTools = enabledToolsList.map((tool) =>
-        formatTool(tool, true)
-      );
-
-      // 格式化未启用的工具
-      const formattedDisabledTools = disabledToolsList.map((tool) =>
-        formatTool(tool, false)
-      );
-
-      setEnabledTools(formattedEnabledTools);
-      setDisabledTools(formattedDisabledTools);
-    } catch (error) {
-      console.error("获取工具列表失败:", error);
-      const errorMessage =
-        error instanceof Error ? error.message : "获取工具列表失败";
-      toast.error(errorMessage);
-
-      // 发生错误时回退到使用 mcpServerConfig
-      if (mcpServerConfig) {
-        const fallbackTools = Object.entries(mcpServerConfig).flatMap(
-          ([serverName, value]) => {
-            return Object.entries(value?.tools || {}).map(
-              ([toolName, tool]) => ({
-                serverName,
-                toolName,
-                ...(tool as any),
-              })
-            );
-          }
-        );
-
-        const enabled = fallbackTools.filter((tool) => tool.enable !== false);
-        const disabled = fallbackTools.filter((tool) => tool.enable === false);
-
-        setEnabledTools(enabled);
-        setDisabledTools(disabled);
-      }
-    }
-  }, [mcpServerConfig, formatTool]);
+  // 使用自定义 Hook 管理工具列表状态和逻辑
+  const { enabledTools, disabledTools, refreshToolLists, fetchTools } =
+    useToolList({ mcpServerConfig });
 
   // 添加刷新状态管理
   const [isRefreshing, setIsRefreshing] = useState(false);
@@ -205,37 +84,6 @@ export function McpServerList({
       setIsRefreshing(false);
     }
   }, [refreshConfig, fetchTools, isRefreshing]);
-
-  // 更新工具列表状态（用于启用/禁用后刷新）
-  const refreshToolLists = useCallback(async () => {
-    try {
-      const [enabledToolsList, disabledToolsList] = await Promise.all([
-        apiClient.getToolsList("enabled"),
-        apiClient.getToolsList("disabled"),
-      ]);
-
-      // 格式化已启用的工具
-      const formattedEnabledTools = enabledToolsList.map((tool) =>
-        formatTool(tool, true)
-      );
-
-      // 格式化未启用的工具
-      const formattedDisabledTools = disabledToolsList.map((tool) =>
-        formatTool(tool, false)
-      );
-
-      setEnabledTools(formattedEnabledTools);
-      setDisabledTools(formattedDisabledTools);
-    } catch (error) {
-      console.error("刷新工具列表失败:", error);
-      toast.error("刷新工具列表失败");
-    }
-  }, [formatTool]);
-
-  // 组件加载时获取工具列表
-  useEffect(() => {
-    fetchTools();
-  }, [fetchTools]);
 
   // 添加状态来管理 Coze 工具确认对话框
   const [cozeToolToRemove, setCozeToolToRemove] = useState<string | null>(null);


### PR DESCRIPTION
创建自定义 Hook useToolList 来统一管理工具列表状态和获取逻辑，
消除 fetchTools 和 refreshToolLists 之间的代码重复。

变更:
- 新增 src/components/hooks/useToolList.ts - 工具列表状态管理 Hook
- 新增 src/components/hooks/index.ts - Hooks 模块统一导出
- 重构 mcp-server-list.tsx 使用新的 Hook
  - 移除 formatTool 函数（已迁移到 Hook）
  - 移除 fetchTools 函数（已迁移到 Hook）
  - 移除 refreshToolLists 函数（已迁移到 Hook）
  - 组件减少约 157 行代码

遵循务实开发原则，优先消除代码重复而非过度抽象。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2469