### PR TITLE
fix: 将 WebSocket readyState 魔法数字替换为常量以提高代码可读性

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -73,7 +73,7 @@ import { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { SimpleConnectionStatus } from "@xiaozhi-client/endpoint";
 import type { Hono } from "hono";
 import { WebSocketServer } from "ws";
-import type WebSocket from "ws";
+import WebSocket from "ws";
 
 import { HTTP_SERVER_CONFIG } from "@/constants/index.js";
 import { MCPServiceManagerNotInitializedError } from "@/errors/mcp-errors.middleware.js";
@@ -708,8 +708,11 @@ export class WebServer {
           error
         );
         // 只有在 WebSocket 处于可关闭状态时才关闭
-        // ws.OPEN = 1, ws.CONNECTING = 0
-        if (ws.readyState === 1 || ws.readyState === 0) {
+        // WebSocket.OPEN = 1, WebSocket.CONNECTING = 0
+        if (
+          ws.readyState === WebSocket.OPEN ||
+          ws.readyState === WebSocket.CONNECTING
+        ) {
           ws.close(1011, "Connection handling failed");
         }
       });


### PR DESCRIPTION
- 将 import type WebSocket 改为 import WebSocket 以访问常量
- 将 readyState === 1 替换为 WebSocket.OPEN
- 将 readyState === 0 替换为 WebSocket.CONNECTING
- 保留原有注释说明常量含义

修复 #2540

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2540