### PR TITLE
perf(notification): 使用环形缓冲区替代数组队列，优化 O(n) 到 O(1)

### DIFF
--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -484,8 +484,9 @@ describe("NotificationService", () => {
       // Register client and check that only the last maxQueueSize messages are sent
       notificationService.registerClient("offline-client", mockWebSocket);
       expect(mockWebSocket.send).toHaveBeenCalledTimes(maxQueueSize);
+      // 使用环形缓冲区时，队列满时自动覆盖最旧消息
       expect(mockLogger.warn).toHaveBeenCalledWith(
-        "客户端 offline-client 消息队列已满，移除最旧消息"
+        "客户端 offline-client 消息队列已满，自动覆盖最旧消息"
       );
     });
 

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -25,6 +25,7 @@ import { logger } from "@/Logger.js";
 import type { EventBus } from "@/services/event-bus.service.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { ClientInfo, RestartStatus } from "@/services/status.service.js";
+import { CircularBuffer } from "@/utils/circular-buffer.js";
 import type { AppConfig } from "@xiaozhi-client/config";
 import { configManager } from "@xiaozhi-client/config";
 
@@ -74,7 +75,9 @@ export class NotificationService {
   private logger: Logger;
   private eventBus: EventBus;
   private clients: Map<string, WebSocketClient> = new Map();
-  private messageQueue: Map<string, NotificationMessage[]> = new Map();
+  /** 每个客户端的消息队列，使用环形缓冲区实现 O(1) 操作 */
+  private messageQueue: Map<string, CircularBuffer<NotificationMessage>> =
+    new Map();
   private maxQueueSize = 100;
 
   constructor() {
@@ -266,28 +269,33 @@ export class NotificationService {
 
   /**
    * 将消息加入队列
+   * 使用环形缓冲区实现 O(1) 的队列操作
    */
   private queueMessage(clientId: string, message: NotificationMessage): void {
     if (!this.messageQueue.has(clientId)) {
-      this.messageQueue.set(clientId, []);
+      this.messageQueue.set(
+        clientId,
+        new CircularBuffer<NotificationMessage>(this.maxQueueSize)
+      );
     }
 
     const queue = this.messageQueue.get(clientId)!;
-    queue.push(message);
 
-    // 限制队列大小
-    if (queue.length > this.maxQueueSize) {
-      queue.shift(); // 移除最旧的消息
-      this.logger.warn(`客户端 ${clientId} 消息队列已满，移除最旧消息`);
+    // 环形缓冲区已满时自动覆盖最旧消息，无需手动移除
+    if (queue.isFull()) {
+      this.logger.warn(`客户端 ${clientId} 消息队列已满，自动覆盖最旧消息`);
     }
+
+    queue.push(message);
   }
 
   /**
    * 发送排队的消息
+   * 使用环形缓冲区的迭代器遍历所有消息
    */
   private sendQueuedMessages(clientId: string): void {
     const queue = this.messageQueue.get(clientId);
-    if (!queue || queue.length === 0) {
+    if (!queue || queue.isEmpty()) {
       return;
     }
 
@@ -296,8 +304,9 @@ export class NotificationService {
       return;
     }
 
-    this.logger.debug(`发送 ${queue.length} 条排队消息给客户端 ${clientId}`);
+    this.logger.debug(`发送 ${queue.getSize()} 条排队消息给客户端 ${clientId}`);
 
+    // 使用迭代器遍历队列中的所有消息
     for (const message of queue) {
       this.sendMessageToClient(client, message, clientId);
     }
@@ -350,7 +359,7 @@ export class NotificationService {
     ).length;
 
     const queuedMessages = Array.from(this.messageQueue.values()).reduce(
-      (total, queue) => total + queue.length,
+      (total, queue) => total + queue.getSize(),
       0
     );
 

--- a/apps/backend/utils/__tests__/circular-buffer.test.ts
+++ b/apps/backend/utils/__tests__/circular-buffer.test.ts
@@ -1,0 +1,253 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import { CircularBuffer } from "../circular-buffer.js";
+
+describe("CircularBuffer", () => {
+  let buffer: CircularBuffer<number>;
+
+  beforeEach(() => {
+    buffer = new CircularBuffer<number>(5);
+  });
+
+  describe("constructor", () => {
+    it("应该创建指定容量的缓冲区", () => {
+      expect(buffer.getCapacity()).toBe(5);
+      expect(buffer.getSize()).toBe(0);
+      expect(buffer.isEmpty()).toBe(true);
+      expect(buffer.isFull()).toBe(false);
+    });
+  });
+
+  describe("push", () => {
+    it("应该添加元素到空缓冲区", () => {
+      buffer.push(1);
+      expect(buffer.getSize()).toBe(1);
+      expect(buffer.isEmpty()).toBe(false);
+      expect(buffer.peekFirst()).toBe(1);
+      expect(buffer.peekLast()).toBe(1);
+    });
+
+    it("应该按顺序添加多个元素", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+      expect(buffer.getSize()).toBe(3);
+      expect(buffer.peekFirst()).toBe(1);
+      expect(buffer.peekLast()).toBe(3);
+    });
+
+    it("应该在缓冲区满时自动覆盖最旧元素", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+      buffer.push(4);
+      buffer.push(5);
+      expect(buffer.isFull()).toBe(true);
+      expect(buffer.peekFirst()).toBe(1);
+      expect(buffer.peekLast()).toBe(5);
+
+      // 添加第 6 个元素，应该覆盖第 1 个元素
+      buffer.push(6);
+      expect(buffer.getSize()).toBe(5);
+      expect(buffer.peekFirst()).toBe(2); // 最旧元素现在是 2
+      expect(buffer.peekLast()).toBe(6);
+    });
+
+    it("应该正确处理连续覆盖多个元素", () => {
+      // 填满缓冲区
+      for (let i = 1; i <= 5; i++) {
+        buffer.push(i);
+      }
+
+      // 覆盖 3 个元素
+      buffer.push(6);
+      buffer.push(7);
+      buffer.push(8);
+
+      expect(buffer.toArray()).toEqual([3, 4, 5, 6, 7, 8].slice(1)); // [4, 5, 6, 7, 8]
+      // 修正预期：应该是 [3, 4, 5, 6, 7, 8] 的最后 5 个，即 [4, 5, 6, 7, 8]
+      // 但实际上覆盖后应该是：push(6) 后是 [2,3,4,5,6], push(7) 后是 [3,4,5,6,7], push(8) 后是 [4,5,6,7,8]
+      expect(buffer.toArray()).toEqual([4, 5, 6, 7, 8]);
+    });
+  });
+
+  describe("popFirst", () => {
+    it("应该从空缓冲区返回 undefined", () => {
+      expect(buffer.popFirst()).toBeUndefined();
+      expect(buffer.getSize()).toBe(0);
+    });
+
+    it("应该移除并返回最旧的元素", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+
+      const first = buffer.popFirst();
+      expect(first).toBe(1);
+      expect(buffer.getSize()).toBe(2);
+      expect(buffer.peekFirst()).toBe(2);
+    });
+
+    it("应该正确处理连续 popFirst", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+
+      expect(buffer.popFirst()).toBe(1);
+      expect(buffer.popFirst()).toBe(2);
+      expect(buffer.popFirst()).toBe(3);
+      expect(buffer.isEmpty()).toBe(true);
+    });
+  });
+
+  describe("peekFirst 和 peekLast", () => {
+    it("应该从空缓冲区返回 undefined", () => {
+      expect(buffer.peekFirst()).toBeUndefined();
+      expect(buffer.peekLast()).toBeUndefined();
+    });
+
+    it("应该正确返回第一个和最后一个元素", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+
+      expect(buffer.peekFirst()).toBe(1);
+      expect(buffer.peekLast()).toBe(3);
+    });
+
+    it("应该在单个元素时返回相同的值", () => {
+      buffer.push(42);
+      expect(buffer.peekFirst()).toBe(42);
+      expect(buffer.peekLast()).toBe(42);
+    });
+  });
+
+  describe("toArray", () => {
+    it("应该返回空数组", () => {
+      expect(buffer.toArray()).toEqual([]);
+    });
+
+    it("应该按顺序返回所有元素", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+      expect(buffer.toArray()).toEqual([1, 2, 3]);
+    });
+
+    it("应该在覆盖元素后正确返回", () => {
+      // 填满并覆盖
+      for (let i = 1; i <= 7; i++) {
+        buffer.push(i);
+      }
+      // 缓冲区容量 5，应该保留最后 5 个元素
+      expect(buffer.toArray()).toEqual([3, 4, 5, 6, 7]);
+    });
+  });
+
+  describe("迭代器", () => {
+    it("应该支持 for-of 迭代", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+
+      const result: number[] = [];
+      for (const item of buffer) {
+        result.push(item);
+      }
+      expect(result).toEqual([1, 2, 3]);
+    });
+
+    it("应该在空缓冲区时不产生任何元素", () => {
+      const result: number[] = [];
+      for (const item of buffer) {
+        result.push(item);
+      }
+      expect(result).toEqual([]);
+    });
+  });
+
+  describe("clear", () => {
+    it("应该清空缓冲区", () => {
+      buffer.push(1);
+      buffer.push(2);
+      buffer.push(3);
+
+      buffer.clear();
+      expect(buffer.isEmpty()).toBe(true);
+      expect(buffer.getSize()).toBe(0);
+      expect(buffer.toArray()).toEqual([]);
+    });
+
+    it("应该允许清空后重新添加元素", () => {
+      buffer.push(1);
+      buffer.clear();
+      buffer.push(2);
+      expect(buffer.getSize()).toBe(1);
+      expect(buffer.peekFirst()).toBe(2);
+    });
+  });
+
+  describe("边界情况", () => {
+    it("应该正确处理容量为 1 的缓冲区", () => {
+      const smallBuffer = new CircularBuffer<number>(1);
+      smallBuffer.push(1);
+      expect(smallBuffer.isFull()).toBe(true);
+      expect(smallBuffer.peekFirst()).toBe(1);
+
+      smallBuffer.push(2);
+      expect(smallBuffer.getSize()).toBe(1);
+      expect(smallBuffer.peekFirst()).toBe(2);
+    });
+
+    it("应该正确处理大量元素的连续操作", () => {
+      const largeBuffer = new CircularBuffer<number>(100);
+
+      // 添加 200 个元素
+      for (let i = 0; i < 200; i++) {
+        largeBuffer.push(i);
+      }
+
+      // 应该保留最后 100 个元素
+      expect(largeBuffer.getSize()).toBe(100);
+      expect(largeBuffer.peekFirst()).toBe(100);
+      expect(largeBuffer.peekLast()).toBe(199);
+
+      // 移除 50 个元素
+      for (let i = 0; i < 50; i++) {
+        largeBuffer.popFirst();
+      }
+
+      expect(largeBuffer.getSize()).toBe(50);
+      expect(largeBuffer.peekFirst()).toBe(150);
+    });
+  });
+
+  describe("性能特性", () => {
+    it("push 操作应该是 O(1)", () => {
+      // 添加大量元素测试性能
+      const start = Date.now();
+      for (let i = 0; i < 10000; i++) {
+        buffer.push(i);
+      }
+      const elapsed = Date.now() - start;
+
+      // 10000 次 push 应该在 100ms 内完成
+      expect(elapsed).toBeLessThan(100);
+    });
+
+    it("popFirst 操作应该是 O(1)", () => {
+      // 填满缓冲区
+      for (let i = 0; i < 5; i++) {
+        buffer.push(i);
+      }
+
+      const start = Date.now();
+      while (!buffer.isEmpty()) {
+        buffer.popFirst();
+      }
+      const elapsed = Date.now() - start;
+
+      // 5 次 popFirst 应该在 10ms 内完成
+      expect(elapsed).toBeLessThan(10);
+    });
+  });
+});

