### PR TITLE
refactor: 消除 ASR 和 TTS 包中的跨包类型重复

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -48,6 +48,7 @@
   "license": "MIT",
   "dependencies": {
     "@discordjs/opus": "^0.10.0",
+    "@xiaozhi-client/shared-types": "workspace:*",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
     "ws": "^8.16.0",

--- a/packages/asr/src/core/index.ts
+++ b/packages/asr/src/core/index.ts
@@ -5,13 +5,15 @@
 // 类型导出（排除与 types/ 重复的类型）
 export type {
   ASRController,
-  PlatformConfig,
   ASRPlatform,
   PlatformRegistry,
   CommonASROptions,
   ASREventType,
   ASREventData,
 } from "./types.js";
+
+// 从 shared-types 重新导出 PlatformConfig
+export type { PlatformConfig } from "@xiaozhi-client/shared-types/platform";
 
 // 平台接口导出
 export {

--- a/packages/asr/src/core/types.ts
+++ b/packages/asr/src/core/types.ts
@@ -3,6 +3,14 @@
  */
 
 import type { Readable } from "node:stream";
+import type {
+  BasePlatform,
+  BasePlatformRegistry,
+  PlatformConfig,
+} from "@xiaozhi-client/shared-types/platform";
+
+// 从 shared-types 重新导出 PlatformConfig
+export type { PlatformConfig } from "@xiaozhi-client/shared-types/platform";
 
 /**
  * 音频输入类型
@@ -54,65 +62,16 @@ export interface ASRController {
 }
 
 /**
- * 平台配置泛型接口
- */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
-
-/**
  * ASR 平台接口
  * 定义平台需要实现的抽象方法
  */
-export interface ASRPlatform {
-  /** 平台唯一标识 */
-  readonly platform: string;
-
-  /**
-   * 创建流式识别控制器
-   * @param config - 平台配置
-   * @returns 控制器实例
-   */
-  createController(config: PlatformConfig): ASRController;
-
-  /**
-   * 校验配置
-   * @param config - 用户配置
-   * @returns 校验后的配置
-   */
-  validateConfig(config: unknown): PlatformConfig;
-
-  /**
-   * 获取认证头
-   * @param config - 平台配置
-   * @returns 认证头
-   */
-  getAuthHeaders(config: PlatformConfig): Record<string, string>;
-
-  /**
-   * 获取服务地址
-   * @param config - 平台配置
-   * @returns WebSocket URL
-   */
-  getEndpoint(config: PlatformConfig): string;
-}
+export interface ASRPlatform extends BasePlatform<ASRController> {}
 
 /**
  * 平台注册表
  * 存储所有已注册的平台
  */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): ASRPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: ASRPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
-}
+export interface PlatformRegistry extends BasePlatformRegistry<ASRPlatform> {}
 
 /**
  * 通用 ASR 选项

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -29,6 +29,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js"
+    },
+    "./platform": {
+      "types": "./dist/platform.d.ts",
+      "import": "./dist/platform.js"
     }
   },
   "files": [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -57,3 +57,9 @@ export { TimeoutError } from "./utils";
 
 // TTS 相关类型
 export type { VoiceInfo, VoicesResponse } from "./tts";
+
+// 平台相关类型
+export type {
+  BasePlatform,
+  BasePlatformRegistry,
+} from "./platform";

--- a/packages/shared-types/src/platform/base.ts
+++ b/packages/shared-types/src/platform/base.ts
@@ -1,0 +1,65 @@
+/**
+ * 平台核心类型（泛型基类）
+ * 用于 ASR、TTS 等需要平台抽象的模块
+ */
+
+/**
+ * 平台配置
+ */
+export interface PlatformConfig {
+  /** 平台类型 */
+  platform: string;
+  [key: string]: unknown;
+}
+
+/**
+ * 平台接口（泛型版本）
+ * @template TController - 控制器类型
+ */
+export interface BasePlatform<TController> {
+  /** 平台唯一标识 */
+  readonly platform: string;
+
+  /**
+   * 创建控制器
+   * @param config - 平台配置
+   * @returns 控制器实例
+   */
+  createController(config: PlatformConfig): TController;
+
+  /**
+   * 校验配置
+   * @param config - 用户配置
+   * @returns 校验后的配置
+   */
+  validateConfig(config: unknown): PlatformConfig;
+
+  /**
+   * 获取认证头
+   * @param config - 平台配置
+   * @returns 认证头
+   */
+  getAuthHeaders(config: PlatformConfig): Record<string, string>;
+
+  /**
+   * 获取服务地址
+   * @param config - 平台配置
+   * @returns WebSocket URL
+   */
+  getEndpoint(config: PlatformConfig): string;
+}
+
+/**
+ * 平台注册表（泛型版本）
+ * @template TPlatform - 平台类型
+ */
+export interface BasePlatformRegistry<TPlatform> {
+  /** 获取平台 */
+  get(platform: string): TPlatform | undefined;
+
+  /** 注册平台 */
+  register(platform: TPlatform): void;
+
+  /** 获取所有已注册的平台 */
+  list(): string[];
+}

