### PR TITLE
fix: prompt-utils.ts 使用 logger 替代 console

### DIFF
--- a/apps/backend/utils/prompt-utils.ts
+++ b/apps/backend/utils/prompt-utils.ts
@@ -16,6 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { logger } from "@/Logger.js";
 import { configManager } from "@xiaozhi-client/config";
 
 // 默认系统提示词
@@ -73,9 +74,7 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件是否存在
     if (!existsSync(resolvedPath)) {
-      console.warn(
-        `[prompt-utils] 提示词文件不存在: ${resolvedPath}，将使用默认提示词`
-      );
+      logger.warn(`提示词文件不存在: ${resolvedPath}，将使用默认提示词`);
       return null;
     }
 
@@ -84,17 +83,15 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件内容是否为空
     if (!content) {
-      console.warn(
-        `[prompt-utils] 提示词文件内容为空: ${resolvedPath}，将使用默认提示词`
-      );
+      logger.warn(`提示词文件内容为空: ${resolvedPath}，将使用默认提示词`);
       return null;
     }
 
-    console.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
+    logger.info(`成功从文件加载提示词: ${resolvedPath}`);
     return content;
   } catch (error) {
-    console.error(
-      `[prompt-utils] 读取提示词文件失败: ${promptPath}`,
+    logger.error(
+      `读取提示词文件失败: ${promptPath}`,
       error instanceof Error ? error.message : String(error)
     );
     return null;
@@ -178,8 +175,8 @@ export function listPromptFiles(): PromptFileInfo[] {
 
     return promptFiles;
   } catch (error) {
-    console.error(
-      "[prompt-utils] 获取提示词文件列表失败:",
+    logger.error(
+      "获取提示词文件列表失败:",
       error instanceof Error ? error.message : String(error)
     );
     return [];


### PR DESCRIPTION
将 apps/backend/utils/prompt-utils.ts 中的 console.warn/error/info
替换为项目统一的 logger 实例，符合项目日志规范。

变更内容:
- 导入 logger 实例
- 替换 console.warn -> logger.warn (2处)
- 替换 console.error -> logger.error (2处)
- 替换 console.info -> logger.info (1处)
- 移除 [prompt-utils] 前缀（logger 会自动处理模块标识）

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2832