### PR TITLE
fix: 移除 adapter.ts 中重复的 MCPServiceConfig 类型定义

### DIFF
--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -31,6 +31,12 @@ export enum MCPTransportType {
   HTTP = "http",
 }
 
+/**
+ * 传输类型输入值（枚举或字符串字面量）
+ * 与 @xiaozhi-client/mcp-core 保持一致
+ */
+export type MCPTransportTypeInput = MCPTransportType | "stdio" | "sse" | "http";
+
 // =========================
 // 2. 配置接口类型
 // =========================
@@ -55,9 +61,12 @@ export interface ModelScopeSSEOptions {
  *
  * 注意：符合 @modelcontextprotocol 官方标准，不包含 name 字段
  * name 应该作为服务标识符独立管理，不是配置的一部分
+ *
+ * @description
+ * 与 @xiaozhi-client/mcp-core 的 MCPServiceConfig 保持一致
  */
 export interface MCPServiceConfig {
-  type?: MCPTransportType; // 现在是可选的，支持自动推断
+  type?: MCPTransportTypeInput; // 支持枚举或字符串字面量，与 mcp-core 保持一致
   // stdio 配置
   command?: string;
   args?: string[];

--- a/packages/config/src/adapter.ts
+++ b/packages/config/src/adapter.ts
@@ -11,7 +11,14 @@ import type {
   SSEMCPServerConfig,
 } from "./manager.js";
 import { ConfigResolver } from "./resolver.js";
+import type { MCPServiceConfig } from "@xiaozhi-client/mcp-core";
 import { MCPTransportType, inferTransportTypeFromUrl } from "@xiaozhi-client/mcp-core";
+
+/**
+ * 传输类型输入值（枚举或字符串字面量）
+ * 本地定义，与 mcp-core 保持一致
+ */
+type MCPTransportTypeInput = MCPTransportType | "stdio" | "sse" | "http";
 
 // 从外部导入 MCP 类型（这些类型将在运行时从 backend 包解析）
 // 为了避免循环依赖，这里使用动态导入的方式
@@ -25,16 +32,6 @@ export class ConfigValidationError extends Error {
     super(message);
     this.name = "ConfigValidationError";
   }
-}
-
-// 定义简化的 MCPServiceConfig 接口
-export interface MCPServiceConfig {
-  type: MCPTransportType;
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  headers?: Record<string, string>;
 }
 
 /**
@@ -325,16 +322,19 @@ export function isModelScopeURL(url: string): boolean {
  * 验证新配置格式
  */
 function validateNewConfig(config: MCPServiceConfig): void {
-  if (config.type && !Object.values(MCPTransportType).includes(config.type)) {
-    throw new ConfigValidationError(`无效的传输类型: ${config.type}`);
-  }
+  // 将 type 转换为枚举类型进行验证
+  // MCPServiceConfig.type 是 MCPTransportTypeInput（可能是字符串字面量或枚举）
+  // 这里需要将其规范化为 MCPTransportType 枚举类型
+  const transportType = config.type
+    ? normalizeTransportType(config.type)
+    : undefined;
 
   // 根据传输类型验证必需字段
-  if (!config.type) {
+  if (!transportType) {
     throw new ConfigValidationError("传输类型未指定，请检查配置或启用自动推断");
   }
 
-  switch (config.type) {
+  switch (transportType) {
     case MCPTransportType.STDIO:
       if (!config.command) {
         throw new ConfigValidationError("STDIO 配置必须包含 command 字段");
@@ -357,7 +357,31 @@ function validateNewConfig(config: MCPServiceConfig): void {
       break;
 
     default:
-      throw new ConfigValidationError(`不支持的传输类型: ${config.type}`);
+      throw new ConfigValidationError(`不支持的传输类型: ${transportType}`);
+  }
+}
+
+/**
+ * 将传输类型字符串规范化为枚举类型
+ */
+function normalizeTransportType(
+  type: MCPTransportTypeInput
+): MCPTransportType {
+  // 如果已经是枚举类型，直接返回
+  if (Object.values(MCPTransportType).includes(type as MCPTransportType)) {
+    return type as MCPTransportType;
+  }
+
+  // 字符串字面量转换为枚举
+  switch (type) {
+    case "stdio":
+      return MCPTransportType.STDIO;
+    case "sse":
+      return MCPTransportType.SSE;
+    case "http":
+      return MCPTransportType.HTTP;
+    default:
+      throw new ConfigValidationError(`无效的传输类型: ${type}`);
   }
 }
 


### PR DESCRIPTION
- 从 @xiaozhi-client/mcp-core 导入 MCPServiceConfig 类型
- 移除 packages/config/src/adapter.ts 中的本地定义
- 添加 normalizeTransportType 辅助函数处理类型转换
- 更新 apps/backend/lib/mcp/types.ts 中的 MCPServiceConfig.type 为 MCPTransportTypeInput

修复 #2550

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2550