### PR TITLE
fix: 完善 services 模块导出，统一 asr/tts/llm 服务访问入口

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -12,7 +12,7 @@ import {
   parseBinaryProtocol2,
   parseBinaryProtocol3,
 } from "@/lib/esp32/audio-protocol.js";
-import type { ASRService } from "@/services/asr.service.js";
+import type { ASRService } from "@/services";
 import {
   type ESP32ConnectionState,
   ESP32ErrorCode,

--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -5,6 +5,8 @@
 
 import { logger } from "@/Logger.js";
 import { ESP32Connection } from "@/lib/esp32/connection.js";
+import { ASRService, LLMService, TTSService } from "@/services";
+import type { DeviceRegistryService } from "@/services";
 import type {
   ESP32DeviceReport,
   ESP32ListenMessage,
@@ -13,10 +15,6 @@ import type {
 } from "@/types/esp32.js";
 import { camelToSnakeCase, extractDeviceInfo } from "@/utils/esp32-utils.js";
 import type WebSocket from "ws";
-import { ASRService } from "./asr.service.js";
-import type { DeviceRegistryService } from "./device-registry.service.js";
-import { LLMService } from "./llm.service.js";
-import { TTSService } from "./tts.service.js";
 
 /**
  * ESP32设备服务

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -5,11 +5,23 @@
  * - StatusService: 统一的状态管理服务，管理客户端连接状态、MCP 服务状态等
  * - NotificationService: 通知服务，处理系统通知和消息推送
  * - EventBus / getEventBus: 事件总线服务，提供发布-订阅模式的事件处理机制
+ * - DeviceRegistryService: 设备注册服务，管理设备的注册、状态和配置
+ * - ESP32Service: ESP32 设备服务，负责 ESP32 设备的连接管理和消息路由
+ * - ASRService: 语音识别服务，处理语音识别功能
+ * - TTSService: 语音合成服务，处理语音合成功能
+ * - LLMService: 大语言模型服务，提供基于 OpenAI SDK 的 LLM 调用封装
  * - CustomMCPHandler: 自定义 MCP 处理器（重新导出，保持向后兼容性）
  *
  * @example
  * ```typescript
- * import { StatusService, NotificationService, getEventBus } from '@/services';
+ * import {
+ *   StatusService,
+ *   NotificationService,
+ *   getEventBus,
+ *   ASRService,
+ *   TTSService,
+ *   LLMService
+ * } from '@/services';
  *
  * // 使用状态服务
  * const statusService = new StatusService();
@@ -20,6 +32,11 @@
  * eventBus.onEvent('event-name', (data) => {
  *   console.log('Event received:', data);
  * });
+ *
+ * // 使用语音服务
+ * const asrService = new ASRService();
+ * const ttsService = new TTSService();
+ * const llmService = new LLMService();
  * ```
  */
 export * from "./status.service.js";
@@ -27,6 +44,9 @@ export * from "./notification.service.js";
 export * from "./event-bus.service.js";
 export * from "./device-registry.service.js";
 export * from "./esp32.service.js";
+export * from "./asr.service.js";
+export * from "./tts.service.js";
+export * from "./llm.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";


### PR DESCRIPTION
- 添加 asr.service.ts、tts.service.ts、llm.service.ts 到 @/services 统一导出
- 更新 esp32.service.ts 使用统一入口导入
- 更新 lib/esp32/connection.ts 使用统一入口导入
- 更新 services/index.ts 文档注释，包含新增服务的说明

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2617