### PR TITLE
fix: 移除 version-manager.tsx 中的调试 console.log 语句

### DIFF
--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -65,12 +65,10 @@ export function VersionManager() {
       setError(null);
       const versionInfo = await apiClient.getVersion();
       setCurrentVersion(versionInfo);
-      console.log("[VersionManager] 当前版本信息:", versionInfo);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "获取版本信息失败";
       setError(errorMessage);
-      console.error("[VersionManager] 获取版本信息失败:", err);
     }
   }, []);
 
@@ -81,10 +79,6 @@ export function VersionManager() {
     try {
       setIsLoading(true);
       setError(null);
-
-      // 这里可以调用检查更新的 API
-      // 暂时模拟一个检查更新的过程
-      console.log("[VersionManager] 检查更新...");
 
       // 模拟 API 调用延迟
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -100,11 +94,9 @@ export function VersionManager() {
       };
 
       setUpdateInfo(mockUpdateInfo);
-      console.log("[VersionManager] 更新检查结果:", mockUpdateInfo);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "检查更新失败";
       setError(errorMessage);
-      console.error("[VersionManager] 检查更新失败:", err);
     } finally {
       setIsLoading(false);
     }
@@ -112,7 +104,6 @@ export function VersionManager() {
 
   // 开始更新
   const startUpdate = (version: string) => {
-    console.log("[VersionManager] 开始更新到版本:", version);
     setTargetVersion(version);
     setShowInstallDialog(true);
   };


### PR DESCRIPTION
移除 6 处违反项目日志规范的 console 语句：
- console.log("[VersionManager] 当前版本信息:", versionInfo);
- console.error("[VersionManager] 获取版本信息失败:", err);
- console.log("[VersionManager] 检查更新...");
- console.log("[VersionManager] 更新检查结果:", mockUpdateInfo);
- console.error("[VersionManager] 检查更新失败:", err);
- console.log("[VersionManager] 开始更新到版本:", version);

修复 Issue #2823

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2823