### PR TITLE
fix: 修复 WebServer 中 endpointManager 事件监听器内存泄漏

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -381,20 +381,22 @@ export class WebServer {
         await this.endpointManager.connect();
 
         // 设置端点添加事件监听器
-        this.endpointManager.on(
-          "endpointAdded",
-          (event: { endpoint: string }) => {
-            this.logger.debug(`端点已添加: ${event.endpoint}`);
-          }
-        );
+        const endpointAddedListener = (event: { endpoint: string }) => {
+          this.logger.debug(`端点已添加: ${event.endpoint}`);
+        };
+        this.endpointManager.on("endpointAdded", endpointAddedListener);
 
         // 设置端点移除事件监听器
-        this.endpointManager.on(
-          "endpointRemoved",
-          (event: { endpoint: string }) => {
-            this.logger.debug(`端点已移除: ${event.endpoint}`);
-          }
-        );
+        const endpointRemovedListener = (event: { endpoint: string }) => {
+          this.logger.debug(`端点已移除: ${event.endpoint}`);
+        };
+        this.endpointManager.on("endpointRemoved", endpointRemovedListener);
+
+        // 存储清理函数，用于在 destroy 时移除监听器
+        this.eventListenerUnsubscribers.push(() => {
+          this.endpointManager?.off("endpointAdded", endpointAddedListener);
+          this.endpointManager?.off("endpointRemoved", endpointRemovedListener);
+        });
 
         this.logger.debug(
           `小智接入点连接管理器初始化完成，管理 ${validEndpoints.length} 个端点`


### PR DESCRIPTION
在 initializeXiaozhiConnection() 方法中，为 endpointManager 注册的
endpointAdded 和 endpointRemoved 事件监听器未在 destroy() 时清理，
导致内存泄漏。

修改内容：
- 将监听器提取为命名函数，以便后续移除
- 添加清理函数到 eventListenerUnsubscribers 数组
- 在 destroy() 中正确移除这些监听器

Fixes #2636

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2636