### PR TITLE
fix: 在 MCPManager.cleanup() 中清理重试定时器防止内存泄漏

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1818,6 +1818,9 @@ export class MCPServiceManager extends EventEmitter {
   async cleanup(): Promise<void> {
     await this.stopAllServices();
 
+    // 清理所有服务重试定时器，防止内存泄漏
+    this.stopAllServiceRetries();
+
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(
       "mcp:service:connected",


### PR DESCRIPTION
修复 issue #2484

在 cleanup() 方法中添加 stopAllServiceRetries() 调用，确保清理时
同时清除所有重试定时器，防止内存泄漏和潜在的定时器回调错误执行。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2484