### PR TITLE
fix(cli): 移除 ConfigCommandHandler 中的 any 类型使用

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -3,6 +3,12 @@
  */
 
 import path from "node:path";
+import type {
+  HTTPMCPServerConfig,
+  LocalMCPServerConfig,
+  MCPServerConfig,
+  SSEMCPServerConfig,
+} from "@xiaozhi-client/config";
 import chalk from "chalk";
 import ora from "ora";
 import type { SubCommand } from "../interfaces/Command";
@@ -163,14 +169,26 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           for (const [name, serverConfig] of Object.entries(
             config.mcpServers
           )) {
-            const server = serverConfig as any;
-            // 检查是否是 SSE 类型
+            const server = serverConfig as MCPServerConfig;
+            // 使用类型守卫区分不同类型的 MCP 服务器配置
             if ("type" in server && server.type === "sse") {
-              console.log(chalk.gray(`  ${name}: [SSE] ${server.url}`));
+              const sseConfig = server as SSEMCPServerConfig;
+              console.log(chalk.gray(`  ${name}: [SSE] ${sseConfig.url}`));
+            } else if (
+              "type" in server &&
+              (server.type === "http" || server.type === "streamable-http")
+            ) {
+              const httpConfig = server as HTTPMCPServerConfig;
+              console.log(chalk.gray(`  ${name}: [HTTP] ${httpConfig.url}`));
+            } else if ("url" in server) {
+              // HTTP 配置（type 未指定，默认为 streamable-http）
+              console.log(chalk.gray(`  ${name}: [HTTP] ${server.url}`));
             } else {
+              // 本地进程配置 (LocalMCPServerConfig)
+              const localConfig = server as LocalMCPServerConfig;
               console.log(
                 chalk.gray(
-                  `  ${name}: ${server.command} ${server.args.join(" ")}`
+                  `  ${name}: ${localConfig.command} ${localConfig.args.join(" ")}`
                 )
               );
             }


### PR DESCRIPTION
- 导入 MCPServerConfig, LocalMCPServerConfig, SSEMCPServerConfig, HTTPMCPServerConfig 类型
- 使用类型守卫替代 as any 断言
- 添加对 HTTP 类型配置的完整处理逻辑

修复 #2830

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2830