### PR TITLE
refactor(frontend): split ApiClient into single-responsibility API clients

### DIFF
--- a/apps/frontend/src/services/api-clients/config-api.ts
+++ b/apps/frontend/src/services/api-clients/config-api.ts
@@ -1,0 +1,224 @@
+/**
+ * 配置管理 API 客户端
+ * 负责所有配置相关的操作
+ */
+
+import type { AppConfig } from "@xiaozhi-client/shared-types";
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * 提示词文件信息接口
+ */
+export interface PromptFileInfo {
+  /** 文件名 */
+  fileName: string;
+  /** 相对路径（相对于配置文件所在目录） */
+  relativePath: string;
+}
+
+/**
+ * 配置管理 API 客户端
+ */
+export class ConfigApiClient extends HttpClient {
+  /**
+   * 获取完整配置
+   */
+  async getConfig(): Promise<AppConfig> {
+    const response: ApiResponse<AppConfig> = await this.request("/api/config");
+    if (!response.success || !response.data) {
+      throw new Error("获取配置失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 更新配置
+   */
+  async updateConfig(config: AppConfig): Promise<void> {
+    const response: ApiResponse = await this.request("/api/config", {
+      method: "PUT",
+      body: JSON.stringify(config),
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "配置更新失败");
+    }
+  }
+
+  /**
+   * 获取 MCP 端点
+   */
+  async getMcpEndpoint(): Promise<string> {
+    const response: ApiResponse<{ endpoint: string }> = await this.request(
+      "/api/config/mcp-endpoint"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取 MCP 端点失败");
+    }
+    return response.data.endpoint;
+  }
+
+  /**
+   * 获取 MCP 端点列表
+   */
+  async getMcpEndpoints(): Promise<string[]> {
+    const response: ApiResponse<{ endpoints: string[] }> = await this.request(
+      "/api/config/mcp-endpoints"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取 MCP 端点列表失败");
+    }
+    return response.data.endpoints;
+  }
+
+  /**
+   * 获取 MCP 服务配置
+   */
+  async getMcpServers(): Promise<Record<string, any>> {
+    const response: ApiResponse<{ servers: Record<string, any> }> =
+      await this.request("/api/config/mcp-servers");
+    if (!response.success || !response.data) {
+      throw new Error("获取 MCP 服务配置失败");
+    }
+    return response.data.servers;
+  }
+
+  /**
+   * 获取连接配置
+   */
+  async getConnectionConfig(): Promise<any> {
+    const response: ApiResponse<{ connection: any }> = await this.request(
+      "/api/config/connection"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取连接配置失败");
+    }
+    return response.data.connection;
+  }
+
+  /**
+   * 重新加载配置
+   */
+  async reloadConfig(): Promise<AppConfig> {
+    const response: ApiResponse<AppConfig> = await this.request(
+      "/api/config/reload",
+      { method: "POST" }
+    );
+    if (!response.success || !response.data) {
+      throw new Error("重新加载配置失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取配置文件路径
+   */
+  async getConfigPath(): Promise<string> {
+    const response: ApiResponse<{ path: string }> =
+      await this.request("/api/config/path");
+    if (!response.success || !response.data) {
+      throw new Error("获取配置文件路径失败");
+    }
+    return response.data.path;
+  }
+
+  /**
+   * 检查配置是否存在
+   */
+  async checkConfigExists(): Promise<boolean> {
+    const response: ApiResponse<{ exists: boolean }> =
+      await this.request("/api/config/exists");
+    if (!response.success || response.data?.exists === undefined) {
+      throw new Error("检查配置是否存在失败");
+    }
+    return response.data.exists;
+  }
+
+  /**
+   * 获取提示词文件列表
+   */
+  async getPromptFiles(): Promise<PromptFileInfo[]> {
+    const response: ApiResponse<{ prompts: PromptFileInfo[] }> =
+      await this.request("/api/config/prompts");
+    if (!response.success || !response.data) {
+      throw new Error("获取提示词文件列表失败");
+    }
+    return response.data.prompts;
+  }
+
+  /**
+   * 获取提示词文件内容
+   */
+  async getPromptFileContent(
+    path: string
+  ): Promise<{ fileName: string; relativePath: string; content: string }> {
+    const response: ApiResponse<{
+      fileName: string;
+      relativePath: string;
+      content: string;
+    }> = await this.request(
+      `/api/config/prompts/content?path=${encodeURIComponent(path)}`
+    );
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取提示词文件内容失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 更新提示词文件内容
+   */
+  async updatePromptFileContent(
+    path: string,
+    content: string
+  ): Promise<{ fileName: string; relativePath: string; content: string }> {
+    const response: ApiResponse<{
+      fileName: string;
+      relativePath: string;
+      content: string;
+    }> = await this.request("/api/config/prompts/content", {
+      method: "PUT",
+      body: JSON.stringify({ path, content }),
+    });
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "更新提示词文件内容失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 创建新的提示词文件
+   */
+  async createPromptFile(
+    fileName: string,
+    content: string
+  ): Promise<{ fileName: string; relativePath: string; content: string }> {
+    const response: ApiResponse<{
+      fileName: string;
+      relativePath: string;
+      content: string;
+    }> = await this.request("/api/config/prompts/content", {
+      method: "POST",
+      body: JSON.stringify({ fileName, content }),
+    });
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "创建提示词文件失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 删除提示词文件
+   */
+  async deletePromptFile(path: string): Promise<void> {
+    const response: ApiResponse = await this.request(
+      `/api/config/prompts/content?path=${encodeURIComponent(path)}`,
+      {
+        method: "DELETE",
+      }
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || "删除提示词文件失败");
+    }
+  }
+}

--- a/apps/frontend/src/services/api-clients/endpoint-api.ts
+++ b/apps/frontend/src/services/api-clients/endpoint-api.ts
@@ -1,0 +1,110 @@
+/**
+ * 端点管理 API 客户端
+ * 负责所有 MCP 端点相关的操作
+ */
+
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * 接入点状态响应接口
+ */
+export interface EndpointStatusResponse {
+  endpoint: string;
+  connected: boolean;
+  initialized: boolean;
+  isReconnecting: boolean;
+  reconnectAttempts: number;
+  nextReconnectTime?: number;
+  reconnectDelay: number;
+}
+
+/**
+ * 端点管理 API 客户端
+ */
+export class EndpointApiClient extends HttpClient {
+  /**
+   * 获取接入点状态
+   */
+  async getEndpointStatus(endpoint: string): Promise<EndpointStatusResponse> {
+    const response: ApiResponse<EndpointStatusResponse> = await this.request(
+      "/api/endpoint/status",
+      {
+        method: "POST",
+        body: JSON.stringify({ endpoint }),
+      }
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取接入点状态失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 连接接入点
+   */
+  async connectEndpoint(endpoint: string): Promise<void> {
+    const response: ApiResponse = await this.request("/api/endpoint/connect", {
+      method: "POST",
+      body: JSON.stringify({ endpoint }),
+    });
+    if (!response.success) {
+      throw new Error(response.error?.message || "连接接入点失败");
+    }
+  }
+
+  /**
+   * 断开接入点
+   */
+  async disconnectEndpoint(endpoint: string): Promise<void> {
+    const response: ApiResponse = await this.request(
+      "/api/endpoint/disconnect",
+      { method: "POST", body: JSON.stringify({ endpoint }) }
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || "断开接入点失败");
+    }
+  }
+
+  /**
+   * 重连接入点
+   */
+  async reconnectEndpoint(endpoint: string): Promise<void> {
+    const response: ApiResponse = await this.request(
+      "/api/endpoint/reconnect",
+      { method: "POST", body: JSON.stringify({ endpoint }) }
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || "重连接入点失败");
+    }
+  }
+
+  /**
+   * 添加新接入点
+   */
+  async addEndpoint(endpoint: string): Promise<EndpointStatusResponse> {
+    const response: ApiResponse<EndpointStatusResponse> = await this.request(
+      "/api/endpoint/add",
+      {
+        method: "POST",
+        body: JSON.stringify({ endpoint }),
+      }
+    );
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "添加接入点失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 移除接入点
+   */
+  async removeEndpoint(endpoint: string): Promise<void> {
+    const response: ApiResponse = await this.request("/api/endpoint/remove", {
+      method: "POST",
+      body: JSON.stringify({ endpoint }),
+    });
+    if (!response.success) {
+      throw new Error(response.error?.message || "移除接入点失败");
+    }
+  }
+}

--- a/apps/frontend/src/services/api-clients/http-client.ts
+++ b/apps/frontend/src/services/api-clients/http-client.ts
@@ -1,0 +1,75 @@
+/**
+ * HTTP 客户端基类
+ * 为所有 API 客户端提供统一的 HTTP 请求方法
+ */
+
+import type { ApiErrorResponse } from "@xiaozhi-client/shared-types";
+
+/**
+ * API 响应格式
+ */
+interface ApiResponse<T = any> {
+  success: boolean;
+  data?: T;
+  error?: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+}
+
+/**
+ * HTTP 客户端基类
+ */
+export class HttpClient {
+  protected baseUrl: string;
+
+  constructor(baseUrl?: string) {
+    // 从当前页面 URL 推断 API 基础 URL
+    if (baseUrl) {
+      this.baseUrl = baseUrl;
+    } else {
+      const protocol = window.location.protocol;
+      const hostname = window.location.hostname;
+      const port = window.location.port;
+      this.baseUrl = `${protocol}//${hostname}${port ? `:${port}` : ""}`;
+    }
+  }
+
+  /**
+   * 通用请求方法
+   */
+  protected async request<T>(
+    endpoint: string,
+    options: RequestInit = {}
+  ): Promise<T> {
+    const url = `${this.baseUrl}${endpoint}`;
+
+    const defaultOptions: RequestInit = {
+      headers: {
+        "Content-Type": "application/json",
+        ...options.headers,
+      },
+    };
+
+    const response = await fetch(url, { ...defaultOptions, ...options });
+
+    if (!response.ok) {
+      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+
+      try {
+        const errorData: ApiErrorResponse = await response.json();
+        errorMessage = errorData.error?.message || errorMessage;
+      } catch {
+        // 如果无法解析错误响应，使用默认错误消息
+      }
+
+      throw new Error(errorMessage);
+    }
+
+    return response.json();
+  }
+}
+
+// 导出 API 响应格式供其他客户端使用
+export type { ApiResponse };

--- a/apps/frontend/src/services/api-clients/index.ts
+++ b/apps/frontend/src/services/api-clients/index.ts
@@ -1,0 +1,35 @@
+/**
+ * API 客户端模块统一导出
+ * 提供独立的 API 客户端类，遵循单一职责原则
+ */
+
+export { HttpClient } from "./http-client";
+export type { ApiResponse } from "./http-client";
+
+export { ConfigApiClient } from "./config-api";
+export type { PromptFileInfo } from "./config-api";
+
+export { StatusApiClient } from "./status-api";
+export type { RestartStatus, FullStatus } from "./status-api";
+
+export { ToolApiClient } from "./tool-api";
+export type { CustomMCPTool } from "./tool-api";
+
+export { ServiceControlApiClient } from "./service-api";
+export type { ServiceStatus, ServiceHealth } from "./service-api";
+
+export { VersionApiClient } from "./version-api";
+export type { VersionInfo } from "./version-api";
+
+export { EndpointApiClient } from "./endpoint-api";
+export type { EndpointStatusResponse } from "./endpoint-api";
+
+export { MCPServerApiClient } from "./mcp-server-api";
+
+export { MCPToolApiClient } from "./mcp-tool-api";
+export type {
+  MCPToolManageRequest,
+  MCPToolManageResponse,
+  MCPToolListRequest,
+  MCPToolListResponse,
+} from "./mcp-tool-api";

--- a/apps/frontend/src/services/api-clients/mcp-server-api.ts
+++ b/apps/frontend/src/services/api-clients/mcp-server-api.ts
@@ -1,0 +1,185 @@
+/**
+ * MCP 服务器管理 API 客户端
+ * 负责所有 MCP 服务器相关的操作
+ */
+
+import type {
+  MCPServerAddRequest,
+  MCPServerConfig,
+  MCPServerListResponse,
+  MCPServerStatus,
+} from "@xiaozhi-client/shared-types";
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * MCP 服务器管理 API 客户端
+ */
+export class MCPServerApiClient extends HttpClient {
+  /**
+   * 添加 MCP 服务器
+   * POST /api/mcp-servers
+   */
+  async addMCPServer(
+    name: string,
+    config: MCPServerConfig
+  ): Promise<MCPServerStatus> {
+    const requestData: MCPServerAddRequest = { name, config };
+
+    const response: ApiResponse<MCPServerStatus> = await this.request(
+      "/api/mcp-servers",
+      {
+        method: "POST",
+        body: JSON.stringify(requestData),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "添加 MCP 服务器失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 删除 MCP 服务器
+   * DELETE /api/mcp-servers/:serverName
+   */
+  async removeMCPServer(
+    serverName: string
+  ): Promise<{ name: string; operation: string; affectedTools: string[] }> {
+    const response: ApiResponse<{
+      name: string;
+      operation: string;
+      affectedTools: string[];
+    }> = await this.request(
+      `/api/mcp-servers/${encodeURIComponent(serverName)}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "删除 MCP 服务器失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 获取 MCP 服务器状态
+   * GET /api/mcp-servers/:serverName/status
+   */
+  async getMCPServerStatus(serverName: string): Promise<MCPServerStatus> {
+    const response: ApiResponse<MCPServerStatus> = await this.request(
+      `/api/mcp-servers/${encodeURIComponent(serverName)}/status`
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取 MCP 服务器状态失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 获取所有 MCP 服务器列表
+   * GET /api/mcp-servers
+   */
+  async listMCPServers(): Promise<MCPServerListResponse> {
+    const response: ApiResponse<MCPServerListResponse> =
+      await this.request("/api/mcp-servers");
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取 MCP 服务器列表失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 检查 MCP 服务器是否存在
+   * GET /api/mcp-servers/:serverName/exists
+   */
+  async checkMCPServerExists(serverName: string): Promise<boolean> {
+    try {
+      const response: ApiResponse<{ exists: boolean }> = await this.request(
+        `/api/mcp-servers/${encodeURIComponent(serverName)}/exists`
+      );
+
+      return response.success ? response.data?.exists || false : false;
+    } catch (error) {
+      // 如果返回 404，说明服务器不存在
+      if (error instanceof Error && error.message.includes("404")) {
+        return false;
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务器配置
+   * PUT /api/mcp-servers/:serverName
+   */
+  async updateMCPServer(
+    serverName: string,
+    config: MCPServerConfig
+  ): Promise<MCPServerStatus> {
+    const response: ApiResponse<MCPServerStatus> = await this.request(
+      `/api/mcp-servers/${encodeURIComponent(serverName)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify({ config }),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "更新 MCP 服务器配置失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 调用 MCP 工具
+   * POST /api/tools/call
+   */
+  async callTool(
+    serviceName: string,
+    toolName: string,
+    args: any = {}
+  ): Promise<any> {
+    const response: ApiResponse = await this.request("/api/tools/call", {
+      method: "POST",
+      body: JSON.stringify({
+        serviceName,
+        toolName,
+        args,
+      }),
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "调用工具失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 重启 MCP 服务器
+   * POST /api/mcp-servers/:serverName/restart
+   */
+  async restartMCPServer(serverName: string): Promise<MCPServerStatus> {
+    const response: ApiResponse<MCPServerStatus> = await this.request(
+      `/api/mcp-servers/${encodeURIComponent(serverName)}/restart`,
+      {
+        method: "POST",
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "重启 MCP 服务器失败");
+    }
+
+    return response.data;
+  }
+}

--- a/apps/frontend/src/services/api-clients/mcp-tool-api.ts
+++ b/apps/frontend/src/services/api-clients/mcp-tool-api.ts
@@ -1,0 +1,111 @@
+/**
+ * MCP 工具管理 API 客户端
+ * 负责 MCP 工具的启用、禁用、列表查询等操作
+ */
+
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * MCP 工具管理操作类型
+ */
+type MCPToolManageAction = "enable" | "disable" | "status" | "toggle";
+
+/**
+ * MCP 工具管理请求接口
+ */
+export interface MCPToolManageRequest {
+  action: MCPToolManageAction;
+  serverName: string;
+  toolName: string;
+  description?: string;
+}
+
+/**
+ * MCP 工具管理响应接口
+ */
+export interface MCPToolManageResponse {
+  serverName: string;
+  toolName: string;
+  enabled: boolean;
+  description?: string;
+  usageCount?: number;
+  lastUsedTime?: string;
+}
+
+/**
+ * MCP 工具列表请求接口
+ */
+export interface MCPToolListRequest {
+  serverName?: string;
+  includeUsageStats?: boolean;
+}
+
+/**
+ * MCP 工具列表响应接口
+ */
+export interface MCPToolListResponse {
+  serverName?: string;
+  tools: Array<{
+    toolName: string;
+    enabled: boolean;
+    description?: string;
+    usageCount?: number;
+    lastUsedTime?: string;
+  }>;
+  total: number;
+  enabledCount: number;
+  disabledCount: number;
+}
+
+/**
+ * MCP 工具管理 API 客户端
+ */
+export class MCPToolApiClient extends HttpClient {
+  /**
+   * 管理 MCP 工具（启用/禁用/查询状态/切换）
+   * POST /api/tools/mcp/manage
+   * @param request 管理请求
+   * @returns 工具状态信息
+   */
+  async manageMCPTool(
+    request: MCPToolManageRequest
+  ): Promise<MCPToolManageResponse> {
+    const response: ApiResponse<MCPToolManageResponse> = await this.request(
+      "/api/tools/mcp/manage",
+      {
+        method: "POST",
+        body: JSON.stringify(request),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "MCP 工具管理操作失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 获取 MCP 工具列表
+   * POST /api/tools/mcp/list
+   * @param request 列表请求（可选）
+   * @returns 工具列表信息
+   */
+  async listMCPTools(
+    request?: MCPToolListRequest
+  ): Promise<MCPToolListResponse> {
+    const response: ApiResponse<MCPToolListResponse> = await this.request(
+      "/api/tools/mcp/list",
+      {
+        method: "POST",
+        body: JSON.stringify(request || {}),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取 MCP 工具列表失败");
+    }
+
+    return response.data;
+  }
+}

--- a/apps/frontend/src/services/api-clients/service-api.ts
+++ b/apps/frontend/src/services/api-clients/service-api.ts
@@ -1,0 +1,102 @@
+/**
+ * 服务控制 API 客户端
+ * 负责所有服务启动、停止、重启和状态查询操作
+ */
+
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * 服务状态接口
+ */
+export interface ServiceStatus {
+  running: boolean;
+  mode?: string;
+  pid?: number;
+}
+
+/**
+ * 服务健康状态接口
+ */
+export interface ServiceHealth {
+  status: string;
+  timestamp: number;
+  uptime: number;
+  memory: {
+    rss: number;
+    heapTotal: number;
+    heapUsed: number;
+    external: number;
+    arrayBuffers: number;
+  };
+  version: string;
+}
+
+/**
+ * 服务控制 API 客户端
+ */
+export class ServiceControlApiClient extends HttpClient {
+  /**
+   * 重启服务
+   */
+  async restartService(): Promise<void> {
+    const response: ApiResponse = await this.request("/api/services/restart", {
+      method: "POST",
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "重启服务失败");
+    }
+  }
+
+  /**
+   * 停止服务
+   */
+  async stopService(): Promise<void> {
+    const response: ApiResponse = await this.request("/api/services/stop", {
+      method: "POST",
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "停止服务失败");
+    }
+  }
+
+  /**
+   * 启动服务
+   */
+  async startService(): Promise<void> {
+    const response: ApiResponse = await this.request("/api/services/start", {
+      method: "POST",
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "启动服务失败");
+    }
+  }
+
+  /**
+   * 获取服务状态
+   */
+  async getServiceStatus(): Promise<ServiceStatus> {
+    const response: ApiResponse<ServiceStatus> = await this.request(
+      "/api/services/status"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取服务状态失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取服务健康状态
+   */
+  async getServiceHealth(): Promise<ServiceHealth> {
+    const response: ApiResponse<ServiceHealth> = await this.request(
+      "/api/services/health"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取服务健康状态失败");
+    }
+    return response.data;
+  }
+}

--- a/apps/frontend/src/services/api-clients/status-api.ts
+++ b/apps/frontend/src/services/api-clients/status-api.ts
@@ -1,0 +1,148 @@
+/**
+ * 状态管理 API 客户端
+ * 负责所有状态查询和更新操作
+ */
+
+import type { ClientStatus } from "@xiaozhi-client/shared-types";
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * 重启状态接口
+ */
+export interface RestartStatus {
+  status: "restarting" | "completed" | "failed";
+  error?: string;
+  timestamp: number;
+}
+
+/**
+ * 完整状态接口
+ */
+export interface FullStatus {
+  client: ClientStatus;
+  restart?: RestartStatus;
+  timestamp: number;
+}
+
+/**
+ * 状态管理 API 客户端
+ */
+export class StatusApiClient extends HttpClient {
+  /**
+   * 获取完整状态
+   */
+  async getStatus(): Promise<FullStatus> {
+    const response: ApiResponse<FullStatus> = await this.request("/api/status");
+    if (!response.success || !response.data) {
+      throw new Error("获取状态失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取客户端状态
+   */
+  async getClientStatus(): Promise<ClientStatus> {
+    const response: ApiResponse<ClientStatus> =
+      await this.request("/api/status/client");
+    if (!response.success || !response.data) {
+      throw new Error("获取客户端状态失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取重启状态
+   */
+  async getRestartStatus(): Promise<RestartStatus | null> {
+    const response: ApiResponse<RestartStatus> = await this.request(
+      "/api/status/restart"
+    );
+    if (!response.success) {
+      throw new Error("获取重启状态失败");
+    }
+    return response.data || null;
+  }
+
+  /**
+   * 检查客户端是否连接
+   */
+  async checkClientConnected(): Promise<boolean> {
+    const response: ApiResponse<{ connected: boolean }> = await this.request(
+      "/api/status/connected"
+    );
+    if (!response.success || response.data?.connected === undefined) {
+      throw new Error("检查客户端连接失败");
+    }
+    return response.data.connected;
+  }
+
+  /**
+   * 获取最后心跳时间
+   */
+  async getLastHeartbeat(): Promise<number | null> {
+    const response: ApiResponse<{ lastHeartbeat?: number }> =
+      await this.request("/api/status/heartbeat");
+    if (!response.success) {
+      throw new Error("获取最后心跳时间失败");
+    }
+    return response.data?.lastHeartbeat || null;
+  }
+
+  /**
+   * 获取活跃的 MCP 服务器列表
+   */
+  async getActiveMCPServers(): Promise<string[]> {
+    const response: ApiResponse<{ servers: string[] }> = await this.request(
+      "/api/status/mcp-servers"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取活跃 MCP 服务器失败");
+    }
+    return response.data.servers;
+  }
+
+  /**
+   * 更新客户端状态
+   */
+  async updateClientStatus(status: Partial<ClientStatus>): Promise<void> {
+    const response: ApiResponse = await this.request("/api/status/client", {
+      method: "PUT",
+      body: JSON.stringify(status),
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "更新客户端状态失败");
+    }
+  }
+
+  /**
+   * 设置活跃的 MCP 服务器列表
+   */
+  async setActiveMCPServers(servers: string[]): Promise<void> {
+    const response: ApiResponse = await this.request(
+      "/api/status/mcp-servers",
+      {
+        method: "PUT",
+        body: JSON.stringify({ servers }),
+      }
+    );
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "设置活跃 MCP 服务器失败");
+    }
+  }
+
+  /**
+   * 重置状态
+   */
+  async resetStatus(): Promise<void> {
+    const response: ApiResponse = await this.request("/api/status/reset", {
+      method: "POST",
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "重置状态失败");
+    }
+  }
+}

--- a/apps/frontend/src/services/api-clients/tool-api.ts
+++ b/apps/frontend/src/services/api-clients/tool-api.ts
@@ -1,0 +1,168 @@
+/**
+ * 工具管理 API 客户端
+ * 负责所有自定义工具相关的操作
+ */
+
+import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * CustomMCPTool 接口定义
+ * 使用共享类型，与后端保持一致
+ */
+export type CustomMCPTool = CustomMCPToolWithStats;
+
+/**
+ * 工具管理 API 客户端
+ */
+export class ToolApiClient extends HttpClient {
+  /**
+   * 添加自定义工具
+   * 支持新的类型化格式和向后兼容的旧格式
+   */
+  async addCustomTool(
+    workflow: any,
+    customName?: string,
+    customDescription?: string,
+    parameterConfig?: any
+  ): Promise<any>;
+
+  /**
+   * 添加自定义工具（新格式）
+   * 支持多种工具类型：MCP 工具、Coze 工作流等
+   */
+  async addCustomTool(request: {
+    type: "mcp" | "coze" | "http" | "function";
+    data: any;
+  }): Promise<any>;
+
+  async addCustomTool(
+    param1: any,
+    customName?: string,
+    customDescription?: string,
+    parameterConfig?: any
+  ): Promise<any> {
+    // 判断是否为新格式调用
+    if (typeof param1 === "object" && "type" in param1 && "data" in param1) {
+      // 新格式：类型化请求
+      const response: ApiResponse<{ tool: any }> = await this.request(
+        "/api/tools/custom",
+        {
+          method: "POST",
+          body: JSON.stringify(param1),
+        }
+      );
+
+      if (!response.success || !response.data) {
+        throw new Error(response.error?.message || "添加自定义工具失败");
+      }
+      return response.data.tool;
+    }
+    // 旧格式：向后兼容
+    const workflow = param1;
+    const response: ApiResponse<{ tool: any }> = await this.request(
+      "/api/tools/custom",
+      {
+        method: "POST",
+        body: JSON.stringify({
+          workflow,
+          customName,
+          customDescription,
+          parameterConfig,
+        }),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "添加自定义工具失败");
+    }
+    return response.data.tool;
+  }
+
+  /**
+   * 更新自定义工具配置
+   * @param toolName 工具名称
+   * @param updateRequest 更新请求
+   */
+  async updateCustomTool(
+    toolName: string,
+    updateRequest: {
+      type: "mcp" | "coze" | "http" | "function";
+      data: any;
+    }
+  ): Promise<any> {
+    const response: ApiResponse<{ tool: any }> = await this.request(
+      `/api/tools/custom/${encodeURIComponent(toolName)}`,
+      {
+        method: "PUT",
+        body: JSON.stringify(updateRequest),
+      }
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "更新自定义工具失败");
+    }
+    return response.data.tool;
+  }
+
+  /**
+   * 删除自定义工具
+   */
+  async removeCustomTool(toolName: string): Promise<void> {
+    const response: ApiResponse = await this.request(
+      `/api/tools/custom/${encodeURIComponent(toolName)}`,
+      {
+        method: "DELETE",
+      }
+    );
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "删除自定义工具失败");
+    }
+  }
+
+  /**
+   * 获取自定义工具列表
+   */
+  async getCustomTools(): Promise<any[]> {
+    const response: ApiResponse<{ tools: any[] }> =
+      await this.request("/api/tools/custom");
+    if (!response.success || !response.data) {
+      throw new Error("获取自定义工具列表失败");
+    }
+    return response.data.tools;
+  }
+
+  /**
+   * 获取工具列表
+   * 调用 /api/tools/list 端点，返回 { list: CustomMCPTool[], total: number } 格式
+   * @param status 筛选状态：'enabled'（已启用）、'disabled'（未启用）、'all'（全部，默认）
+   * @param sortConfig 排序配置：可选的排序字段
+   */
+  async getToolsList(
+    status: "enabled" | "disabled" | "all" = "all",
+    sortConfig?: { field: string }
+  ): Promise<CustomMCPToolWithStats[]> {
+    // 构建查询参数
+    const queryParams = new URLSearchParams();
+    if (status !== "all") {
+      queryParams.append("status", status);
+    }
+
+    // 添加排序参数
+    if (sortConfig) {
+      queryParams.append("sortBy", sortConfig.field);
+    }
+
+    const url = `/api/tools/list${
+      queryParams.toString() ? `?${queryParams.toString()}` : ""
+    }`;
+
+    const response: ApiResponse<{ list: CustomMCPTool[]; total: number }> =
+      await this.request(url);
+    if (!response.success || !response.data) {
+      throw new Error("获取工具列表失败");
+    }
+    return response.data.list;
+  }
+}

--- a/apps/frontend/src/services/api-clients/version-api.ts
+++ b/apps/frontend/src/services/api-clients/version-api.ts
@@ -1,0 +1,146 @@
+/**
+ * 版本信息 API 客户端
+ * 负责所有版本信息和更新相关的操作
+ */
+
+import type { VoicesResponse } from "@xiaozhi-client/shared-types";
+import { type ApiResponse, HttpClient } from "./http-client";
+
+/**
+ * 版本信息接口
+ */
+export interface VersionInfo {
+  name: string;
+  version: string;
+  description: string;
+  author: string;
+}
+
+/**
+ * 版本信息 API 客户端
+ */
+export class VersionApiClient extends HttpClient {
+  /**
+   * 获取 TTS 音色列表
+   */
+  async getTTSVoices(): Promise<VoicesResponse> {
+    const response: ApiResponse<VoicesResponse> =
+      await this.request("/api/tts/voices");
+    if (!response.success || !response.data) {
+      throw new Error("获取音色列表失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取版本信息
+   */
+  async getVersion(): Promise<VersionInfo> {
+    const response: ApiResponse<VersionInfo> =
+      await this.request("/api/version");
+    if (!response.success || !response.data) {
+      throw new Error("获取版本信息失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取版本号（简化接口）
+   */
+  async getVersionSimple(): Promise<{ version: string }> {
+    const response: ApiResponse<{ version: string }> = await this.request(
+      "/api/version/simple"
+    );
+    if (!response.success || !response.data) {
+      throw new Error("获取版本号失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 获取可用版本列表
+   * @param type 版本类型：'stable'（正式版）、'rc'（预览版）、'beta'（测试版）、'all'（全部）
+   */
+  async getAvailableVersions(
+    type: "stable" | "rc" | "beta" | "all" = "stable"
+  ): Promise<{
+    versions: string[];
+    type: string;
+    total: number;
+  }> {
+    // 构建查询参数
+    const queryParams = new URLSearchParams();
+    if (type !== "stable") {
+      queryParams.append("type", type);
+    }
+
+    const url = `/api/version/available${
+      queryParams.toString() ? `?${queryParams.toString()}` : ""
+    }`;
+
+    const response: ApiResponse<{
+      versions: string[];
+      type: string;
+      total: number;
+    }> = await this.request(url);
+    if (!response.success || !response.data) {
+      throw new Error("获取可用版本列表失败");
+    }
+    return response.data;
+  }
+
+  /**
+   * 检查最新版本
+   * 返回当前版本、最新版本以及是否有更新
+   */
+  async getLatestVersion(): Promise<{
+    currentVersion: string;
+    latestVersion: string | null;
+    hasUpdate: boolean;
+    error?: string;
+  }> {
+    const response: ApiResponse<{
+      currentVersion: string;
+      latestVersion: string | null;
+      hasUpdate: boolean;
+      error?: string;
+    }> = await this.request("/api/version/latest");
+
+    if (!response.success || !response.data) {
+      throw new Error("检查最新版本失败");
+    }
+
+    return response.data;
+  }
+
+  /**
+   * 清除版本缓存
+   */
+  async clearVersionCache(): Promise<void> {
+    const response: ApiResponse = await this.request(
+      "/api/version/cache/clear",
+      {
+        method: "POST",
+      }
+    );
+    if (!response.success) {
+      throw new Error(response.error?.message || "清除版本缓存失败");
+    }
+  }
+
+  /**
+   * 更新版本
+   */
+  async updateVersion(version: string): Promise<any> {
+    const response: ApiResponse = await this.request("/api/update", {
+      method: "POST",
+      body: JSON.stringify({ version }),
+    });
+
+    if (!response.success) {
+      throw new Error(response.error?.message || "版本更新失败");
+    }
+
+    return response.data;
+  }
+}

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -1,6 +1,12 @@
 /**
  * 统一的 HTTP API 客户端
  * 负责所有的配置管理、状态查询和服务控制操作
+ *
+ * @deprecated 推荐直接使用具体的 API 客户端类
+ * @example
+ * import { ConfigApiClient, StatusApiClient } from './services/api-clients';
+ * const configClient = new ConfigApiClient();
+ * const statusClient = new StatusApiClient();
  */
 
 import type {
@@ -17,15 +23,62 @@ import type {
   VoicesResponse,
 } from "@xiaozhi-client/shared-types";
 
-/**
- * CustomMCPTool 接口定义
- * 使用共享类型，与后端保持一致
- * CustomMCPTool 是 CustomMCPToolWithStats 的别名
- */
-export type CustomMCPTool = CustomMCPToolWithStats;
+import {
+  ConfigApiClient,
+  type CustomMCPTool,
+  EndpointApiClient,
+  type EndpointStatusResponse,
+  type FullStatus,
+  MCPServerApiClient,
+  MCPToolApiClient,
+  type MCPToolListRequest,
+  type MCPToolListResponse,
+  type MCPToolManageRequest,
+  type MCPToolManageResponse,
+  type PromptFileInfo,
+  type RestartStatus,
+  ServiceControlApiClient,
+  type ServiceHealth,
+  type ServiceStatus,
+  StatusApiClient,
+  ToolApiClient,
+  VersionApiClient,
+  type VersionInfo,
+} from "./api-clients";
+
+// 重新导出所有类型以保持向后兼容
+export type {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+  AppConfig,
+  ClientStatus,
+  CustomMCPToolWithStats,
+  MCPErrorCode,
+  MCPServerAddRequest,
+  MCPServerConfig,
+  MCPServerListResponse,
+  MCPServerStatus,
+  VoicesResponse,
+};
+
+// 重新导出 API 客户端类型
+export type {
+  PromptFileInfo,
+  RestartStatus,
+  FullStatus,
+  VersionInfo,
+  EndpointStatusResponse,
+  ServiceStatus,
+  ServiceHealth,
+  CustomMCPTool,
+  MCPToolManageRequest,
+  MCPToolManageResponse,
+  MCPToolListRequest,
+  MCPToolListResponse,
+};
 
 /**
- * API 响应格式
+ * API 响应格式（向后兼容）
  */
 interface ApiResponse<T = any> {
   success: boolean;
@@ -38,184 +91,31 @@ interface ApiResponse<T = any> {
 }
 
 /**
- * 服务状态接口
- */
-interface ServiceStatus {
-  running: boolean;
-  mode?: string;
-  pid?: number;
-}
-
-/**
- * 服务健康状态接口
- */
-interface ServiceHealth {
-  status: string;
-  timestamp: number;
-  uptime: number;
-  memory: {
-    rss: number;
-    heapTotal: number;
-    heapUsed: number;
-    external: number;
-    arrayBuffers: number;
-  };
-  version: string;
-}
-
-/**
- * 版本信息接口
- */
-interface VersionInfo {
-  name: string;
-  version: string;
-  description: string;
-  author: string;
-}
-
-/**
- * 提示词文件信息接口
- */
-export interface PromptFileInfo {
-  /** 文件名 */
-  fileName: string;
-  /** 相对路径（相对于配置文件所在目录） */
-  relativePath: string;
-}
-
-/**
- * 重启状态接口
- */
-interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-}
-
-/**
- * 接入点状态响应接口
- */
-interface EndpointStatusResponse {
-  endpoint: string;
-  connected: boolean;
-  initialized: boolean;
-  isReconnecting: boolean;
-  reconnectAttempts: number;
-  nextReconnectTime?: number;
-  reconnectDelay: number;
-}
-
-/**
- * 完整状态接口
- */
-interface FullStatus {
-  client: ClientStatus;
-  restart?: RestartStatus;
-  timestamp: number;
-}
-
-/**
- * MCP 工具管理操作类型
- */
-type MCPToolManageAction = "enable" | "disable" | "status" | "toggle";
-
-/**
- * MCP 工具管理请求接口
- */
-interface MCPToolManageRequest {
-  action: MCPToolManageAction;
-  serverName: string;
-  toolName: string;
-  description?: string;
-}
-
-/**
- * MCP 工具管理响应接口
- */
-interface MCPToolManageResponse {
-  serverName: string;
-  toolName: string;
-  enabled: boolean;
-  description?: string;
-  usageCount?: number;
-  lastUsedTime?: string;
-}
-
-/**
- * MCP 工具列表请求接口
- */
-interface MCPToolListRequest {
-  serverName?: string;
-  includeUsageStats?: boolean;
-}
-
-/**
- * MCP 工具列表响应接口
- */
-interface MCPToolListResponse {
-  serverName?: string;
-  tools: Array<{
-    toolName: string;
-    enabled: boolean;
-    description?: string;
-    usageCount?: number;
-    lastUsedTime?: string;
-  }>;
-  total: number;
-  enabledCount: number;
-  disabledCount: number;
-}
-
-/**
- * HTTP API 客户端类
+ * 统一的 API 客户端门面类
+ * 将所有 API 客户端组合在一起，提供向后兼容的接口
+ *
+ * @deprecated 推荐直接使用具体的 API 客户端类
+ * @see {@link ./api-clients/index.ts} 获取独立的 API 客户端类
  */
 export class ApiClient {
-  private baseUrl: string;
+  private config: ConfigApiClient;
+  private status: StatusApiClient;
+  private tool: ToolApiClient;
+  private service: ServiceControlApiClient;
+  private version: VersionApiClient;
+  private endpoint: EndpointApiClient;
+  private mcpServer: MCPServerApiClient;
+  private mcpTool: MCPToolApiClient;
 
   constructor(baseUrl?: string) {
-    // 从当前页面 URL 推断 API 基础 URL
-    if (baseUrl) {
-      this.baseUrl = baseUrl;
-    } else {
-      const protocol = window.location.protocol;
-      const hostname = window.location.hostname;
-      const port = window.location.port;
-      this.baseUrl = `${protocol}//${hostname}${port ? `:${port}` : ""}`;
-    }
-  }
-
-  /**
-   * 通用请求方法
-   */
-  private async request<T>(
-    endpoint: string,
-    options: RequestInit = {}
-  ): Promise<T> {
-    const url = `${this.baseUrl}${endpoint}`;
-
-    const defaultOptions: RequestInit = {
-      headers: {
-        "Content-Type": "application/json",
-        ...options.headers,
-      },
-    };
-
-    const response = await fetch(url, { ...defaultOptions, ...options });
-
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
-
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
-      }
-
-      throw new Error(errorMessage);
-    }
-
-    return response.json();
+    this.config = new ConfigApiClient(baseUrl);
+    this.status = new StatusApiClient(baseUrl);
+    this.tool = new ToolApiClient(baseUrl);
+    this.service = new ServiceControlApiClient(baseUrl);
+    this.version = new VersionApiClient(baseUrl);
+    this.endpoint = new EndpointApiClient(baseUrl);
+    this.mcpServer = new MCPServerApiClient(baseUrl);
+    this.mcpTool = new MCPToolApiClient(baseUrl);
   }
 
   // ==================== 配置管理 API ====================
@@ -224,126 +124,70 @@ export class ApiClient {
    * 获取完整配置
    */
   async getConfig(): Promise<AppConfig> {
-    const response: ApiResponse<AppConfig> = await this.request("/api/config");
-    if (!response.success || !response.data) {
-      throw new Error("获取配置失败");
-    }
-    return response.data;
+    return this.config.getConfig();
   }
 
   /**
    * 更新配置
    */
   async updateConfig(config: AppConfig): Promise<void> {
-    const response: ApiResponse = await this.request("/api/config", {
-      method: "PUT",
-      body: JSON.stringify(config),
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "配置更新失败");
-    }
+    return this.config.updateConfig(config);
   }
 
   /**
    * 获取 MCP 端点
    */
   async getMcpEndpoint(): Promise<string> {
-    const response: ApiResponse<{ endpoint: string }> = await this.request(
-      "/api/config/mcp-endpoint"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取 MCP 端点失败");
-    }
-    return response.data.endpoint;
+    return this.config.getMcpEndpoint();
   }
 
   /**
    * 获取 MCP 端点列表
    */
   async getMcpEndpoints(): Promise<string[]> {
-    const response: ApiResponse<{ endpoints: string[] }> = await this.request(
-      "/api/config/mcp-endpoints"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取 MCP 端点列表失败");
-    }
-    return response.data.endpoints;
+    return this.config.getMcpEndpoints();
   }
 
   /**
    * 获取 MCP 服务配置
    */
   async getMcpServers(): Promise<Record<string, any>> {
-    const response: ApiResponse<{ servers: Record<string, any> }> =
-      await this.request("/api/config/mcp-servers");
-    if (!response.success || !response.data) {
-      throw new Error("获取 MCP 服务配置失败");
-    }
-    return response.data.servers;
+    return this.config.getMcpServers();
   }
 
   /**
    * 获取连接配置
    */
   async getConnectionConfig(): Promise<any> {
-    const response: ApiResponse<{ connection: any }> = await this.request(
-      "/api/config/connection"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取连接配置失败");
-    }
-    return response.data.connection;
+    return this.config.getConnectionConfig();
   }
 
   /**
    * 重新加载配置
    */
   async reloadConfig(): Promise<AppConfig> {
-    const response: ApiResponse<AppConfig> = await this.request(
-      "/api/config/reload",
-      { method: "POST" }
-    );
-    if (!response.success || !response.data) {
-      throw new Error("重新加载配置失败");
-    }
-    return response.data;
+    return this.config.reloadConfig();
   }
 
   /**
    * 获取配置文件路径
    */
   async getConfigPath(): Promise<string> {
-    const response: ApiResponse<{ path: string }> =
-      await this.request("/api/config/path");
-    if (!response.success || !response.data) {
-      throw new Error("获取配置文件路径失败");
-    }
-    return response.data.path;
+    return this.config.getConfigPath();
   }
 
   /**
    * 检查配置是否存在
    */
   async checkConfigExists(): Promise<boolean> {
-    const response: ApiResponse<{ exists: boolean }> =
-      await this.request("/api/config/exists");
-    if (!response.success || response.data?.exists === undefined) {
-      throw new Error("检查配置是否存在失败");
-    }
-    return response.data.exists;
+    return this.config.checkConfigExists();
   }
 
   /**
    * 获取提示词文件列表
    */
   async getPromptFiles(): Promise<PromptFileInfo[]> {
-    const response: ApiResponse<{ prompts: PromptFileInfo[] }> =
-      await this.request("/api/config/prompts");
-    if (!response.success || !response.data) {
-      throw new Error("获取提示词文件列表失败");
-    }
-    return response.data.prompts;
+    return this.config.getPromptFiles();
   }
 
   /**
@@ -352,17 +196,7 @@ export class ApiClient {
   async getPromptFileContent(
     path: string
   ): Promise<{ fileName: string; relativePath: string; content: string }> {
-    const response: ApiResponse<{
-      fileName: string;
-      relativePath: string;
-      content: string;
-    }> = await this.request(
-      `/api/config/prompts/content?path=${encodeURIComponent(path)}`
-    );
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "获取提示词文件内容失败");
-    }
-    return response.data;
+    return this.config.getPromptFileContent(path);
   }
 
   /**
@@ -372,18 +206,7 @@ export class ApiClient {
     path: string,
     content: string
   ): Promise<{ fileName: string; relativePath: string; content: string }> {
-    const response: ApiResponse<{
-      fileName: string;
-      relativePath: string;
-      content: string;
-    }> = await this.request("/api/config/prompts/content", {
-      method: "PUT",
-      body: JSON.stringify({ path, content }),
-    });
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "更新提示词文件内容失败");
-    }
-    return response.data;
+    return this.config.updatePromptFileContent(path, content);
   }
 
   /**
@@ -393,33 +216,14 @@ export class ApiClient {
     fileName: string,
     content: string
   ): Promise<{ fileName: string; relativePath: string; content: string }> {
-    const response: ApiResponse<{
-      fileName: string;
-      relativePath: string;
-      content: string;
-    }> = await this.request("/api/config/prompts/content", {
-      method: "POST",
-      body: JSON.stringify({ fileName, content }),
-    });
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "创建提示词文件失败");
-    }
-    return response.data;
+    return this.config.createPromptFile(fileName, content);
   }
 
   /**
    * 删除提示词文件
    */
   async deletePromptFile(path: string): Promise<void> {
-    const response: ApiResponse = await this.request(
-      `/api/config/prompts/content?path=${encodeURIComponent(path)}`,
-      {
-        method: "DELETE",
-      }
-    );
-    if (!response.success) {
-      throw new Error(response.error?.message || "删除提示词文件失败");
-    }
+    return this.config.deletePromptFile(path);
   }
 
   // ==================== 状态管理 API ====================
@@ -428,118 +232,63 @@ export class ApiClient {
    * 获取完整状态
    */
   async getStatus(): Promise<FullStatus> {
-    const response: ApiResponse<FullStatus> = await this.request("/api/status");
-    if (!response.success || !response.data) {
-      throw new Error("获取状态失败");
-    }
-    return response.data;
+    return this.status.getStatus();
   }
 
   /**
    * 获取客户端状态
    */
   async getClientStatus(): Promise<ClientStatus> {
-    const response: ApiResponse<ClientStatus> =
-      await this.request("/api/status/client");
-    if (!response.success || !response.data) {
-      throw new Error("获取客户端状态失败");
-    }
-    return response.data;
+    return this.status.getClientStatus();
   }
 
   /**
    * 获取重启状态
    */
   async getRestartStatus(): Promise<RestartStatus | null> {
-    const response: ApiResponse<RestartStatus> = await this.request(
-      "/api/status/restart"
-    );
-    if (!response.success) {
-      throw new Error("获取重启状态失败");
-    }
-    return response.data || null;
+    return this.status.getRestartStatus();
   }
 
   /**
    * 检查客户端是否连接
    */
   async checkClientConnected(): Promise<boolean> {
-    const response: ApiResponse<{ connected: boolean }> = await this.request(
-      "/api/status/connected"
-    );
-    if (!response.success || response.data?.connected === undefined) {
-      throw new Error("检查客户端连接失败");
-    }
-    return response.data.connected;
+    return this.status.checkClientConnected();
   }
 
   /**
    * 获取最后心跳时间
    */
   async getLastHeartbeat(): Promise<number | null> {
-    const response: ApiResponse<{ lastHeartbeat?: number }> =
-      await this.request("/api/status/heartbeat");
-    if (!response.success) {
-      throw new Error("获取最后心跳时间失败");
-    }
-    return response.data?.lastHeartbeat || null;
+    return this.status.getLastHeartbeat();
   }
 
   /**
    * 获取活跃的 MCP 服务器列表
    */
   async getActiveMCPServers(): Promise<string[]> {
-    const response: ApiResponse<{ servers: string[] }> = await this.request(
-      "/api/status/mcp-servers"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取活跃 MCP 服务器失败");
-    }
-    return response.data.servers;
+    return this.status.getActiveMCPServers();
   }
 
   /**
    * 更新客户端状态
    */
   async updateClientStatus(status: Partial<ClientStatus>): Promise<void> {
-    const response: ApiResponse = await this.request("/api/status/client", {
-      method: "PUT",
-      body: JSON.stringify(status),
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "更新客户端状态失败");
-    }
+    return this.status.updateClientStatus(status);
   }
 
   /**
    * 设置活跃的 MCP 服务器列表
    */
   async setActiveMCPServers(servers: string[]): Promise<void> {
-    const response: ApiResponse = await this.request(
-      "/api/status/mcp-servers",
-      {
-        method: "PUT",
-        body: JSON.stringify({ servers }),
-      }
-    );
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "设置活跃 MCP 服务器失败");
-    }
+    return this.status.setActiveMCPServers(servers);
   }
 
   /**
    * 重置状态
    */
   async resetStatus(): Promise<void> {
-    const response: ApiResponse = await this.request("/api/status/reset", {
-      method: "POST",
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "重置状态失败");
-    }
+    return this.status.resetStatus();
   }
 
   // ==================== 工具管理 API ====================
@@ -570,41 +319,12 @@ export class ApiClient {
     customDescription?: string,
     parameterConfig?: any
   ): Promise<any> {
-    // 判断是否为新格式调用
-    if (typeof param1 === "object" && "type" in param1 && "data" in param1) {
-      // 新格式：类型化请求
-      const response: ApiResponse<{ tool: any }> = await this.request(
-        "/api/tools/custom",
-        {
-          method: "POST",
-          body: JSON.stringify(param1),
-        }
-      );
-
-      if (!response.success || !response.data) {
-        throw new Error(response.error?.message || "添加自定义工具失败");
-      }
-      return response.data.tool;
-    }
-    // 旧格式：向后兼容
-    const workflow = param1;
-    const response: ApiResponse<{ tool: any }> = await this.request(
-      "/api/tools/custom",
-      {
-        method: "POST",
-        body: JSON.stringify({
-          workflow,
-          customName,
-          customDescription,
-          parameterConfig,
-        }),
-      }
+    return this.tool.addCustomTool(
+      param1,
+      customName,
+      customDescription,
+      parameterConfig
     );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "添加自定义工具失败");
-    }
-    return response.data.tool;
   }
 
   /**
@@ -619,46 +339,21 @@ export class ApiClient {
       data: any;
     }
   ): Promise<any> {
-    const response: ApiResponse<{ tool: any }> = await this.request(
-      `/api/tools/custom/${encodeURIComponent(toolName)}`,
-      {
-        method: "PUT",
-        body: JSON.stringify(updateRequest),
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "更新自定义工具失败");
-    }
-    return response.data.tool;
+    return this.tool.updateCustomTool(toolName, updateRequest);
   }
 
   /**
    * 删除自定义工具
    */
   async removeCustomTool(toolName: string): Promise<void> {
-    const response: ApiResponse = await this.request(
-      `/api/tools/custom/${encodeURIComponent(toolName)}`,
-      {
-        method: "DELETE",
-      }
-    );
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "删除自定义工具失败");
-    }
+    return this.tool.removeCustomTool(toolName);
   }
 
   /**
    * 获取自定义工具列表
    */
   async getCustomTools(): Promise<any[]> {
-    const response: ApiResponse<{ tools: any[] }> =
-      await this.request("/api/tools/custom");
-    if (!response.success || !response.data) {
-      throw new Error("获取自定义工具列表失败");
-    }
-    return response.data.tools;
+    return this.tool.getCustomTools();
   }
 
   /**
@@ -671,27 +366,7 @@ export class ApiClient {
     status: "enabled" | "disabled" | "all" = "all",
     sortConfig?: { field: string }
   ): Promise<CustomMCPToolWithStats[]> {
-    // 构建查询参数
-    const queryParams = new URLSearchParams();
-    if (status !== "all") {
-      queryParams.append("status", status);
-    }
-
-    // 添加排序参数
-    if (sortConfig) {
-      queryParams.append("sortBy", sortConfig.field);
-    }
-
-    const url = `/api/tools/list${
-      queryParams.toString() ? `?${queryParams.toString()}` : ""
-    }`;
-
-    const response: ApiResponse<{ list: CustomMCPTool[]; total: number }> =
-      await this.request(url);
-    if (!response.success || !response.data) {
-      throw new Error("获取工具列表失败");
-    }
-    return response.data.list;
+    return this.tool.getToolsList(status, sortConfig);
   }
 
   // ==================== 服务控制 API ====================
@@ -700,65 +375,35 @@ export class ApiClient {
    * 重启服务
    */
   async restartService(): Promise<void> {
-    const response: ApiResponse = await this.request("/api/services/restart", {
-      method: "POST",
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "重启服务失败");
-    }
+    return this.service.restartService();
   }
 
   /**
    * 停止服务
    */
   async stopService(): Promise<void> {
-    const response: ApiResponse = await this.request("/api/services/stop", {
-      method: "POST",
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "停止服务失败");
-    }
+    return this.service.stopService();
   }
 
   /**
    * 启动服务
    */
   async startService(): Promise<void> {
-    const response: ApiResponse = await this.request("/api/services/start", {
-      method: "POST",
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "启动服务失败");
-    }
+    return this.service.startService();
   }
 
   /**
    * 获取服务状态
    */
   async getServiceStatus(): Promise<ServiceStatus> {
-    const response: ApiResponse<ServiceStatus> = await this.request(
-      "/api/services/status"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取服务状态失败");
-    }
-    return response.data;
+    return this.service.getServiceStatus();
   }
 
   /**
    * 获取服务健康状态
    */
   async getServiceHealth(): Promise<ServiceHealth> {
-    const response: ApiResponse<ServiceHealth> = await this.request(
-      "/api/services/health"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取服务健康状态失败");
-    }
-    return response.data;
+    return this.service.getServiceHealth();
   }
 
   // ==================== 版本信息 API ====================
@@ -767,37 +412,21 @@ export class ApiClient {
    * 获取 TTS 音色列表
    */
   async getTTSVoices(): Promise<VoicesResponse> {
-    const response: ApiResponse<VoicesResponse> =
-      await this.request("/api/tts/voices");
-    if (!response.success || !response.data) {
-      throw new Error("获取音色列表失败");
-    }
-    return response.data;
+    return this.version.getTTSVoices();
   }
 
   /**
    * 获取版本信息
    */
   async getVersion(): Promise<VersionInfo> {
-    const response: ApiResponse<VersionInfo> =
-      await this.request("/api/version");
-    if (!response.success || !response.data) {
-      throw new Error("获取版本信息失败");
-    }
-    return response.data;
+    return this.version.getVersion();
   }
 
   /**
    * 获取版本号（简化接口）
    */
   async getVersionSimple(): Promise<{ version: string }> {
-    const response: ApiResponse<{ version: string }> = await this.request(
-      "/api/version/simple"
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取版本号失败");
-    }
-    return response.data;
+    return this.version.getVersionSimple();
   }
 
   /**
@@ -811,25 +440,7 @@ export class ApiClient {
     type: string;
     total: number;
   }> {
-    // 构建查询参数
-    const queryParams = new URLSearchParams();
-    if (type !== "stable") {
-      queryParams.append("type", type);
-    }
-
-    const url = `/api/version/available${
-      queryParams.toString() ? `?${queryParams.toString()}` : ""
-    }`;
-
-    const response: ApiResponse<{
-      versions: string[];
-      type: string;
-      total: number;
-    }> = await this.request(url);
-    if (!response.success || !response.data) {
-      throw new Error("获取可用版本列表失败");
-    }
-    return response.data;
+    return this.version.getAvailableVersions(type);
   }
 
   /**
@@ -842,49 +453,21 @@ export class ApiClient {
     hasUpdate: boolean;
     error?: string;
   }> {
-    const response: ApiResponse<{
-      currentVersion: string;
-      latestVersion: string | null;
-      hasUpdate: boolean;
-      error?: string;
-    }> = await this.request("/api/version/latest");
-
-    if (!response.success || !response.data) {
-      throw new Error("检查最新版本失败");
-    }
-
-    return response.data;
+    return this.version.getLatestVersion();
   }
 
   /**
    * 清除版本缓存
    */
   async clearVersionCache(): Promise<void> {
-    const response: ApiResponse = await this.request(
-      "/api/version/cache/clear",
-      {
-        method: "POST",
-      }
-    );
-    if (!response.success) {
-      throw new Error(response.error?.message || "清除版本缓存失败");
-    }
+    return this.version.clearVersionCache();
   }
 
   /**
    * 更新版本
    */
   async updateVersion(version: string): Promise<any> {
-    const response: ApiResponse = await this.request("/api/update", {
-      method: "POST",
-      body: JSON.stringify({ version }),
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "版本更新失败");
-    }
-
-    return response.data;
+    return this.version.updateVersion(version);
   }
 
   // ==================== 端点管理 API ====================
@@ -893,86 +476,42 @@ export class ApiClient {
    * 获取接入点状态
    */
   async getEndpointStatus(endpoint: string): Promise<EndpointStatusResponse> {
-    const response: ApiResponse<EndpointStatusResponse> = await this.request(
-      "/api/endpoint/status",
-      {
-        method: "POST",
-        body: JSON.stringify({ endpoint }),
-      }
-    );
-    if (!response.success || !response.data) {
-      throw new Error("获取接入点状态失败");
-    }
-    return response.data;
+    return this.endpoint.getEndpointStatus(endpoint);
   }
 
   /**
    * 连接接入点
    */
   async connectEndpoint(endpoint: string): Promise<void> {
-    const response: ApiResponse = await this.request("/api/endpoint/connect", {
-      method: "POST",
-      body: JSON.stringify({ endpoint }),
-    });
-    if (!response.success) {
-      throw new Error(response.error?.message || "连接接入点失败");
-    }
+    return this.endpoint.connectEndpoint(endpoint);
   }
 
   /**
    * 断开接入点
    */
   async disconnectEndpoint(endpoint: string): Promise<void> {
-    const response: ApiResponse = await this.request(
-      "/api/endpoint/disconnect",
-      { method: "POST", body: JSON.stringify({ endpoint }) }
-    );
-    if (!response.success) {
-      throw new Error(response.error?.message || "断开接入点失败");
-    }
+    return this.endpoint.disconnectEndpoint(endpoint);
   }
 
   /**
    * 重连接入点
    */
   async reconnectEndpoint(endpoint: string): Promise<void> {
-    const response: ApiResponse = await this.request(
-      "/api/endpoint/reconnect",
-      { method: "POST", body: JSON.stringify({ endpoint }) }
-    );
-    if (!response.success) {
-      throw new Error(response.error?.message || "重连接入点失败");
-    }
+    return this.endpoint.reconnectEndpoint(endpoint);
   }
 
   /**
    * 添加新接入点
    */
   async addEndpoint(endpoint: string): Promise<EndpointStatusResponse> {
-    const response: ApiResponse<EndpointStatusResponse> = await this.request(
-      "/api/endpoint/add",
-      {
-        method: "POST",
-        body: JSON.stringify({ endpoint }),
-      }
-    );
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "添加接入点失败");
-    }
-    return response.data;
+    return this.endpoint.addEndpoint(endpoint);
   }
 
   /**
    * 移除接入点
    */
   async removeEndpoint(endpoint: string): Promise<void> {
-    const response: ApiResponse = await this.request("/api/endpoint/remove", {
-      method: "POST",
-      body: JSON.stringify({ endpoint }),
-    });
-    if (!response.success) {
-      throw new Error(response.error?.message || "移除接入点失败");
-    }
+    return this.endpoint.removeEndpoint(endpoint);
   }
 
   // ==================== MCP 服务器管理 API ====================
@@ -985,21 +524,7 @@ export class ApiClient {
     name: string,
     config: MCPServerConfig
   ): Promise<MCPServerStatus> {
-    const requestData: MCPServerAddRequest = { name, config };
-
-    const response: ApiResponse<MCPServerStatus> = await this.request(
-      "/api/mcp-servers",
-      {
-        method: "POST",
-        body: JSON.stringify(requestData),
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "添加 MCP 服务器失败");
-    }
-
-    return response.data;
+    return this.mcpServer.addMCPServer(name, config);
   }
 
   /**
@@ -1009,22 +534,7 @@ export class ApiClient {
   async removeMCPServer(
     serverName: string
   ): Promise<{ name: string; operation: string; affectedTools: string[] }> {
-    const response: ApiResponse<{
-      name: string;
-      operation: string;
-      affectedTools: string[];
-    }> = await this.request(
-      `/api/mcp-servers/${encodeURIComponent(serverName)}`,
-      {
-        method: "DELETE",
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "删除 MCP 服务器失败");
-    }
-
-    return response.data;
+    return this.mcpServer.removeMCPServer(serverName);
   }
 
   /**
@@ -1032,15 +542,7 @@ export class ApiClient {
    * GET /api/mcp-servers/:serverName/status
    */
   async getMCPServerStatus(serverName: string): Promise<MCPServerStatus> {
-    const response: ApiResponse<MCPServerStatus> = await this.request(
-      `/api/mcp-servers/${encodeURIComponent(serverName)}/status`
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "获取 MCP 服务器状态失败");
-    }
-
-    return response.data;
+    return this.mcpServer.getMCPServerStatus(serverName);
   }
 
   /**
@@ -1048,14 +550,7 @@ export class ApiClient {
    * GET /api/mcp-servers
    */
   async listMCPServers(): Promise<MCPServerListResponse> {
-    const response: ApiResponse<MCPServerListResponse> =
-      await this.request("/api/mcp-servers");
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "获取 MCP 服务器列表失败");
-    }
-
-    return response.data;
+    return this.mcpServer.listMCPServers();
   }
 
   /**
@@ -1063,19 +558,7 @@ export class ApiClient {
    * GET /api/mcp-servers/:serverName/exists
    */
   async checkMCPServerExists(serverName: string): Promise<boolean> {
-    try {
-      const response: ApiResponse<{ exists: boolean }> = await this.request(
-        `/api/mcp-servers/${encodeURIComponent(serverName)}/exists`
-      );
-
-      return response.success ? response.data?.exists || false : false;
-    } catch (error) {
-      // 如果返回 404，说明服务器不存在
-      if (error instanceof Error && error.message.includes("404")) {
-        return false;
-      }
-      throw error;
-    }
+    return this.mcpServer.checkMCPServerExists(serverName);
   }
 
   /**
@@ -1086,19 +569,7 @@ export class ApiClient {
     serverName: string,
     config: MCPServerConfig
   ): Promise<MCPServerStatus> {
-    const response: ApiResponse<MCPServerStatus> = await this.request(
-      `/api/mcp-servers/${encodeURIComponent(serverName)}`,
-      {
-        method: "PUT",
-        body: JSON.stringify({ config }),
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "更新 MCP 服务器配置失败");
-    }
-
-    return response.data;
+    return this.mcpServer.updateMCPServer(serverName, config);
   }
 
   /**
@@ -1110,20 +581,7 @@ export class ApiClient {
     toolName: string,
     args: any = {}
   ): Promise<any> {
-    const response: ApiResponse = await this.request("/api/tools/call", {
-      method: "POST",
-      body: JSON.stringify({
-        serviceName,
-        toolName,
-        args,
-      }),
-    });
-
-    if (!response.success) {
-      throw new Error(response.error?.message || "调用工具失败");
-    }
-
-    return response.data;
+    return this.mcpServer.callTool(serviceName, toolName, args);
   }
 
   /**
@@ -1131,18 +589,7 @@ export class ApiClient {
    * POST /api/mcp-servers/:serverName/restart
    */
   async restartMCPServer(serverName: string): Promise<MCPServerStatus> {
-    const response: ApiResponse<MCPServerStatus> = await this.request(
-      `/api/mcp-servers/${encodeURIComponent(serverName)}/restart`,
-      {
-        method: "POST",
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "重启 MCP 服务器失败");
-    }
-
-    return response.data;
+    return this.mcpServer.restartMCPServer(serverName);
   }
 
   // ==================== MCP 工具管理 API ====================
@@ -1156,19 +603,7 @@ export class ApiClient {
   async manageMCPTool(
     request: MCPToolManageRequest
   ): Promise<MCPToolManageResponse> {
-    const response: ApiResponse<MCPToolManageResponse> = await this.request(
-      "/api/tools/mcp/manage",
-      {
-        method: "POST",
-        body: JSON.stringify(request),
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "MCP 工具管理操作失败");
-    }
-
-    return response.data;
+    return this.mcpTool.manageMCPTool(request);
   }
 
   /**
@@ -1180,38 +615,24 @@ export class ApiClient {
   async listMCPTools(
     request?: MCPToolListRequest
   ): Promise<MCPToolListResponse> {
-    const response: ApiResponse<MCPToolListResponse> = await this.request(
-      "/api/tools/mcp/list",
-      {
-        method: "POST",
-        body: JSON.stringify(request || {}),
-      }
-    );
-
-    if (!response.success || !response.data) {
-      throw new Error(response.error?.message || "获取 MCP 工具列表失败");
-    }
-
-    return response.data;
+    return this.mcpTool.listMCPTools(request);
   }
 }
 
 // 创建默认的 API 客户端实例
 export const apiClient = new ApiClient();
 
-// 导出类型
-export type {
-  ApiResponse,
-  ApiErrorResponse,
-  ServiceStatus,
-  ServiceHealth,
-  RestartStatus,
-  FullStatus,
-  VersionInfo,
-  EndpointStatusResponse,
-  MCPServerAddRequest,
-  MCPServerStatus,
-  MCPServerListResponse,
-  ApiSuccessResponse,
-  MCPErrorCode,
-};
+// 导出 API 响应格式（向后兼容）
+export type { ApiResponse };
+
+// 导出独立的 API 客户端类（推荐使用）
+export {
+  ConfigApiClient,
+  StatusApiClient,
+  ToolApiClient,
+  ServiceControlApiClient,
+  VersionApiClient,
+  EndpointApiClient,
+  MCPServerApiClient,
+  MCPToolApiClient,
+} from "./api-clients";


### PR DESCRIPTION
将 ApiClient 类（1217行）拆分为8个独立的 API 客户端类，
遵循单一职责原则，提高代码可维护性和可测试性。

**变更内容：**
- 创建 HttpClient 基类，提供统一的 HTTP 请求方法
- 创建 ConfigApiClient：配置管理 API
- 创建 StatusApiClient：状态管理 API
- 创建 ToolApiClient：工具管理 API
- 创建 ServiceControlApiClient：服务控制 API
- 创建 VersionApiClient：版本信息 API
- 创建 EndpointApiClient：端点管理 API
- 创建 MCPServerApiClient：MCP 服务器管理 API
- 创建 MCPToolApiClient：MCP 工具管理 API
- 重写 api.ts 为门面类，保持向后兼容

**影响范围：**
- 所有现有导入继续工作（向后兼容）
- 导出独立的 API 客户端类供新代码使用
- 代码从1217行拆分为约80-150行/文件

Fixes #2728

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2728