### PR TITLE
fix: 移除 ASR.ts 中重复的 close 事件监听器

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -756,11 +756,6 @@ export class ASR extends EventEmitter {
         reject(error);
       });
 
-      this.ws.on("close", () => {
-        this.connected = false;
-        this.emit("close");
-      });
-
       // Register global message handler for event-driven mode
       // In streaming mode, this enables result/vad_end events via on()
       this.ws.on("message", (data: Buffer) => {


### PR DESCRIPTION
- 移除 _connect() 方法中重复注册的 close 事件监听器
- 修复 WebSocket 连接关闭时事件处理逻辑重复执行的问题
- 统一事件监听器顺序：open -> close -> error -> message

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2488