### PR TITLE
docs: 为 site-header 和 restart-button 添加文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/components/restart-button.tsx
+++ b/apps/frontend/src/components/restart-button.tsx
@@ -1,3 +1,8 @@
+/**
+ * 重启按钮组件
+ *
+ * 用于触发服务重启操作，显示重启状态和进度
+ */
 import { Button } from "@/components/ui/button";
 import { useRestartPollingStatus, useStatusStore } from "@/stores/status";
 import clsx from "clsx";

--- a/apps/frontend/src/components/site-header.tsx
+++ b/apps/frontend/src/components/site-header.tsx
@@ -1,3 +1,8 @@
+/**
+ * 网站头部组件
+ *
+ * 显示页面标题、版本信息和社交链接（GitHub、QQ）
+ */
 import { GithubIcon, QQIcon } from "@/components/icons";
 import { VersionDisplay } from "./version-display";
 


### PR DESCRIPTION
- 为 site-header.tsx 添加文件级文档注释，描述其作为网站头部组件的功能
- 为 restart-button.tsx 添加文件级文档注释，描述其作为重启按钮组件的功能
- 保持与其他业务组件（如 dashboard-status-card.tsx）的文档风格一致

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2872