### PR TITLE
fix(endpoint): 修复 InternalMCPManagerAdapter 内存泄漏问题

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      removeListener: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);
@@ -354,6 +355,8 @@ describe("InternalMCPManagerAdapter", () => {
       await adapter.initialize();
       await adapter.cleanup();
 
+      expect(mockMCPManager.removeListener).toHaveBeenCalledWith("connected", expect.any(Function));
+      expect(mockMCPManager.removeListener).toHaveBeenCalledWith("error", expect.any(Function));
       expect(mockMCPManager.disconnect).toHaveBeenCalled();
     });
 

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,11 +4,11 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { MCPManager } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -18,6 +18,10 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
   private mcpManager: MCPManager;
   private tools: Map<string, EnhancedToolInfo> = new Map();
   private isInitialized = false;
+
+  // 保存事件监听器引用，用于 cleanup 时移除
+  private connectedHandler: (data: any) => void;
+  private errorHandler: (data: any) => void;
 
   constructor(private config: EndpointConfig) {
     this.mcpManager = new MCPManager();
@@ -30,16 +34,19 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       this.mcpManager.addServer(serviceName, mcpConfig);
     }
 
-    // 设置事件监听
-    this.mcpManager.on("connected", (data) => {
+    // 设置事件监听，保存监听器引用以便在 cleanup 时移除
+    this.connectedHandler = (data) => {
       console.info(
         `MCP 服务 ${data.serverName} 已连接，工具数: ${data.tools.length}`
       );
-    });
+    };
 
-    this.mcpManager.on("error", (data) => {
+    this.errorHandler = (data) => {
       console.error(`MCP 服务 ${data.serverName} 出错:`, data.error);
-    });
+    };
+
+    this.mcpManager.on("connected", this.connectedHandler);
+    this.mcpManager.on("error", this.errorHandler);
   }
 
   /**
@@ -88,6 +95,10 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
    * 清理资源
    */
   async cleanup(): Promise<void> {
+    // 移除事件监听器，防止内存泄漏
+    this.mcpManager.removeListener("connected", this.connectedHandler);
+    this.mcpManager.removeListener("error", this.errorHandler);
+
     await this.mcpManager.disconnect();
     this.tools.clear();
     this.isInitialized = false;


### PR DESCRIPTION
在构造函数中添加的事件监听器未在 cleanup() 时移除，导致适配器实例无法被垃圾回收。

修改内容：
1. 添加 connectedHandler 和 errorHandler 属性保存事件监听器引用
2. 在 cleanup() 方法中调用 removeListener() 移除事件监听器
3. 更新单元测试，添加 removeListener mock 并验证调用

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2681