### PR TITLE
refactor: 提取 VolcengineConfigFields 组件消除 ASR/TTS 配置重复代码

### DIFF
--- a/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
+++ b/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
@@ -7,6 +7,9 @@
 import { PromptEditorDialog } from "@/components/prompt-editor-dialog";
 import { Button } from "@/components/ui/button";
 import {
+  VolcengineConfigFields,
+} from "@/components/volcengine-config-fields";
+import {
   Dialog,
   DialogClose,
   DialogContent,
@@ -301,42 +304,11 @@ export function VoiceInteractionSettingDialog() {
                     ASR 配置
                   </h3>
                   <div className="grid gap-4">
-                    <FormField
+                    <VolcengineConfigFields
                       control={form.control}
-                      name="asr.appid"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>应用 ID</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="请输入火山引擎语音识别应用 ID"
-                              className="font-mono text-sm"
-                              disabled={isLoading}
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="asr.accessToken"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>访问令牌</FormLabel>
-                          <FormControl>
-                            <PasswordInput
-                              placeholder="请输入访问令牌"
-                              className="font-mono text-sm"
-                              disabled={isLoading}
-                              autoComplete="off"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                      prefix="asr"
+                      serviceLabel="语音识别"
+                      disabled={isLoading}
                     />
                   </div>
                 </div>
@@ -487,42 +459,11 @@ export function VoiceInteractionSettingDialog() {
                     TTS 配置
                   </h3>
                   <div className="grid gap-4">
-                    <FormField
+                    <VolcengineConfigFields
                       control={form.control}
-                      name="tts.appid"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>应用 ID</FormLabel>
-                          <FormControl>
-                            <Input
-                              placeholder="请输入火山引擎语音合成应用 ID"
-                              className="font-mono text-sm"
-                              disabled={isLoading}
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-                    <FormField
-                      control={form.control}
-                      name="tts.accessToken"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>访问令牌</FormLabel>
-                          <FormControl>
-                            <PasswordInput
-                              placeholder="请输入访问令牌"
-                              className="font-mono text-sm"
-                              disabled={isLoading}
-                              autoComplete="off"
-                              {...field}
-                            />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
+                      prefix="tts"
+                      serviceLabel="语音合成"
+                      disabled={isLoading}
                     />
                     <FormField
                       control={form.control}

--- a/apps/frontend/src/components/volcengine-config-fields.tsx
+++ b/apps/frontend/src/components/volcengine-config-fields.tsx
@@ -1,0 +1,88 @@
+/**
+ * 火山引擎配置表单字段组件
+ *
+ * 提供可复用的应用 ID 和访问令牌表单字段，用于 ASR 和 TTS 配置。
+ */
+
+import {
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { PasswordInput } from "@/components/ui/password-input";
+import type { Control, FieldPath, FieldValues } from "react-hook-form";
+
+/**
+ * 火山引擎配置字段组件属性
+ */
+interface VolcengineConfigFieldsProps<
+  TFieldValues extends FieldValues = FieldValues,
+> {
+  /** 表单控制器 */
+  control: Control<TFieldValues>;
+  /** 字段名前缀（"asr" 或 "tts"） */
+  prefix: "asr" | "tts";
+  /** 服务类型标签（用于 placeholder） */
+  serviceLabel: "语音识别" | "语音合成";
+  /** 是否禁用输入 */
+  disabled?: boolean;
+}
+
+/**
+ * 火山引擎配置表单字段组件
+ *
+ * 提供应用 ID 和访问令牌两个表单字段，消除了 ASR 和 TTS 配置中的代码重复。
+ */
+export function VolcengineConfigFields<
+  TFieldValues extends FieldValues = FieldValues,
+>({
+  control,
+  prefix,
+  serviceLabel,
+  disabled = false,
+}: VolcengineConfigFieldsProps<TFieldValues>) {
+  return (
+    <>
+      <FormField
+        control={control}
+        name={`${prefix}.appid` as FieldPath<TFieldValues>}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>应用 ID</FormLabel>
+            <FormControl>
+              <Input
+                placeholder={`请输入火山引擎${serviceLabel}应用 ID`}
+                className="font-mono text-sm"
+                disabled={disabled}
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+      <FormField
+        control={control}
+        name={`${prefix}.accessToken` as FieldPath<TFieldValues>}
+        render={({ field }) => (
+          <FormItem>
+            <FormLabel>访问令牌</FormLabel>
+            <FormControl>
+              <PasswordInput
+                placeholder="请输入访问令牌"
+                className="font-mono text-sm"
+                disabled={disabled}
+                autoComplete="off"
+                {...field}
+              />
+            </FormControl>
+            <FormMessage />
+          </FormItem>
+        )}
+      />
+    </>
+  );
+}


### PR DESCRIPTION
创建可复用的 VolcengineConfigFields 组件来替代 ASR 和 TTS 配置
中重复的 appid 和 accessToken 表单字段，减少约 40 行重复代码。

- 新增 VolcengineConfigFields 组件，支持动态前缀和服务标签配置
- 更新 VoiceInteractionSettingDialog 使用新组件
- 保持原有功能和样式不变

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2770