### PR TITLE
fix(vitest): 调整 reportsDirectory 配置适配 Nx 22.6 破坏性变更

### DIFF
--- a/apps/backend/vitest.config.ts
+++ b/apps/backend/vitest.config.ts
@@ -27,7 +27,7 @@ export default defineConfig({
       enabled: true,
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],
-      reportsDirectory: resolve(__dirname, "../coverage"),
+      reportsDirectory: "coverage/apps/backend",
       exclude: [
         "node_modules/**",
         "dist/**",

--- a/packages/cli/vitest.config.ts
+++ b/packages/cli/vitest.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
       enabled: true,
       provider: "v8",
       reporter: ["text", "json", "html", "lcov"],
-      reportsDirectory: resolve(__dirname, "../coverage"),
+      reportsDirectory: "coverage/packages/cli",
       exclude: [
         "node_modules/**",
         "dist/**",


### PR DESCRIPTION
Nx 22.6.0 引入破坏性变更：vitest 的 reportsDirectory 配置现在
相对于工作区根目录解析，而非相对于 vitest 配置文件位置。

变更：
- apps/backend: 使用 "coverage/apps/backend" 替代 resolve(__dirname, "../coverage")
- packages/cli: 使用 "coverage/packages/cli" 替代 resolve(__dirname, "../coverage")

此变更将所有覆盖率报告集中到工作区根目录下的 coverage/ 目录，
按包名组织子目录，符合 Nx 22.6+ 的新行为。

相关 Issue: #2795

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2795