### PR TITLE
fix(stores): 修复 WebSocket 事件监听器内存泄漏

### DIFF
--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -95,6 +95,11 @@ interface ConfigActions {
 export interface ConfigStore extends ConfigState, ConfigActions {}
 
 /**
+ * WebSocket 事件取消订阅函数引用
+ */
+let unsubscribeConfigUpdate: (() => void) | null = null;
+
+/**
  * 初始状态
  */
 const initialState: ConfigState = {
@@ -316,6 +321,14 @@ export const useConfigStore = create<ConfigStore>()(
 
       reset: () => {
         console.log("[ConfigStore] 重置状态");
+
+        // 取消 WebSocket 事件订阅
+        if (unsubscribeConfigUpdate) {
+          unsubscribeConfigUpdate();
+          unsubscribeConfigUpdate = null;
+        }
+
+        // 重置状态
         set(initialState, false, "reset");
       },
 
@@ -327,10 +340,13 @@ export const useConfigStore = create<ConfigStore>()(
           console.log("[ConfigStore] 初始化配置 Store");
 
           // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:configUpdate", (config) => {
-            console.log("[ConfigStore] 收到 WebSocket 配置更新");
-            get().setConfig(config, "websocket");
-          });
+          unsubscribeConfigUpdate = webSocketManager.subscribe(
+            "data:configUpdate",
+            (config) => {
+              console.log("[ConfigStore] 收到 WebSocket 配置更新");
+              get().setConfig(config, "websocket");
+            }
+          );
 
           // 获取初始配置
           await refreshConfig();

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -211,6 +211,12 @@ let pollingTimer: NodeJS.Timeout | null = null;
 let restartPollingTimer: NodeJS.Timeout | null = null;
 
 /**
+ * WebSocket 事件取消订阅函数引用
+ */
+let unsubscribeStatusUpdate: (() => void) | null = null;
+let unsubscribeRestartStatus: (() => void) | null = null;
+
+/**
  * 创建状态 Store
  */
 export const useStatusStore = create<StatusStore>()(
@@ -681,6 +687,16 @@ export const useStatusStore = create<StatusStore>()(
         get().stopPolling();
         get().stopRestartPolling();
 
+        // 取消 WebSocket 事件订阅
+        if (unsubscribeStatusUpdate) {
+          unsubscribeStatusUpdate();
+          unsubscribeStatusUpdate = null;
+        }
+        if (unsubscribeRestartStatus) {
+          unsubscribeRestartStatus();
+          unsubscribeRestartStatus = null;
+        }
+
         // 重置状态
         set(initialState, false, "reset");
       },
@@ -693,15 +709,21 @@ export const useStatusStore = create<StatusStore>()(
           console.log("[StatusStore] 初始化状态 Store");
 
           // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:statusUpdate", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 状态更新");
-            get().setClientStatus(status, "websocket");
-          });
+          unsubscribeStatusUpdate = webSocketManager.subscribe(
+            "data:statusUpdate",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 状态更新");
+              get().setClientStatus(status, "websocket");
+            }
+          );
 
-          webSocketManager.subscribe("data:restartStatus", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 重启状态更新");
-            get().setRestartStatus(status, "websocket");
-          });
+          unsubscribeRestartStatus = webSocketManager.subscribe(
+            "data:restartStatus",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 重启状态更新");
+              get().setRestartStatus(status, "websocket");
+            }
+          );
 
           // 获取初始状态
           await refreshStatus();

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -108,6 +108,16 @@ interface WebSocketActions {
 export interface WebSocketStore extends WebSocketState, WebSocketActions {}
 
 /**
+ * WebSocket 事件取消订阅函数引用
+ */
+let unsubscribeConnecting: (() => void) | null = null;
+let unsubscribeConnected: (() => void) | null = null;
+let unsubscribeDisconnected: (() => void) | null = null;
+let unsubscribeReconnecting: (() => void) | null = null;
+let unsubscribeConnectionError: (() => void) | null = null;
+let unsubscribeHeartbeat: (() => void) | null = null;
+
+/**
  * 初始状态（简化版）
  */
 const initialState: WebSocketState = {
@@ -258,6 +268,34 @@ export const useWebSocketStore = create<WebSocketStore>()(
 
       reset: () => {
         console.log("[WebSocketStore] 重置状态");
+
+        // 取消 WebSocket 事件订阅
+        if (unsubscribeConnecting) {
+          unsubscribeConnecting();
+          unsubscribeConnecting = null;
+        }
+        if (unsubscribeConnected) {
+          unsubscribeConnected();
+          unsubscribeConnected = null;
+        }
+        if (unsubscribeDisconnected) {
+          unsubscribeDisconnected();
+          unsubscribeDisconnected = null;
+        }
+        if (unsubscribeReconnecting) {
+          unsubscribeReconnecting();
+          unsubscribeReconnecting = null;
+        }
+        if (unsubscribeConnectionError) {
+          unsubscribeConnectionError();
+          unsubscribeConnectionError = null;
+        }
+        if (unsubscribeHeartbeat) {
+          unsubscribeHeartbeat();
+          unsubscribeHeartbeat = null;
+        }
+
+        // 重置状态
         set(initialState, false, "reset");
       },
 
@@ -267,32 +305,50 @@ export const useWebSocketStore = create<WebSocketStore>()(
         console.log("[WebSocketStore] 初始化 WebSocket Store");
 
         // 设置 WebSocket 事件监听
-        webSocketManager.subscribe("connection:connecting", () => {
-          get().setConnectionState(ConnectionState.CONNECTING);
-        });
+        unsubscribeConnecting = webSocketManager.subscribe(
+          "connection:connecting",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTING);
+          }
+        );
 
-        webSocketManager.subscribe("connection:connected", () => {
-          get().setConnectionState(ConnectionState.CONNECTED);
-        });
+        unsubscribeConnected = webSocketManager.subscribe(
+          "connection:connected",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:disconnected", () => {
-          get().setConnectionState(ConnectionState.DISCONNECTED);
-        });
+        unsubscribeDisconnected = webSocketManager.subscribe(
+          "connection:disconnected",
+          () => {
+            get().setConnectionState(ConnectionState.DISCONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:reconnecting", () => {
-          get().setConnectionState(ConnectionState.RECONNECTING);
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        unsubscribeReconnecting = webSocketManager.subscribe(
+          "connection:reconnecting",
+          () => {
+            get().setConnectionState(ConnectionState.RECONNECTING);
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
-        webSocketManager.subscribe("connection:error", ({ error }) => {
-          get().setLastError(error);
-        });
+        unsubscribeConnectionError = webSocketManager.subscribe(
+          "connection:error",
+          ({ error }) => {
+            get().setLastError(error);
+          }
+        );
 
-        webSocketManager.subscribe("system:heartbeat", () => {
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        unsubscribeHeartbeat = webSocketManager.subscribe(
+          "system:heartbeat",
+          () => {
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
         // 初始化连接状态
         const initialStats = webSocketManager.getConnectionStats();


### PR DESCRIPTION
在 StatusStore、ConfigStore 和 WebSocketStore 中添加了取消订阅功能，
确保 reset() 方法正确清理所有 WebSocket 事件监听器。

- status.ts: 添加 2 个事件监听器的取消订阅（data:statusUpdate, data:restartStatus）
- config.ts: 添加 1 个事件监听器的取消订阅（data:configUpdate）
- websocket.ts: 添加 6 个事件监听器的取消订阅

修复 issue #2697

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2697