### PR TITLE
fix: 使用 JSONSchema 类型替代 any 类型以增强类型安全性

### DIFF
--- a/apps/frontend/src/lib/schema-utils.ts
+++ b/apps/frontend/src/lib/schema-utils.ts
@@ -1,9 +1,18 @@
 import { z } from "zod";
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
+
+/**
+ * JSON Schema 工具函数模块
+ *
+ * 提供 JSON Schema 到 Zod schema 的转换、默认值生成等功能
+ *
+ * @module schema-utils
+ */
 
 /**
  * 根据 JSON Schema 动态生成 Zod schema
  */
-export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
+export function createZodSchemaFromJsonSchema(jsonSchema: JSONSchema): z.ZodTypeAny {
   if (!jsonSchema || typeof jsonSchema !== "object") {
     return z.any();
   }
@@ -92,7 +101,7 @@ export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
 /**
  * 获取字段的默认值
  */
-export function getDefaultValueForSchema(schema: any): any {
+export function getDefaultValueForSchema(schema: JSONSchema): unknown {
   if (!schema) return undefined;
 
   switch (schema.type) {
@@ -112,7 +121,7 @@ export function getDefaultValueForSchema(schema: any): any {
 
     case "object":
       if (schema.properties) {
-        const defaults: Record<string, any> = {};
+        const defaults: Record<string, unknown> = {};
         for (const [key, propSchema] of Object.entries(schema.properties)) {
           defaults[key] = getDefaultValueForSchema(propSchema);
         }
@@ -128,10 +137,10 @@ export function getDefaultValueForSchema(schema: any): any {
 /**
  * 根据 JSON Schema 生成默认值对象
  */
-export function createDefaultValues(jsonSchema: any): Record<string, any> {
+export function createDefaultValues(jsonSchema: JSONSchema): Record<string, unknown> {
   if (!jsonSchema || !jsonSchema.properties) return {};
 
-  const defaults: Record<string, any> = {};
+  const defaults: Record<string, unknown> = {};
   const requiredFields = jsonSchema.required || [];
 
   for (const [key, propSchema] of Object.entries(jsonSchema.properties)) {

--- a/packages/shared-types/src/mcp/schema.ts
+++ b/packages/shared-types/src/mcp/schema.ts
@@ -16,6 +16,25 @@ export interface JSONSchema {
   description?: string;
   enum?: unknown[];
   const?: unknown;
+  // 字符串类型约束
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: string;
+  // 数值类型约束
+  minimum?: number;
+  maximum?: number;
+  exclusiveMinimum?: number;
+  exclusiveMaximum?: number;
+  multipleOf?: number;
+  // 数组类型约束
+  minItems?: number;
+  maxItems?: number;
+  uniqueItems?: boolean;
+  // 其他常见属性
+  title?: string;
+  default?: unknown;
+  examples?: unknown[];
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
- 在 schema-utils.ts 中导入并使用 JSONSchema 类型
- 添加文件级 JSDoc 注释（模块说明）
- 更新公共 API 函数签名使用具体类型
- 更新返回类型使用 unknown 替代 any
- 增强 JSONSchema 类型定义，添加常用 JSON Schema 属性

修复 #2503

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2503