### PR TITLE
refactor(config): 将类型定义从 manager.ts 分离到独立目录

### DIFF
--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -26,7 +26,11 @@
 // 导出
 // =========================
 
+// 从 manager.ts 导出配置管理器和类型（向后兼容）
 export * from "./manager.js";
+// 从独立的类型文件导出所有类型定义
+export * from "./types/index.js";
+// 导出其他模块
 export * from "./adapter.js";
 export * from "./resolver.js";
 export * from "./initializer.js";

--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -42,6 +42,64 @@ import * as commentJson from "comment-json";
 import dayjs from "dayjs";
 import { createJson5Writer, parseJson5 } from "./json5-adapter.js";
 import { ConfigResolver } from "./resolver.js";
+// 从独立的类型文件导入所有类型定义
+import type {
+  AppConfig,
+  ASRConfig,
+  ChainHandlerConfig,
+  ConnectionConfig,
+  CozePlatformConfig,
+  CustomMCPConfig,
+  CustomMCPTool,
+  FunctionHandlerConfig,
+  HandlerConfig,
+  HttpHandlerConfig,
+  LLMConfig,
+  MCPHandlerConfig,
+  MCPServerConfig,
+  MCPServerToolsConfig,
+  MCPToolConfig,
+  ModelScopeConfig,
+  PlatformConfig,
+  PlatformsConfig,
+  ProxyHandlerConfig,
+  ScriptHandlerConfig,
+  TTSConfig,
+  ToolCallLogConfig,
+  WebServerInstance,
+  WebUIConfig,
+} from "./types/index.js";
+// 重新导出所有类型定义（保持向后兼容）
+export type {
+  AppConfig,
+  ASRConfig,
+  ChainHandlerConfig,
+  ConnectionConfig,
+  CozePlatformConfig,
+  CustomMCPTool,
+  CustomMCPConfig,
+  FunctionHandlerConfig,
+  HandlerConfig,
+  HttpHandlerConfig,
+  LLMConfig,
+  MCPHandlerConfig,
+  MCPServerConfig,
+  MCPServerToolsConfig,
+  MCPToolConfig,
+  ModelScopeConfig,
+  PlatformConfig,
+  PlatformsConfig,
+  ProxyHandlerConfig,
+  ScriptHandlerConfig,
+  SSEMCPServerConfig,
+  StreamableHTTPMCPServerConfig,
+  TTSConfig,
+  ToolCallLogConfig,
+  WebServerInstance,
+  WebUIConfig,
+  LocalMCPServerConfig,
+  HTTPMCPServerConfig,
+} from "./types/index.js";
 
 // 在 ESM 中，需要从 import.meta.url 获取当前文件目录
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -52,243 +110,6 @@ const DEFAULT_CONNECTION_CONFIG: Required<ConnectionConfig> = {
   heartbeatTimeout: 10000, // 10秒心跳超时
   reconnectInterval: 5000, // 5秒重连间隔
 };
