### PR TITLE
fix: 统一 version-manager.tsx 中的路径导入为路径别名

### DIFF
--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -28,8 +28,8 @@ import {
   RefreshCw,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
-import { InstallLogDialog } from "./install-log-dialog";
-import { VersionDisplay } from "./version-display";
+import { InstallLogDialog } from "@/components/install-log-dialog";
+import { VersionDisplay } from "@/components/version-display";
 
 interface VersionInfo {
   name: string;


### PR DESCRIPTION
将相对路径导入改为使用 @/components/ 路径别名，保持代码一致性。

- InstallLogDialog: ./install-log-dialog → @/components/install-log-dialog
- VersionDisplay: ./version-display → @/components/version-display

Fixes #2582

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2582