### PR TITLE
fix: 移除 web-url-setting-button.tsx 中遗留的调试 console.log 语句

### DIFF
--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -101,9 +101,6 @@ export function WebUrlSettingButton() {
       return;
     }
 
-    console.log(
-      `[WebUrlSettingButton] 开始端口切换: ${currentPort} -> ${newPort}`
-    );
     setIsLoading(true);
 
     try {


### PR DESCRIPTION
修复 Issue #2580: 移除第 104 行的 console.log 调试语句，该语句违反项目的日志规范。代码已通过 toast 消息向用户提供足够的反馈。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2580