### PR TITLE
fix: 统一 API 响应类型定义，消除重复

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -99,13 +99,6 @@ import {
   versionRoutes,
 } from "./routes/index.js";
 
-// 统一成功响应格式
-interface ApiSuccessResponse<T = unknown> {
-  success: boolean;
-  data?: T;
-  message?: string;
-}
-
 // 小智连接状态响应格式
 interface XiaozhiConnectionStatusResponse {
   type: "multi-endpoint" | "single-endpoint" | "none";

--- a/apps/backend/middlewares/error.middleware.ts
+++ b/apps/backend/middlewares/error.middleware.ts
@@ -10,22 +10,17 @@
  * @module middlewares/error.middleware
  */
 
+import type {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+} from "@/types/api.response.js";
 import type { Context } from "hono";
 
-// 统一错误响应格式
-export interface ApiErrorResponse {
-  error: {
-    code: string;
-    message: string;
-    details?: unknown;
-  };
-}
-
-export interface ApiSuccessResponse<T> {
-  success: boolean;
-  data?: T;
-  message?: string;
-}
+// 重新导出 API 响应类型，统一使用 types/api.response.ts 中的定义
+export type {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+} from "@/types/api.response.js";
 
 /**
  * 创建统一的错误响应
@@ -37,6 +32,7 @@ export const createErrorResponse = (
   details?: unknown
 ): ApiErrorResponse => {
   return {
+    success: false,
     error: {
       code,
       message,

--- a/apps/backend/middlewares/index.ts
+++ b/apps/backend/middlewares/index.ts
@@ -15,7 +15,7 @@
  * - {@link hasMCPServiceManager} - 检查是否存在 MCP 服务管理器
  * - {@link getMCPServiceManager} - 获取 MCP 服务管理器
  * - {@link requireMCPServiceManager} - 获取 MCP 服务管理器（不存在则抛错）
- * - {@link ApiErrorResponse} / {@link ApiSuccessResponse} - API 响应类型
+ * - {@link ApiErrorResponse} / {@link ApiSuccessResponse} - API 响应类型（从 @/types/api.response.js 重新导出）
  *
  * @module middlewares
  *


### PR DESCRIPTION
- 将 ApiSuccessResponse 和 ApiErrorResponse 类型定义统一到 types/api.response.ts
- error.middleware.ts 现在重新导出这些类型，而不是重复定义
- 修复 createErrorResponse 函数，添加缺失的 success: false 字段
- 移除 WebServer.ts 中未使用的本地 ApiSuccessResponse 定义
- 更新 middlewares/index.ts 的注释说明类型来源

这解决了类型不一致问题：
- error.middleware.ts 中 success 字段类型从 boolean 改为字面量类型 true/false
- 确保所有模块使用相同的类型定义，提高类型安全性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2665