### PR TITLE
fix(cli): 替换 EndpointCommandHandler 中 getService<any> 为具体类型

### DIFF
--- a/packages/cli/src/commands/EndpointCommandHandler.ts
+++ b/packages/cli/src/commands/EndpointCommandHandler.ts
@@ -4,6 +4,7 @@
 
 import chalk from "chalk";
 import ora from "ora";
+import type { ConfigManager } from "@xiaozhi-client/config";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
@@ -74,7 +75,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("读取端点配置...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       const endpoints = configManager.getMcpEndpoints();
       spinner.succeed("端点列表");
 
@@ -101,7 +102,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("添加端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       configManager.addMcpEndpoint(url);
       spinner.succeed(`成功添加端点: ${url}`);
 
@@ -122,7 +123,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("移除端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
       configManager.removeMcpEndpoint(url);
       spinner.succeed(`成功移除端点: ${url}`);
 
@@ -143,7 +144,7 @@ export class EndpointCommandHandler extends BaseCommandHandler {
     const spinner = ora("设置端点...").start();
 
     try {
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<ConfigManager>("configManager");
 
       if (urls.length === 1) {
         configManager.updateMcpEndpoint(urls[0]);


### PR DESCRIPTION
修复 EndpointCommandHandler.ts 中 4 处 getService<any> 使用，
提高代码类型安全性。添加 ConfigManager 类型导入，替换所有
getService<any> 为 getService<ConfigManager>。

修复位置:
- handleList 方法 (第 78 行)
- handleAdd 方法 (第 105 行)
- handleRemove 方法 (第 126 行)
- handleSet 方法 (第 147 行)

Closes #2901

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2901