### PR TITLE
fix: 修复 ESP32Connection.close() 方法中的内存泄漏

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -436,6 +436,12 @@ export class ESP32Connection {
 
     logger.info(`关闭连接: deviceId=${this.deviceId}`);
 
+    // 清理所有事件监听器，防止内存泄漏
+    this.ws.removeAllListeners("message");
+    this.ws.removeAllListeners("error");
+    this.ws.removeAllListeners("pong");
+    this.ws.removeAllListeners("close");
+
     // 如果连接已断开，直接返回
     if (
       this.ws.readyState !== this.ws.OPEN &&


### PR DESCRIPTION
在 close() 方法开始时清理所有 WebSocket 事件监听器，
防止在频繁连接/断开场景下累积未清理的监听器。

修复内容：
- 移除 message 事件监听器
- 移除 error 事件监听器
- 移除 pong 事件监听器
- 移除 close 事件监听器

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2711