### PR TITLE
docs: 为多个 npm 包添加 description 字段

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xiaozhi-client/backend",
   "version": "1.0.0",
+  "description": "小智 AI 客户端后端服务，提供 MCP 协议支持和 Web UI",
   "private": true,
   "type": "module",
   "scripts": {

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xiaozhi-client/cli",
   "version": "2.2.0",
+  "description": "小智 AI 客户端命令行工具，提供项目创建、服务启动、配置管理等功能",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xiaozhi-client/config",
   "version": "2.2.0",
+  "description": "小智项目配置管理模块，支持配置文件的读取、解析、验证和更新",
   "private": false,
   "repository": {
     "type": "git",

--- a/packages/version/package.json
+++ b/packages/version/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xiaozhi-client/version",
   "version": "2.2.0",
+  "description": "小智客户端版本管理工具，提供版本号获取、比较、验证等功能",
   "private": false,
   "repository": {
     "type": "git",


### PR DESCRIPTION
为以下包的 package.json 添加了 description 字段：
- @xiaozhi-client/cli: 小智 AI 客户端命令行工具
- @xiaozhi-client/config: 小智项目配置管理模块
- @xiaozhi-client/version: 小智客户端版本管理工具
- @xiaozhi-client/backend: 小智 AI 客户端后端服务

这将改善 npm registry 的显示效果和用户搜索体验。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2530