### PR TITLE
fix: 使用 ConnectionConfig 类型替代 any 提高类型安全性

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -8,6 +8,7 @@ import type {
   ApiSuccessResponse,
   AppConfig,
   ClientStatus,
+  ConnectionConfig,
   CustomMCPToolWithStats,
   MCPErrorCode,
   MCPServerAddRequest,
@@ -286,8 +287,8 @@ export class ApiClient {
   /**
    * 获取连接配置
    */
-  async getConnectionConfig(): Promise<any> {
-    const response: ApiResponse<{ connection: any }> = await this.request(
+  async getConnectionConfig(): Promise<ConnectionConfig> {
+    const response: ApiResponse<{ connection: ConnectionConfig }> = await this.request(
       "/api/config/connection"
     );
     if (!response.success || !response.data) {

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -3,7 +3,7 @@
  * 整合 HTTP API 客户端和 WebSocket 管理器
  */
 
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
+import type { AppConfig, ClientStatus, ConnectionConfig } from "@xiaozhi-client/shared-types";
 import { type ApiClient, apiClient } from "./api";
 import {
   type ConnectionState,
@@ -140,7 +140,7 @@ export class NetworkService {
   /**
    * 获取连接配置 (HTTP)
    */
-  async getConnectionConfig(): Promise<any> {
+  async getConnectionConfig(): Promise<ConnectionConfig> {
     return this.apiClient.getConnectionConfig();
   }
 


### PR DESCRIPTION
- 在 api.ts 中导入 ConnectionConfig 类型
- 更新 getConnectionConfig 方法返回类型为 Promise<ConnectionConfig>
- 更新 index.ts 中的方法签名

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2568