### PR TITLE
refactor(frontend): 统一复制功能组件，消除重复代码

### DIFF
--- a/apps/frontend/src/components/common/copy-button.tsx
+++ b/apps/frontend/src/components/common/copy-button.tsx
@@ -1,0 +1,163 @@
+/**
+ * CopyButton 组件 - 统一的复制功能组件
+ *
+ * 功能：
+ * - 提供统一的复制到剪贴板功能
+ * - 支持可选的 toast 提示
+ * - 支持传统复制方法的降级方案
+ * - 支持可选的文本标签显示
+ * - 组件卸载时自动清理定时器
+ *
+ * @module apps/frontend/src/components/common/copy-button
+ */
+
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { CheckIcon, CopyIcon } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import { toast } from "sonner";
+
+interface CopyButtonProps {
+  /** 要复制的内容 */
+  content: string;
+  /** 按钮大小 */
+  size?: "sm" | "default" | "lg" | "icon";
+  /** 是否显示 toast 提示 */
+  showToast?: boolean;
+  /** 复制成功的提示消息 */
+  successMessage?: string;
+  /** 复制失败的提示消息 */
+  errorMessage?: string;
+  /** 是否使用 execCommand 降级方案 */
+  fallback?: boolean;
+  /** 自定义类名 */
+  className?: string;
+  /** 按钮变体样式 */
+  variant?: "default" | "destructive" | "outline" | "secondary" | "ghost" | "link";
+  /** 复制成功状态的持续时间（毫秒） */
+  duration?: number;
+  /** 按钮标题（tooltip） */
+  title?: string;
+  /** 是否禁用 */
+  disabled?: boolean;
+  /** 是否显示文本标签 */
+  showText?: boolean;
+  /** 未复制时的文本标签 */
+  copyLabel?: string;
+  /** 已复制时的文本标签 */
+  copiedLabel?: string;
+}
+
+/**
+ * 统一的复制按钮组件
+ *
+ * @param props - 组件属性
+ * @returns 复制按钮组件
+ */
+export function CopyButton({
+  content,
+  size = "sm",
+  showToast = false,
+  successMessage = "已复制到剪贴板",
+  errorMessage = "复制失败",
+  fallback = false,
+  className = "",
+  variant = "ghost",
+  duration = 2000,
+  title,
+  disabled = false,
+  showText = false,
+  copyLabel = "复制",
+  copiedLabel = "已复制",
+}: CopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const handleCopy = async () => {
+    try {
+      // 优先使用现代 Clipboard API
+      if (navigator.clipboard?.writeText) {
+        await navigator.clipboard.writeText(content);
+      } else if (fallback) {
+        // 降级方案：使用传统的复制方法
+        const textArea = document.createElement("textarea");
+        textArea.value = content;
+        textArea.style.position = "fixed";
+        textArea.style.opacity = "0";
+        textArea.style.left = "-9999px";
+        document.body.appendChild(textArea);
+        textArea.focus();
+        textArea.select();
+        const successful = document.execCommand("copy");
+        document.body.removeChild(textArea);
+        if (!successful) {
+          throw new Error("复制命令执行失败");
+        }
+      } else {
+        throw new Error("不支持复制功能");
+      }
+
+      setCopied(true);
+
+      if (showToast) {
+        toast.success(successMessage);
+      }
+
+      // 清除之前的定时器
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+
+      // 设置定时器，自动恢复状态
+      copiedTimerRef.current = setTimeout(() => {
+        setCopied(false);
+      }, duration);
+    } catch (error) {
+      if (showToast) {
+        toast.error(errorMessage);
+      }
+      console.error("复制失败:", error);
+    }
+  };
+
+  // 组件卸载时清理定时器
+  useEffect(() => {
+    return () => {
+      if (copiedTimerRef.current) {
+        clearTimeout(copiedTimerRef.current);
+      }
+    };
+  }, []);
+
+  return (
+    <Button
+      variant={variant}
+      size={size}
+      className={`${className} ${
+        copied ? "text-green-600 hover:text-green-700" : ""
+      }`}
+      onClick={handleCopy}
+      title={title}
+      disabled={disabled}
+    >
+      {showText ? (
+        <>
+          {copied ? (
+            <>
+              <CheckIcon className="h-4 w-4 mr-1" />
+              {copiedLabel}
+            </>
+          ) : (
+            <>
+              <CopyIcon className="h-4 w-4 mr-1" />
+              {copyLabel}
+            </>
+          )}
+        </>
+      ) : (
+        copied ? <CheckIcon className="h-4 w-4" /> : <CopyIcon className="h-4 w-4" />
+      )}
+    </Button>
+  );
+}

