### PR TITLE
fix: 修复 Nx lint --reporter=compact 与 Biome 不兼容问题

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -35,7 +35,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm --filter backend run lint"
+        "command": "bash scripts/biome-lint.sh apps/backend"
       }
     },
     "lint:fix": {

--- a/apps/frontend/project.json
+++ b/apps/frontend/project.json
@@ -50,7 +50,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check apps/frontend/src"
+        "command": "bash scripts/biome-lint.sh apps/frontend/src"
       }
     },
     "lint:fix": {

--- a/mcps/calculator-mcp/project.json
+++ b/mcps/calculator-mcp/project.json
@@ -29,8 +29,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check src/",
-        "cwd": "mcps/calculator-mcp"
+        "command": "bash scripts/biome-lint.sh mcps/calculator-mcp"
       }
     },
     "lint:fix": {

--- a/mcps/datetime-mcp/project.json
+++ b/mcps/datetime-mcp/project.json
@@ -29,8 +29,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check src/",
-        "cwd": "mcps/datetime-mcp"
+        "command": "bash scripts/biome-lint.sh mcps/datetime-mcp"
       }
     },
     "lint:fix": {

--- a/packages/asr/project.json
+++ b/packages/asr/project.json
@@ -45,7 +45,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm --filter asr run lint"
+        "command": "bash scripts/biome-lint.sh packages/asr"
       }
     },
     "lint:fix": {

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -39,7 +39,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "biome check packages/cli"
+        "command": "bash scripts/biome-lint.sh packages/cli"
       }
     },
     "lint:fix": {

--- a/packages/tts/project.json
+++ b/packages/tts/project.json
@@ -45,7 +45,7 @@
     "lint": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm --filter tts run lint"
+        "command": "bash scripts/biome-lint.sh packages/tts"
       }
     },
     "lint:fix": {

--- a/scripts/biome-lint.sh
+++ b/scripts/biome-lint.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+# Biome lint wrapper that filters out nx-incompatible arguments
+# This script removes --reporter arguments that Biome doesn't support
+
+PROJECT_ROOT="${1:-.}"
+shift
+
+# Filter out --reporter arguments as Biome uses --log-kind instead
+FILTERED_ARGS=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --reporter*)
+      # Skip --reporter arguments
+      shift
+      ;;
+    *)
+      # Keep other arguments
+      FILTERED_ARGS+=("$1")
+      shift
+      ;;
+  esac
+done
+
+# Run biome check with filtered arguments
+biome check "$PROJECT_ROOT" "${FILTERED_ARGS[@]}"


### PR DESCRIPTION
创建包装脚本过滤掉不兼容的 --reporter 参数，确保 Biome 正常运行。

- 新增 scripts/biome-lint.sh 包装脚本，过滤 nx 传递的 --reporter 参数
- 更新所有 project.json 文件使用包装脚本替代直接调用 biome check
- 修复 nx lint --reporter=compact 命令失败的问题

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2647