### PR TITLE
fix: tts.service.ts 中 sendStopAndCleanup 方法添加 processBuffer 错误处理

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -313,7 +313,15 @@ export class TTSService implements ITTSService {
     // 如果缓冲区还有数据，继续处理
     const buffer = this.opusPacketBuffer.get(deviceId);
     if (buffer && buffer.length > 0) {
-      await this.processBuffer(deviceId);
+      try {
+        await this.processBuffer(deviceId);
+      } catch (error) {
+        logger.error(
+          `[TTSService] processBuffer 处理失败: deviceId=${deviceId}`,
+          error
+        );
+        // 继续执行清理操作
+      }
     }
 
     // 再次检查缓冲区是否已清空


### PR DESCRIPTION
在 sendStopAndCleanup 方法中为 processBuffer 调用添加 try-catch 错误处理，
防止因 processBuffer 抛出异常而跳过后续的 cleanup 操作，避免资源泄漏。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2519