### PR TITLE
fix(types): 重命名重复的 ValidationResult 类型以避免命名冲突

### DIFF
--- a/apps/backend/handlers/endpoint.handler.ts
+++ b/apps/backend/handlers/endpoint.handler.ts
@@ -23,9 +23,10 @@ import type {
 import type { Context } from "hono";
 
 /**
- * 验证结果类型定义
+ * 端点验证结果类型定义
+ * 用于端点 URL 格式验证，返回简化的验证结果
  */
-interface ValidationResult {
+interface EndpointValidationResult {
   isValid: boolean;
   errors: string[];
 }
@@ -94,7 +95,7 @@ export class EndpointHandler {
    * @param endpoint 端点 URL
    * @returns 验证结果
    */
-  private validateEndpoint(endpoint: string): ValidationResult {
+  private validateEndpoint(endpoint: string): EndpointValidationResult {
     const errors: string[] = [];
 
     if (!endpoint || typeof endpoint !== "string") {

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -113,8 +113,9 @@ export type {
 
 /**
  * 配置验证结果接口
+ * 用于 MCP 服务配置验证，返回简化的验证结果
  */
-export interface ValidationResult {
+export interface ConfigValidationResult {
   isValid: boolean;
   errors: string[];
 }
@@ -916,7 +917,7 @@ export class MCPHandler {
    */
   private validateBatchServers(
     mcpServers: Record<string, MCPServerConfig>
-  ): ValidationResult {
+  ): ConfigValidationResult {
     const errors: string[] = [];
 
     if (!mcpServers || typeof mcpServers !== "object") {
@@ -1039,7 +1040,9 @@ export namespace MCPServerConfigValidator {
   /**
    * 验证服务配置
    */
-  export function validateConfig(config: MCPServerConfig): ValidationResult {
+  export function validateConfig(
+    config: MCPServerConfig
+  ): ConfigValidationResult {
     const errors: string[] = [];
 
     // 验证配置基本结构
@@ -1080,7 +1083,7 @@ export namespace MCPServerConfigValidator {
   /**
    * 验证服务名称
    */
-  export function validateServiceName(name: string): ValidationResult {
+  export function validateServiceName(name: string): ConfigValidationResult {
     const errors: string[] = [];
 
     if (!name || typeof name !== "string") {

--- a/apps/frontend/src/utils/mcpValidation.ts
+++ b/apps/frontend/src/utils/mcpValidation.ts
@@ -5,8 +5,11 @@
 
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 
-// 验证结果接口
-export interface ValidationResult {
+/**
+ * MCP 配置验证结果接口
+ * 用于高级模式下的 MCP 配置验证，包含解析后的数据
+ */
+export interface MCPConfigValidationResult {
   success: boolean;
   data?: Record<string, MCPServerConfig>;
   error?: string;
@@ -83,7 +86,7 @@ export function validateSingleServerConfig(
  * @param input - JSON 字符串格式的配置
  * @returns 验证结果，包含是否成功、解析后的数据和错误信息
  */
-export function validateMCPConfig(input: string): ValidationResult {
+export function validateMCPConfig(input: string): MCPConfigValidationResult {
   try {
     const trimmed = input.trim();
     if (!trimmed) {

--- a/packages/cli/src/interfaces/Config.ts
+++ b/packages/cli/src/interfaces/Config.ts
@@ -15,9 +15,10 @@ export interface IDIContainer {
 }
 
 /**
- * 配置验证结果
+ * 配置文件验证结果接口
+ * 用于 CLI 配置文件验证，返回简单的验证结果
  */
-export interface ValidationResult {
+export interface ConfigFileValidationResult {
   /** 是否有效 */
   valid: boolean;
   /** 错误信息 */


### PR DESCRIPTION
将 5 个位置定义的同名但结构不同的 ValidationResult 类型重命名为专用名称：
- mcp-manage.handler.ts: ValidationResult → ConfigValidationResult
- endpoint.handler.ts: ValidationResult → EndpointValidationResult
- frontend/mcpValidation.ts: ValidationResult → MCPConfigValidationResult
- cli/interfaces/Config.ts: ValidationResult → ConfigFileValidationResult

保留 shared-types/validation.ts 的 ValidationResult 作为 API 验证的标准类型。

修复 #2800

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2800