### PR TITLE
fix: 修复 ASRService 中 ASR 客户端事件监听器未在 destroy 时移除导致内存泄漏

### DIFF
--- a/apps/backend/services/asr.service.ts
+++ b/apps/backend/services/asr.service.ts
@@ -432,6 +432,10 @@ export class ASRService implements IASRService {
   destroy(): void {
     // 清理 ASR 客户端
     for (const asrClient of this.asrClients.values()) {
+      // 移除事件监听器，防止内存泄漏
+      asrClient.removeAllListeners("error");
+      asrClient.removeAllListeners("close");
+      // 关闭连接
       asrClient.close();
     }
     this.asrClients.clear();


### PR DESCRIPTION
- 在 destroy() 方法中添加 removeAllListeners() 调用
- 移除 'error' 和 'close' 事件监听器，防止内存泄漏
- 修复 Issue #2480

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2480