### PR TITLE
fix(tts): 为 waitForBufferDrain 中的 sendStopAndCleanup 添加错误处理

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -216,7 +216,12 @@ export class TTSService implements ITTSService {
         `[TTSService] 缓冲区排空检查: deviceId=${deviceId}, buffer=${buffer?.length}, isProcessing=${isProcessing}`
       );
       if ((!buffer || buffer.length === 0) && !isProcessing) {
-        this.sendStopAndCleanup(deviceId);
+        void this.sendStopAndCleanup(deviceId).catch((error) => {
+          logger.error(
+            `[TTSService] sendStopAndCleanup 执行失败 (waitForBufferDrain): deviceId=${deviceId}`,
+            error
+          );
+        });
         return true;
       }
 


### PR DESCRIPTION
修复了 apps/backend/services/tts.service.ts 第 219 行缺少 .catch() 错误处理的问题。
与同一文件第 193 行的错误处理模式保持一致，避免未捕获异常导致 TTS 状态不一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2878