### PR TITLE
refactor: 提取分页参数魔法数字为命名常量

### DIFF
--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -11,6 +11,20 @@ import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
 /**
+ * Coze API 分页参数常量
+ */
+const COZE_PAGINATION_LIMITS = {
+  /** 页码最小值 */
+  MIN_PAGE_NUM: 1,
+  /** 页码最大值 */
+  MAX_PAGE_NUM: 1000,
+  /** 每页数量最小值 */
+  MIN_PAGE_SIZE: 1,
+  /** 每页数量最大值 */
+  MAX_PAGE_SIZE: 100,
+} as const;
+
+/**
  * 错误代码类型
  */
 type CozeErrorCode =
@@ -185,19 +199,25 @@ export class CozeHandler extends BaseHandler {
       }
 
       // 验证分页参数
-      if (page_num < 1 || page_num > 1000) {
+      if (
+        page_num < COZE_PAGINATION_LIMITS.MIN_PAGE_NUM ||
+        page_num > COZE_PAGINATION_LIMITS.MAX_PAGE_NUM
+      ) {
         return c.fail(
           "INVALID_PARAMETER",
-          "page_num 必须在 1-1000 之间",
+          `page_num 必须在 ${COZE_PAGINATION_LIMITS.MIN_PAGE_NUM}-${COZE_PAGINATION_LIMITS.MAX_PAGE_NUM} 之间`,
           undefined,
           400
         );
       }
 
-      if (page_size < 1 || page_size > 100) {
+      if (
+        page_size < COZE_PAGINATION_LIMITS.MIN_PAGE_SIZE ||
+        page_size > COZE_PAGINATION_LIMITS.MAX_PAGE_SIZE
+      ) {
         return c.fail(
           "INVALID_PARAMETER",
-          "page_size 必须在 1-100 之间",
+          `page_size 必须在 ${COZE_PAGINATION_LIMITS.MIN_PAGE_SIZE}-${COZE_PAGINATION_LIMITS.MAX_PAGE_SIZE} 之间`,
           undefined,
           400
         );


### PR DESCRIPTION
将 coze.handler.ts 中的分页参数验证逻辑使用的硬编码魔法数字（1、1000、100）提取为命名常量 COZE_PAGINATION_LIMITS，提高代码可维护性和可读性。

- 新增 COZE_PAGINATION_LIMITS 常量对象定义
- 更新 page_num 和 page_size 验证逻辑使用常量
- 添加 JSDoc 注释说明各常量含义

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2534