### PR TITLE
fix(ci): 添加 backend 测试目标的构建依赖

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -10,14 +10,15 @@
         "command": "pnpm --filter backend run build"
       },
       "outputs": ["{workspaceRoot}/dist/backend"],
-      "dependsOn": ["shared-types:build", "config:build"]
+      "dependsOn": ["shared-types:build", "config:build", "endpoint:build", "version:build", "mcp-core:build"]
     },
     "test": {
       "executor": "nx:run-commands",
       "options": {
         "command": "pnpm --filter backend run test"
       },
-      "outputs": ["{workspaceRoot}/coverage"]
+      "outputs": ["{workspaceRoot}/coverage"],
+      "dependsOn": ["config:build", "endpoint:build", "version:build"]
     },
     "test:watch": {
       "executor": "nx:run-commands",
@@ -30,7 +31,8 @@
       "options": {
         "command": "pnpm --filter backend run test:coverage"
       },
-      "outputs": ["{workspaceRoot}/coverage"]
+      "outputs": ["{workspaceRoot}/coverage"],
+      "dependsOn": ["config:build", "endpoint:build", "version:build"]
     },
     "lint": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
修复 packages/endpoint 缺少 dist 目录导致测试覆盖率检查失败的问题。

- 在 backend 的 build 目标添加 endpoint:build, version:build, mcp-core:build 依赖
- 在 backend 的 test 目标添加 config:build, endpoint:build, version:build 依赖
- 在 backend 的 test:coverage 目标添加 config:build, endpoint:build, version:build 依赖

Fixes #2805

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2805