--- a/apps/backend/utils/circular-buffer.ts
+++ b/apps/backend/utils/circular-buffer.ts
@@ -1,0 +1,164 @@
+/**
+ * 环形缓冲区
+ *
+ * 高性能固定大小队列，使用环形数组实现：
+ * - O(1) push 操作
+ * - O(1) popFirst 操作
+ * - 固定内存占用
+ * - 自动处理队列满的情况（覆盖最旧元素）
+ *
+ * 相比普通数组的 shift() 操作，避免了 O(n) 的数组重新索引开销。
+ */
+
+/**
+ * 环形缓冲区类
+ * @template T - 缓冲区元素类型
+ */
+export class CircularBuffer<T> {
+  /** 固定大小的缓冲区数组 */
+  private buffer: T[];
+
+  /** 头部指针（指向最旧元素） */
+  private head = 0;
+
+  /** 尾部指针（指向下一个写入位置） */
+  private tail = 0;
+
+  /** 当前元素数量 */
+  private size = 0;
+
+  /** 缓冲区容量 */
+  private readonly capacity: number;
+
+  /**
+   * 构造函数
+   * @param capacity - 缓冲区容量
+   */
+  constructor(capacity: number) {
+    this.capacity = capacity;
+    this.buffer = new Array(capacity);
+  }
+
+  /**
+   * 添加元素到缓冲区尾部
+   * 如果缓冲区已满，自动覆盖最旧的元素
+   * @param item - 要添加的元素
+   */
+  push(item: T): void {
+    if (this.size === this.capacity) {
+      // 缓冲区已满，移动头部指针以覆盖最旧元素
+      this.head = (this.head + 1) % this.capacity;
+    } else {
+      this.size++;
+    }
+
+    this.buffer[this.tail] = item;
+    this.tail = (this.tail + 1) % this.capacity;
+  }
+
+  /**
+   * 移除并返回最旧的元素
+   * @returns 最旧的元素，如果缓冲区为空则返回 undefined
+   */
+  popFirst(): T | undefined {
+    if (this.size === 0) {
+      return undefined;
+    }
+
+    const item = this.buffer[this.head];
+    this.buffer[this.head] = undefined as T; // 清理引用
+    this.head = (this.head + 1) % this.capacity;
+    this.size--;
+
+    return item;
+  }
+
+  /**
+   * 获取当前元素数量
+   * @returns 元素数量
+   */
+  getSize(): number {
+    return this.size;
+  }
+
+  /**
+   * 检查缓冲区是否为空
+   * @returns 如果为空返回 true
+   */
+  isEmpty(): boolean {
+    return this.size === 0;
+  }
+
+  /**
+   * 检查缓冲区是否已满
+   * @returns 如果已满返回 true
+   */
+  isFull(): boolean {
+    return this.size === this.capacity;
+  }
+
+  /**
+   * 获取最旧的元素（不移除）
+   * @returns 最旧的元素，如果缓冲区为空则返回 undefined
+   */
+  peekFirst(): T | undefined {
+    if (this.size === 0) {
+      return undefined;
+    }
+    return this.buffer[this.head];
+  }
+
+  /**
+   * 获取最新的元素（不移除）
+   * @returns 最新的元素，如果缓冲区为空则返回 undefined
+   */
+  peekLast(): T | undefined {
+    if (this.size === 0) {
+      return undefined;
+    }
+    // tail 指向下一个写入位置，所以最新元素在 tail - 1
+    const lastIndex = (this.tail - 1 + this.capacity) % this.capacity;
+    return this.buffer[lastIndex];
+  }
+
+  /**
+   * 将缓冲区内容转换为数组（按顺序从旧到新）
+   * @returns 包含所有元素的数组
+   */
+  toArray(): T[] {
+    const result: T[] = [];
+    for (let i = 0; i < this.size; i++) {
+      const index = (this.head + i) % this.capacity;
+      result.push(this.buffer[index]);
+    }
+    return result;
+  }
+
+  /**
+   * 清空缓冲区
+   */
+  clear(): void {
+    this.buffer = new Array(this.capacity);
+    this.head = 0;
+    this.tail = 0;
+    this.size = 0;
+  }
+
+  /**
+   * 迭代器支持 - 按顺序从旧到新迭代
+   */
+  *[Symbol.iterator](): Iterator<T> {
+    for (let i = 0; i < this.size; i++) {
+      const index = (this.head + i) % this.capacity;
+      yield this.buffer[index];
+    }
+  }
+
+  /**
+   * 获取缓冲区容量
+   * @returns 缓冲区容量
+   */
+  getCapacity(): number {
+    return this.capacity;
+  }
+}

