### PR TITLE
fix: endpoint.route.ts 使用 logger.error 替代 console.error

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,6 +4,7 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import { logger } from "@/Logger.js";
 import type { RouteDefinition } from "@/routes/types.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
@@ -43,7 +44,7 @@ const withEndpointHandler = async (
     // 使用类型安全的方式调用方法
     return await endpointHandler[handlerName](c);
   } catch (error) {
-    console.error(`端点处理器错误 [${handlerName}]:`, error);
+    logger.error(`端点处理器错误 [${handlerName}]:`, error);
     return c.fail(
       "ENDPOINT_HANDLER_ERROR",
       error instanceof Error ? error.message : "端点处理失败",


### PR DESCRIPTION
将 console.error 替换为项目统一的 logger.error 方法，遵循项目日志规范。

修复：
- 导入 Logger 模块
- 使用 logger.error 替代 console.error
- 调整导入顺序以符合 biome 规范

Issue: #2848

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2848