### PR TITLE
fix(tts): 保留 setupMessageHandler 中的原始错误堆栈跟踪

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/protocols.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/protocols.ts
@@ -607,7 +607,11 @@ function setupMessageHandler(ws: WebSocket) {
           queue.push(msg);
         }
       } catch (error) {
-        throw new Error(`Error processing message: ${error}`);
+        const wrappedError = new Error(
+          `Error processing message: ${error instanceof Error ? error.message : String(error)}`
+        );
+        wrappedError.cause = error;
+        throw wrappedError;
       }
     });
 


### PR DESCRIPTION
使用 Error.cause 保留原始错误的堆栈信息，便于调试。

- 将 `throw new Error(\`Error processing message: ${error}\`)`
  改为使用 Error.cause 保留原始错误
- 当错误处理过程中发生错误时，现在可以访问完整的堆栈跟踪
- 符合最佳实践：包装错误时保留原始错误信息

修复 #2675

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2675