### PR TITLE
refactor: 提取公共的路径验证逻辑以消除重复代码

### DIFF
--- a/apps/backend/utils/prompt-utils.ts
+++ b/apps/backend/utils/prompt-utils.ts
@@ -285,6 +285,33 @@ export function resolvePromptPath(relativePath: string): string {
 }
 
 /**
+ * 验证并解析提示文件路径
+ *
+ * 整合了路径验证、路径解析和文件存在性检查的公共逻辑
+ *
+ * @param relativePath - 相对路径
+ * @returns 解析后的绝对路径
+ * @throws 如果路径无效或文件不存在
+ */
+function validateAndResolvePath(relativePath: string): string {
+  // 验证路径
+  const validation = validatePromptPath(relativePath);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 解析绝对路径
+  const absolutePath = resolvePromptPath(relativePath);
+
+  // 检查文件是否存在
+  if (!existsSync(absolutePath)) {
+    throw new Error(`文件不存在: ${relativePath}`);
+  }
+
+  return absolutePath;
+}
+
+/**
  * 提示词文件内容信息
  */
 export interface PromptFileContent {
@@ -304,19 +331,7 @@ export interface PromptFileContent {
  * @throws 如果路径无效或文件不存在
  */
 export function readPromptFile(relativePath: string): PromptFileContent {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 检查文件大小
   const stats = statSync(absolutePath);
@@ -345,24 +360,12 @@ export function updatePromptFile(
   relativePath: string,
   content: string
 ): PromptFileContent {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
   // 验证内容大小（按 UTF-8 字节数，与文件大小限制保持一致）
   if (Buffer.byteLength(content, "utf8") > MAX_FILE_SIZE) {
     throw new Error("内容大小超过限制（最大 100KB）");
   }
 
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 写入文件
   writeFileSync(absolutePath, content, "utf-8");
@@ -432,19 +435,7 @@ export function createPromptFile(
  * @throws 如果路径无效或文件不存在
  */
 export function deletePromptFile(relativePath: string): void {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 删除文件
   rmSync(absolutePath);


### PR DESCRIPTION
- 新增 validateAndResolvePath 函数整合路径验证、解析和存在性检查
- 更新 readPromptFile、updatePromptFile、deletePromptFile 使用新函数
- 共计减少约 35 行重复代码，提高代码可维护性

修复 #2593

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2593