### PR TITLE
fix: 为 NPMManager.getCurrentVersion 添加错误处理

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -154,11 +154,16 @@ export class NPMManager {
    * 获取当前版本
    */
   async getCurrentVersion(): Promise<string> {
-    const { stdout } = await execAsync(
-      "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
-    );
-    const info = JSON.parse(stdout);
-    return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+    try {
+      const { stdout } = await execAsync(
+        "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
+      );
+      const info = JSON.parse(stdout);
+      return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+    } catch (error) {
+      logger.error("获取当前版本失败", { error });
+      return "unknown";
+    }
   }
 
   /**


### PR DESCRIPTION
修复 #2638

- 添加 try-catch 块捕获 execAsync 和 JSON.parse 可能抛出的错误
- 在错误情况下返回 "unknown" 而不是抛出未捕获的 Promise rejection
- 与 getAvailableVersions 方法保持一致的错误处理风格
- 记录错误日志以便调试

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2638