### PR TITLE
fix: 使用更精确的类型断言替代 `as never` 以提高类型安全性

### DIFF
--- a/apps/backend/middlewares/response-enhancer.middleware.ts
+++ b/apps/backend/middlewares/response-enhancer.middleware.ts
@@ -5,6 +5,7 @@
 
 import type { PaginationInfo } from "@/types/api.response.js";
 import type { MiddlewareHandler } from "hono";
+import type { ContentfulStatusCode, StatusCode } from "hono/utils/http-status";
 
 /**
  * 扩展 Hono Context 接口
@@ -107,7 +108,7 @@ export const responseEnhancerMiddleware: MiddlewareHandler = async (
   next
 ) => {
   // 成功响应方法
-  c.success = <T>(data?: T, message?: string, status = 200) => {
+  c.success = <T>(data?: T, message?: string, status: number = 200) => {
     const response: {
       success: true;
       data?: T;
@@ -122,11 +123,12 @@ export const responseEnhancerMiddleware: MiddlewareHandler = async (
       response.data = data;
     }
 
-    return c.json(response, status as never);
+    // 类型断言：确保 status 是 ContentfulStatusCode（JSON 响应不支持 204 等无内容状态码）
+    return c.json(response, status as ContentfulStatusCode);
   };
 
   // 失败响应方法
-  c.fail = (code: string, message: string, details?: unknown, status = 400) => {
+  c.fail = (code: string, message: string, details?: unknown, status: number = 400) => {
     const response: {
       success: false;
       error: {
@@ -147,7 +149,8 @@ export const responseEnhancerMiddleware: MiddlewareHandler = async (
       response.error.details = details;
     }
 
-    return c.json(response, status as never);
+    // 类型断言：确保 status 是 ContentfulStatusCode（JSON 响应不支持 204 等无内容状态码）
+    return c.json(response, status as ContentfulStatusCode);
   };
 
   // 分页响应方法


### PR DESCRIPTION
- 将 `status as never` 替换为 `status as ContentfulStatusCode`
- 添加 `ContentfulStatusCode` 类型导入以支持类型断言
- 添加注释说明类型断言的原因（JSON 响应不支持 204 等无内容状态码）
- 保持 `number` 类型作为接口参数以维持向后兼容性

这个修复解决了 Issue #2471 中提到的类型安全问题。
使用 `as ContentfulStatusCode` 比原来的 `as never` 更安全，
因为它明确表达了类型转换的意图，并且会在 Hono 类型定义
发生变化时提供更好的类型检查。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2471