--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -1,3 +1,4 @@
+import { CopyButton } from "@/components/common/copy-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 
@@ -27,7 +28,6 @@ import { webSocketManager } from "@/services/websocket";
 import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
 import {
   BadgeInfoIcon,
-  CopyIcon,
   Loader2Icon,
   PlusIcon,
   SettingsIcon,
@@ -225,34 +225,6 @@ export function McpEndpointSettingButton() {
         },
       });
       toast.error(error instanceof Error ? error.message : "接入点断开失败");
-    }
-  };
-
-  // 复制接入点地址到剪贴板
-  const handleCopy = async (endpoint: string) => {
-    try {
-      if (navigator.clipboard?.writeText) {
-        await navigator.clipboard.writeText(endpoint);
-        toast.success("接入点地址已复制到剪贴板");
-      } else {
-        // 降级方案：使用传统的复制方法
-        const textArea = document.createElement("textarea");
-        textArea.value = endpoint;
-        textArea.style.position = "fixed";
-        textArea.style.opacity = "0";
-        document.body.appendChild(textArea);
-        textArea.select();
-        const successful = document.execCommand("copy");
-        document.body.removeChild(textArea);
-        if (successful) {
-          toast.success("接入点地址已复制到剪贴板");
-        } else {
-          throw new Error("复制命令执行失败");
-        }
-      }
-    } catch (error) {
-      console.error("复制失败:", error);
-      toast.error("复制失败，请手动复制");
     }
   };
 
