### PR TITLE
fix: 移除 mcp-endpoint-setting-button.tsx 中遗留的 console.log 调试语句

### DIFF
--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -389,11 +389,6 @@ export function McpEndpointSettingButton() {
         (event: any) => {
           // 只处理当前端点的事件
           if (event.endpoint === endpoint) {
-            console.log(
-              `[McpEndpointSettingButton] 接收到端点 ${endpoint} 状态变更:`,
-              event
-            );
-
             // 更新端点状态
             updateEndpointState(endpoint, {
               connected: event.connected,


### PR DESCRIPTION
移除第 392-395 行的 console.log 调试代码，因为：
1. 代码已通过 toast 通知向用户展示状态变更信息
2. 此 console.log 是遗留的调试代码，无实际业务价值
3. 避免在生产环境中泄露端点状态信息

Fixes #2671

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2671