### PR TITLE
fix(cli): 修复 CLI 包类型检查隐藏的 3 个类型错误

### DIFF
--- a/packages/cli/project.json
+++ b/packages/cli/project.json
@@ -51,8 +51,10 @@
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "echo 'CLI type-check skipped: bundled by tsup which strips types'"
-      }
+        "command": "tsc --noEmit",
+        "cwd": "packages/cli"
+      },
+      "dependsOn": ["backend:build", "config:build"]
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -4,7 +4,7 @@
 
 import path from "node:path";
 import chalk from "chalk";
-import ora from "ora";
+import ora, { type Ora } from "ora";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
@@ -113,7 +113,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   /**
    * 确保配置文件存在，如果不存在则显示提示并返回 false
    */
-  private async ensureConfigExists(spinner: ora.Ora): Promise<boolean> {
+  private async ensureConfigExists(spinner: Ora): Promise<boolean> {
     const configManager = this.getService<any>("configManager");
 
     if (!configManager.configExists()) {

--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -69,7 +69,7 @@ export class ProjectCommandHandler extends BaseCommandHandler {
         return;
       }
 
-      if (options.template) {
+      if (options.template && typeof options.template === "string") {
         // 使用模板创建项目
         await this.createFromTemplate(
           projectName,

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -13,9 +13,17 @@
 import type { ChildProcess } from "node:child_process";
 import { spawn } from "node:child_process";
 import fs from "node:fs";
-import type { WebServer } from "@/WebServer";
 import consola from "consola";
 import { RETRY_CONSTANTS } from "../Constants";
+
+/**
+ * WebServer 类型声明
+ * 用于类型注解，实际实现由 backend 包提供
+ */
+interface WebServer {
+  start(): Promise<void>;
+  stop(): Promise<void>;
+}
 import { ProcessError, ServiceError } from "../errors/index";
 import type {
   DaemonManager as IDaemonManager,


### PR DESCRIPTION
修复了 CLI 包中因跳过类型检查而隐藏的 3 个 TypeScript 类型错误：

1. **ConfigCommandHandler.ts** - 修复 ora.Ora 命名空间类型错误
   - 从 ora 包导入 Ora 类型：`import ora, { type Ora } from "ora"`
   - 使用 `Ora` 替代 `ora.Ora`

2. **ProjectCommandHandler.ts** - 修复 options.template 类型不匹配
   - 添加类型守卫：`typeof options.template === "string"`
   - 确保 template 选项在使用前是有效的字符串类型

3. **DaemonManager.ts** - 修复 @/WebServer 模块找不到错误
   - 移除使用 backend 路径别名的导入
   - 定义本地 WebServer 接口用于类型注解

4. **project.json** - 恢复 type-check 目标
   - 移除跳过类型检查的 echo 命令
   - 恢复 `tsc --noEmit` 类型检查
   - 添加对 backend:build 和 config:build 的依赖

这些修复确保了 CLI 包的类型安全，防止运行时错误。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2706