### PR TITLE
fix: replace any types with WebSocketLike in heartbeat.handler.ts

### DIFF
--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -10,6 +10,7 @@ import { HEARTBEAT_MONITORING } from "@/constants/index.js";
 import type { NotificationService } from "@/services/notification.service.js";
 import type { StatusService } from "@/services/status.service.js";
 import { sendWebSocketError } from "@/utils/websocket-helper.js";
+import type { WebSocketLike } from "@/utils/websocket-helper.js";
 import { configManager } from "@xiaozhi-client/config";
 
 /**
@@ -46,7 +47,7 @@ export class HeartbeatHandler {
    * 处理客户端状态更新（心跳）
    */
   async handleClientStatus(
-    ws: any,
+    ws: WebSocketLike,
     message: HeartbeatMessage,
     clientId: string
   ): Promise<void> {
@@ -82,7 +83,10 @@ export class HeartbeatHandler {
   /**
    * 发送最新配置给客户端
    */
-  private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
+  private async sendLatestConfig(
+    ws: WebSocketLike,
+    clientId: string
+  ): Promise<void> {
     try {
       const latestConfig = configManager.getConfig();
       const message = {
@@ -200,7 +204,7 @@ export class HeartbeatHandler {
   /**
    * 发送心跳响应
    */
-  sendHeartbeatResponse(ws: any, clientId: string): void {
+  sendHeartbeatResponse(ws: WebSocketLike, clientId: string): void {
     try {
       const response = {
         type: "heartbeatResponse",
@@ -220,13 +224,15 @@ export class HeartbeatHandler {
   /**
    * 验证心跳消息格式
    */
-  validateHeartbeatMessage(message: any): message is HeartbeatMessage {
+  validateHeartbeatMessage(message: unknown): message is HeartbeatMessage {
     return (
-      message &&
       typeof message === "object" &&
+      message !== null &&
+      "type" in message &&
       message.type === "clientStatus" &&
-      message.data &&
-      typeof message.data === "object"
+      "data" in message &&
+      typeof message.data === "object" &&
+      message.data !== null
     );
   }
 }


### PR DESCRIPTION
- Import WebSocketLike type from websocket-helper
- Replace `ws: any` with `ws: WebSocketLike` in handleClientStatus, sendLatestConfig, and sendHeartbeatResponse
- Replace `message: any` with `message: unknown` in validateHeartbeatMessage and add proper type narrowing

Improves type safety and aligns with project type safety standards.

Fixes #2738

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2738