### PR TITLE
docs(asr): 将 audio 模块中的英文注释翻译为中文

### DIFF
--- a/packages/asr/src/audio/WavParser.ts
+++ b/packages/asr/src/audio/WavParser.ts
@@ -6,22 +6,22 @@ import { Buffer } from "node:buffer";
 import type { WavInfo } from "@/audio/types.js";
 
 /**
- * Read WAV file information
+ * 读取 WAV 文件信息
  */
 export function readWavInfo(data: Buffer): WavInfo {
-  // Check RIFF header
+  // 检查 RIFF 头部
   const riff = data.subarray(0, 4).toString("ascii");
   if (riff !== "RIFF") {
     throw new Error("Invalid WAV file: missing RIFF header");
   }
 
-  // Check WAVE format
+  // 检查 WAVE 格式
   const wave = data.subarray(8, 12).toString("ascii");
   if (wave !== "WAVE") {
     throw new Error("Invalid WAV file: missing WAVE format");
   }
 
-  // Find fmt chunk
+  // 查找 fmt 块
   let offset = 12;
   let fmtChunk: Buffer | null = null;
   let dataChunk: Buffer | null = null;
@@ -38,7 +38,7 @@ export function readWavInfo(data: Buffer): WavInfo {
     }
 
     offset += 8 + chunkSize;
-    // Word alignment
+    // 字对齐
     if (chunkSize % 2 !== 0) {
       offset += 1;
     }
@@ -48,13 +48,13 @@ export function readWavInfo(data: Buffer): WavInfo {
     throw new Error("Invalid WAV file: missing fmt chunk");
   }
 
-  // Parse fmt chunk
-  fmtChunk.readUInt16LE(0); // audio format (1=PCM)
+  // 解析 fmt 块
+  fmtChunk.readUInt16LE(0); // 音频格式 (1=PCM)
   const nchannels = fmtChunk.readUInt16LE(2);
   const framerate = fmtChunk.readUInt32LE(4);
   const sampwidth = fmtChunk.readUInt16LE(14);
 
-  // Calculate frames
+  // 计算帧数
   const dataSize = dataChunk ? dataChunk.length : 0;
   const nframes = Math.floor(dataSize / (nchannels * sampwidth));
 
@@ -68,10 +68,10 @@ export function readWavInfo(data: Buffer): WavInfo {
 }
 
 /**
- * Read WAV audio data (skipping header)
+ * 读取 WAV 音频数据（跳过头部）
  */
 export function readWavData(data: Buffer): Buffer {
-  // Find data chunk
+  // 查找数据块
   let offset = 12;
   while (offset < data.length - 8) {
     const chunkId = data.subarray(offset, offset + 4).toString("ascii");
@@ -91,7 +91,7 @@ export function readWavData(data: Buffer): Buffer {
 }
 
 /**
- * Create WAV file from PCM data
+ * 从 PCM 数据创建 WAV 文件
  */
 export function createWavFile(
   pcmData: Buffer,
@@ -106,22 +106,22 @@ export function createWavFile(
 
   const header = Buffer.alloc(44);
 
-  // RIFF header
+  // RIFF 头部
   header.write("RIFF", 0);
   header.writeUInt32LE(chunkSize, 4);
   header.write("WAVE", 8);
 
-  // fmt chunk
+  // fmt 块
   header.write("fmt ", 12);
-  header.writeUInt32LE(16, 16); // chunk size
-  header.writeUInt16LE(1, 20); // audio format (PCM)
+  header.writeUInt32LE(16, 16); // 块大小
+  header.writeUInt16LE(1, 20); // 音频格式 (PCM)
   header.writeUInt16LE(channels, 22);
   header.writeUInt32LE(sampleRate, 24);
   header.writeUInt32LE(byteRate, 28);
   header.writeUInt16LE(blockAlign, 32);
   header.writeUInt16LE(bitsPerSample, 34);
 
-  // data chunk
+  // 数据块
   header.write("data", 36);
   header.writeUInt32LE(dataSize, 40);
 

--- a/packages/asr/src/audio/index.ts
+++ b/packages/asr/src/audio/index.ts
@@ -1,5 +1,5 @@
 /**
- * Audio module exports
+ * 音频模块导出
  */
 
 export * from "./types.js";

--- a/packages/asr/src/audio/types.ts
+++ b/packages/asr/src/audio/types.ts
@@ -1,5 +1,5 @@
 /**
- * Audio type definitions
+ * 音频类型定义
  */
 
 export enum AudioFormat {
@@ -9,16 +9,16 @@ export enum AudioFormat {
   RAW = "raw",
 }
 
-// WAV file information
+// WAV 文件信息
 export interface WavInfo {
-  nchannels: number; // Number of channels
-  sampwidth: number; // Sample width in bytes
-  framerate: number; // Sample rate
-  nframes: number; // Number of frames
-  dataSize: number; // Size of audio data
+  nchannels: number; // 声道数
+  sampwidth: number; // 采样宽度（字节）
+  framerate: number; // 采样率
+  nframes: number; // 帧数
+  dataSize: number; // 音频数据大小
 }
 
-// Audio configuration
+// 音频配置
 export interface AudioConfig {
   format: AudioFormat;
   sampleRate: number;
@@ -28,7 +28,7 @@ export interface AudioConfig {
   codec?: string;
 }
 
-// Audio data with metadata
+// 带元数据的音频数据
 export interface AudioData {
   data: Buffer;
   config: AudioConfig;


### PR DESCRIPTION
将 packages/asr/src/audio/ 目录中的所有英文 JSDoc 注释和代码注释翻译为中文，以符合项目本地化规范。

修改文件：
- WavParser.ts: 将函数 JSDoc 注释和行内注释翻译为中文
- types.ts: 将文件级注释、接口注释和属性注释翻译为中文
- index.ts: 将文件级注释翻译为中文

Fixes #2504

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2504