### PR TITLE
fix: add asr:build and tts:build dependencies to backend type-check target

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -10,7 +10,7 @@
         "command": "pnpm --filter backend run build"
       },
       "outputs": ["{workspaceRoot}/dist/backend"],
-      "dependsOn": ["shared-types:build", "config:build"]
+      "dependsOn": ["shared-types:build", "config:build", "asr:build", "tts:build"]
     },
     "test": {
       "executor": "nx:run-commands",
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "asr:build", "tts:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
- Add asr:build and tts:build to type-check target's dependsOn
- Add asr:build and tts:build to build target's dependsOn

This fixes TypeScript module resolution errors when running pnpm check:type,
as the backend imports types from @xiaozhi-client/tts and @xiaozhi-client/asr.

Fixes #2512

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2512