### PR TITLE
fix(asr): 在 close() 方法中清理事件监听器防止内存泄漏

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -566,6 +566,8 @@ export class ASR extends EventEmitter {
     this.reqid = "";
     // 重置 VAD 触发记录
     this.triggeredVADSequences.clear();
+    // 清理所有事件监听器，防止内存泄漏
+    this.removeAllListeners();
   }
 
   /**


### PR DESCRIPTION
ASR 类继承自 EventEmitter，但 close() 方法只关闭了 WebSocket 连接，
没有清理事件监听器。在频繁创建和销毁 ASR 实例的场景下可能导致内存泄漏。

在 close() 方法末尾添加 this.removeAllListeners() 调用以清理所有事件监听器。

修复 Issue #2691

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2691