### PR TITLE
fix: packages/tts 中使用 @/ 路径别名替代相对路径

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -3,12 +3,12 @@
  */
 
 import { randomUUID } from "node:crypto";
-import WebSocket from "ws";
 import type {
   AudioChunkCallback,
   PlatformConfig,
   TTSController,
-} from "../../core/index.js";
+} from "@/core/index.js";
+import WebSocket from "ws";
 import {
   FullClientRequest,
   MsgType,

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -2,7 +2,7 @@
  * 字节跳动 TTS 平台模块导出
  */
 
-import { platformRegistry } from "../../core/index.js";
+import { platformRegistry } from "@/core/index.js";
 import { ByteDanceTTSPlatform } from "./TTSController.js";
 
 // 注册字节跳动平台


### PR DESCRIPTION
- TTSController.ts: 将 ../../core/index.js 改为 @/core/index.js
- index.ts: 将 ../../core/index.js 改为 @/core/index.js
- 同时修复了导入语句排序以符合 Biome 规范

Closes #2631

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2631