### PR TITLE
fix: 使用 ensureToolJSONSchema 替代 as any 类型断言

### DIFF
--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -4,11 +4,11 @@
  * 使用 @xiaozhi-client/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
-import { MCPManager } from "@xiaozhi-client/mcp-core";
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { MCPManager, ensureToolJSONSchema } from "@xiaozhi-client/mcp-core";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
-import { normalizeServiceConfig } from "@xiaozhi-client/config";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -105,7 +105,7 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       const enhancedTool: EnhancedToolInfo = {
         name: `${mcpTool.serverName}__${mcpTool.name}`,
         description: mcpTool.description,
-        inputSchema: mcpTool.inputSchema as any,
+        inputSchema: ensureToolJSONSchema(mcpTool.inputSchema),
         serviceName: mcpTool.serverName,
         originalName: mcpTool.name,
         enabled: true,

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -3,10 +3,10 @@
  * 统一管理所有 MCP 相关的类型定义
  */
 
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 // =========================
 // 1. 基础传输类型
@@ -211,8 +211,10 @@ export function isValidToolJSONSchema(obj: unknown): obj is {
 
 /**
  * 确保对象符合 MCP Tool JSON Schema 格式
+ * 接受 unknown 类型输入并返回有效的 JSON Schema 结构
+ * 返回类型兼容 MCP SDK 的 Tool.inputSchema 类型
  */
-export function ensureToolJSONSchema(schema: JSONSchema): {
+export function ensureToolJSONSchema(schema: unknown): {
   type: "object";
   properties?: Record<string, object>;
   required?: string[];


### PR DESCRIPTION
修复 InternalMCPManagerAdapter 中使用 as any 绕过类型检查的问题：

1. 更新 ensureToolJSONSchema 函数签名：
   - 参数类型从 JSONSchema 改为 unknown
   - 返回类型使用 Record<string, object> 以兼容 MCP SDK 的 Tool 类型

2. 修复 internal-mcp-manager.ts 中的类型断言：
   - 导入 ensureToolJSONSchema 函数
   - 使用 ensureToolJSONSchema(mcpTool.inputSchema) 替代 as any

相关 issue: #2781

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2781