### PR TITLE
fix(security): upgrade smol-toml to 1.6.1+ to fix CVE-2026-33942

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "rollup@<5.0.0": ">=4.59.0",
       "express-rate-limit@<9.0.0": ">=8.2.2",
       "dompurify@<4.0.0": ">=3.3.2",
-      "immutable@<6.0.0": ">=5.1.5"
+      "immutable@<6.0.0": ">=5.1.5",
+      "smol-toml@<1.6.1": ">=1.6.1"
     }
   },
   "packageManager": "pnpm@10.13.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   express-rate-limit@<9.0.0: '>=8.2.2'
   dompurify@<4.0.0: '>=3.3.2'
   immutable@<6.0.0: '>=5.1.5'
+  smol-toml@<1.6.1: '>=1.6.1'
 
 importers:
 
@@ -6719,8 +6720,8 @@ packages:
     resolution: {integrity: sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==}
     engines: {node: '>=14.16'}
 
-  smol-toml@1.6.0:
-    resolution: {integrity: sha512-4zemZi0HvTnYwLfrpk/CF9LOd9Lt87kAt50GnqhMpyF9U3poDAP2+iukq2bZsO/ufegbYehBkqINbsWxj4l4cw==}
+  smol-toml@1.6.1:
+    resolution: {integrity: sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==}
     engines: {node: '>= 18'}
 
   sonic-boom@4.2.1:
@@ -11044,7 +11045,7 @@ snapshots:
     dependencies:
       '@cspell/cspell-types': 9.6.2
       comment-json: 4.5.1
-      smol-toml: 1.6.0
+      smol-toml: 1.6.1
       yaml: 2.8.2
 
   cspell-dictionary@9.6.2:
@@ -14279,7 +14280,7 @@ snapshots:
 
   slash@5.1.0: {}
 
-  smol-toml@1.6.0: {}
+  smol-toml@1.6.1: {}
 
   sonic-boom@4.2.1:
     dependencies:


### PR DESCRIPTION
Add pnpm override for smol-toml to force version 1.6.1 or higher,
addressing the security vulnerability in the cspell transitive dependency
chain (cspell > cspell-config-lib > smol-toml).

Fixes #2751

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2751