### PR TITLE
fix: 使用 logger.error 替换 console.log 遵守日志规范

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -71,7 +71,7 @@ export class NPMManager {
       // 监听进程启动失败事件
       npmProcess.on("error", (error) => {
         const errorMessage = `进程启动失败: ${error.message}`;
-        console.log(errorMessage, { error });
+        logger.error(errorMessage, { error });
 
         // 清理资源
         cleanup();


### PR DESCRIPTION
将 apps/backend/lib/npm/manager.ts 第 74 行的 console.log 替换为
logger.error，确保日志输出格式一致并支持日志级别控制。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2562