### PR TITLE
fix(mcp-core): 使用 async/await 替代 Promise 链以正确处理 refreshTools 错误

### DIFF
--- a/packages/mcp-core/src/connection.ts
+++ b/packages/mcp-core/src/connection.ts
@@ -92,7 +92,7 @@ export class MCPConnection {
       `[MCP-${this.name}] 正在连接 MCP 服务: ${this.name}`
     );
 
-    return new Promise((resolve, reject) => {
+    return new Promise(async (resolve, reject) => {
       // 设置连接超时（使用固定默认值 30 秒）
       const CONNECTION_TIMEOUT = 30000;
       this.connectionTimeout = setTimeout(() => {
@@ -119,28 +119,28 @@ export class MCPConnection {
         };
         this.transport = TransportFactory.create(fullConfig);
 
-        // 连接到 MCP 服务
-        this.client
-          .connect(this.transport as MCPServerTransport)
-          .then(async () => {
-            this.handleConnectionSuccess();
+        // 连接到 MCP 服务（使用 async/await 确保错误正确传播）
+        await this.client.connect(this.transport as MCPServerTransport);
 
-            // 获取工具列表
-            await this.refreshTools();
+        // 检查是否因超时而导致状态已变为 DISCONNECTED
+        if (this.connectionState === ConnectionState.DISCONNECTED) {
+          // 超时已触发，连接已被清理，不再继续处理
+          return;
+        }
 
-            // 发射连接成功事件
-            this.callbacks?.onConnected?.({
-              serviceName: this.name,
-              tools: this.getTools(),
-              connectionTime: new Date(),
-            });
+        this.handleConnectionSuccess();
 
-            resolve();
-          })
-          .catch((error) => {
-            this.handleConnectionError(error);
-            reject(error);
-          });
+        // 获取工具列表
+        await this.refreshTools();
+
+        // 发射连接成功事件
+        this.callbacks?.onConnected?.({
+          serviceName: this.name,
+          tools: this.getTools(),
+          connectionTime: new Date(),
+        });
+
+        resolve();
       } catch (error) {
         this.handleConnectionError(error as Error);
         reject(error);


### PR DESCRIPTION
修复 attemptConnection 方法中 refreshTools 错误未被捕获的问题：
- 将 Promise executor 回调改为 async，使 await 可以正确使用
- 使用 async/await 替代 .then().catch() Promise 链
- 添加超时状态检查，防止连接超时后仍继续处理
- 现在所有错误（包括 connect 和 refreshTools）都会被统一的 catch 块捕获

关闭 #2857

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2857