### PR TITLE
refactor: 消除 TTSController 中的代码重复

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -50,17 +50,10 @@ export class ByteDanceTTSController implements TTSController {
   }
 
   /**
-   * 流式合成语音
+   * 设置 WebSocket 连接
    */
-  async synthesizeStream(
-    text: string,
-    onAudioChunk: AudioChunkCallback
-  ): Promise<void> {
-    this.isStreamClosed = false;
-
+  private async setupWebSocket(): Promise<void> {
     const endpoint = this.config.endpoint || DEFAULT_TTS_ENDPOINT;
-    const encoding = this.config.audio.encoding || "wav";
-
     const headers = {
       Authorization: `Bearer;${this.config.app.accessToken}`,
     };
@@ -78,8 +71,13 @@ export class ByteDanceTTSController implements TTSController {
       this.ws.on("open", () => resolve());
       this.ws.on("error", (err) => reject(err));
     });
+  }
 
-    const request = {
+  /**
+   * 构建 TTS 请求对象
+   */
+  private buildTTSRequest(text: string, encoding: string): object {
+    return {
       app: {
         appid: this.config.app.appid,
         token: this.config.app.accessToken,
@@ -113,7 +111,12 @@ export class ByteDanceTTSController implements TTSController {
         with_timestamp: "1",
       },
     };
+  }
 
+  /**
+   * 发送请求到 WebSocket
+   */
+  private async sendRequest(request: object): Promise<void> {
     if (!this.ws) {
       throw new Error("WebSocket 未创建");
     }
@@ -122,6 +125,22 @@ export class ByteDanceTTSController implements TTSController {
       this.ws,
       new TextEncoder().encode(JSON.stringify(request))
     );
+  }
+
+  /**
+   * 流式合成语音
+   */
+  async synthesizeStream(
+    text: string,
+    onAudioChunk: AudioChunkCallback
+  ): Promise<void> {
+    this.isStreamClosed = false;
+    const encoding = this.config.audio.encoding || "wav";
+
+    await this.setupWebSocket();
+
+    const request = this.buildTTSRequest(text, encoding);
+    await this.sendRequest(request);
 
     while (true) {
       if (this.isStreamClosed || !this.ws) {
@@ -159,71 +178,12 @@ export class ByteDanceTTSController implements TTSController {
    */
   async synthesize(text: string): Promise<Uint8Array> {
     this.isStreamClosed = false;
-
-    const endpoint = this.config.endpoint || DEFAULT_TTS_ENDPOINT;
     const encoding = this.config.audio.encoding || "wav";
 
-    const headers = {
-      Authorization: `Bearer;${this.config.app.accessToken}`,
-    };
+    await this.setupWebSocket();
 
-    this.ws = new WebSocket(endpoint, {
-      headers,
-      skipUTF8Validation: true,
-    });
-
-    await new Promise<void>((resolve, reject) => {
-      if (!this.ws) {
-        reject(new Error("WebSocket 未创建"));
-        return;
-      }
-      this.ws.on("open", () => resolve());
-      this.ws.on("error", (err) => reject(err));
-    });
-
-    const request = {
-      app: {
-        appid: this.config.app.appid,
-        token: this.config.app.accessToken,
-        cluster:
-          this.config.cluster?.trim() ||
-          voiceToCluster(this.config.audio.voice_type),
-      },
-      user: {
-        uid: randomUUID(),
-      },
-      audio: {
-        voice_type: this.config.audio.voice_type,
-        encoding: encoding,
-        ...(this.config.audio.speed !== undefined && {
-          speed: this.config.audio.speed,
-        }),
-        ...(this.config.audio.pitch !== undefined && {
-          pitch: this.config.audio.pitch,
-        }),
-        ...(this.config.audio.volume !== undefined && {
-          volume: this.config.audio.volume,
-        }),
-      },
-      request: {
-        reqid: randomUUID(),
-        text: text,
-        operation: "submit",
-        extra_param: JSON.stringify({
-          disable_markdown_filter: false,
-        }),
-        with_timestamp: "1",
-      },
-    };
-
-    if (!this.ws) {
-      throw new Error("WebSocket 未创建");
-    }
-
-    await FullClientRequest(
-      this.ws,
-      new TextEncoder().encode(JSON.stringify(request))
-    );
+    const request = this.buildTTSRequest(text, encoding);
+    await this.sendRequest(request);
 
     const totalAudio: Uint8Array[] = [];
 


### PR DESCRIPTION
- 提取 setupWebSocket() 私有方法处理 WebSocket 连接设置
- 提取 buildTTSRequest() 私有方法处理请求对象构建
- 提取 sendRequest() 私有方法处理请求发送
- 消除 synthesizeStream 和 synthesize 方法间约 68 行重复代码

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2695