### PR TITLE
refactor: 使用常量替换 status.ts 中的魔法数字

### DIFF
--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -18,6 +18,16 @@ import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
 
 /**
+ * 状态缓存持续时间（毫秒）
+ */
+const STATUS_CACHE_DURATION = 30 * 1000; // 30秒
+
+/**
+ * 默认轮询间隔（毫秒）
+ */
+const DEFAULT_POLLING_INTERVAL = 30 * 1000; // 30秒
+
+/**
  * 重启状态接口
  */
 interface RestartStatus {
@@ -185,7 +195,7 @@ const initialState: StatusState = {
   },
   polling: {
     enabled: false,
-    interval: 30000, // 30秒
+    interval: DEFAULT_POLLING_INTERVAL,
     maxRetries: 3,
     currentRetries: 0,
   },
@@ -312,7 +322,7 @@ export const useStatusStore = create<StatusStore>()(
         if (
           fullStatus &&
           loading.lastUpdated &&
-          Date.now() - loading.lastUpdated < 30 * 1000
+          Date.now() - loading.lastUpdated < STATUS_CACHE_DURATION
         ) {
           return fullStatus;
         }
@@ -442,7 +452,7 @@ export const useStatusStore = create<StatusStore>()(
 
       // ==================== 轮询控制 ====================
 
-      startPolling: (interval = 30000) => {
+      startPolling: (interval = DEFAULT_POLLING_INTERVAL) => {
         const { polling, refreshStatus } = get();
 
         if (polling.enabled) {


### PR DESCRIPTION
- 添加 STATUS_CACHE_DURATION 常量表示状态缓存持续时间（30秒）
- 添加 DEFAULT_POLLING_INTERVAL 常量表示默认轮询间隔（30秒）
- 替换第 188 行的魔法数字 30000 为 DEFAULT_POLLING_INTERVAL
- 替换第 315 行的魔法数字 30 * 1000 为 STATUS_CACHE_DURATION
- 替换第 445 行的魔法数字 30000 为 DEFAULT_POLLING_INTERVAL

提高代码可维护性，统一管理时间间隔配置。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2584