### PR TITLE
fix: 移除 TTS handler 中的硬编码文件写入

### DIFF
--- a/apps/backend/handlers/tts.handler.ts
+++ b/apps/backend/handlers/tts.handler.ts
@@ -3,7 +3,6 @@
  * 提供语音合成 RESTful API 接口
  */
 
-import fs from "node:fs";
 import { TTS_VOICES, getVoiceScenes } from "@/constants/voices.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
@@ -128,7 +127,6 @@ export class TTSApiHandler extends BaseHandler {
 
       // 调用 TTS 合成（非流式）
       const audioData = await ttsClient.synthesize(body.text);
-      fs.writeFileSync("audio.wav", Buffer.from(audioData));
 
       c.get("logger").info(`语音合成成功: audioSize=${audioData.length} bytes`);
 


### PR DESCRIPTION
修复问题：
- 移除硬编码文件名 "audio.wav" 的同步写入
- 消除并发请求冲突风险
- 避免同步写入阻塞事件循环
- 减少磁盘空间浪费

音频数据已通过 HTTP 响应返回给客户端，无需额外写入文件。

参考 #2748

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2748