### PR TITLE
fix: 将 timeout.ts 中的 any 类型替换为 unknown 以提升类型安全性

### DIFF
--- a/apps/backend/types/timeout.ts
+++ b/apps/backend/types/timeout.ts
@@ -108,13 +108,23 @@ function getDefaultTimeoutMessage(taskId: string): string {
 /**
  * 验证是否为超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
+export function isTimeoutResponse(
+  response: unknown
+): response is TimeoutResponse {
   return !!(
     response &&
+    typeof response === "object" &&
+    response !== null &&
+    "status" in response &&
     response.status === "timeout" &&
+    "taskId" in response &&
     typeof response.taskId === "string" &&
+    "content" in response &&
     Array.isArray(response.content) &&
     response.content.length > 0 &&
+    typeof response.content[0] === "object" &&
+    response.content[0] !== null &&
+    "type" in response.content[0] &&
     response.content[0].type === "text"
   );
 }
@@ -122,9 +132,12 @@ export function isTimeoutResponse(response: any): response is TimeoutResponse {
 /**
  * 验证是否为超时错误
  */
-export function isTimeoutError(error: any): error is TimeoutError {
+export function isTimeoutError(error: unknown): error is TimeoutError {
   return !!(
     error &&
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
     error.name === "TimeoutError" &&
     error instanceof TimeoutError
   );


### PR DESCRIPTION
- isTimeoutResponse 函数参数类型从 any 改为 unknown
- isTimeoutError 函数参数类型从 any 改为 unknown
- 添加完整的类型守卫以确保类型安全

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2693