### PR TITLE
docs: 增强工具类文件级 JSDoc 注释

### DIFF
--- a/packages/cli/src/utils/FileUtils.ts
+++ b/packages/cli/src/utils/FileUtils.ts
@@ -1,5 +1,52 @@
 /**
- * 文件操作工具
+ * 文件操作工具类
+ *
+ * 提供文件和目录操作的封装方法，简化常见的文件系统操作。
+ *
+ * @module FileUtils
+ *
+ * ## 功能类别
+ *
+ * - **文件检查**：检查文件是否存在、获取文件信息、检查权限
+ * - **文件读写**：读取文件内容、写入文件（支持覆盖控制）
+ * - **文件操作**：复制文件、删除文件
+ * - **目录操作**：创建目录、复制目录（支持递归和排除）、删除目录
+ * - **路径处理**：获取扩展名、基础文件名、路径规范化
+ * - **临时文件**：创建临时文件路径
+ *
+ * ## 错误处理
+ *
+ * 所有操作在失败时会抛出 `FileError` 异常，
+ * 包含详细的错误信息和文件路径。
+ *
+ * ## 注意事项
+ *
+ * - 所有写入操作默认不会覆盖已存在的文件（需显式设置 `overwrite: true`）
+ * - 目录删除默认为递归删除
+ * - 路径参数可以是相对路径或绝对路径
+ *
+ * @example
+ * ```typescript
+ * import { FileUtils } from '@xiaozhi-client/cli';
+ *
+ * // 检查文件是否存在
+ * if (FileUtils.exists('./config.json')) {
+ *   const content = FileUtils.readFile('./config.json');
+ * }
+ *
+ * // 写入文件（不覆盖）
+ * FileUtils.writeFile('./output.txt', 'Hello, World!');
+ *
+ * // 复制目录（递归，排除 node_modules）
+ * FileUtils.copyDirectory('./src', './dist', {
+ *   recursive: true,
+ *   exclude: ['node_modules', '.git']
+ * });
+ *
+ * // 获取文件信息
+ * const info = FileUtils.getFileInfo('./package.json');
+ * console.log(`文件大小: ${info.size} bytes`);
+ * ```
  */
 
 import fs from "node:fs";

