### PR TITLE
fix(shared-types): 移除 ConnectionConfig 重复定义，统一使用 connection.ts 中的定义

### DIFF
--- a/packages/shared-types/src/config/app.ts
+++ b/packages/shared-types/src/config/app.ts
@@ -2,15 +2,7 @@
  * 应用配置相关类型定义
  */
 
-// 连接配置接口
-export interface ConnectionConfig {
-  heartbeatInterval?: number;
-  heartbeatTimeout?: number;
-  reconnectInterval?: number;
-  maxReconnectAttempts?: number;
-  connectionTimeout?: number;
-  autoReconnect?: boolean;
-}
+import type { ConnectionConfig } from "./connection";
 
 /**
  * 本地 MCP 服务器配置

--- a/packages/shared-types/src/config/index.ts
+++ b/packages/shared-types/src/config/index.ts
@@ -19,7 +19,7 @@ export type {
 
 // 连接配置相关类型
 export type {
-  ConnectionConfig as ConfigConnectionConfig,
+  ConnectionConfig,
   EndpointConfig,
   LoadBalancingConfig,
 } from "./connection";
@@ -30,9 +30,6 @@ export type {
   ServerInfo,
   RestartStatus,
 } from "./server";
-
-// 重新导出 ConnectionConfig 以避免命名冲突，使用默认的 app.ts 中的定义
-export type { ConnectionConfig } from "./app";
 
 // 语音交互配置相关类型
 export type {


### PR DESCRIPTION
- 删除 app.ts 中重复的 ConnectionConfig 定义
- 添加从 connection.ts 导入 ConnectionConfig 的语句
- 更新 index.ts 直接从 connection.ts 导出 ConnectionConfig
- 修复违反 DRY 原则的问题，降低维护成本

参考 #2586

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2586