### PR TITLE
fix: 修复 DaemonManager.setupLogging 中 logStream 文件句柄泄漏

### DIFF
--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -43,6 +43,7 @@ export interface DaemonOptions {
  */
 export class DaemonManagerImpl implements IDaemonManager {
   private currentDaemon: ChildProcess | null = null;
+  private logStream: fs.WriteStream | null = null;
 
   constructor(private processManager: ProcessManager) {}
 
@@ -100,6 +101,12 @@ export class DaemonManagerImpl implements IDaemonManager {
 
       // 清理 PID 文件
       this.processManager.cleanupPidFile();
+
+      // 关闭日志流，防止文件句柄泄漏
+      if (this.logStream) {
+        this.logStream.end();
+        this.logStream = null;
+      }
 
       // 清理当前守护进程引用
       this.currentDaemon = null;
@@ -238,16 +245,18 @@ export class DaemonManagerImpl implements IDaemonManager {
         fs.mkdirSync(logDir, { recursive: true });
       }
 
-      // 创建日志流
-      const logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+      // 创建日志流并保存为实例变量，以便后续关闭
+      this.logStream = fs.createWriteStream(logFilePath, { flags: "a" });
 
       // 重定向标准输出和错误输出
-      child.stdout?.pipe(logStream);
-      child.stderr?.pipe(logStream);
+      child.stdout?.pipe(this.logStream);
+      child.stderr?.pipe(this.logStream);
 
       // 写入启动日志
       const timestamp = new Date().toISOString();
-      logStream.write(`\n[${timestamp}] 守护进程启动 (PID: ${child.pid})\n`);
+      this.logStream.write(
+        `\n[${timestamp}] 守护进程启动 (PID: ${child.pid})\n`
+      );
     } catch (error) {
       consola.warn(
         `设置日志重定向失败: ${error instanceof Error ? error.message : String(error)}`
@@ -324,6 +333,18 @@ export class DaemonManagerImpl implements IDaemonManager {
         );
       }
       this.currentDaemon = null;
+    }
+
+    // 关闭日志流，防止文件句柄泄漏
+    if (this.logStream) {
+      try {
+        this.logStream.end();
+      } catch (error) {
+        consola.warn(
+          `关闭日志流失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+      this.logStream = null;
     }
   }
 }


### PR DESCRIPTION
在 setupLogging 方法中创建的 logStream 未被保存为实例变量，
导致在停止守护进程或清理资源时无法关闭文件流。

- 添加 logStream 实例变量用于保存文件流引用
- 在 stopDaemon 方法中关闭日志流
- 在 cleanup 方法中关闭日志流
- 防止多次启动/停止守护进程时累积未关闭的文件句柄

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2496