### PR TITLE
fix: Claude: [CODE] WebServer.ts 中使用 WebSocket readyState 魔法数字而非常量降低代码可读

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -708,8 +708,7 @@ export class WebServer {
           error
         );
         // 只有在 WebSocket 处于可关闭状态时才关闭
-        // ws.OPEN = 1, ws.CONNECTING = 0
-        if (ws.readyState === 1 || ws.readyState === 0) {
+        if (ws.readyState === ws.OPEN || ws.readyState === ws.CONNECTING) {
           ws.close(1011, "Connection handling failed");
         }
       });


### PR DESCRIPTION
Fixes #2540

Replaces magic numbers `0` and `1` in the `readyState` check in `apps/backend/WebServer.ts` with the named constants `ws.OPEN` and `ws.CONNECTING`. Also removes the now-redundant inline comment that explained the numeric values.