### PR TITLE
refactor(types): 消除 apps/backend/types/toolApi.ts 与 shared-types 的重复定义

### DIFF
--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -1,87 +1,57 @@
 /**
  * 工具添加 API 相关类型定义
  * 支持多种工具类型的添加，包括 MCP 工具、Coze 工作流等
+ *
+ * 注意：此文件现在从 @xiaozhi-client/shared-types 重导出类型，
+ * 以消除与 packages/shared-types/src/api/toolApi.ts 的重复定义。
+ * 权威定义位置：packages/shared-types/src/api/toolApi.ts
+ *
+ * 注意：JSONSchema 类型保留本地定义，因为 backend 的 JSONSchema
+ * 使用 MCP SDK 兼容格式（Record<string, unknown>），而 shared-types
+ * 使用严格的递归格式（Record<string, JSONSchema>）。
  */
 
+// =========================
+// 本地类型定义（与 shared-types 不兼容）
+// =========================
+
 import type { JSONSchema as LibJSONSchema } from "@/lib/mcp/types.js";
-import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
+
+// 从 shared-types 导入处理器配置类型（用于本地接口定义）
+import type {
+  FunctionHandlerConfig,
+  HttpHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  ToolHandlerConfig as SharedToolHandlerConfig,
+} from "@xiaozhi-client/shared-types";
+
+// 使用本地别名以便在接口中使用
+type ToolHandlerConfig = SharedToolHandlerConfig;
 
 /**
  * JSON Schema 类型
  * 重新导出 @/lib/mcp/types.js 中的 JSONSchema
  *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 JSONSchema 相同
- * TODO：将来应从 shared-types 导入 JSONSchema 以消除重复定义
+ * 注意：此类型与 shared-types 的 JSONSchema 定义不同：
+ * - backend 版本：Record<string, unknown>（宽松格式，兼容 MCP SDK）
+ * - shared-types 版本：Record<string, JSONSchema>（严格递归格式）
+ * 保持本地定义以确保 MCP SDK 兼容性
  */
 export type JSONSchema = LibJSONSchema;
 
