### PR TITLE
fix: 替换 heartbeat.handler.ts 中的 any 类型为 WebSocketLike

### DIFF
--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -9,7 +9,10 @@ import { logger } from "@/Logger.js";
 import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
-import { sendWebSocketError } from "@/utils/websocket-helper.js";
+import {
+  type WebSocketLike,
+  sendWebSocketError,
+} from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
 
 /**
@@ -46,7 +49,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -82,7 +85,10 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -200,7 +206,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",


### PR DESCRIPTION
- 在 handleClientStatus、sendLatestConfig 和 sendHeartbeatResponse 方法中使用 WebSocketLike 替代 any
- 从 @/utils/websocket-helper.js 导入 WebSocketLike 类型
- 提升类型安全性，使编译时能够捕获类型错误

Fixes #2514

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2514