### PR TITLE
fix: 为 backend 添加 asr 和 tts 的 TypeScript 项目引用

### DIFF
--- a/apps/backend/tsconfig.json
+++ b/apps/backend/tsconfig.json
@@ -19,5 +19,9 @@
     "scripts/**/*",
     "templates/**/*",
     "**/*.config.ts"
+  ],
+  "references": [
+    { "path": "../../packages/asr" },
+    { "path": "../../packages/tts" }
   ]
 }


### PR DESCRIPTION
修复 #2669

在 apps/backend/tsconfig.json 中添加了对 @xiaozhi-client/asr 和
@xiaozhi-client/tts 的项目引用，以符合 composite 模式要求。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2669