-/**
- * 工具处理器配置相关类型
- *
- * 注意：这些类型与 @xiaozhi-client/shared-types/src/mcp/tool-definition.ts 中定义的类型相同
- * TODO：将 toolApi.ts 的类型迁移为从 shared-types 导入，消除重复定义
- * 目前保持本地定义以避免 TypeScript 子路径解析问题（影响 tts、asr 等其他包）
- *
- * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts
- */
-export type ToolHandlerConfig =
-  | MCPHandlerConfig
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig;
-
-/**
- * MCP 处理器配置
- * 用于标准 MCP 服务中的工具
- */
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
-
-/**
- * 代理处理器配置
- * 用于第三方平台代理（如 Coze、OpenAI 等）
- */
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: Record<string, unknown>;
-}
-
-/**
- * HTTP 处理器配置
- * 用于 HTTP API 工具
- */
-export interface HttpHandlerConfig {
-  type: "http";
-  config: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
-  };
-}
-
-/**
- * 函数处理器配置
- * 用于自定义函数工具
- */
-export interface FunctionHandlerConfig {
-  type: "function";
-  config: {
-    module: string;
-    function: string;
-  };
-}
+// 导出处理器配置类型
+export type {
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+};
 
 /**
  * CustomMCP 工具基础接口
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPTool 相同
- * TODO：将来应从 shared-types 导入 CustomMCPTool 以消除重复定义
+ * 使用 backend 本地的 JSONSchema 类型
  */
 export interface CustomMCPToolBase {
   /** 工具唯一标识符 */
@@ -96,10 +66,8 @@ export interface CustomMCPToolBase {
 
 /**
  * 带统计信息的 CustomMCP 工具
+ * 使用 backend 本地的 JSONSchema 类型
  * 用于 API 响应，使用扁平的统计信息结构
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPToolWithStats 类似
- * 但不包含 `enabled` 字段。如需完整功能，请从 shared-types 导入
  */
 export interface CustomMCPToolWithStats extends CustomMCPToolBase {
   /** 工具使用次数（扁平结构，与 API 响应格式一致） */
@@ -108,192 +76,23 @@ export interface CustomMCPToolWithStats extends CustomMCPToolBase {
   lastUsedTime?: string;
 }
 
-/**
- * 工具类型枚举
- */
-export enum ToolType {
-  /** MCP 工具（标准 MCP 服务中的工具） */
-  MCP = "mcp",
-  /** Coze 工作流工具 */
-  COZE = "coze",
-  /** HTTP API 工具（预留） */
-  HTTP = "http",
-  /** 自定义函数工具（预留） */
-  FUNCTION = "function",
-}
+// =========================
+// 从 shared-types 重导出的类型
+// =========================
 
-/**
- * MCP 工具数据
- * 用于将标准 MCP 服务中的工具添加到 customMCP.tools 配置中
- */
-export interface MCPToolData {
-  /** MCP 服务名称 */
-  serviceName: string;
-  /** 工具名称 */
-  toolName: string;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
+// 工具 API 数据类型
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ExtendedCustomMCPTool,
+  ToolValidationErrorDetail,
+} from "@xiaozhi-client/shared-types";
 
-/**
- * Coze 工作流数据
- * 保持与现有格式的兼容性
- */
-export interface CozeWorkflowData {
-  /** Coze 工作流信息 */
-  workflow: CozeWorkflow;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-  /** 可选的参数配置 */
-  parameterConfig?: WorkflowParameterConfig;
-}
-
-/**
- * HTTP API 工具数据（预留）
- */
-export interface HttpApiToolData {
-  /** API 地址 */
-  url: string;
-  /** HTTP 方法 */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  /** API 描述 */
-  description: string;
-  /** 请求头 */
-  headers?: Record<string, string>;
-  /** 请求体模板 */
-  bodyTemplate?: string;
-  /** 认证配置 */
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    apiKey?: string;
-    apiKeyHeader?: string;
-  };
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 函数工具数据（预留）
- */
-export interface FunctionToolData {
-  /** 模块路径 */
-  module: string;
-  /** 函数名 */
-  function: string;
-  /** 函数描述 */
-  description: string;
-  /** 函数执行上下文 */
-  context?: Record<string, any>;
-  /** 超时时间 */
-  timeout?: number;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 添加自定义工具的统一请求接口
- */
-export interface AddCustomToolRequest {
-  /** 工具类型 */
-  type: ToolType;
-  /** 工具数据（根据类型不同而不同） */
-  data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
-}
-
-/**
- * 工具验证错误类型
- */
-export enum ToolValidationError {
-  /** 无效的工具类型 */
-  INVALID_TOOL_TYPE = "INVALID_TOOL_TYPE",
-  /** 缺少必需字段 */
-  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
-  /** 服务不存在 */
-  SERVICE_NOT_FOUND = "SERVICE_NOT_FOUND",
-  /** 工具名称冲突 */
-  TOOL_NAME_CONFLICT = "TOOL_NAME_CONFLICT",
-  /** 配置验证失败 */
-  CONFIG_VALIDATION_FAILED = "CONFIG_VALIDATION_FAILED",
-  /** 系统配置错误 */
-  SYSTEM_CONFIG_ERROR = "SYSTEM_CONFIG_ERROR",
-  /** 资源限制超出 */
-  RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED",
-}
-
-/**
- * 工具验证错误详情
- */
-export interface ToolValidationErrorDetail {
-  /** 错误类型 */
-  error: ToolValidationError;
-  /** 错误消息 */
-  message: string;
-  /** 错误详情 */
-  details?: any;
-  /** 建议的解决方案 */
-  suggestions?: string[];
-}
-
-/**
- * 添加工具的响应数据
- */
-export interface AddToolResponse {
-  /** 成功添加的工具 */
-  tool: any;
-  /** 工具名称 */
-  toolName: string;
-  /** 工具类型 */
-  toolType: ToolType;
-  /** 添加时间戳 */
-  addedAt: string;
-}
-
-/**
- * 工具元数据信息
- */
-export interface ToolMetadata {
-  /** 工具原始来源 */
-  source: {
-    type: "mcp" | "coze" | "http" | "function";
-    serviceName?: string;
-    toolName?: string;
-    url?: string;
-  };
-  /** 添加时间 */
-  addedAt: string;
-  /** 最后更新时间 */
-  updatedAt?: string;
-  /** 版本信息 */
-  version?: string;
-}
-
-/**
- * 工具配置选项
- */
-export interface ToolConfigOptions {
-  /** 是否启用工具（默认 true） */
-  enabled?: boolean;
-  /** 超时时间（毫秒） */
-  timeout?: number;
-  /** 重试次数 */
-  retryCount?: number;
-  /** 重试间隔（毫秒） */
-  retryDelay?: number;
-  /** 自定义标签 */
-  tags?: string[];
-  /** 工具分组 */
-  group?: string;
-}
+// 导出枚举类型
+export { ToolType, ToolValidationError } from "@xiaozhi-client/shared-types";

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -25,10 +25,34 @@ export type {
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
   JSONSchema,
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
 } from "./mcp";
 
 // 工具API相关类型
-export type { ToolType, MCPToolData } from "./api";
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ExtendedCustomMCPTool,
+  ToolValidationErrorDetail,
+} from "./api";
+
+export {
+  ToolType,
+} from "./api";
+
+// 导出 ToolValidationError（从 api 导入时名称为 ApiToolValidationError）
+import { ApiToolValidationError } from "./api";
+export { ApiToolValidationError as ToolValidationError };
 
 // 配置相关类型
 export type {


### PR DESCRIPTION
- 将 apps/backend/types/toolApi.ts 的重复类型改为从 @xiaozhi-client/shared-types 导入
- 更新 packages/shared-types/src/index.ts 导出所有工具 API 类型
- 保留 backend 本地 JSONSchema 定义（因 MCP SDK 兼容性要求）
- 保留 CustomMCPToolBase 和 CustomMCPToolWithStats 本地定义（依赖本地 JSONSchema）

消除约 188 行重复代码，解决 jscpd 检测到的跨包类型重复问题

Closes #2836

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2836