-
-// 配置文件接口定义
-// 本地 MCP 服务配置
-export interface LocalMCPServerConfig {
-  command: string;
-  args: string[];
-  env?: Record<string, string>;
-}
-
-// SSE MCP 服务配置
-export interface SSEMCPServerConfig {
-  type: "sse";
-  url: string;
-  headers?: Record<string, string>;
-}
-
-// HTTP MCP 服务配置
-export interface HTTPMCPServerConfig {
-  type?: "http" | "streamable-http"; // 可选，默认就是 http
-  url: string;
-  headers?: Record<string, string>;
-}
-
-// 向后兼容的别名
-/** @deprecated 使用 HTTPMCPServerConfig 代替 */
-export type StreamableHTTPMCPServerConfig = HTTPMCPServerConfig;
-
-// 统一的 MCP 服务配置
-export type MCPServerConfig =
-  | LocalMCPServerConfig
-  | SSEMCPServerConfig
-  | HTTPMCPServerConfig;
-
-export interface MCPToolConfig {
-  description?: string;
-  enable: boolean;
-  usageCount?: number; // 工具使用次数
-  lastUsedTime?: string; // 最后使用时间（ISO 8601 格式）
-}
-
-export interface MCPServerToolsConfig {
-  tools: Record<string, MCPToolConfig>;
-}
-
-export interface ConnectionConfig {
-  heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
-  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000
-  reconnectInterval?: number; // 重连间隔（毫秒），默认5000
-}
-
-export interface ModelScopeConfig {
-  apiKey?: string; // ModelScope API 密钥
-}
-
-export interface WebUIConfig {
-  port?: number; // Web UI 端口号，默认 9999
-  autoRestart?: boolean; // 是否在配置更新后自动重启服务，默认 true
-}
-
-// 工具调用日志配置接口
-// TTS 配置接口
-export interface TTSConfig {
-  appid?: string; // 应用 ID
-  accessToken?: string; // 访问令牌
-  voice_type?: string; // 声音类型
-  encoding?: string; // 编码格式（默认 wav）
-  cluster?: string; // 集群类型
-  endpoint?: string; // WebSocket 端点
-}
-
-// ASR 配置接口
-export interface ASRConfig {
-  appid?: string; // 应用 ID
-  accessToken?: string; // 访问令牌
-  cluster?: string; // 集群类型（默认：volcengine_streaming_common）
-  wsUrl?: string; // WebSocket 端点
-}
-
-// LLM 配置接口
-export interface LLMConfig {
-  model: string; // 模型名称
-  apiKey: string; // API 密钥
-  baseURL: string; // API 基础地址
-  prompt?: string; // 自定义系统提示词（支持纯字符串或文件路径）
-}
-
-export interface ToolCallLogConfig {
-  maxRecords?: number; // 最大记录条数，默认 100
-  logFilePath?: string; // 自定义日志文件路径（可选）
-}
-
-// CustomMCP 相关接口定义
-
-// 代理处理器配置
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: {
-    // Coze 平台配置
-    workflow_id?: string;
-    bot_id?: string;
-    api_key?: string;
-    base_url?: string;
-    // 通用配置
-    timeout?: number;
-    retry_count?: number;
-    retry_delay?: number;
-    headers?: Record<string, string>;
-    params?: Record<string, unknown>;
-  };
-}
-
-// HTTP 处理器配置
-export interface HttpHandlerConfig {
-  type: "http";
-  url: string;
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  headers?: Record<string, string>;
-  timeout?: number;
-  retry_count?: number;
-  retry_delay?: number;
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    api_key?: string;
-    api_key_header?: string;
-  };
-  body_template?: string; // 支持模板变量替换
-  response_mapping?: {
-    success_path?: string; // JSONPath 表达式
-    error_path?: string;
-    data_path?: string;
-  };
-}
-
-// 函数处理器配置
-export interface FunctionHandlerConfig {
-  type: "function";
-  module: string; // 模块路径
-  function: string; // 函数名
-  timeout?: number;
-  context?: Record<string, unknown>; // 函数执行上下文
-}
-
-// 脚本处理器配置
-export interface ScriptHandlerConfig {
-  type: "script";
-  script: string; // 脚本内容或文件路径
-  interpreter?: "node" | "python" | "bash";
-  timeout?: number;
-  env?: Record<string, string>; // 环境变量
-}
-
-// 链式处理器配置
-export interface ChainHandlerConfig {
-  type: "chain";
-  tools: string[]; // 要链式调用的工具名称
-  mode: "sequential" | "parallel"; // 执行模式
-  error_handling: "stop" | "continue" | "retry"; // 错误处理策略
-}
-
-// MCP 处理器配置（用于同步的工具）
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
-
-export type HandlerConfig =
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig
-  | ScriptHandlerConfig
-  | ChainHandlerConfig
-  | MCPHandlerConfig;
-
-// CustomMCP 工具接口
-// TODO: 注意：此定义应与 @xiaozhi-client/shared-types 中的 CustomMCPToolConfig 保持一致
-// 未来将迁移到从 shared-types 导入
-export interface CustomMCPTool {
-  // 确保必填字段
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-  handler: HandlerConfig;
-
-  // 使用统计信息（可选）
-  stats?: {
-    usageCount?: number; // 工具使用次数
-    lastUsedTime?: string; // 最后使用时间（ISO 8601格式）
-  };
-}
-
-// CustomMCP 配置接口
-export interface CustomMCPConfig {
-  tools: CustomMCPTool[];
-}
-
-// Web 服务器实例接口（用于配置更新通知）
-export interface WebServerInstance {
-  broadcastConfigUpdate(config: AppConfig): void;
-}
-
-export interface PlatformsConfig {
-  [platformName: string]: PlatformConfig;
-}
-
-export interface PlatformConfig {
-  token?: string;
-}
-
-/**
- * 扣子平台配置接口
- */
-export interface CozePlatformConfig extends PlatformConfig {
-  /** 扣子 API Token */
-  token: string;
-}
-
-export interface AppConfig {
-  mcpEndpoint: string | string[];
-  mcpServers: Record<string, MCPServerConfig>;
-  mcpServerConfig?: Record<string, MCPServerToolsConfig>;
-  customMCP?: CustomMCPConfig; // 新增 customMCP 配置支持
-  connection?: ConnectionConfig; // 连接配置（可选，用于向后兼容）
-  modelscope?: ModelScopeConfig; // ModelScope 配置（可选）
-  webUI?: WebUIConfig; // Web UI 配置（可选）
-  platforms?: PlatformsConfig; // 平台配置（可选）
-  toolCallLog?: ToolCallLogConfig; // 工具调用日志配置（可选）
-  tts?: TTSConfig; // TTS 配置（可选）
-  asr?: ASRConfig; // ASR 配置（可选）
-  llm?: LLMConfig; // LLM 配置（可选）
-}
 
 /**
  * 配置管理类

--- a/packages/config/src/types/app.types.ts
+++ b/packages/config/src/types/app.types.ts
@@ -1,0 +1,43 @@
+/**
+ * 核心应用配置类型定义
+ *
+ * 包含 AppConfig 核心配置类型和 WebServerInstance 接口
+ */
+
+import type { ConnectionConfig } from "./connection.types.js";
+import type { CustomMCPConfig } from "./custom-mcp.types.js";
+import type { MCPServerConfig, MCPServerToolsConfig } from "./mcp.types.js";
+import type {
+  ASRConfig,
+  LLMConfig,
+  ModelScopeConfig,
+  PlatformsConfig,
+  TTSConfig,
+  ToolCallLogConfig,
+  WebUIConfig,
+} from "./platform.types.js";
+
+/**
+ * Web 服务器实例接口（用于配置更新通知）
+ */
+export interface WebServerInstance {
+  broadcastConfigUpdate(config: AppConfig): void;
+}
+
+/**
+ * 应用配置
+ */
+export interface AppConfig {
+  mcpEndpoint: string | string[];
+  mcpServers: Record<string, MCPServerConfig>;
+  mcpServerConfig?: Record<string, MCPServerToolsConfig>;
+  customMCP?: CustomMCPConfig; // 新增 customMCP 配置支持
+  connection?: ConnectionConfig; // 连接配置（可选，用于向后兼容）
+  modelscope?: ModelScopeConfig; // ModelScope 配置（可选）
+  webUI?: WebUIConfig; // Web UI 配置（可选）
+  platforms?: PlatformsConfig; // 平台配置（可选）
+  toolCallLog?: ToolCallLogConfig; // 工具调用日志配置（可选）
+  tts?: TTSConfig; // TTS 配置（可选）
+  asr?: ASRConfig; // ASR 配置（可选）
+  llm?: LLMConfig; // LLM 配置（可选）
+}

