### PR TITLE
fix: 使用 HTTP_SERVER_CONFIG.DEFAULT_PORT 替换硬编码端口号 9999

### DIFF
--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -4,6 +4,7 @@
  */
 
 import { logger } from "@/Logger.js";
+import { HTTP_SERVER_CONFIG } from "@/constants/http.constants.js";
 import { ESP32Connection } from "@/lib/esp32/connection.js";
 import type {
   ESP32DeviceReport,
@@ -227,7 +228,9 @@ export class ESP32Service {
     }
 
     // 如果 host 不包含端口，添加默认端口
-    const serverAddress = host.includes(":") ? host : `${host}:9999`;
+    const serverAddress = host.includes(":")
+      ? host
+      : `${host}:${HTTP_SERVER_CONFIG.DEFAULT_PORT}`;
 
     // 构建完整的 WebSocket URL
     const wsUrl = `ws://${serverAddress}/ws`;


### PR DESCRIPTION
违反配置外部化原则，使用常量替代魔法数字。

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2634