### PR TITLE
fix: 修复 backend 类型检查缺少 tts 和 asr 构建依赖

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "tts:build", "asr:build"]
     },
     "dev": {
       "executor": "nx:run-commands",

--- a/packages/asr/project.json
+++ b/packages/asr/project.json
@@ -38,7 +38,7 @@
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm --filter asr run type-check",
+        "command": "pnpm --filter asr run check:type",
         "cwd": "packages/asr"
       }
     },

--- a/packages/tts/project.json
+++ b/packages/tts/project.json
@@ -38,7 +38,7 @@
     "type-check": {
       "executor": "nx:run-commands",
       "options": {
-        "command": "pnpm --filter tts run type-check",
+        "command": "pnpm --filter tts run check:type",
         "cwd": "packages/tts"
       }
     },


### PR DESCRIPTION
问题：
- backend 的 type-check 依赖声明中缺少 tts:build 和 asr:build
- tts 和 asr 的 project.json 中 type-check 命令引用了错误的脚本名

修复：
- 在 apps/backend/project.json 的 type-check dependsOn 中添加 tts:build 和 asr:build
- 修正 packages/tts/project.json 中的 type-check 命令为 check:type
- 修正 packages/asr/project.json 中的 type-check 命令为 check:type

这确保了在运行 backend 类型检查前，tts 和 asr 包会自动构建，
解决 "Cannot find module '@xiaozhi-client/tts'" 和
"Cannot find module '@xiaozhi-client/asr'" 错误。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2768