### PR TITLE
fix(cli): 移除依赖注入容器中的 any 类型泛型

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -3,6 +3,7 @@
  */
 
 import path from "node:path";
+import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
 import chalk from "chalk";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
@@ -79,7 +80,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         throw new Error("格式必须是 json, json5 或 jsonc");
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (configManager.configExists()) {
         spinner.warn("配置文件已存在");
@@ -114,7 +115,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
    * 确保配置文件存在，如果不存在则显示提示并返回 false
    */
   private async ensureConfigExists(spinner: ora.Ora): Promise<boolean> {
-    const configManager = this.getService<any>("configManager");
+    const configManager = this.getService<ConfigManager>("configManager");
 
     if (!configManager.configExists()) {
       spinner.fail("配置文件不存在");
@@ -138,7 +139,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         return;
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       const config = configManager.getConfig();
 
       switch (key) {
@@ -163,7 +164,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           for (const [name, serverConfig] of Object.entries(
             config.mcpServers
           )) {
-            const server = serverConfig as any;
+            const server = serverConfig as MCPServerConfig;
             // 检查是否是 SSE 类型
             if ("type" in server && server.type === "sse") {
               console.log(chalk.gray(`  ${name}: [SSE] ${server.url}`));
@@ -242,7 +243,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         return;
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       switch (key) {
         case "mcpEndpoint":

--- a/packages/cli/src/commands/index.ts
+++ b/packages/cli/src/commands/index.ts
@@ -2,6 +2,7 @@
  * 命令注册器
  */
 
+import { VersionUtils } from "@xiaozhi-client/version";
 import type { Command } from "commander";
 import { ErrorHandler } from "../errors/ErrorHandlers";
 import type {
@@ -155,9 +156,7 @@ export class CommandRegistry implements ICommandRegistry {
    * 注册版本命令
    */
   private registerVersionCommand(program: Command): void {
-    const versionUtils = this.container.get("versionUtils") as any;
-
-    program.version(versionUtils.getVersion(), "-v, --version", "显示版本信息");
+    program.version(VersionUtils.getVersion(), "-v, --version", "显示版本信息");
 
     // 注册 --info 选项
     program.option("--info", "显示详细信息");


### PR DESCRIPTION
- 在 commands/index.ts 中直接导入 VersionUtils 并调用静态方法
- 在 ConfigCommandHandler.ts 中使用 ConfigManager 和 MCPServerConfig 类型
- 替换所有 getService<any> 为 getService<ConfigManager>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2793