### PR TITLE
fix(tts): 在 cleanup 方法中正确销毁 OggDemuxer 防止内存泄漏

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -346,6 +346,13 @@ export class TTSService implements ITTSService {
    * @param deviceId - 设备 ID
    */
   cleanup(deviceId: string): void {
+    // 获取并销毁 demuxer，释放资源
+    const demuxer = this.audioDemuxers.get(deviceId);
+    if (demuxer) {
+      demuxer.destroy();
+      demuxer.removeAllListeners();
+    }
+
     this.audioDemuxers.delete(deviceId);
     this.cumulativeTimestamps.delete(deviceId);
     this.packetIndices.delete(deviceId);


### PR DESCRIPTION
在 cleanup() 方法中添加 demuxer.destroy() 和 removeAllListeners()
调用，确保 Transform 流及其事件监听器被正确释放。

修复问题:
- OggDemuxer 的资源（文件描述符、缓冲区）未被释放
- 事件监听器（data、end、error）仍然持有对 TTSService 实例的引用
- 频繁 TTS 操作会导致内存持续增长

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2596