### PR TITLE
fix: 为 ServiceManager 中的 spawn 调用添加 error 事件监听器

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -261,6 +261,12 @@ export class ServiceManagerImpl implements IServiceManager {
         }
       );
 
+      // 添加错误处理
+      child.on("error", (error) => {
+        consola.error(`启动子进程失败: ${error.message}`);
+        process.exit(1);
+      });
+
       // 保存 PID 信息
       this.processManager.savePidInfo(child.pid || 0, "daemon");
 
@@ -315,6 +321,12 @@ export class ServiceManagerImpl implements IServiceManager {
         XIAOZHI_CONFIG_DIR: PathUtils.getConfigDir(),
         XIAOZHI_DAEMON: "true",
       },
+    });
+
+    // 添加错误处理
+    child.on("error", (error) => {
+      consola.error(`启动子进程失败: ${error.message}`);
+      process.exit(1);
     });
 
     // 保存 PID 信息


### PR DESCRIPTION
修复问题：
- 在 startMcpServerMode 方法的 daemon 模式 spawn 调用中添加 error 事件监听器
- 在 startWebServerInDaemon 方法的 spawn 调用中添加 error 事件监听器

影响：
- 当子进程启动失败时，现在会正确捕获错误并输出有用的错误信息
- 避免进程意外崩溃和 PID 文件损坏

Closes #2474

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2474