### PR TITLE
fix: 使用实例 logger 替代 Context logger 避免异步回调中日志丢失

### DIFF
--- a/apps/backend/handlers/service.handler.ts
+++ b/apps/backend/handlers/service.handler.ts
@@ -82,7 +82,7 @@ export class ServiceApiHandler {
             this.statusService.updateRestartStatus("completed");
           }, SERVICE_RESTART_DELAYS.SUCCESS_NOTIFICATION_DELAY);
         } catch (error) {
-          c.get("logger").error("服务重启失败:", error);
+          this.logger.error("服务重启失败:", error);
           this.statusService.updateRestartStatus(
             "failed",
             error instanceof Error ? error.message : "未知错误"


### PR DESCRIPTION
在 restartService 方法的 setTimeout 回调中，使用 c.get("logger") 记录
错误日志。由于 HTTP 响应立即返回，而 setTimeout 回调延迟执行，此时
Context 对象可能已被清理，导致错误日志无法正确记录。

修改为使用类实例的 this.logger，其生命周期与对象一致，不会因请求
结束而失效。

修复问题: #2720

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2720