### PR TITLE
fix: 修复 api.ts 中 addCustomTool 和 updateCustomTool 方法的类型安全问题

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -4,6 +4,7 @@
  */
 
 import type {
+  AddCustomToolRequest,
   ApiErrorResponse,
   ApiSuccessResponse,
   AppConfig,
@@ -559,27 +560,28 @@ export class ApiClient {
    * 添加自定义工具（新格式）
    * 支持多种工具类型：MCP 工具、Coze 工作流等
    */
-  async addCustomTool(request: {
-    type: "mcp" | "coze" | "http" | "function";
-    data: any;
-  }): Promise<any>;
+  async addCustomTool(request: AddCustomToolRequest): Promise<CustomMCPToolWithStats>;
 
   async addCustomTool(
-    param1: any,
+    param1: unknown,
     customName?: string,
     customDescription?: string,
-    parameterConfig?: any
-  ): Promise<any> {
+    parameterConfig?: unknown
+  ): Promise<CustomMCPToolWithStats> {
     // 判断是否为新格式调用
-    if (typeof param1 === "object" && "type" in param1 && "data" in param1) {
+    if (
+      typeof param1 === "object" &&
+      param1 !== null &&
+      "type" in param1 &&
+      "data" in param1
+    ) {
       // 新格式：类型化请求
-      const response: ApiResponse<{ tool: any }> = await this.request(
-        "/api/tools/custom",
-        {
+      const request = param1 as AddCustomToolRequest;
+      const response: ApiResponse<{ tool: CustomMCPToolWithStats }> =
+        await this.request("/api/tools/custom", {
           method: "POST",
-          body: JSON.stringify(param1),
-        }
-      );
+          body: JSON.stringify(request),
+        });
 
       if (!response.success || !response.data) {
         throw new Error(response.error?.message || "添加自定义工具失败");
@@ -588,9 +590,8 @@ export class ApiClient {
     }
     // 旧格式：向后兼容
     const workflow = param1;
-    const response: ApiResponse<{ tool: any }> = await this.request(
-      "/api/tools/custom",
-      {
+    const response: ApiResponse<{ tool: CustomMCPToolWithStats }> =
+      await this.request("/api/tools/custom", {
         method: "POST",
         body: JSON.stringify({
           workflow,
@@ -598,8 +599,7 @@ export class ApiClient {
           customDescription,
           parameterConfig,
         }),
-      }
-    );
+      });
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "添加自定义工具失败");
@@ -614,18 +614,16 @@ export class ApiClient {
    */
   async updateCustomTool(
     toolName: string,
-    updateRequest: {
-      type: "mcp" | "coze" | "http" | "function";
-      data: any;
-    }
-  ): Promise<any> {
-    const response: ApiResponse<{ tool: any }> = await this.request(
-      `/api/tools/custom/${encodeURIComponent(toolName)}`,
-      {
-        method: "PUT",
-        body: JSON.stringify(updateRequest),
-      }
-    );
+    updateRequest: AddCustomToolRequest
+  ): Promise<CustomMCPToolWithStats> {
+    const response: ApiResponse<{ tool: CustomMCPToolWithStats }> =
+      await this.request(
+        `/api/tools/custom/${encodeURIComponent(toolName)}`,
+        {
+          method: "PUT",
+          body: JSON.stringify(updateRequest),
+        }
+      );
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "更新自定义工具失败");

--- a/packages/shared-types/src/api/toolApi.ts
+++ b/packages/shared-types/src/api/toolApi.ts
@@ -104,7 +104,7 @@ export interface FunctionToolData {
  */
 export interface AddCustomToolRequest {
   /** 工具类型 */
-  type: ToolType;
+  type: "mcp" | "coze" | "http" | "function";
   /** 工具数据（根据类型不同而不同） */
   data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -28,7 +28,12 @@ export type {
 } from "./mcp";
 
 // 工具API相关类型
-export type { ToolType, MCPToolData } from "./api";
+export type {
+  MCPToolData,
+  AddCustomToolRequest,
+} from "./api";
+
+export { ToolType } from "./api";
 
 // 配置相关类型
 export type {


### PR DESCRIPTION
- 将 AddCustomToolRequest 类型添加到 shared-types 主导出
- 使用 CustomMCPToolWithStats 替换 any 类型作为返回类型
- 使用 AddCustomToolRequest 替换内联类型定义
- 将 AddCustomToolRequest.type 从 ToolType 枚举改为字符串字面量以兼容现有代码
- 将旧格式的参数类型从 any 改为 unknown，保持向后兼容

修复 #2704

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2704