--- a/packages/cli/src/utils/FormatUtils.ts
+++ b/packages/cli/src/utils/FormatUtils.ts
@@ -1,5 +1,38 @@
 /**
- * 格式化工具
+ * 格式化工具类
+ *
+ * 提供各种数据格式化功能，用于 CLI 输出美化。
+ *
+ * @module FormatUtils
+ *
+ * ## 功能类别
+ *
+ * - **时间格式化**：运行时间、时间戳、进程 ID 等
+ * - **数据大小格式化**：字节转换为人类可读的单位（B、KB、MB、GB、TB）
+ * - **进度显示**：进度条、百分比显示
+ * - **数据展示**：表格、列表、JSON 格式化
+ * - **网络信息**：URL、端口号格式化
+ * - **文本处理**：截断、布尔值本地化
+ *
+ * @example
+ * ```typescript
+ * import { FormatUtils } from '@xiaozhi-client/cli';
+ *
+ * // 格式化运行时间
+ * FormatUtils.formatUptime(3665000); // "1小时 1分钟 5秒"
+ *
+ * // 格式化文件大小
+ * FormatUtils.formatFileSize(1536); // "1.5 KB"
+ *
+ * // 格式化进度条
+ * FormatUtils.formatProgressBar(75, 100); // "[████████████░░░░░░░░] 75% (75/100)"
+ *
+ * // 格式化表格数据
+ * FormatUtils.formatTable([
+ *   { name: 'Alice', age: 30 },
+ *   { name: 'Bob', age: 25 }
+ * ]);
+ * ```
  */
 
 /**

--- a/packages/cli/src/utils/PathUtils.ts
+++ b/packages/cli/src/utils/PathUtils.ts
@@ -1,5 +1,50 @@
 /**
- * 路径处理工具
+ * 路径处理工具类
+ *
+ * 提供项目中各种路径的获取和解析功能，支持多种部署环境。
+ *
+ * @module PathUtils
+ *
+ * ## 功能类别
+ *
+ * - **配置路径**：配置文件路径、配置目录路径
+ * - **日志路径**：日志文件路径、PID 文件路径
+ * - **模板路径**：模板目录查找、模板文件路径解析
+ * - **项目路径**：项目根目录、构建输出目录、相对路径
+ * - **安全验证**：路径遍历攻击防护、路径安全检查
+ * - **系统路径**：临时目录、用户主目录
+ * - **可执行文件**：CLI 可执行文件路径、Web 服务器路径
+ *
+ * ## 环境适配
+ *
+ * - 支持开发环境（源码目录）
+ * - 支持构建环境（dist 目录）
+ * - 支持全局 npm 安装环境
+ *
+ * ## 安全注意事项
+ *
+ * - 使用 `validatePath()` 防止路径遍历攻击
+ * - 使用 `ensurePathWithin()` 确保路径在指定目录内
+ * - 使用 `createSafePath()` 创建安全的文件路径
+ *
+ * @example
+ * ```typescript
+ * import { PathUtils } from '@xiaozhi-client/cli';
+ *
+ * // 获取配置文件路径
+ * const configPath = PathUtils.resolveConfigPath();
+ *
+ * // 获取模板路径
+ * const templatePath = PathUtils.getTemplatePath('default');
+ *
+ * // 验证路径安全性
+ * if (PathUtils.validatePath(userInput)) {
+ *   const safePath = PathUtils.ensurePathWithin(userInput, baseDir);
+ * }
+ *
+ * // 获取 Web 服务器启动器路径
+ * const launcherPath = PathUtils.getWebServerLauncherPath();
+ * ```
  */
 
 import { realpathSync } from "node:fs";

--- a/packages/cli/src/utils/Validation.ts
+++ b/packages/cli/src/utils/Validation.ts
@@ -1,5 +1,39 @@
 /**
- * 输入验证工具
+ * 输入验证工具类
+ *
+ * 提供统一的输入验证功能，确保配置和数据的有效性。
+ *
+ * @module Validation
+ *
+ * ## 功能类别
+ *
+ * - **网络验证**：端口号、URL（HTTP/WebSocket）格式验证
+ * - **名称验证**：项目名称、模板名称、环境变量名称验证
+ * - **数据类型验证**：字符串长度、数字范围、数组长度验证
+ * - **格式验证**：JSON 格式、正则表达式、配置文件格式验证
+ * - **对象验证**：必填字段、对象属性验证
+ *
+ * ## 错误处理
+ *
+ * 所有验证方法在失败时会抛出 `ValidationError` 异常，
+ * 包含详细的错误信息和建议。
+ *
+ * @example
+ * ```typescript
+ * import { Validation } from '@xiaozhi-client/cli';
+ *
+ * // 验证端口号
+ * Validation.validatePort(8080); // 通过
+ * Validation.validatePort(70000); // 抛出 ValidationError
+ *
+ * // 验证 URL 格式
+ * Validation.validateHttpUrl('https://example.com'); // 通过
+ * Validation.validateWebSocketUrl('ws://localhost:3000'); // 通过
+ *
+ * // 验证项目名称
+ * Validation.validateProjectName('my-project'); // 通过
+ * Validation.validateProjectName('.hidden'); // 抛出 ValidationError
+ * ```
  */
 
 import type { ConfigFormat } from "../Types";


### PR DESCRIPTION
为 packages/cli/src/utils 目录下的工具类添加详细的文件级 JSDoc 注释，包括：

- FormatUtils.ts: 添加格式化工具的功能概述、使用示例和功能类别说明
- Validation.ts: 添加输入验证工具的错误处理说明和完整功能列表
- FileUtils.ts: 添加文件操作工具的注意事项和完整 API 说明
- PathUtils.ts: 添加路径处理工具的安全注意事项和环境适配说明

这些改进将提升开发者体验和代码可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2548