### PR TITLE
fix: 修复 MCPCacheManager 实例未清理导致定时器泄漏

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
@@ -250,6 +250,7 @@ describe("MCPToolHandler - 核心功能测试", () => {
                 inputSchema: { type: "object", properties: {} },
               },
             ]),
+            cleanup: vi.fn(),
           }) as any
       );
 

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -668,7 +668,13 @@ export class MCPToolHandler {
 
     // 从缓存中获取工具信息
     const cacheManager = new MCPCacheManager();
-    const cachedTools = await cacheManager.getAllCachedTools();
+    let cachedTools: Tool[];
+    try {
+      cachedTools = await cacheManager.getAllCachedTools();
+    } finally {
+      // 确保清理定时器，避免资源泄漏
+      cacheManager.cleanup();
+    }
 
     // 查找对应的工具
     const fullToolName = `${serviceName}__${toolName}`;


### PR DESCRIPTION
在 addCustomTool 方法中，每次请求都会创建一个新的 MCPCacheManager
实例来获取缓存工具信息，但使用完后从未调用 cleanup() 方法来
清理定时器，导致资源泄漏。

修复方案：
- 使用 try-finally 模式确保 cacheManager 在使用后立即清理
- 添加正确的类型注解 Tool[]
- 更新相关测试以包含 cleanup() mock

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2753