### PR TITLE
fix: 解决 event-bus.service.ts 和 status.service.ts 之间的循环依赖

### DIFF
--- a/apps/backend/services/__tests__/event-bus.service.test.ts
+++ b/apps/backend/services/__tests__/event-bus.service.test.ts
@@ -1,10 +1,10 @@
+import type { ClientInfo } from "@/types/service-types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import {
   EventBus,
   destroyEventBus,
   getEventBus,
 } from "../event-bus.service.js";
-import type { ClientInfo } from "../status.service.js";
 
 // 模拟依赖
 vi.mock("../../Logger.js", () => ({

--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -1,8 +1,8 @@
+import type { ClientInfo } from "@/types/service-types.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { NotificationService } from "../notification.service.js";
 import type { WebSocketClient } from "../notification.service.js";
-import type { ClientInfo } from "../status.service.js";
 
 // 模拟 EventBus
 vi.mock("../event-bus.service.js", () => ({

--- a/apps/backend/services/__tests__/status.service.test.ts
+++ b/apps/backend/services/__tests__/status.service.test.ts
@@ -1,5 +1,5 @@
+import type { ClientInfo } from "@/types/service-types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { ClientInfo } from "../status.service.js";
 import { StatusService } from "../status.service.js";
 
 // Mock dependencies

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -14,7 +14,7 @@
 import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import type { ClientInfo } from "@/services/status.service.js";
+import type { ClientInfo } from "@/types/service-types.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 /**

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -24,7 +24,7 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
-import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
+import type { ClientInfo, RestartStatus } from "@/types/service-types.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 

--- a/apps/backend/services/status.service.ts
+++ b/apps/backend/services/status.service.ts
@@ -22,27 +22,10 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
+import type { ClientInfo, RestartStatus } from "@/types/service-types.js";
 
-/**
- * 客户端信息接口
- */
-export interface ClientInfo {
-  status: "connected" | "disconnected";
-  mcpEndpoint: string;
-  activeMCPServers: string[];
-  lastHeartbeat?: number;
-}
-
-/**
- * 重启状态接口
- */
-export interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-  serviceName?: string;
-  attempt?: number;
-}
+// 重新导出类型以保持向后兼容性
+export type { ClientInfo, RestartStatus };
 
 /**
  * 状态服务 - 统一的状态管理服务

--- a/apps/backend/types/service-types.ts
+++ b/apps/backend/types/service-types.ts
@@ -1,0 +1,26 @@
+/**
+ * 服务相关的共享类型定义
+ *
+ * 此文件包含多个服务之间共享的接口类型，避免服务之间的循环依赖。
+ */
+
+/**
+ * 客户端信息接口
+ */
+export interface ClientInfo {
+  status: "connected" | "disconnected";
+  mcpEndpoint: string;
+  activeMCPServers: string[];
+  lastHeartbeat?: number;
+}
+
+/**
+ * 重启状态接口
+ */
+export interface RestartStatus {
+  status: "restarting" | "completed" | "failed";
+  error?: string;
+  timestamp: number;
+  serviceName?: string;
+  attempt?: number;
+}


### PR DESCRIPTION
- 创建 apps/backend/types/service-types.ts 存放共享类型定义
- 将 ClientInfo 和 RestartStatus 接口移至独立文件
- 更新 event-bus.service.ts 从 service-types.ts 导入类型
- 更新 status.service.ts 从 service-types.ts 导入类型并重新导出以保持向后兼容
- 更新 notification.service.ts 从 service-types.ts 导入类型
- 更新相关测试文件的导入

此修复遵循依赖倒置原则 (DIP)，降低模块耦合度，提高代码可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2486