### PR TITLE
fix: 移除遗留的调试 console.log/console.error 语句

### DIFF
--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -60,10 +60,9 @@ export function InstallLogDialog({
   // 对话框打开时开始安装
   useEffect(() => {
     if (isOpen && version) {
-      console.log("[InstallLogDialog] 对话框打开，开始安装版本:", version);
       clearStatus();
-      startInstall(version).catch((error) => {
-        console.error("[InstallLogDialog] 启动安装失败:", error);
+      startInstall(version).catch((_error) => {
+        // 错误已在 hook 中处理，此处无需额外处理
       });
     }
   }, [isOpen, version, startInstall, clearStatus]);

--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -101,9 +101,6 @@ export function WebUrlSettingButton() {
       return;
     }
 
-    console.log(
-      `[WebUrlSettingButton] 开始端口切换: ${currentPort} -> ${newPort}`
-    );
     setIsLoading(true);
 
     try {
@@ -124,7 +121,6 @@ export function WebUrlSettingButton() {
       );
       setOpen(false);
     } catch (error) {
-      console.error("端口切换失败:", error);
       const errorMessage =
         error instanceof Error ? error.message : "端口切换失败";
       toast.error(`端口切换失败: ${errorMessage}`);


### PR DESCRIPTION
移除两个前端组件中违反项目日志规范的调试语句：
- install-log-dialog.tsx: 移除 console.log 和 console.error
- web-url-setting-button.tsx: 移除 console.log 和 console.error

错误信息已通过 toast.error 显示给用户，无需 console.error。

Closes #2852

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2852