### PR TITLE
fix(endpoint): 修复 EndpointManager.cleanup() 中 MCP 事件监听器移除逻辑错误

### DIFF
--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -57,7 +57,7 @@ export class EndpointManager extends EventEmitter {
   private connectionStates: Map<string, SimpleConnectionStatus> = new Map();
   private mcpManager: IMCPServiceManager | null = null;
   private sharedMCPAdapter: SharedMCPAdapter | null = null;
-  private mcpEventListeners: Array<(...args: unknown[]) => void> = [];
+  private mcpEventListeners: Array<{ event: string; listener: (...args: unknown[]) => void }> = [];
 
   /**
    * 构造函数
@@ -103,8 +103,9 @@ export class EndpointManager extends EventEmitter {
       mcpManager.on("connected", connectedHandler);
       mcpManager.on("error", errorHandler);
 
-      // 保存监听器引用以便后续清理
-      this.mcpEventListeners.push(connectedHandler, errorHandler);
+      // 保存事件名和监听器的配对以便后续正确清理
+      this.mcpEventListeners.push({ event: "connected", listener: connectedHandler });
+      this.mcpEventListeners.push({ event: "error", listener: errorHandler });
     }
 
     console.info("[EndpointManager] MCPManager 已设置");
@@ -475,9 +476,8 @@ export class EndpointManager extends EventEmitter {
       "removeListener" in this.mcpManager &&
       typeof this.mcpManager.removeListener === "function"
     ) {
-      for (const listener of this.mcpEventListeners) {
-        this.mcpManager.removeListener("connected", listener);
-        this.mcpManager.removeListener("error", listener);
+      for (const { event, listener } of this.mcpEventListeners) {
+        this.mcpManager.removeListener(event, listener);
       }
     }
     this.mcpEventListeners = [];


### PR DESCRIPTION
将 mcpEventListeners 从简单的函数数组改为事件-监听器配对数组，
确保清理时从正确的事件中移除对应的监听器，避免内存泄漏。

- 修改 mcpEventListeners 类型为 Array<{ event: string; listener: ... }>
- 在 setMcpManager() 中存储事件名和监听器的配对
- 在 cleanup() 中使用解构从正确的事件移除监听器

修复问题: #2732

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2732