### PR TITLE
fix: 统一 CustomMCPTool 类型定义，解决跨包类型不一致问题

### DIFF
--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -228,8 +228,10 @@ export class CozeHandler extends BaseHandler {
         const addedTool = customMCPTools.find(
           (tool) =>
             tool.handler.type === "proxy" &&
+            "platform" in tool.handler &&
             tool.handler.platform === "coze" &&
-            tool.handler.config.workflow_id === item.workflow_id
+            "workflow_id" in (tool.handler.config || {}) &&
+            tool.handler.config?.workflow_id === item.workflow_id
         );
 
         return {

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -937,6 +937,7 @@ export class MCPToolHandler {
     // 验证是否为 Coze 工具
     if (
       existingTool.handler.type !== "proxy" ||
+      !("platform" in existingTool.handler) ||
       existingTool.handler.platform !== "coze"
     ) {
       return c.fail(
@@ -949,7 +950,7 @@ export class MCPToolHandler {
 
     // 如果前端提供的 workflow 中没有 workflow_id，尝试从现有工具中获取
     if (!workflow.workflow_id && existingTool.handler?.config?.workflow_id) {
-      workflow.workflow_id = existingTool.handler.config.workflow_id;
+      workflow.workflow_id = String(existingTool.handler.config.workflow_id);
     }
 
     // 如果还没有 workflow_id，尝试从其他字段获取
@@ -1082,8 +1083,10 @@ export class MCPToolHandler {
 
       if (toolToDelete && toolToDelete.handler.type === "mcp") {
         // 这是 MCP 工具，需要在 mcpServerConfig 中同步禁用
-        const mcpConfig = toolToDelete.handler.config;
-        if (mcpConfig.serviceName && mcpConfig.toolName) {
+        const mcpConfig = toolToDelete.handler.config as
+          | { serviceName?: string; toolName?: string }
+          | undefined;
+        if (mcpConfig?.serviceName && mcpConfig?.toolName) {
           c.get("logger").info(
             `检测到 MCP 工具删除，同步禁用 mcpServerConfig 中的工具: ${mcpConfig.serviceName}/${mcpConfig.toolName}`
           );

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -539,14 +539,8 @@ export class MCPServiceManager extends EventEmitter {
    * @param tool 工具对象
    * @returns 服务名称
    */
-  private getServiceNameForTool(tool: CustomMCPTool): string {
-    if (tool.handler?.type === "mcp") {
-      // 如果是从 MCP 同步的工具，返回原始服务名称
-      const config = tool.handler.config as
-        | { serviceName?: string; toolName?: string }
-        | undefined;
-      return config?.serviceName || "customMCP";
-    }
+  private getServiceNameForTool(tool: Tool): string {
+    // CustomMCP 工具默认返回 customMCP 服务名
     return "customMCP";
   }
 
@@ -634,17 +628,26 @@ export class MCPServiceManager extends EventEmitter {
 
         if (customTool?.handler?.type === "mcp") {
           // 对于 mcp 类型的工具，直接路由到对应的 MCP 服务
+          const mcpHandlerConfig = customTool.handler.config as
+            | { serviceName: string; toolName: string }
+            | undefined;
+
+          // 确保 MCP 配置存在
+          if (!mcpHandlerConfig?.serviceName || !mcpHandlerConfig?.toolName) {
+            throw new Error(`MCP 工具 ${toolName} 配置无效`);
+          }
+
           result = await this.callMCPTool(
             toolName,
-            customTool.handler.config,
+            mcpHandlerConfig,
             arguments_
           );
 
           // 异步更新工具调用统计（成功调用）
           this.updateToolStatsSafe(
             toolName,
-            customTool.handler.config.serviceName,
-            customTool.handler.config.toolName,
+            mcpHandlerConfig.serviceName,
+            mcpHandlerConfig.toolName,
             true
           );
         } else {
@@ -725,10 +728,13 @@ export class MCPServiceManager extends EventEmitter {
       if (this.customMCPHandler.hasTool(toolName)) {
         const customTool = this.customMCPHandler.getToolInfo(toolName);
         if (customTool?.handler?.type === "mcp") {
+          const mcpHandlerConfig = customTool.handler.config as
+            | { serviceName: string; toolName: string }
+            | undefined;
           this.updateToolStatsSafe(
             toolName,
-            customTool.handler.config.serviceName,
-            customTool.handler.config.toolName,
+            mcpHandlerConfig?.serviceName || "customMCP",
+            mcpHandlerConfig?.toolName || toolName,
             false
           );
         } else {

--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -185,19 +185,9 @@ export function ensureToolJSONSchema(schema: JSONSchema): {
   };
 }
 
-/**
- * CustomMCP 工具类型定义
- * 统一了 manager.ts 和 configManager.ts 中的定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
-  };
-}
+// 从 shared-types 导入 CustomMCPTool 类型
+// 保持与权威定义的一致性
+export type { CustomMCPTool } from "@xiaozhi-client/shared-types";
 
 /**
  * 工具信息接口

--- a/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
+++ b/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
@@ -126,9 +126,10 @@ function extractParametersFromSchema(
 
       return {
         fieldName,
-        description: schema.description || "",
+        description:
+          typeof schema.description === "string" ? schema.description : "",
         type,
-        required: required.includes(fieldName),
+        required: Array.isArray(required) && required.includes(fieldName),
       };
     }
   );

--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -95,7 +95,10 @@ export function McpServerList({
   // 格式化工具信息的辅助函数
   const formatTool = useCallback(
     (tool: CustomMCPToolWithStats, enable: boolean) => {
-      const { serviceName, toolName } = (() => {
+      const getServiceInfo = (): {
+        serviceName: string;
+        toolName: string;
+      } => {
         // 安全检查：确保 handler 存在
         if (!tool || !tool.handler) {
           return {
@@ -105,13 +108,18 @@ export function McpServerList({
         }
 
         if (tool.handler.type === "mcp") {
+          const handler = tool.handler as import("@xiaozhi-client/shared-types").MCPHandlerConfig;
           return {
             serviceName:
-              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
-            toolName: tool.handler.config?.toolName || tool.name,
+              handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
+            toolName: handler.config?.toolName || tool.name,
           };
         }
-        if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
+        if (
+          tool.handler.type === "proxy" &&
+          "platform" in tool.handler &&
+          tool.handler.platform === "coze"
+        ) {
           return {
             serviceName: "customMCP",
             toolName: tool.name,
@@ -121,7 +129,9 @@ export function McpServerList({
           serviceName: CUSTOM_SERVICE_NAME,
           toolName: tool.name,
         };
-      })();
+      };
+
+      const { serviceName, toolName } = getServiceInfo();
 
       return {
         serverName: serviceName,

--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -116,7 +116,10 @@ export function McpToolTable({
   // 格式化工具信息的辅助函数
   const formatTool = useCallback(
     (tool: CustomMCPToolWithStats, enabled: boolean): ToolRowData => {
-      const { serviceName, toolName } = (() => {
+      const getServiceInfo = (): {
+        serviceName: string;
+        toolName: string;
+      } => {
         if (!tool || !tool.handler) {
           return {
             serviceName: UNKNOWN_SERVICE_NAME,
@@ -125,13 +128,18 @@ export function McpToolTable({
         }
 
         if (tool.handler.type === "mcp") {
+          const handler = tool.handler as import("@xiaozhi-client/shared-types").MCPHandlerConfig;
           return {
             serviceName:
-              tool.handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
-            toolName: tool.handler.config?.toolName || tool.name,
+              handler.config?.serviceName || UNKNOWN_SERVICE_NAME,
+            toolName: handler.config?.toolName || tool.name,
           };
         }
-        if (tool.handler.type === "proxy" && tool.handler.platform === "coze") {
+        if (
+          tool.handler.type === "proxy" &&
+          "platform" in tool.handler &&
+          tool.handler.platform === "coze"
+        ) {
           return {
             serviceName: "customMCP",
             toolName: tool.name,
@@ -141,7 +149,9 @@ export function McpToolTable({
           serviceName: CUSTOM_SERVICE_NAME,
           toolName: tool.name,
         };
-      })();
+      };
+
+      const { serviceName, toolName } = getServiceInfo();
 
       return {
         name: tool.name,

--- a/packages/config/package.json
+++ b/packages/config/package.json
@@ -26,6 +26,7 @@
   },
   "dependencies": {
     "@xiaozhi-client/mcp-core": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*",
     "comment-json": "^4.2.5",
     "dayjs": "^1.11.13"
   },

--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -144,104 +144,34 @@ export interface ToolCallLogConfig {
 }
 
 // CustomMCP 相关接口定义
+// 从 shared-types 导入处理器配置类型，保持类型一致性
+import type {
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
+  MCPHandlerConfig,
+  ToolHandlerConfig,
+  CustomMCPTool as BaseCustomMCPTool,
+} from "@xiaozhi-client/shared-types";
 
-// 代理处理器配置
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: {
-    // Coze 平台配置
-    workflow_id?: string;
-    bot_id?: string;
-    api_key?: string;
-    base_url?: string;
-    // 通用配置
-    timeout?: number;
-    retry_count?: number;
-    retry_delay?: number;
-    headers?: Record<string, string>;
-    params?: Record<string, unknown>;
-  };
-}
+// 向后兼容：重新导出处理器配置类型
+export type {
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
+  MCPHandlerConfig,
+};
 
-// HTTP 处理器配置
-export interface HttpHandlerConfig {
-  type: "http";
-  url: string;
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  headers?: Record<string, string>;
-  timeout?: number;
-  retry_count?: number;
-  retry_delay?: number;
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    api_key?: string;
-    api_key_header?: string;
-  };
-  body_template?: string; // 支持模板变量替换
-  response_mapping?: {
-    success_path?: string; // JSONPath 表达式
-    error_path?: string;
-    data_path?: string;
-  };
-}
+// 向后兼容：HandlerConfig 别名
+export type HandlerConfig = ToolHandlerConfig;
 
-// 函数处理器配置
-export interface FunctionHandlerConfig {
-  type: "function";
-  module: string; // 模块路径
-  function: string; // 函数名
-  timeout?: number;
-  context?: Record<string, unknown>; // 函数执行上下文
-}
-
-// 脚本处理器配置
-export interface ScriptHandlerConfig {
-  type: "script";
-  script: string; // 脚本内容或文件路径
-  interpreter?: "node" | "python" | "bash";
-  timeout?: number;
-  env?: Record<string, string>; // 环境变量
-}
-
-// 链式处理器配置
-export interface ChainHandlerConfig {
-  type: "chain";
-  tools: string[]; // 要链式调用的工具名称
-  mode: "sequential" | "parallel"; // 执行模式
-  error_handling: "stop" | "continue" | "retry"; // 错误处理策略
-}
-
-// MCP 处理器配置（用于同步的工具）
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
-
-export type HandlerConfig =
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig
-  | ScriptHandlerConfig
-  | ChainHandlerConfig
-  | MCPHandlerConfig;
-
-// CustomMCP 工具接口
-// TODO: 注意：此定义应与 @xiaozhi-client/shared-types 中的 CustomMCPToolConfig 保持一致
-// 未来将迁移到从 shared-types 导入
-export interface CustomMCPTool {
-  // 确保必填字段
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-  handler: HandlerConfig;
-
+// 配置文件中使用的 CustomMCP 工具类型
+// 使用 shared-types 的 CustomMCPTool 作为基础，添加 stats 字段（相当于 CustomMCPToolConfig）
+export interface CustomMCPTool extends BaseCustomMCPTool {
   // 使用统计信息（可选）
   stats?: {
     usageCount?: number; // 工具使用次数
@@ -1436,17 +1366,29 @@ export class ConfigManager {
   ): boolean {
     switch (handler.type) {
       case "proxy":
-        return this.validateProxyHandler(toolName, handler);
+        return this.validateProxyHandler(
+          toolName,
+          handler as ProxyHandlerConfig
+        );
       case "http":
-        return this.validateHttpHandler(toolName, handler);
+        return this.validateHttpHandler(toolName, handler as HttpHandlerConfig);
       case "function":
-        return this.validateFunctionHandler(toolName, handler);
+        return this.validateFunctionHandler(
+          toolName,
+          handler as FunctionHandlerConfig
+        );
       case "script":
-        return this.validateScriptHandler(toolName, handler);
+        return this.validateScriptHandler(
+          toolName,
+          handler as ScriptHandlerConfig
+        );
       case "chain":
-        return this.validateChainHandler(toolName, handler);
+        return this.validateChainHandler(
+          toolName,
+          handler as ChainHandlerConfig
+        );
       case "mcp":
-        return this.validateMCPHandler(toolName, handler);
+        return this.validateMCPHandler(toolName, handler as MCPHandlerConfig);
       default:
         console.warn("CustomMCP 工具使用了未知的处理器类型", {
           toolName,

--- a/packages/mcp-core/package.json
+++ b/packages/mcp-core/package.json
@@ -26,6 +26,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@xiaozhi-client/shared-types": "workspace:*",
     "eventsource": "^4.0.0",
     "ws": "^8.14.2"
   },

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -235,18 +235,9 @@ export function ensureToolJSONSchema(schema: JSONSchema): {
   };
 }
 
-/**
- * CustomMCP 工具类型定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
-  };
-}
+// 从 shared-types 导入 CustomMCPTool 类型
+// 保持与权威定义的一致性
+export type { CustomMCPTool } from "@xiaozhi-client/shared-types";
 
 /**
  * 工具信息接口

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -24,6 +24,14 @@ export type {
   CustomMCPTool,
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
+  ToolHandlerConfig,
+  BaseHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
   JSONSchema,
 } from "./mcp";
 

--- a/packages/shared-types/src/mcp/index.ts
+++ b/packages/shared-types/src/mcp/index.ts
@@ -53,10 +53,13 @@ export type {
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
   ToolHandlerConfig,
+  BaseHandlerConfig,
   MCPHandlerConfig,
   ProxyHandlerConfig,
   HttpHandlerConfig,
   FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
 } from "./tool-definition";
 
 // JSON Schema 类型

--- a/packages/shared-types/src/mcp/schema.ts
+++ b/packages/shared-types/src/mcp/schema.ts
@@ -5,19 +5,21 @@
 
 /**
  * JSON Schema 类型
- * 带类型守卫的严格 JSON Schema 类型定义
+ * 兼容多种定义方式的宽松类型
  */
-export interface JSONSchema {
-  type?: string | string[];
-  properties?: Record<string, JSONSchema>;
-  required?: string[];
-  items?: JSONSchema;
-  additionalProperties?: boolean | JSONSchema;
-  description?: string;
-  enum?: unknown[];
-  const?: unknown;
-  [key: string]: unknown;
-}
+export type JSONSchema =
+  | {
+      type?: string | string[];
+      properties?: Record<string, JSONSchema>;
+      required?: string[];
+      items?: JSONSchema;
+      additionalProperties?: boolean | JSONSchema;
+      description?: string;
+      enum?: unknown[];
+      const?: unknown;
+      [key: string]: unknown;
+    }
+  | Record<string, unknown>;
 
 /**
  * 检查值是否为有效的 JSON Schema

--- a/packages/shared-types/src/mcp/tool-definition.ts
+++ b/packages/shared-types/src/mcp/tool-definition.ts
@@ -6,13 +6,13 @@
 import type { JSONSchema } from "./schema.js";
 
 /**
- * 工具处理器配置联合类型
+ * 基础处理器配置接口
+ * 允许自定义处理器类型
  */
-export type ToolHandlerConfig =
-  | MCPHandlerConfig
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig;
+export interface BaseHandlerConfig {
+  type: string;
+  config?: Record<string, unknown>;
+}
 
 /**
  * MCP 处理器配置
@@ -33,7 +33,17 @@ export interface MCPHandlerConfig {
 export interface ProxyHandlerConfig {
   type: "proxy";
   platform: "coze" | "openai" | "anthropic" | "custom";
-  config: Record<string, unknown>;
+  config: {
+    workflow_id?: string;
+    bot_id?: string;
+    api_key?: string;
+    base_url?: string;
+    timeout?: number;
+    retry_count?: number;
+    retry_delay?: number;
+    headers?: Record<string, string>;
+    params?: Record<string, unknown>;
+  };
 }
 
 /**
@@ -42,10 +52,25 @@ export interface ProxyHandlerConfig {
  */
 export interface HttpHandlerConfig {
   type: "http";
-  config: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry_count?: number;
+  retry_delay?: number;
+  auth?: {
+    type: "bearer" | "basic" | "api_key";
+    token?: string;
+    username?: string;
+    password?: string;
+    api_key?: string;
+    api_key_header?: string;
+  };
+  body_template?: string;
+  response_mapping?: {
+    success_path?: string;
+    error_path?: string;
+    data_path?: string;
   };
 }
 
@@ -55,11 +80,47 @@ export interface HttpHandlerConfig {
  */
 export interface FunctionHandlerConfig {
   type: "function";
-  config: {
-    module: string;
-    function: string;
-  };
+  module: string;
+  function: string;
+  timeout?: number;
+  context?: Record<string, unknown>;
 }
+
+/**
+ * 脚本处理器配置
+ * 用于执行脚本的工具
+ */
+export interface ScriptHandlerConfig {
+  type: "script";
+  script: string;
+  interpreter?: "node" | "python" | "bash";
+  timeout?: number;
+  env?: Record<string, string>;
+}
+
+/**
+ * 链式处理器配置
+ * 用于链式调用多个工具
+ */
+export interface ChainHandlerConfig {
+  type: "chain";
+  tools: string[];
+  mode: "sequential" | "parallel";
+  error_handling: "stop" | "continue" | "retry";
+}
+
+/**
+ * 工具处理器配置联合类型
+ * 包含所有已知的处理器类型
+ */
+export type ToolHandlerConfig =
+  | MCPHandlerConfig
+  | ProxyHandlerConfig
+  | HttpHandlerConfig
+  | FunctionHandlerConfig
+  | ScriptHandlerConfig
+  | ChainHandlerConfig
+  | BaseHandlerConfig; // 允许自定义处理器类型
 
 /**
  * CustomMCP 工具基础接口

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -628,6 +628,9 @@ importers:
       '@xiaozhi-client/mcp-core':
         specifier: workspace:*
         version: link:../mcp-core
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       comment-json:
         specifier: ^4.2.5
         version: 4.5.1
@@ -687,6 +690,9 @@ importers:
       '@modelcontextprotocol/sdk':
         specifier: ^1.26.0
         version: 1.26.0(zod@4.3.6)
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       eventsource:
         specifier: ^4.0.0
         version: 4.1.0


### PR DESCRIPTION
## 问题
CustomMCPTool 类型在多个包中重复定义且结构不一致，可能导致类型检查通过但实际运行时出错。

## 修复内容
1. **shared-types**: 添加 BaseHandlerConfig、ScriptHandlerConfig、ChainHandlerConfig，扩展 ToolHandlerConfig 联合类型
2. **mcp-core**: 移除本地 CustomMCPTool 定义，改为从 shared-types 导入
3. **backend/lib/mcp/types.ts**: 移除本地 CustomMCPTool 定义，改为从 shared-types 导入
4. **config/manager.ts**: 从 shared-types 导入处理器配置类型，扩展 CustomMCPTool 添加 stats 字段
5. **前端组件**: 修复类型收窄问题，添加类型守卫
6. **后端处理器**: 修复 handler.config 可选访问问题

## 类型变更
- CustomMCPTool.handler 现在为必填字段
- 添加 BaseHandlerConfig 支持自定义处理器类型
- JSONSchema 类型改为联合类型以兼容不同定义

Closes #2846

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2846