### PR TITLE
fix(coze): 添加分页参数 NaN 检查防止无效输入绕过验证

### DIFF
--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -185,19 +185,19 @@ export class CozeHandler extends BaseHandler {
       }
 
       // 验证分页参数
-      if (page_num < 1 || page_num > 1000) {
+      if (Number.isNaN(page_num) || page_num < 1 || page_num > 1000) {
         return c.fail(
           "INVALID_PARAMETER",
-          "page_num 必须在 1-1000 之间",
+          "page_num 必须是有效的 1-1000 之间的数字",
           undefined,
           400
         );
       }
 
-      if (page_size < 1 || page_size > 100) {
+      if (Number.isNaN(page_size) || page_size < 1 || page_size > 100) {
         return c.fail(
           "INVALID_PARAMETER",
-          "page_size 必须在 1-100 之间",
+          "page_size 必须是有效的 1-100 之间的数字",
           undefined,
           400
         );


### PR DESCRIPTION
修复 Number.parseInt 返回 NaN 时绕过参数验证的问题。
当传入无效数字字符串（如 page_num=abc）时，Number.parseInt
返回 NaN，由于 NaN 与任何数字的比较结果都是 false，导致
原有验证逻辑失效。

- 在 page_num 和 page_size 验证中添加 Number.isNaN() 检查
- 更新错误消息以明确要求"有效数字"

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2758