### PR TITLE
fix: 删除 TTS 处理器中遗留的调试文件写入代码

### DIFF
--- a/apps/backend/handlers/tts.handler.ts
+++ b/apps/backend/handlers/tts.handler.ts
@@ -3,7 +3,6 @@
  * 提供语音合成 RESTful API 接口
  */
 
-import fs from "node:fs";
 import { TTS_VOICES, getVoiceScenes } from "@/constants/voices.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
@@ -128,7 +127,6 @@ export class TTSApiHandler extends BaseHandler {
 
       // 调用 TTS 合成（非流式）
       const audioData = await ttsClient.synthesize(body.text);
-      fs.writeFileSync("audio.wav", Buffer.from(audioData));
 
       c.get("logger").info(`语音合成成功: audioSize=${audioData.length} bytes`);
 


### PR DESCRIPTION
修复 #2528

删除了 apps/backend/handlers/tts.handler.ts 中遗留的调试代码，该代码在每次 TTS 请求时都会将音频数据写入固定的 `audio.wav` 文件。

问题影响：
- 并发竞态条件：多个请求同时写入同一文件导致数据损坏
- 磁盘空间浪费：文件持续累积未被清理
- 性能影响：不必要的磁盘 I/O 操作
- 安全风险：多租户环境中可能的数据泄露

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2528