### PR TITLE
fix(cli): 移除 Container.ts 中的 as any 类型断言

### DIFF
--- a/packages/cli/src/Container.ts
+++ b/packages/cli/src/Container.ts
@@ -10,10 +10,11 @@
  * @module packages/cli/src/Container
  */
 
-import { configManager } from "@xiaozhi-client/config";
+import { type ConfigManager, configManager } from "@xiaozhi-client/config";
 import { VersionUtils } from "@xiaozhi-client/version";
 import { ErrorHandler } from "./errors/ErrorHandlers";
 import type { IDIContainer } from "./interfaces/Config";
+import type { ProcessManager } from "./interfaces/Service";
 import { FileUtils } from "./utils/FileUtils";
 import { FormatUtils } from "./utils/FormatUtils";
 import { PathUtils } from "./utils/PathUtils";
@@ -154,14 +155,14 @@ export class DIContainer implements IDIContainer {
 
     container.registerSingleton("daemonManager", () => {
       const DaemonManagerModule = require("./services/DaemonManager.js");
-      const processManager = container.get("processManager") as any;
+      const processManager = container.get<ProcessManager>("processManager");
       return new DaemonManagerModule.DaemonManagerImpl(processManager);
     });
 
     container.registerSingleton("serviceManager", () => {
       const ServiceManagerModule = require("./services/ServiceManager.js");
-      const processManager = container.get("processManager") as any;
-      const configManager = container.get("configManager") as any;
+      const processManager = container.get<ProcessManager>("processManager");
+      const configManager = container.get<ConfigManager>("configManager");
       return new ServiceManagerModule.ServiceManagerImpl(
         processManager,
         configManager


### PR DESCRIPTION
使用泛型类型参数替代 as any，提升类型安全性：
- container.get<ProcessManager>("processManager")
- container.get<ConfigManager>("configManager")

修复 #2742

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2742