### PR TITLE
refactor: 消除 toolApi.ts 与 shared-types 之间的类型重复定义

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -313,11 +313,13 @@ export class MCPToolHandler {
       rawTools = sortTools(rawTools, { field: sortBy });
 
       // 转换为 CustomMCPToolWithStats 格式（使用共享类型）
+      // 注意：inputSchema 需要类型断言，因为本地 JSONSchema 与 shared-types 中的定义略有不同
+      // 这是一个已知的技术债，将来应该统一 JSONSchema 定义
       const tools: CustomMCPToolWithStats[] = rawTools.map(
         (tool: EnhancedToolInfo) => ({
           name: tool.name,
           description: tool.description,
-          inputSchema: tool.inputSchema,
+          inputSchema: tool.inputSchema as JSONSchema,
           handler: {
             type: "mcp",
             config: {
@@ -1891,12 +1893,14 @@ export class MCPToolHandler {
       }
     }
 
+    // 注意：properties 类型断言是因为本地 JSONSchema 与 shared-types 中的定义略有不同
+    // 这是一个已知的技术债，将来应该统一 JSONSchema 定义
     return {
       type: "object",
-      properties,
+      properties: properties as Record<string, JSONSchema>,
       required: required.length > 0 ? required : undefined,
       additionalProperties: false,
-    };
+    } as JSONSchema;
   }
 
   /**

--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -1,299 +1,44 @@
 /**
  * 工具添加 API 相关类型定义
  * 支持多种工具类型的添加，包括 MCP 工具、Coze 工作流等
- */
-
-import type { JSONSchema as LibJSONSchema } from "@/lib/mcp/types.js";
-import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
-
-/**
- * JSON Schema 类型
- * 重新导出 @/lib/mcp/types.js 中的 JSONSchema
  *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 JSONSchema 相同
- * TODO：将来应从 shared-types 导入 JSONSchema 以消除重复定义
+ * 这些类型从 @xiaozhi-client/shared-types 重新导出，消除重复定义
+ * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts 和 packages/shared-types/src/api/toolApi.ts
  */
-export type JSONSchema = LibJSONSchema;
+
+// 从 shared-types 导入核心工具类型
+export type {
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  CustomMCPTool,
+  CustomMCPToolWithStats,
+  CustomMCPToolConfig,
+  JSONSchema,
+} from "@xiaozhi-client/shared-types";
+
+// 从 shared-types 导入 API 相关类型
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  ToolValidationErrorDetail,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+} from "@xiaozhi-client/shared-types";
+
+// 导出枚举（作为值，同时包含类型）
+export { ToolType, ToolValidationError } from "@xiaozhi-client/shared-types";
 
 /**
- * 工具处理器配置相关类型
- *
- * 注意：这些类型与 @xiaozhi-client/shared-types/src/mcp/tool-definition.ts 中定义的类型相同
- * TODO：将 toolApi.ts 的类型迁移为从 shared-types 导入，消除重复定义
- * 目前保持本地定义以避免 TypeScript 子路径解析问题（影响 tts、asr 等其他包）
- *
- * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts
+ * CustomMCPToolBase 类型别名
+ * 保持向后兼容，等同于 CustomMCPTool
+ * @deprecated 请直接使用 CustomMCPTool
  */
-export type ToolHandlerConfig =
-  | MCPHandlerConfig
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig;
-
-/**
- * MCP 处理器配置
- * 用于标准 MCP 服务中的工具
- */
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
-
-/**
- * 代理处理器配置
- * 用于第三方平台代理（如 Coze、OpenAI 等）
- */
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: Record<string, unknown>;
-}
-
-/**
- * HTTP 处理器配置
- * 用于 HTTP API 工具
- */
-export interface HttpHandlerConfig {
-  type: "http";
-  config: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
-  };
-}
-
-/**
- * 函数处理器配置
- * 用于自定义函数工具
- */
-export interface FunctionHandlerConfig {
-  type: "function";
-  config: {
-    module: string;
-    function: string;
-  };
-}
-
-/**
- * CustomMCP 工具基础接口
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPTool 相同
- * TODO：将来应从 shared-types 导入 CustomMCPTool 以消除重复定义
- */
-export interface CustomMCPToolBase {
-  /** 工具唯一标识符 */
-  name: string;
-  /** 工具描述信息 */
-  description: string;
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-  /** 处理器配置 */
-  handler: ToolHandlerConfig;
-}
-
-/**
- * 带统计信息的 CustomMCP 工具
- * 用于 API 响应，使用扁平的统计信息结构
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPToolWithStats 类似
- * 但不包含 `enabled` 字段。如需完整功能，请从 shared-types 导入
- */
-export interface CustomMCPToolWithStats extends CustomMCPToolBase {
-  /** 工具使用次数（扁平结构，与 API 响应格式一致） */
-  usageCount?: number;
-  /** 最后使用时间（ISO 8601 格式） */
-  lastUsedTime?: string;
-}
-
-/**
- * 工具类型枚举
- */
-export enum ToolType {
-  /** MCP 工具（标准 MCP 服务中的工具） */
-  MCP = "mcp",
-  /** Coze 工作流工具 */
-  COZE = "coze",
-  /** HTTP API 工具（预留） */
-  HTTP = "http",
-  /** 自定义函数工具（预留） */
-  FUNCTION = "function",
-}
-
-/**
- * MCP 工具数据
- * 用于将标准 MCP 服务中的工具添加到 customMCP.tools 配置中
- */
-export interface MCPToolData {
-  /** MCP 服务名称 */
-  serviceName: string;
-  /** 工具名称 */
-  toolName: string;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * Coze 工作流数据
- * 保持与现有格式的兼容性
- */
-export interface CozeWorkflowData {
-  /** Coze 工作流信息 */
-  workflow: CozeWorkflow;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-  /** 可选的参数配置 */
-  parameterConfig?: WorkflowParameterConfig;
-}
-
-/**
- * HTTP API 工具数据（预留）
- */
-export interface HttpApiToolData {
-  /** API 地址 */
-  url: string;
-  /** HTTP 方法 */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  /** API 描述 */
-  description: string;
-  /** 请求头 */
-  headers?: Record<string, string>;
-  /** 请求体模板 */
-  bodyTemplate?: string;
-  /** 认证配置 */
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    apiKey?: string;
-    apiKeyHeader?: string;
-  };
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 函数工具数据（预留）
- */
-export interface FunctionToolData {
-  /** 模块路径 */
-  module: string;
-  /** 函数名 */
-  function: string;
-  /** 函数描述 */
-  description: string;
-  /** 函数执行上下文 */
-  context?: Record<string, any>;
-  /** 超时时间 */
-  timeout?: number;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 添加自定义工具的统一请求接口
- */
-export interface AddCustomToolRequest {
-  /** 工具类型 */
-  type: ToolType;
-  /** 工具数据（根据类型不同而不同） */
-  data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
-}
-
-/**
- * 工具验证错误类型
- */
-export enum ToolValidationError {
-  /** 无效的工具类型 */
-  INVALID_TOOL_TYPE = "INVALID_TOOL_TYPE",
-  /** 缺少必需字段 */
-  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
-  /** 服务不存在 */
-  SERVICE_NOT_FOUND = "SERVICE_NOT_FOUND",
-  /** 工具名称冲突 */
-  TOOL_NAME_CONFLICT = "TOOL_NAME_CONFLICT",
-  /** 配置验证失败 */
-  CONFIG_VALIDATION_FAILED = "CONFIG_VALIDATION_FAILED",
-  /** 系统配置错误 */
-  SYSTEM_CONFIG_ERROR = "SYSTEM_CONFIG_ERROR",
-  /** 资源限制超出 */
-  RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED",
-}
-
-/**
- * 工具验证错误详情
- */
-export interface ToolValidationErrorDetail {
-  /** 错误类型 */
-  error: ToolValidationError;
-  /** 错误消息 */
-  message: string;
-  /** 错误详情 */
-  details?: any;
-  /** 建议的解决方案 */
-  suggestions?: string[];
-}
-
-/**
- * 添加工具的响应数据
- */
-export interface AddToolResponse {
-  /** 成功添加的工具 */
-  tool: any;
-  /** 工具名称 */
-  toolName: string;
-  /** 工具类型 */
-  toolType: ToolType;
-  /** 添加时间戳 */
-  addedAt: string;
-}
-
-/**
- * 工具元数据信息
- */
-export interface ToolMetadata {
-  /** 工具原始来源 */
-  source: {
-    type: "mcp" | "coze" | "http" | "function";
-    serviceName?: string;
-    toolName?: string;
-    url?: string;
-  };
-  /** 添加时间 */
-  addedAt: string;
-  /** 最后更新时间 */
-  updatedAt?: string;
-  /** 版本信息 */
-  version?: string;
-}
-
-/**
- * 工具配置选项
- */
-export interface ToolConfigOptions {
-  /** 是否启用工具（默认 true） */
-  enabled?: boolean;
-  /** 超时时间（毫秒） */
-  timeout?: number;
-  /** 重试次数 */
-  retryCount?: number;
-  /** 重试间隔（毫秒） */
-  retryDelay?: number;
-  /** 自定义标签 */
-  tags?: string[];
-  /** 工具分组 */
-  group?: string;
-}
+import type { CustomMCPTool as _CustomMCPTool } from "@xiaozhi-client/shared-types";
+export type CustomMCPToolBase = _CustomMCPTool;

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,10 +25,30 @@ export type {
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
   JSONSchema,
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
 } from "./mcp";
 
 // 工具API相关类型
-export type { ToolType, MCPToolData } from "./api";
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  ToolValidationErrorDetail,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ExtendedCustomMCPTool,
+} from "./api";
+
+// 导出枚举（同时作为类型和值）
+// 从 toolApi 直接导入，避免通过 api 中转造成的命名冲突
+export { ToolType, ToolValidationError } from "./api/toolApi";
 
 // 配置相关类型
 export type {


### PR DESCRIPTION
- 将 apps/backend/types/toolApi.ts 从 300 行减少到 48 行
- 所有类型现在从 @xiaozhi-client/shared-types 重新导出
- 更新 packages/shared-types/src/index.ts 以导出所有需要的类型
- 添加类型断言以处理 JSONSchema 兼容性差异
- 修复 issue #2490

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2490