### PR TITLE
fix: 将 DaemonManager.startDaemon 的 serverFactory 返回类型从 any 改为 WebServer

### DIFF
--- a/packages/cli/src/interfaces/Service.ts
+++ b/packages/cli/src/interfaces/Service.ts
@@ -2,6 +2,8 @@
  * 服务接口定义
  */
 
+import type { WebServer } from "@/WebServer";
+
 /**
  * 服务管理器接口
  */
@@ -75,7 +77,7 @@ export interface ProcessManager {
  */
 export interface DaemonManager {
   /** 启动守护进程 */
-  startDaemon(serverFactory: () => Promise<any>): Promise<void>;
+  startDaemon(serverFactory: () => Promise<WebServer>): Promise<void>;
   /** 停止守护进程 */
   stopDaemon(): Promise<void>;
 }


### PR DESCRIPTION
- 在 Service.ts 中导入 WebServer 类型
- 更新 DaemonManager.startDaemon 接口签名使用具体的 WebServer 类型
- 提升类型安全性，使接口定义与实现保持一致

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2557