### PR TITLE
fix: 移除遗留的 console.log 调试语句

### DIFF
--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -60,7 +60,6 @@ export function InstallLogDialog({
   // 对话框打开时开始安装
   useEffect(() => {
     if (isOpen && version) {
-      console.log("[InstallLogDialog] 对话框打开，开始安装版本:", version);
       clearStatus();
       startInstall(version).catch((error) => {
         console.error("[InstallLogDialog] 启动安装失败:", error);

--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -101,9 +101,6 @@ export function WebUrlSettingButton() {
       return;
     }
 
-    console.log(
-      `[WebUrlSettingButton] 开始端口切换: ${currentPort} -> ${newPort}`
-    );
     setIsLoading(true);
 
     try {

--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -88,12 +88,10 @@ export function NetworkServiceProvider({
 
     const initStores = async () => {
       try {
-        console.log("[WebSocketProvider] 开始初始化 stores");
         await initializeStores();
 
         if (mounted) {
           setStoresInitialized(true);
-          console.log("[WebSocketProvider] Stores 初始化完成");
         }
       } catch (error) {
         console.error("[WebSocketProvider] Stores 初始化失败:", error);


### PR DESCRIPTION
移除以下文件中的调试 console.log 语句，符合项目日志规范：
- WebSocketProvider.tsx: 移除 stores 初始化的开始和完成日志
- install-log-dialog.tsx: 移除对话框打开时的安装版本日志
- web-url-setting-button.tsx: 移除端口切换开始的日志

保留 console.error 用于错误处理，符合项目规范。

Closes #2802

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2802