### PR TITLE
fix: 修复 ConfigCommandHandler 中 ora.Ora 类型错误

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -113,7 +113,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   /**
    * 确保配置文件存在，如果不存在则显示提示并返回 false
    */
-  private async ensureConfigExists(spinner: ora.Ora): Promise<boolean> {
+  private async ensureConfigExists(spinner: ReturnType<typeof ora>): Promise<boolean> {
     const configManager = this.getService<any>("configManager");
 
     if (!configManager.configExists()) {


### PR DESCRIPTION
将 ensureConfigExists 方法的 spinner 参数类型从 ora.Ora 改为
ReturnType<typeof ora>，以匹配项目其他命令处理器的类型定义方式。

修复 issue #2619

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2619