### PR TITLE
fix: add missing exports for middleware error classes

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -76,7 +76,7 @@ import { WebSocketServer } from "ws";
 import type WebSocket from "ws";
 
 import { HTTP_SERVER_CONFIG } from "@/constants/index.js";
-import { MCPServiceManagerNotInitializedError } from "@/errors/mcp-errors.middleware.js";
+import { MCPServiceManagerNotInitializedError } from "@/errors/index.js";
 // 路由系统导入
 import {
   type HandlerDependencies,

--- a/apps/backend/errors/index.ts
+++ b/apps/backend/errors/index.ts
@@ -23,5 +23,8 @@
 
 export * from "./mcp-errors.js";
 
+// 导出中间件相关的错误类
+export * from "./mcp-errors.middleware.js";
+
 // ErrorHelper 使用命名空间导出以避免与 mcp-errors 中的类型冲突
 export * as ErrorHelper from "./error-helper.js";

--- a/apps/backend/middlewares/mcpServiceManager.middleware.ts
+++ b/apps/backend/middlewares/mcpServiceManager.middleware.ts
@@ -7,7 +7,7 @@
 import {
   MCPServiceManagerNotInitializedError,
   WebServerNotAvailableError,
-} from "@/errors/mcp-errors.middleware.js";
+} from "@/errors/index.js";
 import type { AppContextVariables } from "@/types/hono.context.js";
 import type { Context, Next } from "hono";
 


### PR DESCRIPTION
- Add MCPServiceManagerNotInitializedError and WebServerNotAvailableError exports to errors/index.ts
- Update imports in affected files to use unified @/errors/index.js path
- Fixes #2623

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2623