### PR TITLE
fix: 修复 toolsApi.ts 中的定时器泄漏问题

### DIFF
--- a/apps/frontend/src/services/toolsApi.ts
+++ b/apps/frontend/src/services/toolsApi.ts
@@ -283,15 +283,27 @@ export class ToolsApiService {
     let lastError: Error;
 
     for (let attempt = 0; attempt <= retries; attempt++) {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
       try {
         // 设置超时
         const timeoutPromise = new Promise<never>((_, reject) => {
-          setTimeout(() => reject(new Error("请求超时")), this.REQUEST_TIMEOUT);
+          timeoutId = setTimeout(() => reject(new Error("请求超时")), this.REQUEST_TIMEOUT);
         });
 
         const result = await Promise.race([operation(), timeoutPromise]);
+
+        // 成功后清理定时器
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
+
         return result;
       } catch (error) {
+        // 失败时也要清理定时器
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+        }
         lastError = error instanceof Error ? error : new Error(String(error));
 
         // 如果是最后一次尝试，或者是不可重试的错误，直接抛出


### PR DESCRIPTION
在 executeWithRetry 方法中，当 operation() 成功完成后，
timeoutPromise 中的 setTimeout 不会被清理，导致定时器泄漏。

修复方案：
- 存储 setTimeout 返回的 timeoutId
- 在成功和失败情况下都调用 clearTimeout 清理定时器
- 避免频繁 API 调用时累积未清理的定时器

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2686