--- a/packages/config/src/types/connection.types.ts
+++ b/packages/config/src/types/connection.types.ts
@@ -1,0 +1,14 @@
+/**
+ * 连接配置相关类型定义
+ *
+ * 包含心跳检测、重连等连接参数配置类型
+ */
+
+/**
+ * 连接配置
+ */
+export interface ConnectionConfig {
+  heartbeatInterval?: number; // 心跳检测间隔（毫秒），默认30000
+  heartbeatTimeout?: number; // 心跳超时时间（毫秒），默认10000
+  reconnectInterval?: number; // 重连间隔（毫秒），默认5000
+}

--- a/packages/config/src/types/custom-mcp.types.ts
+++ b/packages/config/src/types/custom-mcp.types.ts
@@ -1,0 +1,34 @@
+/**
+ * CustomMCP 相关类型定义
+ *
+ * 包含自定义 MCP 工具的配置类型
+ *
+ * TODO: 注意：CustomMCPTool 定义应与 @xiaozhi-client/shared-types 中的 CustomMCPToolConfig 保持一致
+ * 未来将迁移到从 shared-types 导入
+ */
+
+import type { HandlerConfig } from "./handler.types.js";
+
+/**
+ * CustomMCP 工具接口
+ */
+export interface CustomMCPTool {
+  // 确保必填字段
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: HandlerConfig;
+
+  // 使用统计信息（可选）
+  stats?: {
+    usageCount?: number; // 工具使用次数
+    lastUsedTime?: string; // 最后使用时间（ISO 8601格式）
+  };
+}
+
+/**
+ * CustomMCP 配置接口
+ */
+export interface CustomMCPConfig {
+  tools: CustomMCPTool[];
+}

