### PR TITLE
fix(esp32): WebSocket 错误事件处理时更新状态并关闭连接

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -132,6 +132,10 @@ export class ESP32Connection {
 
     this.ws.on("error", (error: Error) => {
       logger.error(`WebSocket连接错误: deviceId=${this.deviceId}`, error);
+      // 更新状态为 disconnected，确保状态一致性
+      this.state = "disconnected";
+      // 确保连接被正确关闭
+      this.ws.close();
       this.config.onError(error);
     });
 


### PR DESCRIPTION
当 WebSocket 发生错误时，原代码只记录错误和调用回调，
没有更新连接状态，可能导致设备状态显示不一致。

修复内容：
- 在 error 事件处理中更新 state 为 "disconnected"
- 调用 ws.close() 确保连接被正确关闭
- 与 close 事件处理逻辑保持一致

Fixes #2892

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2892