### PR TITLE
fix(event-bus): 将 mcp:server:batch_added 事件的 results 类型从 any[] 改为 MCPServerAddResult[]

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -16,6 +16,7 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { ClientInfo } from "@/services/status.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerAddResult } from "@/handlers/mcp-manage.handler.js";
 
 /**
  * 事件类型定义
@@ -160,7 +161,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {


### PR DESCRIPTION
- 添加 MCPServerAddResult 类型导入
- 提高类型安全性，避免绕过 TypeScript 类型检查

修复 #2507

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2507