### PR TITLE
fix(security): override flatted to >=3.4.0 for CVE-2026-32141

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "rollup@<5.0.0": ">=4.59.0",
       "express-rate-limit@<9.0.0": ">=8.2.2",
       "dompurify@<4.0.0": ">=3.3.2",
-      "immutable@<6.0.0": ">=5.1.5"
+      "immutable@<6.0.0": ">=5.1.5",
+      "flatted": "^3.4.0"
     }
   },
   "packageManager": "pnpm@10.13.1"


### PR DESCRIPTION
修复 cspell 传递依赖 flatted 的 DoS 漏洞 (CVE-2026-32141)。
添加 pnpm override 强制使用 flatted >= 3.4.0，以防止堆栈溢出攻击。

- CVE-2026-32141: flatted < 3.4.0 存在 DoS 漏洞
- 影响: cspell -> flatted (当前使用 3.3.3)
- 修复: 通过 pnpm overrides 强制使用安全版本

Fixes #2626

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2626