### PR TITLE
fix: 完善 utils 统一导出模块

### DIFF
--- a/apps/backend/utils/index.ts
+++ b/apps/backend/utils/index.ts
@@ -16,3 +16,26 @@ export {
   type DeviceInfoFromHeaders,
   type ExtractedDeviceInfo,
 } from "./esp32-utils.js";
+// Prompt 管理工具
+export {
+  resolvePrompt,
+  getDefaultSystemPrompt,
+  listPromptFiles,
+  validatePromptPath,
+  validatePromptFileName,
+  getPromptsDir,
+  resolvePromptPath,
+  readPromptFile,
+  updatePromptFile,
+  createPromptFile,
+  deletePromptFile,
+  type PromptFileInfo,
+  type PromptFileContent,
+} from "./prompt-utils.js";
+// 工具排序工具
+export {
+  toolSorters,
+  sortTools,
+  type ToolSortField,
+  type ToolSortConfig,
+} from "./toolSorters.js";


### PR DESCRIPTION
添加 prompt-utils 和 toolSorters 模块的统一导出，使这些工具类可以通过 @/utils 统一访问。

- 添加 prompt-utils 相关导出：resolvePrompt、getDefaultSystemPrompt、listPromptFiles 等 11 个函数和 2 个类型
- 添加 toolSorters 相关导出：toolSorters、sortTools 和相关类型

修复 #2643

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2643