### PR TITLE
fix(ci): add test:coverage dependsOn build in nx.json

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -20,6 +20,12 @@
       "cache": false
     },
     "test": {
+      "dependsOn": ["^build"],
+      "inputs": ["default", "^production", "sharedGlobals"],
+      "cache": false
+    },
+    "test:coverage": {
+      "dependsOn": ["^build"],
       "inputs": ["default", "^production", "sharedGlobals"],
       "cache": false
     },


### PR DESCRIPTION
Fixes issue where test:coverage fails due to missing dist directories
in dependent packages (config, endpoint, mcp-core). The test:coverage
target was missing the dependsOn configuration to build dependencies
before running tests.

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2811