--- a/apps/backend/utils/index.ts
+++ b/apps/backend/utils/index.ts
@@ -16,3 +16,5 @@ export {
   type DeviceInfoFromHeaders,
   type ExtractedDeviceInfo,
 } from "./esp32-utils.js";
+// 高性能环形缓冲区
+export { CircularBuffer } from "./circular-buffer.js";


### PR DESCRIPTION
问题：notification.service.ts 中的 queueMessage 方法使用 Array.shift()
移除最旧消息，这会导致 O(n) 的数组重新索引开销。

解决方案：
- 创建 CircularBuffer 类，使用环形数组实现 O(1) 的 push 和 popFirst
- NotificationService 使用 CircularBuffer 替代普通数组作为消息队列
- 环形缓冲区容量固定，满时自动覆盖最旧元素

修改的文件：
- utils/circular-buffer.ts: 新建高性能环形缓冲区类
- services/notification.service.ts: 使用 CircularBuffer 作为消息队列
- utils/index.ts: 导出 CircularBuffer
- services/__tests__/notification.service.test.ts: 更新测试预期
- utils/__tests__/circular-buffer.test.ts: 新建环形缓冲区测试

测试结果：通知服务测试 46 个通过，环形缓冲区测试 22 个通过

Fixes #2887

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2887