### PR TITLE
fix(cli): 改进 TemplateManager JSON 解析错误信息

### DIFF
--- a/packages/cli/src/services/TemplateManager.ts
+++ b/packages/cli/src/services/TemplateManager.ts
@@ -97,7 +97,10 @@ export class TemplateManagerImpl implements ITemplateManager {
           const configContent = FileUtils.readFile(configPath);
           config = JSON.parse(configContent);
         } catch (error) {
-          console.warn(`模板配置文件解析失败: ${templateName}`);
+          console.warn(
+            `模板配置文件解析失败: ${templateName}`,
+            error instanceof Error ? error.message : String(error)
+          );
         }
       }
 


### PR DESCRIPTION
在 getTemplateInfo() 方法中，当 template.json 配置文件解析失败时，
现在会输出详细的错误信息（语法错误、编码问题等），而不仅仅是模板名称。

修复 #2541

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2541