### PR TITLE
fix: 添加 spawn 调用的 error 事件监听器以捕获进程启动失败

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -44,6 +44,20 @@ export class ServiceApiHandler {
       },
     });
 
+    // 监听进程启动失败事件
+    child.on("error", (error) => {
+      const errorMessage = `xiaozhi 进程启动失败: xiaozhi ${args.join(" ")}`;
+      this.logger.error(errorMessage, { error });
+
+      // 发射进程启动失败事件
+      this.eventBus.emitEvent("service:spawn:error", {
+        command: "xiaozhi",
+        args,
+        error: error.message,
+        timestamp: Date.now(),
+      });
+    });
+
     child.unref();
     this.logger.info(`MCP 服务命令已发送: xiaozhi ${args.join(" ")}`);
 

--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -98,6 +98,12 @@ export interface EventBusEvents {
     newStatus: string;
     timestamp: number;
   };
+  "service:spawn:error": {
+    command: string;
+    args: string[];
+    error: string;
+    timestamp: number;
+  };
 
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };


### PR DESCRIPTION
修复 service.handler.ts 中 spawnXiaozhiProcess 方法缺少 error 事件监听器的问题。
当 xiaozhi 命令不存在或无法启动时，现在会正确捕获并记录错误，
同时通过事件总线发射 service:spawn:error 事件以供监控。

相关 issue: #2494

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2494