--- a/packages/config/src/types/handler.types.ts
+++ b/packages/config/src/types/handler.types.ts
@@ -1,0 +1,107 @@
+/**
+ * Handler 配置相关类型定义
+ *
+ * 包含各种处理器（Proxy、HTTP、Function、Script、Chain、MCP）的配置类型
+ */
+
+/**
+ * 代理处理器配置
+ */
+export interface ProxyHandlerConfig {
+  type: "proxy";
+  platform: "coze" | "openai" | "anthropic" | "custom";
+  config: {
+    // Coze 平台配置
+    workflow_id?: string;
+    bot_id?: string;
+    api_key?: string;
+    base_url?: string;
+    // 通用配置
+    timeout?: number;
+    retry_count?: number;
+    retry_delay?: number;
+    headers?: Record<string, string>;
+    params?: Record<string, unknown>;
+  };
+}
+
+/**
+ * HTTP 处理器配置
+ */
+export interface HttpHandlerConfig {
+  type: "http";
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry_count?: number;
+  retry_delay?: number;
+  auth?: {
+    type: "bearer" | "basic" | "api_key";
+    token?: string;
+    username?: string;
+    password?: string;
+    api_key?: string;
+    api_key_header?: string;
+  };
+  body_template?: string; // 支持模板变量替换
+  response_mapping?: {
+    success_path?: string; // JSONPath 表达式
+    error_path?: string;
+    data_path?: string;
+  };
+}
+
+/**
+ * 函数处理器配置
+ */
+export interface FunctionHandlerConfig {
+  type: "function";
+  module: string; // 模块路径
+  function: string; // 函数名
+  timeout?: number;
+  context?: Record<string, unknown>; // 函数执行上下文
+}
+
+/**
+ * 脚本处理器配置
+ */
+export interface ScriptHandlerConfig {
+  type: "script";
+  script: string; // 脚本内容或文件路径
+  interpreter?: "node" | "python" | "bash";
+  timeout?: number;
+  env?: Record<string, string>; // 环境变量
+}
+
+/**
+ * 链式处理器配置
+ */
+export interface ChainHandlerConfig {
+  type: "chain";
+  tools: string[]; // 要链式调用的工具名称
+  mode: "sequential" | "parallel"; // 执行模式
+  error_handling: "stop" | "continue" | "retry"; // 错误处理策略
+}
+
+/**
+ * MCP 处理器配置（用于同步的工具）
+ */
+export interface MCPHandlerConfig {
+  type: "mcp";
+  config: {
+    serviceName: string;
+    toolName: string;
+  };
+}
+
+/**
+ * 统一的 Handler 配置类型
+ */
+export type HandlerConfig =
+  | ProxyHandlerConfig
+  | HttpHandlerConfig
+  | FunctionHandlerConfig
+  | ScriptHandlerConfig
+  | ChainHandlerConfig
+  | MCPHandlerConfig;

--- a/packages/config/src/types/index.ts
+++ b/packages/config/src/types/index.ts
@@ -1,0 +1,49 @@
+/**
+ * 类型定义统一导出
+ *
+ * 从各个类型文件中统一导出所有类型定义
+ */
+
+// MCP 相关类型
+export type {
+  LocalMCPServerConfig,
+  SSEMCPServerConfig,
+  HTTPMCPServerConfig,
+  StreamableHTTPMCPServerConfig,
+  MCPServerConfig,
+  MCPToolConfig,
+  MCPServerToolsConfig,
+} from "./mcp.types.js";
+
+// 连接配置类型
+export type { ConnectionConfig } from "./connection.types.js";
+
+// Handler 配置类型
+export type {
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
+  MCPHandlerConfig,
+  HandlerConfig,
+} from "./handler.types.js";
+
+// CustomMCP 类型
+export type { CustomMCPTool, CustomMCPConfig } from "./custom-mcp.types.js";
+
+// 平台配置类型
+export type {
+  ModelScopeConfig,
+  WebUIConfig,
+  TTSConfig,
+  ASRConfig,
+  LLMConfig,
+  ToolCallLogConfig,
+  PlatformConfig,
+  PlatformsConfig,
+  CozePlatformConfig,
+} from "./platform.types.js";
+
+// 核心配置类型
+export type { AppConfig, WebServerInstance } from "./app.types.js";

