### PR TITLE
fix: 使用常量替代 manager.ts 中的重试延迟魔法数字

### DIFF
--- a/apps/backend/constants/timeout.constants.ts
+++ b/apps/backend/constants/timeout.constants.ts
@@ -47,6 +47,10 @@ export const RETRY_DELAYS = {
   MAX: 30000,
   /** 重连延迟 */
   RECONNECT: 2000,
+  /** 服务重试最小延迟（30秒） */
+  SERVICE_RETRY_MIN: 30000,
+  /** 服务重试延迟范围（60秒范围，总延迟为30-90秒） */
+  SERVICE_RETRY_RANGE: 60000,
 } as const;
 
 /**

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -6,6 +6,7 @@
 
 import { EventEmitter } from "node:events";
 import { logger } from "@/Logger.js";
+import { RETRY_DELAYS } from "@/constants/timeout.constants";
 import { MCPService } from "@/lib/mcp";
 import { MCPCacheManager } from "@/lib/mcp";
 import { ConnectionState } from "@/lib/mcp/types";
@@ -1431,7 +1432,7 @@ export class MCPServiceManager extends EventEmitter {
     logger.info(`[MCPManager] 安排 ${failedServices.length} 个失败服务的重试`);
 
     // 初始重试延迟：30秒
-    const initialDelay = 30000;
+    const initialDelay = RETRY_DELAYS.SERVICE_RETRY_MIN;
 
     for (const serviceName of failedServices) {
       this.failedServices.add(serviceName);
@@ -1512,7 +1513,9 @@ export class MCPServiceManager extends EventEmitter {
     const hash = serviceName
       .split("")
       .reduce((acc, char) => acc + char.charCodeAt(0), 0);
-    return 30000 + (hash % 60000); // 30-90秒之间的初始延迟
+    return (
+      RETRY_DELAYS.SERVICE_RETRY_MIN + (hash % RETRY_DELAYS.SERVICE_RETRY_RANGE)
+    ); // 30-90秒之间的初始延迟
   }
 
   /**


### PR DESCRIPTION
- 在 timeout.constants.ts 中添加 SERVICE_RETRY_MIN 和 SERVICE_RETRY_RANGE 常量
- 修改 manager.ts 使用新常量替代硬编码的 30000 和 60000
- 提高代码可维护性，统一管理重试延迟配置

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2607