### PR TITLE
fix: 升级 express 至 5.2.1 修复 path-to-regexp DoS 漏洞

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -36,7 +36,7 @@
     "dayjs": "^1.11.13",
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "hono": "^4.12.7",
     "json5": "^2.2.3",
     "jsonc-parser": "^3.3.1",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "dayjs": "^1.11.13",
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",
-    "express": "^5.1.0",
+    "express": "^5.2.1",
     "hono": "^4.12.7",
     "node-cache": "^5.1.2",
     "openai": "^6.24.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,7 +90,7 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       express:
-        specifier: ^5.1.0
+        specifier: ^5.2.1
         version: 5.2.1
       hono:
         specifier: ^4.12.7
@@ -247,7 +247,7 @@ importers:
         specifier: ^4.0.0
         version: 4.1.0
       express:
-        specifier: ^5.1.0
+        specifier: ^5.2.1
         version: 5.2.1
       hono:
         specifier: ^4.12.7


### PR DESCRIPTION
修复以下安全漏洞:
- GHSA-j3q9: DoS via sequential optional groups
- GHSA-27v5: ReDoS via multiple wildcards

express 5.2.1 使用 path-to-regexp 8.4.0+，已修复上述漏洞。

Closes #2760

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2760