### PR TITLE
fix: 修复 NotificationService.destroy 方法未移除事件监听器导致的内存泄漏

### DIFF
--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -22,7 +22,7 @@
 
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
-import type { EventBus } from "@/services/event-bus.service.js";
+import type { EventBus, EventBusEvents } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
 import type { AppConfig } from "@xiaozhi-client/config";
@@ -76,6 +76,27 @@ export class NotificationService {
   private clients: Map<string, WebSocketClient> = new Map();
   private messageQueue: Map<string, NotificationMessage[]> = new Map();
   private maxQueueSize = 100;
+  /**
+   * 保存事件监听器引用，用于在销毁时移除
+   */
+  private eventListeners: {
+    configUpdated: (data: EventBusEvents["config:updated"]) => void;
+    statusUpdated: (data: EventBusEvents["status:updated"]) => void;
+    restartStarted: (data: EventBusEvents["service:restart:started"]) => void;
+    restartCompleted: (
+      data: EventBusEvents["service:restart:completed"]
+    ) => void;
+    restartFailed: (data: EventBusEvents["service:restart:failed"]) => void;
+    npmInstallStarted: (data: EventBusEvents["npm:install:started"]) => void;
+    npmInstallLog: (data: EventBusEvents["npm:install:log"]) => void;
+    npmInstallCompleted: (
+      data: EventBusEvents["npm:install:completed"]
+    ) => void;
+    npmInstallFailed: (data: EventBusEvents["npm:install:failed"]) => void;
+    notificationBroadcast: (
+      data: EventBusEvents["notification:broadcast"]
+    ) => void;
+  } | null = null;
 
   constructor() {
     this.logger = logger;
@@ -87,56 +108,82 @@ export class NotificationService {
    * 设置事件监听器
    */
   private setupEventListeners(): void {
-    // 监听配置更新事件
-    this.eventBus.onEvent("config:updated", (data) => {
-      // 获取最新的配置
-      const config = configManager.getConfig();
-      this.broadcastConfigUpdate(config);
-    });
+    // 创建并保存监听器引用
+    this.eventListeners = {
+      configUpdated: (data) => {
+        // 获取最新的配置
+        const config = configManager.getConfig();
+        this.broadcastConfigUpdate(config);
+      },
+      statusUpdated: (data) => {
+        this.broadcastStatusUpdate(data.status);
+      },
+      restartStarted: (data) => {
+        this.broadcastRestartStatus("restarting", undefined, data.timestamp);
+      },
+      restartCompleted: (data) => {
+        this.broadcastRestartStatus("completed", undefined, data.timestamp);
+      },
+      restartFailed: (data) => {
+        this.broadcastRestartStatus(
+          "failed",
+          data.error.message,
+          data.timestamp
+        );
+      },
+      npmInstallStarted: (data) => {
+        this.broadcast("npm:install:started", data);
+      },
+      npmInstallLog: (data) => {
+        this.broadcast("npm:install:log", data);
+      },
+      npmInstallCompleted: (data) => {
+        this.broadcast("npm:install:completed", data);
+      },
+      npmInstallFailed: (data) => {
+        this.broadcast("npm:install:failed", data);
+      },
+      notificationBroadcast: (data) => {
+        if (data.target) {
+          this.sendToClient(data.target, data.type, data.data);
+        } else {
+          this.broadcast(data.type, data.data);
+        }
+      },
+    };
 
-    // 监听状态更新事件
-    this.eventBus.onEvent("status:updated", (data) => {
-      this.broadcastStatusUpdate(data.status);
-    });
-
-    // 监听重启状态事件
-    this.eventBus.onEvent("service:restart:started", (data) => {
-      this.broadcastRestartStatus("restarting", undefined, data.timestamp);
-    });
-
-    this.eventBus.onEvent("service:restart:completed", (data) => {
-      this.broadcastRestartStatus("completed", undefined, data.timestamp);
-    });
-
-    this.eventBus.onEvent("service:restart:failed", (data) => {
-      this.broadcastRestartStatus("failed", data.error.message, data.timestamp);
-    });
-
-    // 监听 NPM 安装事件
-    this.eventBus.onEvent("npm:install:started", (data) => {
-      this.broadcast("npm:install:started", data);
-    });
-
-    this.eventBus.onEvent("npm:install:log", (data) => {
-      this.broadcast("npm:install:log", data);
-    });
-
-    this.eventBus.onEvent("npm:install:completed", (data) => {
-      this.broadcast("npm:install:completed", data);
-    });
-
-    this.eventBus.onEvent("npm:install:failed", (data) => {
-      this.broadcast("npm:install:failed", data);
-    });
-
-    // 监听通知广播事件
-    this.eventBus.onEvent("notification:broadcast", (data) => {
-      if (data.target) {
-        this.sendToClient(data.target, data.type, data.data);
-      } else {
-        this.broadcast(data.type, data.data);
-      }
-    });
+    // 注册监听器
+    this.eventBus.onEvent("config:updated", this.eventListeners.configUpdated);
+    this.eventBus.onEvent("status:updated", this.eventListeners.statusUpdated);
+    this.eventBus.onEvent(
+      "service:restart:started",
+      this.eventListeners.restartStarted
+    );
+    this.eventBus.onEvent(
+      "service:restart:completed",
+      this.eventListeners.restartCompleted
+    );
+    this.eventBus.onEvent(
+      "service:restart:failed",
+      this.eventListeners.restartFailed
+    );
+    this.eventBus.onEvent(
+      "npm:install:started",
+      this.eventListeners.npmInstallStarted
+    );
+    this.eventBus.onEvent("npm:install:log", this.eventListeners.npmInstallLog);
+    this.eventBus.onEvent(
+      "npm:install:completed",
+      this.eventListeners.npmInstallCompleted
+    );
+    this.eventBus.onEvent(
+      "npm:install:failed",
+      this.eventListeners.npmInstallFailed
+    );
+    this.eventBus.onEvent(
+      "notification:broadcast",
+      this.eventListeners.notificationBroadcast
+    );
   }
 
   /**
@@ -388,6 +435,52 @@ export class NotificationService {
    */
   destroy(): void {
     this.logger.debug("销毁通知服务");
+
+    // 移除所有事件监听器
+    if (this.eventListeners) {
+      this.eventBus.offEvent(
+        "config:updated",
+        this.eventListeners.configUpdated
+      );
+      this.eventBus.offEvent(
+        "status:updated",
+        this.eventListeners.statusUpdated
+      );
+      this.eventBus.offEvent(
+        "service:restart:started",
+        this.eventListeners.restartStarted
+      );
+      this.eventBus.offEvent(
+        "service:restart:completed",
+        this.eventListeners.restartCompleted
+      );
+      this.eventBus.offEvent(
+        "service:restart:failed",
+        this.eventListeners.restartFailed
+      );
+      this.eventBus.offEvent(
+        "npm:install:started",
+        this.eventListeners.npmInstallStarted
+      );
+      this.eventBus.offEvent(
+        "npm:install:log",
+        this.eventListeners.npmInstallLog
+      );
+      this.eventBus.offEvent(
+        "npm:install:completed",
+        this.eventListeners.npmInstallCompleted
+      );
+      this.eventBus.offEvent(
+        "npm:install:failed",
+        this.eventListeners.npmInstallFailed
+      );
+      this.eventBus.offEvent(
+        "notification:broadcast",
+        this.eventListeners.notificationBroadcast
+      );
+      this.eventListeners = null;
+    }
+
     this.clients.clear();
     this.messageQueue.clear();
   }


### PR DESCRIPTION
在 setupEventListeners() 中保存事件监听器引用，并在 destroy() 方法中调用 offEvent() 移除所有监听器，防止内存泄漏。

Changes:
- 添加 eventListeners 私有属性保存监听器引用
- 导入 EventBusEvents 类型用于类型安全
- 修改 setupEventListeners() 先创建监听器函数再注册
- 修改 destroy() 在清理资源前移除所有事件监听器

Fixes #2575

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2575