### PR TITLE
fix(mcp): 为事件监听器添加 try-catch 错误处理

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -115,13 +115,25 @@ export class MCPServiceManager extends EventEmitter {
     // 初始化事件监听器引用
     this.eventListeners = {
       serviceConnected: async (data) => {
-        await this.handleServiceConnected(data);
+        try {
+          await this.handleServiceConnected(data);
+        } catch (error) {
+          logger.error("[MCPManager] 处理服务连接成功事件失败:", error);
+        }
       },
       serviceDisconnected: async (data) => {
-        await this.handleServiceDisconnected(data);
+        try {
+          await this.handleServiceDisconnected(data);
+        } catch (error) {
+          logger.error("[MCPManager] 处理服务断开事件失败:", error);
+        }
       },
       serviceConnectionFailed: async (data) => {
-        await this.handleServiceConnectionFailed(data);
+        try {
+          await this.handleServiceConnectionFailed(data);
+        } catch (error) {
+          logger.error("[MCPManager] 处理服务连接失败事件失败:", error);
+        }
       },
     };
 


### PR DESCRIPTION
修复 MCPServiceManager 中三个事件监听器异步处理函数缺少 try-catch 的问题：
- serviceConnected 事件处理
- serviceDisconnected 事件处理
- serviceConnectionFailed 事件处理

当处理方法内部抛出异常时，错误会被正确记录而不是被吞掉。

Fixes #2884

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2884