### PR TITLE
fix: 修复 CLI 包 npm 发布配置错误

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,8 +18,9 @@
     "ai"
   ],
   "type": "module",
-  "main": "dist/cli/index.js",
+  "main": "packages/cli/dist/index.js",
   "files": [
+    "packages/cli/dist",
     "dist",
     "templates",
     "README.md",
@@ -30,8 +31,8 @@
     "registry": "https://registry.npmjs.org"
   },
   "bin": {
-    "xiaozhi": "dist/cli/index.js",
-    "xiaozhi-client": "dist/cli/index.js"
+    "xiaozhi": "packages/cli/dist/index.js",
+    "xiaozhi-client": "packages/cli/dist/index.js"
   },
   "scripts": {
     "build": "pnpm run clean:dist && nx run-many -t build --exclude=docs,xiaozhi-client --parallel=false",

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -11,11 +11,14 @@
     "access": "public"
   },
   "type": "module",
-  "main": "../../dist/cli/index.js",
+  "main": "./dist/index.js",
   "bin": {
-    "xiaozhi": "../../dist/cli/index.js",
-    "xiaozhi-client": "../../dist/cli/index.js"
+    "xiaozhi": "./dist/index.js",
+    "xiaozhi-client": "./dist/index.js"
   },
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsup",
     "type-check": "tsc --noEmit"

--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -10,7 +10,7 @@
         "command": "tsup",
         "cwd": "packages/cli"
       },
-      "outputs": ["{workspaceRoot}/dist/cli"],
+      "outputs": ["packages/cli/dist"],
       "dependsOn": ["backend:build", "config:build"]
     },
     "test": {

--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -2,7 +2,7 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "composite": true,
-    "outDir": "../../dist/cli",
+    "outDir": "./dist",
     "rootDir": "src"
   },
   "include": ["src/**/*.ts"],

--- a/packages/cli/tsup.config.ts
+++ b/packages/cli/tsup.config.ts
@@ -12,7 +12,7 @@ export default defineConfig({
   },
   format: ["esm"],
   target: "node20",
-  outDir: "../../dist/cli",
+  outDir: "./dist",
   clean: true,
   sourcemap: true,
   dts: false,
@@ -74,7 +74,7 @@ export default defineConfig({
   }),
   onSuccess: async () => {
     // 构建后处理：修复导入路径
-    const filePath = resolve("../../dist/cli/index.js");
+    const filePath = resolve("./dist/index.js");
     let content = readFileSync(filePath, "utf-8");
 
     // 替换 @/* 为指向正确位置的相对路径
@@ -96,7 +96,7 @@ export default defineConfig({
       );
 
     writeFileSync(filePath, content);
-    console.log("✅ 已修复 dist/cli/index.js 中的导入路径");
+    console.log("✅ 已修复 dist/index.js 中的导入路径");
 
     // 同步根 package.json 版本到与 CLI 包一致
     const cliPkgPath = resolve("../../packages/cli/package.json");


### PR DESCRIPTION
将 CLI 包构建产物从 monorepo 根目录移至包目录内，解决 npm 发布后无法使用的问题。

**更改内容:**
- `packages/cli/tsup.config.ts`: 输出目录从 `../../dist/cli` 改为 `./dist`
- `packages/cli/package.json`:
  - `main` 和 `bin` 路径从 `../../dist/cli/index.js` 改为 `./dist/index.js`
  - 添加 `files` 字段包含 `dist` 目录
- `packages/cli/project.json`: outputs 路径更新
- `packages/cli/tsconfig.json`: outDir 更新为 `./dist`
- `package.json`: 入口点路径更新为 `packages/cli/dist/index.js`

**修复问题:**
- npm 发布包现在包含 `dist/index.js` 构建产物
- `xiaozhi` 和 `xiaozhi-client` 命令在安装后可正常使用
- tarball 内容正确（已验证包含 `dist/index.js`）

**⚠️ 需要手动更新**:
- `.github/workflows/ci.yml` 中的 CLI 测试路径需要从 `dist/cli/index.js` 改为 `packages/cli/dist/index.js`

Closes #2703

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2703