### PR TITLE
fix(frontend): 移除 version-manager.tsx 中的调试 console 语句

### DIFF
--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -65,12 +65,10 @@ export function VersionManager() {
       setError(null);
       const versionInfo = await apiClient.getVersion();
       setCurrentVersion(versionInfo);
-      console.log("[VersionManager] 当前版本信息:", versionInfo);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "获取版本信息失败";
       setError(errorMessage);
-      console.error("[VersionManager] 获取版本信息失败:", err);
     }
   }, []);
 
@@ -84,7 +82,6 @@ export function VersionManager() {
 
       // 这里可以调用检查更新的 API
       // 暂时模拟一个检查更新的过程
-      console.log("[VersionManager] 检查更新...");
 
       // 模拟 API 调用延迟
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -100,11 +97,9 @@ export function VersionManager() {
       };
 
       setUpdateInfo(mockUpdateInfo);
-      console.log("[VersionManager] 更新检查结果:", mockUpdateInfo);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "检查更新失败";
       setError(errorMessage);
-      console.error("[VersionManager] 检查更新失败:", err);
     } finally {
       setIsLoading(false);
     }
@@ -112,7 +107,6 @@ export function VersionManager() {
 
   // 开始更新
   const startUpdate = (version: string) => {
-    console.log("[VersionManager] 开始更新到版本:", version);
     setTargetVersion(version);
     setShowInstallDialog(true);
   };


### PR DESCRIPTION
- 移除 4 处 console.log 调试语句
- 移除 2 处 console.error 语句（错误已通过 UI 的 setError 状态显示）
- 修复 Issue #2750

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2750