### PR TITLE
docs(shared-types): 消除 ConnectionConfig 重复定义，统一使用带完整 JSDoc 注释的版本

### DIFF
--- a/packages/shared-types/src/config/app.ts
+++ b/packages/shared-types/src/config/app.ts
@@ -2,15 +2,10 @@
  * 应用配置相关类型定义
  */
 
-// 连接配置接口
-export interface ConnectionConfig {
-  heartbeatInterval?: number;
-  heartbeatTimeout?: number;
-  reconnectInterval?: number;
-  maxReconnectAttempts?: number;
-  connectionTimeout?: number;
-  autoReconnect?: boolean;
-}
+// 从 connection.ts 导入 ConnectionConfig，避免重复定义并保持文档一致性
+import type { ConnectionConfig } from "./connection";
+// 重新导出 ConnectionConfig 供外部使用
+export { ConnectionConfig };
 
 /**
  * 本地 MCP 服务器配置


### PR DESCRIPTION
- 移除 app.ts 中缺少属性级 JSDoc 注释的 ConnectionConfig 定义
- 从 connection.ts 导入并重新导出 ConnectionConfig
- 保持向后兼容性，同时确保文档一致性

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2841