### PR TITLE
fix: 将信号监听器从 process.on 改为 process.once

### DIFF
--- a/scripts/simple-mcp-client.ts
+++ b/scripts/simple-mcp-client.ts
@@ -314,12 +314,12 @@ process.on(
 );
 
 // 优雅退出处理
-process.on("SIGINT", () => {
+process.once("SIGINT", () => {
   log("info", "接收到 SIGINT 信号，正在退出...");
   process.exit(0);
 });
 
-process.on("SIGTERM", () => {
+process.once("SIGTERM", () => {
   log("info", "接收到 SIGTERM 信号，正在退出...");
   process.exit(0);
 });


### PR DESCRIPTION
修复 scripts/simple-mcp-client.ts 中使用 process.on() 注册信号监听器
导致的监听器累积风险。改用 process.once() 确保监听器只触发一次，
避免在模块多次加载场景下的内存泄漏。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2783