### PR TITLE
fix: 修复 EventEmitter 内存泄漏问题

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -566,6 +566,8 @@ export class ASR extends EventEmitter {
     this.reqid = "";
     // 重置 VAD 触发记录
     this.triggeredVADSequences.clear();
+    // 清理所有事件监听器，防止内存泄漏
+    this.removeAllListeners();
   }
 
   /**

--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -484,6 +484,9 @@ export class EndpointManager extends EventEmitter {
 
     await this.clearEndpoints();
 
+    // 清理所有事件监听器，防止内存泄漏
+    this.removeAllListeners();
+
     console.debug("[EndpointManager] 资源清理完成");
   }
 

--- a/packages/mcp-core/src/manager.ts
+++ b/packages/mcp-core/src/manager.ts
@@ -168,6 +168,8 @@ export class MCPManager extends EventEmitter {
     this.connections.clear();
 
     this.emit("disconnect");
+    // 清理所有事件监听器，防止内存泄漏
+    this.removeAllListeners();
   }
 
   /**

--- a/packages/tts/src/client/TTS.ts
+++ b/packages/tts/src/client/TTS.ts
@@ -252,6 +252,8 @@ export class TTS extends EventEmitter {
       this.controller = null;
     }
     this.emit("close");
+    // 清理所有事件监听器，防止内存泄漏
+    this.removeAllListeners();
   }
 
   /**


### PR DESCRIPTION
在 TTS、ASR、EndpointManager 和 MCPManager 的清理方法中添加
removeAllListeners() 调用，防止事件监听器导致的内存泄漏。

涉及文件:
- packages/tts/src/client/TTS.ts
- packages/asr/src/client/ASR.ts
- packages/endpoint/src/manager.ts
- packages/mcp-core/src/manager.ts

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2610