--- a/packages/shared-types/src/platform/index.ts
+++ b/packages/shared-types/src/platform/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 平台相关类型导出
+ */
+
+export type {
+  BasePlatform,
+  BasePlatformRegistry,
+  PlatformConfig,
+} from "./base";

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     api: "src/api/index.ts",
     config: "src/config/index.ts",
     utils: "src/utils/index.ts",
+    platform: "src/platform/index.ts",
   },
   format: ["esm"],
   target: "node20",

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -49,6 +49,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@xiaozhi-client/shared-types": "workspace:*",
     "ws": "^8.16.0",
     "zod": "^3.23.8"
   },

--- a/packages/tts/src/core/types.ts
+++ b/packages/tts/src/core/types.ts
@@ -2,6 +2,15 @@
  * TTS 核心类型定义
  */
 
+import type {
+  BasePlatform,
+  BasePlatformRegistry,
+  PlatformConfig,
+} from "@xiaozhi-client/shared-types/platform";
+
+// 从 shared-types 重新导出 PlatformConfig
+export type { PlatformConfig } from "@xiaozhi-client/shared-types/platform";
+
 /**
  * 音频块回调类型
  * @param chunk - 音频数据块
@@ -53,65 +62,16 @@ export interface TTSController {
 }
 
 /**
- * 平台配置泛型接口
- */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
-
-/**
  * TTS 平台接口
  * 定义平台需要实现的抽象方法
  */
-export interface TTSPlatform {
-  /** 平台唯一标识 */
-  readonly platform: string;
-
-  /**
-   * 创建 TTS 控制器
-   * @param config - 平台配置
-   * @returns 控制器实例
-   */
-  createController(config: PlatformConfig): TTSController;
-
-  /**
-   * 校验配置
-   * @param config - 用户配置
-   * @returns 校验后的配置
-   */
-  validateConfig(config: unknown): PlatformConfig;
-
-  /**
-   * 获取认证头
-   * @param config - 平台配置
-   * @returns 认证头
-   */
-  getAuthHeaders(config: PlatformConfig): Record<string, string>;
-
-  /**
-   * 获取服务地址
-   * @param config - 平台配置
-   * @returns WebSocket URL
-   */
-  getEndpoint(config: PlatformConfig): string;
-}
+export interface TTSPlatform extends BasePlatform<TTSController> {}
 
 /**
  * 平台注册表
  * 存储所有已注册的平台
  */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): TTSPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: TTSPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
-}
+export interface PlatformRegistry extends BasePlatformRegistry<TTSPlatform> {}
 
 /**
  * 通用 TTS 选项

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       '@discordjs/opus':
         specifier: ^0.10.0
         version: 0.10.0
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)
@@ -724,6 +727,9 @@ importers:
 
   packages/tts:
     dependencies:
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       ws:
         specifier: ^8.16.0
         version: 8.19.0


### PR DESCRIPTION
创建 @xiaozhi-client/shared-types/platform 模块，提供泛型基类：
- BasePlatform<TController> - 泛型平台接口
- BasePlatformRegistry<TPlatform> - 泛型注册表接口
- PlatformConfig - 平台配置接口

ASR 和 TTS 包现在通过继承这些泛型基类来定义各自的平台类型，
消除了约 60 行重复代码，提高了可维护性。

修复 #2784

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2784