### PR TITLE
fix: 添加 asr:build 和 tts:build 依赖到 backend type-check

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "asr:build", "tts:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
修复 backend 包的 type-check 目标缺少 asr:build 和 tts:build 依赖的问题。
这些依赖在运行类型检查时需要预先构建，否则 TypeScript 无法找到
@xiaozhi-client/asr 和 @xiaozhi-client/tts 模块的类型声明文件。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2521