### PR TITLE
fix: 移除 install-log-dialog.tsx 中的遗留调试 console 语句

### DIFF
--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -60,10 +60,9 @@ export function InstallLogDialog({
   // 对话框打开时开始安装
   useEffect(() => {
     if (isOpen && version) {
-      console.log("[InstallLogDialog] 对话框打开，开始安装版本:", version);
       clearStatus();
-      startInstall(version).catch((error) => {
-        console.error("[InstallLogDialog] 启动安装失败:", error);
+      startInstall(version).catch(() => {
+        // 启动安装失败，状态会在 useNPMInstall 中更新
       });
     }
   }, [isOpen, version, startInstall, clearStatus]);


### PR DESCRIPTION
- 移除第 63 行的 console.log 调试语句
- 移除第 66 行的 console.error 语句
- 统一使用项目状态管理而非 console 日志

Fixes #2478

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2478