### PR TITLE
fix: 在 spawnDaemonProcess 中添加立即错误处理以防止启动失败时错误静默忽略

### DIFF
--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -214,6 +214,15 @@ export class DaemonManagerImpl implements IDaemonManager {
       cwd: options.cwd || process.cwd(),
     });
 
+    // 立即添加错误处理，防止在 setupEventHandlers 调用之前丢失错误事件
+    // 注意：setupEventHandlers 中会再次添加 error 监听器，Node.js 允许多个监听器
+    child.on("error", (error) => {
+      consola.error(`启动守护进程失败: ${error.message}`);
+      this.processManager.cleanupPidFile();
+      this.currentDaemon = null;
+      throw new ProcessError(`无法启动守护进程: ${error.message}`, 0);
+    });
+
     if (!child.pid) {
       throw new ProcessError("无法启动守护进程", 0);
     }


### PR DESCRIPTION
在 spawn() 调用后立即添加 error 事件监听器，防止在 setupEventHandlers()
调用之前丢失错误事件。这确保了当 node 命令不存在、文件路径错误或权限
问题时，用户能够获得有用的错误信息。

修复 #2595

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2595