### PR TITLE
fix(frontend): 使用统一日志系统替换 console 调用

### DIFF
--- a/apps/frontend/src/services/__tests__/websocket.test.ts
+++ b/apps/frontend/src/services/__tests__/websocket.test.ts
@@ -340,8 +340,12 @@ describe("WebSocketManager", () => {
       expect(goodListener).toHaveBeenCalled();
       expect(badListener).toHaveBeenCalled();
       expect(consoleSpy).toHaveBeenCalledWith(
+        expect.stringContaining("[WebSocket]"),
         expect.stringContaining("事件监听器执行失败"),
-        expect.any(Error)
+        expect.objectContaining({
+          event: "connection:connected",
+          error: expect.any(Error),
+        })
       );
 
       consoleSpy.mockRestore();
@@ -446,7 +450,7 @@ describe("WebSocketManager", () => {
     });
 
     it("应该处理未知消息类型", () => {
-      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+      const consoleSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
 
       const testMessage = {
         type: "unknown",
@@ -456,8 +460,9 @@ describe("WebSocketManager", () => {
       (manager as any).ws.mockMessage(testMessage);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[WebSocket] 未处理的消息类型:",
-        "unknown"
+        expect.stringContaining("[WebSocket]"),
+        expect.stringContaining("未处理的消息类型"),
+        expect.objectContaining({ type: "unknown" })
       );
 
       consoleSpy.mockRestore();
@@ -472,8 +477,9 @@ describe("WebSocketManager", () => {
       (manager as any).ws.onmessage?.({ data: "invalid json" } as MessageEvent);
 
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[WebSocket] 消息解析失败:",
-        expect.any(Error)
+        expect.stringContaining("[WebSocket]"),
+        expect.stringContaining("消息解析失败"),
+        expect.objectContaining({ error: expect.any(Error) })
       );
 
       consoleSpy.mockRestore();
@@ -626,7 +632,8 @@ describe("WebSocketManager", () => {
 
       expect(result).toBe(false);
       expect(consoleSpy).toHaveBeenCalledWith(
-        "[WebSocket] 连接未建立，无法发送消息"
+        expect.stringContaining("[WebSocket]"),
+        expect.stringContaining("连接未建立，无法发送消息")
       );
 
       consoleSpy.mockRestore();

--- a/apps/frontend/src/services/cozeApi.ts
+++ b/apps/frontend/src/services/cozeApi.ts
@@ -3,6 +3,7 @@
  * 负责与后端扣子 API 的通信
  */
 
+import { cozeLogger } from "@/services/logger";
 import type {
   CozeWorkflowsParams,
   CozeWorkflowsResult,
@@ -100,7 +101,7 @@ export class CozeApiClient {
 
       return response.data;
     } catch (error) {
-      console.error("获取工作空间列表失败:", error);
+      cozeLogger.error("获取工作空间列表失败", { error });
       throw error;
     }
   }
@@ -133,7 +134,7 @@ export class CozeApiClient {
 
       return response.data;
     } catch (error) {
-      console.error("获取工作流列表失败:", error);
+      cozeLogger.error("获取工作流列表失败", { error });
       throw error;
     }
   }
@@ -154,7 +155,7 @@ export class CozeApiClient {
         throw new Error(response.message || "清除缓存失败");
       }
     } catch (error) {
-      console.error("清除缓存失败:", error);
+      cozeLogger.error("清除缓存失败", { error });
       throw error;
     }
   }
@@ -174,7 +175,7 @@ export class CozeApiClient {
 
       return response.data;
     } catch (error) {
-      console.error("获取缓存统计失败:", error);
+      cozeLogger.error("获取缓存统计失败", { error });
       throw error;
     }
   }

--- a/apps/frontend/src/services/index.ts
+++ b/apps/frontend/src/services/index.ts
@@ -3,6 +3,7 @@
  * 整合 HTTP API 客户端和 WebSocket 管理器
  */
 
+import { networkLogger } from "@/services/logger";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 import { type ApiClient, apiClient } from "./api";
 import {
@@ -33,20 +34,20 @@ export class NetworkService {
       return;
     }
 
-    console.log("[NetworkService] 初始化网络服务");
+    networkLogger.info("初始化网络服务");
 
     // 启动 WebSocket 连接
     this.webSocketManager.connect();
 
     this.initialized = true;
-    console.log("[NetworkService] 网络服务初始化完成");
+    networkLogger.info("网络服务初始化完成");
   }
 
   /**
    * 销毁网络服务
    */
   destroy(): void {
-    console.log("[NetworkService] 销毁网络服务");
+    networkLogger.info("销毁网络服务");
     this.webSocketManager.disconnect();
     this.initialized = false;
   }

--- a/apps/frontend/src/services/logger.ts
+++ b/apps/frontend/src/services/logger.ts
@@ -1,0 +1,191 @@
+/**
+ * 前端日志服务
+ * 提供统一的日志接口，支持日志级别控制和模块标识
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  DEBUG = 0,
+  INFO = 1,
+  WARN = 2,
+  ERROR = 3,
+  NONE = 4, // 禁用所有日志
+}
+
+/**
+ * 日志配置接口
+ */
+interface LoggerConfig {
+  /** 日志级别 */
+  level: LogLevel;
+  /** 是否启用时间戳 */
+  enableTimestamp: boolean;
+  /** 是否为生产模式（生产模式下默认禁用 DEBUG 日志） */
+  isProduction: boolean;
+}
+
+/**
+ * 默认日志配置
+ */
+const defaultConfig: LoggerConfig = {
+  level: LogLevel.DEBUG,
+  enableTimestamp: true,
+  isProduction: false,
+};
+
+/**
+ * 日志服务类
+ */
+class LoggerService {
+  private config: LoggerConfig;
+  private globalLevel: LogLevel;
+
+  constructor(config: Partial<LoggerConfig> = {}) {
+    // 检测是否为生产环境
+    const isProduction =
+      config.isProduction ?? process.env.NODE_ENV === "production";
+
+    this.config = {
+      ...defaultConfig,
+      ...config,
+      isProduction,
+    };
+
+    // 生产环境下默认使用 INFO 级别
+    this.globalLevel = isProduction ? LogLevel.INFO : this.config.level;
+  }
+
+  /**
+   * 创建带模块标识的日志器
+   * @param prefix 模块标识前缀
+   * @returns Logger 实例
+   */
+  createLogger(prefix: string): Logger {
+    return new Logger(prefix, this.globalLevel, this.config.enableTimestamp);
+  }
+
+  /**
+   * 设置全局日志级别
+   * @param level 新的日志级别
+   */
+  setLevel(level: LogLevel): void {
+    this.globalLevel = level;
+  }
+
+  /**
+   * 获取当前日志级别
+   * @returns 当前日志级别
+   */
+  getLevel(): LogLevel {
+    return this.globalLevel;
+  }
+
+  /**
+   * 是否为生产模式
+   * @returns 是否为生产模式
+   */
+  isProduction(): boolean {
+    return this.config.isProduction;
+  }
+}
+
+/**
+ * 日志器类
+ */
+class Logger {
+  private prefix: string;
+  private level: LogLevel;
+  private enableTimestamp: boolean;
+
+  constructor(prefix: string, level: LogLevel, enableTimestamp: boolean) {
+    this.prefix = prefix;
+    this.level = level;
+    this.enableTimestamp = enableTimestamp;
+  }
+
+  /**
+   * 格式化日志前缀
+   * @returns 格式化后的前缀字符串
+   */
+  private formatPrefix(): string {
+    if (this.enableTimestamp) {
+      const timestamp = new Date().toISOString().split("T")[1].slice(0, 8);
+      return `[${timestamp}] [${this.prefix}]`;
+    }
+    return `[${this.prefix}]`;
+  }
+
+  /**
+   * 检查是否应该输出该级别的日志
+   * @param level 要检查的日志级别
+   * @returns 是否应该输出
+   */
+  private shouldLog(level: LogLevel): boolean {
+    return level >= this.level;
+  }
+
+  /**
+   * 记录调试级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  debug(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.DEBUG)) {
+      console.debug(this.formatPrefix(), message, ...args);
+    }
+  }
+
+  /**
+   * 记录信息级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  info(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.INFO)) {
+      console.info(this.formatPrefix(), message, ...args);
+    }
+  }
+
+  /**
+   * 记录警告级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  warn(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.WARN)) {
+      console.warn(this.formatPrefix(), message, ...args);
+    }
+  }
+
+  /**
+   * 记录错误级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   */
+  error(message: string, ...args: unknown[]): void {
+    if (this.shouldLog(LogLevel.ERROR)) {
+      console.error(this.formatPrefix(), message, ...args);
+    }
+  }
+
+  /**
+   * 设置日志级别
+   * @param level 新的日志级别
+   */
+  setLevel(level: LogLevel): void {
+    this.level = level;
+  }
+}
+
+// 创建默认的日志服务实例
+export const loggerService = new LoggerService();
+
+// 导出常用日志器
+export const wsLogger = loggerService.createLogger("WebSocket");
+export const networkLogger = loggerService.createLogger("NetworkService");
+export const cozeLogger = loggerService.createLogger("CozeApi");
+
+// 导出类型
+export type { LoggerConfig };

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -8,6 +8,7 @@
  */
 
 import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
+import { wsLogger } from "@/services/logger";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 
 /**
@@ -198,7 +199,7 @@ class EventBus {
         try {
           listener(data);
         } catch (error) {
-          console.error(`[EventBus] 事件监听器执行失败 (${event}):`, error);
+          wsLogger.error("事件监听器执行失败", { event, error });
         }
       }
     }
@@ -268,7 +269,7 @@ export class WebSocketManager {
     WebSocketManager.isCreating = true;
     try {
       WebSocketManager.instance = new WebSocketManager(config);
-      console.log("[WebSocketManager] 单例实例已创建");
+      wsLogger.info("单例实例已创建");
       return WebSocketManager.instance;
     } finally {
       WebSocketManager.isCreating = false;
@@ -283,7 +284,7 @@ export class WebSocketManager {
       WebSocketManager.instance.disconnect();
       WebSocketManager.instance.eventBus.clear();
       WebSocketManager.instance = null;
-      console.log("[WebSocketManager] 单例实例已重置");
+      wsLogger.info("单例实例已重置");
     }
   }
 
@@ -317,7 +318,7 @@ export class WebSocketManager {
     }
 
     this.state = ConnectionState.CONNECTING;
-    console.log(`[WebSocket] 连接到: ${this.url}`);
+    wsLogger.info("连接到", { url: this.url });
 
     // 发布连接中事件
     this.eventBus.emit("connection:connecting", undefined);
@@ -326,7 +327,7 @@ export class WebSocketManager {
       this.ws = new WebSocket(this.url);
       this.setupEventHandlers();
     } catch (error) {
-      console.error("[WebSocket] 连接失败:", error);
+      wsLogger.error("连接失败", { error });
       this.handleConnectionError(error as Error);
     }
   }
@@ -335,7 +336,7 @@ export class WebSocketManager {
    * 断开 WebSocket 连接
    */
   disconnect(): void {
-    console.log("[WebSocket] 主动断开连接");
+    wsLogger.info("主动断开连接");
 
     this.clearTimers();
     this.state = ConnectionState.DISCONNECTED;
@@ -412,7 +413,7 @@ export class WebSocketManager {
    */
   send(message: unknown): boolean {
     if (!this.isConnected()) {
-      console.warn("[WebSocket] 连接未建立，无法发送消息");
+      wsLogger.warn("连接未建立，无法发送消息");
       return false;
     }
 
@@ -422,7 +423,7 @@ export class WebSocketManager {
       this.ws!.send(messageStr);
       return true;
     } catch (error) {
-      console.error("[WebSocket] 发送消息失败:", error);
+      wsLogger.error("发送消息失败", { error });
       this.eventBus.emit("connection:error", {
         error: error as Error,
         context: "send_message",
@@ -459,7 +460,7 @@ export class WebSocketManager {
     if (!this.ws) return;
 
     this.ws.onopen = () => {
-      console.log("[WebSocket] 连接已建立");
+      wsLogger.info("连接已建立");
       this.state = ConnectionState.CONNECTED;
       this.reconnectAttempts = 0;
       this.startHeartbeat();
@@ -473,17 +474,17 @@ export class WebSocketManager {
         const message: WebSocketMessage = JSON.parse(event.data);
         this.handleMessage(message);
       } catch (error) {
-        console.error("[WebSocket] 消息解析失败:", error);
+        wsLogger.error("消息解析失败", { error });
       }
     };
 
     this.ws.onclose = (event) => {
-      console.log(`[WebSocket] 连接已关闭 (code: ${event.code})`);
+      wsLogger.info("连接已关闭", { code: event.code });
       this.handleConnectionClose();
     };
 
     this.ws.onerror = (error) => {
-      console.error("[WebSocket] 连接错误:", error);
+      wsLogger.error("连接错误", { error });
       this.handleConnectionError(new Error("WebSocket 连接错误"));
     };
   }
@@ -492,7 +493,7 @@ export class WebSocketManager {
    * 处理 WebSocket 消息
    */
   private handleMessage(message: WebSocketMessage): void {
-    console.log("[WebSocket] 收到消息:", message.type);
+    wsLogger.info("收到消息", { type: message.type });
 
     // 发布原始消息事件
     this.eventBus.emit("system:message", message);
@@ -579,7 +580,7 @@ export class WebSocketManager {
 
         case "error": {
           const error = new Error(message.error?.message || "服务器错误");
-          console.error("[WebSocket] 服务器错误:", message.error);
+          wsLogger.error("服务器错误", { error: message.error });
           this.eventBus.emit("system:error", { error, message });
           this.eventBus.emit("connection:error", {
             error,
@@ -589,10 +590,10 @@ export class WebSocketManager {
         }
 
         default:
-          console.log("[WebSocket] 未处理的消息类型:", message.type);
+          wsLogger.debug("未处理的消息类型", { type: message.type });
       }
     } catch (error) {
-      console.error("[WebSocket] 消息处理失败:", error);
+      wsLogger.error("消息处理失败", { error });
       this.eventBus.emit("system:error", {
         error: error as Error,
         message,
@@ -614,7 +615,7 @@ export class WebSocketManager {
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.scheduleReconnect();
     } else {
-      console.error("[WebSocket] 达到最大重连次数，停止重连");
+      wsLogger.error("达到最大重连次数，停止重连");
       this.eventBus.emit("connection:error", {
         error: new Error("达到最大重连次数"),
         context: "max_reconnect_attempts",
@@ -639,7 +640,7 @@ export class WebSocketManager {
     if (this.reconnectAttempts < this.maxReconnectAttempts) {
       this.scheduleReconnect();
     } else {
-      console.error("[WebSocket] 达到最大重连次数，停止重连");
+      wsLogger.error("达到最大重连次数，停止重连");
     }
   }
 
@@ -650,9 +651,11 @@ export class WebSocketManager {
     this.reconnectAttempts++;
     this.state = ConnectionState.RECONNECTING;
 
-    console.log(
-      `[WebSocket] 安排重连 (${this.reconnectAttempts}/${this.maxReconnectAttempts}) 在 ${this.reconnectInterval}ms 后`
-    );
+    wsLogger.info("安排重连", {
+      attempt: this.reconnectAttempts,
+      maxAttempts: this.maxReconnectAttempts,
+      interval: this.reconnectInterval,
+    });
 
     // 发布重连事件
     this.eventBus.emit("connection:reconnecting", {
@@ -679,7 +682,7 @@ export class WebSocketManager {
         // 检查心跳超时
         const now = Date.now();
         if (now - this.lastHeartbeat > this.heartbeatTimeout) {
-          console.warn("[WebSocket] 心跳超时，重新连接");
+          wsLogger.warn("心跳超时，重新连接");
           this.disconnect();
           this.connect();
         }


### PR DESCRIPTION
- 创建前端日志服务 (logger.ts)，支持日志级别控制和模块标识
- 替换 websocket.ts 中 20 处 console 调用为 wsLogger
- 替换 cozeApi.ts 中 4 处 console.error 为 cozeLogger
- 替换 index.ts 中 3 处 console.log 为 networkLogger
- 更新测试文件以匹配新的日志格式

Closes #2874

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2874