### PR TITLE
fix(tts): 添加 sendStopAndCleanup 方法中 processBuffer 调用的错误处理

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -313,7 +313,15 @@ export class TTSService implements ITTSService {
     // 如果缓冲区还有数据，继续处理
     const buffer = this.opusPacketBuffer.get(deviceId);
     if (buffer && buffer.length > 0) {
-      await this.processBuffer(deviceId);
+      try {
+        await this.processBuffer(deviceId);
+      } catch (error) {
+        logger.error(
+          `[TTSService] 处理缓冲区失败: deviceId=${deviceId}`,
+          error
+        );
+        // 继续执行清理操作，不中断流程
+      }
     }
 
     // 再次检查缓冲区是否已清空


### PR DESCRIPTION
- 在 sendStopAndCleanup 方法中为 processBuffer 调用添加 try-catch 错误处理
- 确保即使缓冲区处理失败，清理操作仍会继续执行
- 防止资源泄漏和设备状态不一致

修复 #2573

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2573