### PR TITLE
fix(esp32): 为 ASR 服务调用添加错误处理

### DIFF
--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -403,7 +403,14 @@ export class ESP32Service {
             `[ESP32Service] 处理唤醒词检测: deviceId=${deviceId}, word="${text}"`
           );
           // 初始化 ASR 服务
-          await this.asrService.init(deviceId);
+          try {
+            await this.asrService.init(deviceId);
+          } catch (error) {
+            logger.error(
+              `[ESP32Service] ASR 初始化失败: deviceId=${deviceId}`,
+              error
+            );
+          }
         } else {
           logger.warn(
             `[ESP32Service] 唤醒词消息缺少必要字段: text="${text}", mode=${mode}`
@@ -417,7 +424,14 @@ export class ESP32Service {
         // 开始监听，建立 ASR 连接
         // 注意：硬件端会在发送 start 消息后立刻发送音频数据
         // 所以这里需要尽快建立连接，音频数据会在缓冲区中等待
-        await this.asrService.connect(deviceId);
+        try {
+          await this.asrService.connect(deviceId);
+        } catch (error) {
+          logger.error(
+            `[ESP32Service] ASR 连接失败: deviceId=${deviceId}`,
+            error
+          );
+        }
         if (mode === "manual" || mode === "realtime") {
           logger.info(
             `[ESP32Service] 开始手动/实时监听会话: deviceId=${deviceId}, mode=${mode}`
@@ -436,7 +450,14 @@ export class ESP32Service {
       case "stop":
         // 停止监听，中断当前会话
         logger.info(`[ESP32Service] 停止监听，中断会话: deviceId=${deviceId}`);
-        await this.asrService.end(deviceId);
+        try {
+          await this.asrService.end(deviceId);
+        } catch (error) {
+          logger.error(
+            `[ESP32Service] ASR 结束失败: deviceId=${deviceId}`,
+            error
+          );
+        }
         break;
       default:
         logger.warn(`[ESP32Service] 未知的监听状态: ${state}`);
@@ -482,7 +503,14 @@ export class ESP32Service {
     }
 
     // 交给 ASR 服务处理
-    await this.asrService.handleAudioData(deviceId, audioData);
+    try {
+      await this.asrService.handleAudioData(deviceId, audioData);
+    } catch (error) {
+      logger.error(
+        `[ESP32Service] 处理音频数据失败: deviceId=${deviceId}`,
+        error
+      );
+    }
   }
 
   /**


### PR DESCRIPTION
在 handleListenMessage 和 handleAudioMessage 方法中为 ASR 服务调用
添加 try-catch 错误处理，避免 ASR 服务调用失败时产生未处理的 Promise
rejection，并记录错误日志便于排查问题。

影响位置：
- asrService.init() - 唤醒词检测时的初始化
- asrService.connect() - 开始监听时的连接建立
- asrService.end() - 停止监听时的会话结束
- asrService.handleAudioData() - 音频数据处理

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2796