@@ -480,15 +452,17 @@ export function McpEndpointSettingButton() {
                   </Badge>
                 </div>
                 <div className="flex items-center gap-1 sm:gap-2 flex-wrap justify-end">
-                  <Button
+                  <CopyButton
+                    content={item}
                     variant="outline"
                     size="icon"
-                    onClick={() => handleCopy(item)}
+                    showToast
+                    successMessage="接入点地址已复制到剪贴板"
+                    errorMessage="复制失败，请手动复制"
+                    fallback
                     title="复制完整地址"
                     className="transition-all duration-200 hover:scale-105"
-                  >
-                    <CopyIcon className="size-4" />
-                  </Button>
+                  />
                   {/* 连接/断开按钮 */}
                   {isConnected ? (
                     <Button

--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -13,6 +13,7 @@
 
 "use client";
 
+import { CopyButton } from "@/components/common/copy-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card } from "@/components/ui/card";
@@ -47,16 +48,14 @@ import type {
 } from "@xiaozhi-client/shared-types";
 import {
   CheckCircle,
-  CheckIcon,
   Code,
-  CopyIcon,
   FileText,
   Loader2,
   RefreshCw,
   RotateCwIcon,
   XCircle,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 export function ToolCallLogsDialog() {
   const [open, setOpen] = useState(false);
@@ -323,62 +322,6 @@ export function ToolCallLogsDialog() {
   );
 }
 
-// 复制按钮组件
-interface CopyButtonProps {
-  size?: "sm" | "default" | "lg";
-  copyContent: string;
-  className?: string;
-}
-
-function CopyButton({
-  size = "sm",
-  copyContent,
-  className = "",
-}: CopyButtonProps) {
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
-  const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(copyContent);
-      setCopied(true);
-
-      // 清除之前的定时器
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-
-      // 保存定时器引用，3秒后自动恢复状态
-      copiedTimerRef.current = setTimeout(() => {
-        setCopied(false);
-      }, 3000);
-    } catch (error) {
-      console.error("复制失败:", error);
-    }
-  };
-
-  // 组件卸载时清理定时器
-  useEffect(() => {
-    return () => {
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-    };
-  }, []);
-
-  return (
-    <Button
-      variant="ghost"
-      size={size}
-      className={`${className} ${
-        copied ? "text-green-600 hover:text-green-700" : ""
-      }`}
-      onClick={handleCopy}
-    >
-      {copied ? <CheckIcon /> : <CopyIcon />}
-    </Button>
-  );
-}
 
 // 详情展示组件
 interface CallLogDetailProps {
@@ -417,7 +360,7 @@ function CallLogDetail({ log }: CallLogDetailProps) {
                       {formatJson(log.arguments)}
                     </pre>
                     <CopyButton
-                      copyContent={formatJson(log.arguments) || ""}
+                      content={formatJson(log.arguments) || ""}
                       className="absolute top-2 right-2 hover:bg-slate-200 w-[30px] h-[30px]"
                     />
                   </div>
@@ -442,7 +385,7 @@ function CallLogDetail({ log }: CallLogDetailProps) {
                         {formatJson(log.result)}
                       </pre>
                       <CopyButton
-                        copyContent={formatJson(log.result) || ""}
+                        content={formatJson(log.result) || ""}
                         className="absolute top-2 right-2 hover:bg-slate-200 w-[30px] h-[30px]"
                       />
                     </div>
@@ -469,7 +412,7 @@ function CallLogDetail({ log }: CallLogDetailProps) {
                     </div>
                     {log.error && (
                       <CopyButton
-                        copyContent={log.error || ""}
+                        content={log.error || ""}
                         className="absolute top-2 right-2"
                       />
                     )}
@@ -488,7 +431,7 @@ function CallLogDetail({ log }: CallLogDetailProps) {
                     {formatRawData(log)}
                   </pre>
                   <CopyButton
-                    copyContent={formatRawData(log)}
+                    content={formatRawData(log)}
                     className="absolute top-2 right-2 hover:bg-slate-200 w-[30px] h-[30px]"
                   />
                 </div>

--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { CopyButton } from "@/components/common/copy-button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -47,7 +48,6 @@ import {
   BrushCleaningIcon,
   CheckIcon,
   Code,
-  CopyIcon,
   InfoIcon,
   Loader2,
   PlayIcon,
@@ -56,7 +56,7 @@ import {
   Zap,
 } from "lucide-react";
 import type React from "react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { memo, useCallback, useEffect, useMemo, useState } from "react";
 import { Controller, useFieldArray, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
@@ -446,8 +446,6 @@ export function ToolDebugDialog({
   const [result, setResult] = useState<any>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   // 创建动态 schema
   const formSchema = useMemo(() => {
@@ -484,21 +482,12 @@ export function ToolDebugDialog({
     }
   }, [tool?.inputSchema, defaultValues, form]); // 添加 form 依赖以满足 linter 要求
 
-  useEffect(() => {
-    return () => {
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-    };
-  }, []);
-
   // 重置状态
   const resetState = useCallback(() => {
     setInputMode("form");
     setJsonInput("{\n  \n}");
     setResult(null);
     setError(null);
-    setCopied(false);
     // 只在有工具且有输入schema时才重置表单
     if (tool?.inputSchema) {
       form.reset(defaultValues);
@@ -606,22 +595,6 @@ export function ToolDebugDialog({
       setLoading(false);
     }
   }, [tool, inputMode, form, jsonInput, validateJSON]);
-
-  // 复制结果
-  const handleCopy = useCallback(async () => {
-    const content = result ? JSON.stringify(result, null, 2) : error || "";
-    try {
-      await navigator.clipboard.writeText(content);
-      setCopied(true);
-      toast.success("已复制到剪贴板");
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-      copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
-    } catch {
-      toast.error("复制失败");
-    }
-  }, [result, error]);
 
   // 清空输入
   const handleClear = useCallback(() => {
@@ -964,24 +937,18 @@ export function ToolDebugDialog({
                   <div className="flex items-center justify-between h-[40px]">
                     <h3 className="text-sm font-medium">调用结果</h3>
                     {(result || error) && (
-                      <Button
+                      <CopyButton
+                        content={formatResult(result || error)}
                         variant="outline"
                         size="sm"
-                        onClick={handleCopy}
+                        showToast
+                        successMessage="已复制到剪贴板"
+                        errorMessage="复制失败"
+                        showText
+                        copyLabel="复制结果"
+                        copiedLabel="已复制"
                         className="gap-0"
-                      >
-                        {copied ? (
-                          <>
-                            <CheckIcon className="h-4 w-4 mr-1" />
-                            已复制
-                          </>
-                        ) : (
-                          <>
-                            <CopyIcon className="h-4 w-4 mr-1" />
-                            复制结果
-                          </>
-                        )}
-                      </Button>
+                      />
                     )}
                   </div>
                   <div className="flex-1 min-h-0">

--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -9,6 +9,7 @@
  * - 支持版本切换
  */
 
+import { CopyButton } from "@/components/common/copy-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,8 +20,8 @@ import {
 } from "@/components/ui/tooltip";
 import type { VersionInfo } from "@/services/api";
 import { apiClient } from "@/services/api";
-import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
-import { useEffect, useRef, useState } from "react";
+import { InfoIcon, RocketIcon } from "lucide-react";
+import { useEffect, useState } from "react";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";
 
 interface VersionDisplayProps {
@@ -41,8 +42,6 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
   const [loading, setLoading] = useState(true);
   const [checkingUpdate, setCheckingUpdate] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [copied, setCopied] = useState(false);
-  const copiedTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     const fetchVersion = async () => {
@@ -60,14 +59,6 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
     };
 
     fetchVersion();
-  }, []);
-
-  useEffect(() => {
-    return () => {
-      if (copiedTimerRef.current) {
-        clearTimeout(copiedTimerRef.current);
-      }
-    };
   }, []);
 
   useEffect(() => {
@@ -95,21 +86,6 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
       checkForUpdates();
     }
   }, [versionInfo]);
-
-  const handleCopyVersion = async () => {
-    if (versionInfo?.version) {
-      try {
-        await navigator.clipboard.writeText(versionInfo.version);
-        setCopied(true);
-        if (copiedTimerRef.current) {
-          clearTimeout(copiedTimerRef.current);
-        }
-        copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
-      } catch (err) {
-        console.error("复制版本号失败:", err);
-      }
-    }
-  };
 
   if (loading) {
     return (
@@ -164,14 +140,15 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         </div>
       </div>
       <div className="pt-1 border-t">
-        <button
-          type="button"
-          onClick={handleCopyVersion}
-          className="text-xs text-primary hover:underline flex items-center gap-1"
-        >
-          <CopyIcon className="h-3 w-3" />
-          {copied ? "已复制!" : "复制版本号"}
-        </button>
+        <CopyButton
+          content={versionInfo.version}
+          variant="link"
+          size="sm"
+          showText
+          copyLabel="复制版本号"
+          copiedLabel="已复制!"
+          className="text-xs p-0 h-auto"
+        />
       </div>
     </div>
   );


### PR DESCRIPTION
- 创建 CopyButton 公共组件，支持多种使用场景
- 支持可选的 toast 提示、文本标签显示和降级方案
- 更新 4 个组件使用统一的 CopyButton：
  - tool-call-logs-dialog.tsx
  - tool-debug-dialog.tsx
  - version-display.tsx
  - mcp-endpoint-setting-button.tsx
- 移除约 80 行重复的复制逻辑代码
- 保持功能完整性，所有测试通过

Fixes #2885

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2885