### PR TITLE
docs: 为 mcp-endpoint-setting-button.tsx 添加文件级 JSDoc 注释

### DIFF
--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -1,3 +1,28 @@
+/**
+ * MCP 端点设置按钮组件
+ *
+ * 提供 MCP 端点的添加、编辑、删除和连接状态管理功能。
+ * 主要功能包括：
+ * - 端点列表展示和管理
+ * - 端点添加和删除对话框
+ * - 端点连接状态实时显示
+ * - 端点配置编辑和验证
+ * - WebSocket 实时状态同步
+ *
+ * @module McpEndpointSettingButton
+ *
+ * @requires @/stores/config - 配置状态管理（useConfig, useConfigActions, useMcpEndpoint）
+ * @requires @/services/api - API 客户端（端点增删改查、连接/断开操作）
+ * @requires @/services/websocket - WebSocket 连接管理（实时状态订阅）
+ *
+ * @example
+ * ```tsx
+ * import { McpEndpointSettingButton } from "@/components/mcp-endpoint-setting-button";
+ *
+ * // 在页面中使用
+ * <McpEndpointSettingButton />
+ * ```
+ */
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 


### PR DESCRIPTION
为 625 行的 MCP 端点设置按钮组件添加完整的文件级文档说明，
包括模块用途、主要功能、依赖服务和使用示例，与其他业务组件
文档风格保持一致。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2889