### PR TITLE
docs: 添加 mcp-server-setting-button.tsx 文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -1,3 +1,9 @@
+/**
+ * MCP 服务器设置按钮组件
+ *
+ * 提供一个按钮，点击后打开对话框用于编辑现有 MCP 服务器的配置。
+ * 支持多种传输协议（stdio、http、sse）和配置选项，提供表单模式和高级 JSON 模式两种编辑方式。
+ */
 import { McpServerForm } from "@/components/mcp-server-form";
 import { Button } from "@/components/ui/button";
 import {


### PR DESCRIPTION
为 MCP 服务器设置按钮组件添加文件级 JSDoc 注释，说明组件的功能和用途，
保持与其他业务组件文档风格一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2566