### PR TITLE
fix: 统一 apps/backend/lib/mcp/index.ts 使用相对路径导出

### DIFF
--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -29,11 +29,11 @@
  * const result = await manager.callTool('tool-name', { param: 'value' });
  * ```
  */
-export * from "@/lib/mcp/manager.js";
-export * from "@/lib/mcp/connection.js";
-export * from "@/lib/mcp/types.js";
-export * from "@/lib/mcp/utils.js";
+export * from "./manager.js";
+export * from "./connection.js";
+export * from "./types.js";
+export * from "./utils.js";
 export * from "./message.js";
-export * from "@/lib/mcp/cache.js";
+export * from "./cache.js";
 export * from "./custom.js";
 export * from "./log.js";


### PR DESCRIPTION
将混合使用的路径别名 @/lib/mcp/ 和相对路径 ./ 统一为相对路径，
提高代码一致性和可维护性。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2640