### PR TITLE
fix(tts): 修复 synthesizeSpeechStream 函数中 WebSocket 资源泄漏问题

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/binary.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/binary.ts
@@ -198,7 +198,13 @@ export async function synthesizeSpeechStream(
       case MsgType.AudioOnlyServer: {
         // 每收到一个音频块立即调用回调处理
         const isLast = msg.sequence !== undefined && msg.sequence < 0;
-        await onAudioChunk(msg.payload, isLast);
+        try {
+          await onAudioChunk(msg.payload, isLast);
+        } catch (error) {
+          // 确保回调失败时关闭 WebSocket，防止资源泄漏
+          ws.close();
+          throw error;
+        }
 
         if (isLast) {
           // 最后一块，结束循环


### PR DESCRIPTION
在 onAudioChunk 回调抛出错误时，WebSocket 连接不会被关闭，导致资源泄漏。

修复方案：
- 使用 try-catch 包装 onAudioChunk 回调
- 在回调失败时确保关闭 WebSocket
- 保持原有的错误传播行为

修复 #2523

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2523