--- a/packages/config/src/types/mcp.types.ts
+++ b/packages/config/src/types/mcp.types.ts
@@ -1,0 +1,63 @@
+/**
+ * MCP 服务相关类型定义
+ *
+ * 包含 MCP 服务器配置、工具配置等类型
+ */
+
+/**
+ * 本地 MCP 服务配置
+ */
+export interface LocalMCPServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+/**
+ * SSE MCP 服务配置
+ */
+export interface SSEMCPServerConfig {
+  type: "sse";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * HTTP MCP 服务配置
+ */
+export interface HTTPMCPServerConfig {
+  type?: "http" | "streamable-http"; // 可选，默认就是 http
+  url: string;
+  headers?: Record<string, string>;
+}
+
+/**
+ * 向后兼容的别名
+ * @deprecated 使用 HTTPMCPServerConfig 代替
+ */
+export type StreamableHTTPMCPServerConfig = HTTPMCPServerConfig;
+
+/**
+ * 统一的 MCP 服务配置
+ */
+export type MCPServerConfig =
+  | LocalMCPServerConfig
+  | SSEMCPServerConfig
+  | HTTPMCPServerConfig;
+
+/**
+ * MCP 工具配置
+ */
+export interface MCPToolConfig {
+  description?: string;
+  enable: boolean;
+  usageCount?: number; // 工具使用次数
+  lastUsedTime?: string; // 最后使用时间（ISO 8601 格式）
+}
+
+/**
+ * MCP 服务器工具配置
+ */
+export interface MCPServerToolsConfig {
+  tools: Record<string, MCPToolConfig>;
+}

--- a/packages/config/src/types/platform.types.ts
+++ b/packages/config/src/types/platform.types.ts
@@ -1,0 +1,82 @@
+/**
+ * 平台配置相关类型定义
+ *
+ * 包含 ModelScope、WebUI、TTS、ASR、LLM、平台等配置类型
+ */
+
+/**
+ * ModelScope 配置
+ */
+export interface ModelScopeConfig {
+  apiKey?: string; // ModelScope API 密钥
+}
+
+/**
+ * Web UI 配置
+ */
+export interface WebUIConfig {
+  port?: number; // Web UI 端口号，默认 9999
+  autoRestart?: boolean; // 是否在配置更新后自动重启服务，默认 true
+}
+
+/**
+ * TTS 配置接口
+ */
+export interface TTSConfig {
+  appid?: string; // 应用 ID
+  accessToken?: string; // 访问令牌
+  voice_type?: string; // 声音类型
+  encoding?: string; // 编码格式（默认 wav）
+  cluster?: string; // 集群类型
+  endpoint?: string; // WebSocket 端点
+}
+
+/**
+ * ASR 配置接口
+ */
+export interface ASRConfig {
+  appid?: string; // 应用 ID
+  accessToken?: string; // 访问令牌
+  cluster?: string; // 集群类型（默认：volcengine_streaming_common）
+  wsUrl?: string; // WebSocket 端点
+}
+
+/**
+ * LLM 配置接口
+ */
+export interface LLMConfig {
+  model: string; // 模型名称
+  apiKey: string; // API 密钥
+  baseURL: string; // API 基础地址
+  prompt?: string; // 自定义系统提示词（支持纯字符串或文件路径）
+}
+
+/**
+ * 工具调用日志配置接口
+ */
+export interface ToolCallLogConfig {
+  maxRecords?: number; // 最大记录条数，默认 100
+  logFilePath?: string; // 自定义日志文件路径（可选）
+}
+
+/**
+ * 平台配置
+ */
+export interface PlatformConfig {
+  token?: string;
+}
+
+/**
+ * 平台配置集合
+ */
+export interface PlatformsConfig {
+  [platformName: string]: PlatformConfig;
+}
+
+/**
+ * 扣子平台配置接口
+ */
+export interface CozePlatformConfig extends PlatformConfig {
+  /** 扣子 API Token */
+  token: string;
+}


### PR DESCRIPTION
第一阶段重构：将类型定义从 manager.ts (2406行) 分离到独立的 types 目录。

变更内容：
- 创建 types/ 目录，包含 7 个类型文件
- mcp.types.ts: MCP 服务相关类型 (63行)
- connection.types.ts: 连接配置类型 (14行)
- handler.types.ts: Handler 配置类型 (107行)
- custom-mcp.types.ts: CustomMCP 类型 (34行)
- platform.types.ts: 平台配置类型 (82行)
- app.types.ts: 核心配置类型 (43行)
- index.ts: 统一导出 (49行)

效果：
- manager.ts 从 2406 行减少到 2227 行 (-179行, -7.4%)
- 类型定义现在集中在 types/ 目录中，更易维护
- 保持完全向后兼容，所有类型仍然可以从 @xiaozhi-client/config 导入

相关问题: #2860

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2860