### PR TITLE
fix: 将 mcp:server:added 事件的 config 字段类型从 any 替换为 MCPServerConfig

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -16,6 +16,7 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import type { ClientInfo } from "@/services/status.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
 
 /**
  * 事件类型定义
@@ -126,7 +127,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };


### PR DESCRIPTION
- 导入 MCPServerConfig 类型从 @xiaozhi-client/config
- 将 EventBusEvents 接口中 mcp:server:added 事件的 config 字段类型从 any 替换为 MCPServerConfig
- 提高类型安全性，使事件定义与实际使用保持一致

修复 #2538

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2538