### PR TITLE
fix: 将 ToolDebugDialog 的 inputSchema 参数类型从 any 改为 JSONSchema

### DIFF
--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -41,6 +41,7 @@ import {
   createZodSchemaFromJsonSchema,
 } from "@/lib/schema-utils";
 import { apiClient } from "@/services/api";
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   AlertCircle,
@@ -374,7 +375,7 @@ const FormRenderer = memo(function FormRenderer({
                   <FormItem>
                     <div className="flex items-center gap-2">
                       <FormLabel>
-                        {tool.inputSchema.required?.includes(fieldName) && (
+                        {tool.inputSchema?.required?.includes(fieldName) && (
                           <span className="text-red-500 mr-1">*</span>
                         )}
                         {fieldName}
@@ -432,7 +433,7 @@ interface ToolDebugDialogProps {
     serverName: string;
     toolName: string;
     description?: string;
-    inputSchema?: any;
+    inputSchema?: JSONSchema;
   } | null;
 }
 


### PR DESCRIPTION
修复 #2650

- 添加 JSONSchema 类型导入从 @xiaozhi-client/shared-types
- 将 inputSchema 参数类型从 any 改为 JSONSchema
- 添加可选链操作符处理可能未定义的 inputSchema
- 提升类型安全性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2650