### PR TITLE
fix: 使用公共 API 替代类型断言访问私有属性

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
@@ -27,6 +27,7 @@ const createMockMCPServiceManager = (): Partial<MCPServiceManager> => ({
   startService: vi.fn(),
   stopService: vi.fn(),
   removeServiceConfig: vi.fn(),
+  getService: vi.fn(),
   // MCPServiceManager 的其他模拟方法将在后续里程碑中添加
 });
 
@@ -260,9 +261,9 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["new-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     // 修复 mock 配置 - 确保初始配置不包含新服务，但 updateMcpServer 后包含
     const currentConfig = {
@@ -430,9 +431,9 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["disconnected-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const response = await handler.addMCPServer(mockContext as Context);
 
@@ -547,9 +548,9 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -619,9 +620,9 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     // 模拟服务停止失败
     mockMCPServiceManager.stopService = vi
@@ -654,9 +655,9 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     // 修改配置管理器让它认为这个服务存在
     const originalGetConfig = mockConfigManager.getConfig;
@@ -705,9 +706,9 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -960,9 +961,9 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -984,9 +985,9 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -1125,10 +1126,13 @@ describe("listMCPServers", () => {
       getTools: vi.fn().mockReturnValue([]),
     };
     // service3 不在 services Map 中（未启动）
-    (mockMCPServiceManager as any).services = new Map([
-      ["service1", mockService1],
-      ["service2", mockService2],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockImplementation((name: string) => {
+        if (name === "service1") return mockService1;
+        if (name === "service2") return mockService2;
+        return undefined;
+      });
 
     const response = await handler.listMCPServers(mockContext as Context);
 
@@ -1316,9 +1320,9 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1356,9 +1360,9 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1396,9 +1400,9 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -26,14 +26,6 @@ import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
 
 /**
- * MCPServiceManager 扩展接口，用于访问私有属性
- * 这个接口定义了我们需要访问但实际上是私有的属性
- */
-interface MCPServiceManagerAccess {
-  services: Map<string, MCPService>;
-}
-
-/**
  * 配置详情接口，包含时间戳
  */
 interface ConfigDetails {
@@ -421,9 +413,7 @@ export class MCPHandler {
 
     // 尝试从 MCPServiceManager 获取实际状态
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.isConnected?.()) {
         const currentTools = service.getTools().map((tool: Tool) => tool.name);
@@ -530,9 +520,7 @@ export class MCPHandler {
    */
   private getServiceTools(serverName: string): Tool[] {
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.getTools) {
         return service.getTools();


### PR DESCRIPTION
修复 mcp-manage.handler.ts 中通过类型断言访问
MCPServiceManager 私有属性违反封装原则的问题。

主要更改：
- 删除 MCPServiceManagerAccess 接口
- 在 getServiceStatus 方法中使用 mcpServiceManager.getService()
- 在 getServiceTools 方法中使用 mcpServiceManager.getService()
- 更新测试 mock 使用 getService() 方法

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2659