### PR TITLE
fix(cli): 修复 DaemonManager 日志流文件句柄泄漏

### DIFF
--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -43,6 +43,7 @@ export interface DaemonOptions {
  */
 export class DaemonManagerImpl implements IDaemonManager {
   private currentDaemon: ChildProcess | null = null;
+  private logStream: fs.WriteStream | null = null;
 
   constructor(private processManager: ProcessManager) {}
 
@@ -238,16 +239,27 @@ export class DaemonManagerImpl implements IDaemonManager {
         fs.mkdirSync(logDir, { recursive: true });
       }
 
-      // 创建日志流
-      const logStream = fs.createWriteStream(logFilePath, { flags: "a" });
+      // 关闭旧的日志流（如果存在）
+      if (this.logStream) {
+        try {
+          this.logStream.end();
+        } catch (error) {
+          consola.warn("关闭旧日志流失败", error);
+        }
+      }
+
+      // 创建日志流并保存引用
+      this.logStream = fs.createWriteStream(logFilePath, { flags: "a" });
 
       // 重定向标准输出和错误输出
-      child.stdout?.pipe(logStream);
-      child.stderr?.pipe(logStream);
+      child.stdout?.pipe(this.logStream);
+      child.stderr?.pipe(this.logStream);
 
       // 写入启动日志
       const timestamp = new Date().toISOString();
-      logStream.write(`\n[${timestamp}] 守护进程启动 (PID: ${child.pid})\n`);
+      this.logStream.write(
+        `\n[${timestamp}] 守护进程启动 (PID: ${child.pid})\n`
+      );
     } catch (error) {
       consola.warn(
         `设置日志重定向失败: ${error instanceof Error ? error.message : String(error)}`
@@ -324,6 +336,18 @@ export class DaemonManagerImpl implements IDaemonManager {
         );
       }
       this.currentDaemon = null;
+    }
+
+    // 关闭日志流
+    if (this.logStream) {
+      try {
+        this.logStream.end();
+        this.logStream = null;
+      } catch (error) {
+        consola.warn(
+          `关闭日志流失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
     }
   }
 }


### PR DESCRIPTION
- 添加 logStream 实例属性以保存日志流引用
- 在 setupLogging 方法中关闭旧日志流并保存新流引用
- 在 cleanup 方法中关闭日志流
- 修复守护进程重启时的文件句柄累积问题

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2591