### PR TITLE
fix: 修复 TTS 服务 processAudioBuffer 中的定时器泄漏

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -475,9 +475,11 @@ export class TTSService implements ITTSService {
         })
         .on("end", () => {
           // 等待所有包处理完成
+          let checkTimer: ReturnType<typeof setTimeout> | undefined;
+
           const checkEnd = (): void => {
             if (packetQueue.length > 0 || isProcessing) {
-              setTimeout(checkEnd, 10);
+              checkTimer = setTimeout(checkEnd, 10);
             } else {
               logger.info(
                 `处理完成，共 ${packetIndex} 个包，总时长 ${(totalDuration / 1000).toFixed(2)}s`
@@ -488,7 +490,16 @@ export class TTSService implements ITTSService {
               });
             }
           };
+
           checkEnd();
+
+          // 如果流被销毁，清除定时器
+          stream.on("close", () => {
+            if (checkTimer) {
+              clearTimeout(checkTimer);
+              checkTimer = undefined;
+            }
+          });
         })
         .on("error", reject);
     });


### PR DESCRIPTION
在 processAudioBuffer 方法的 checkEnd 函数中，setTimeout 的返回值
没有被存储，导致流被销毁时定时器无法被清除，造成资源泄漏。

修复方案：
- 添加 checkTimer 变量存储定时器引用
- 在 stream.on("close") 事件中清除定时器

修复 #2778

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2778