### PR TITLE
refactor(tts): 使用 TTSFactory 实现依赖注入原则

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -58,6 +58,7 @@ import {
   ESP32Service,
   NotificationService,
   StatusService,
+  TTSFactory,
   destroyEventBus,
   getEventBus,
 } from "@/services/index.js";
@@ -137,6 +138,7 @@ export class WebServer {
   private notificationService: NotificationService;
   private deviceRegistryService: DeviceRegistryService;
   private esp32Service: ESP32Service;
+  private ttsFactory: TTSFactory;
 
   // HTTP API 处理器
   private configApiHandler: ConfigApiHandler;
@@ -192,6 +194,8 @@ export class WebServer {
     this.esp32Service = new ESP32Service(this.deviceRegistryService);
     // 设置 TTS 服务的获取连接回调
     this.esp32Service.setupTTSGetConnection();
+    // 创建 TTS 工厂
+    this.ttsFactory = new TTSFactory();
 
     // 初始化 HTTP API 处理器
     this.configApiHandler = new ConfigApiHandler();
@@ -204,7 +208,7 @@ export class WebServer {
     this.mcpRouteHandler = new MCPRouteHandler();
     this.updateApiHandler = new UpdateApiHandler();
     this.cozeHandler = new CozeHandler();
-    this.ttsApiHandler = new TTSApiHandler();
+    this.ttsApiHandler = new TTSApiHandler(this.ttsFactory);
     this.esp32Handler = new ESP32Handler(this.esp32Service);
 
     // MCPServerApiHandler 将在 start() 方法中初始化，因为它需要 mcpServiceManager
@@ -1093,6 +1097,8 @@ export class WebServer {
     this.deviceRegistryService.destroy();
     // 异步销毁 ESP32 服务（fire and forget）
     this.esp32Service.destroy();
+    // 销毁 TTS 工厂
+    this.ttsFactory.destroy();
 
     // 销毁事件总线
     destroyEventBus();

--- a/apps/backend/__tests__/webserver/webserver.integration.test.ts
+++ b/apps/backend/__tests__/webserver/webserver.integration.test.ts
@@ -114,6 +114,18 @@ vi.mock("@/services/index.js", () => {
     setupTTSGetConnection: vi.fn(),
   };
 
+  // Mock TTSFactory
+  const mockTTSFactoryInstance = {
+    getOrCreateClient: vi.fn(() => ({
+      synthesize: vi.fn().mockResolvedValue(new Uint8Array(100)),
+      close: vi.fn(),
+    })),
+    removeClient: vi.fn(),
+    clearCache: vi.fn(),
+    getCacheStats: vi.fn(() => ({ size: 0, maxSize: 10, entries: [] })),
+    destroy: vi.fn(),
+  };
+
   return {
     // EventBus 相关
     getEventBus: vi.fn(() => mockEventBus),
@@ -127,6 +139,8 @@ vi.mock("@/services/index.js", () => {
     DeviceRegistryService: vi.fn(() => mockDeviceRegistryServiceInstance),
     // ESP32Service 相关
     ESP32Service: vi.fn(() => mockESP32ServiceInstance),
+    // TTSFactory 相关
+    TTSFactory: vi.fn(() => mockTTSFactoryInstance),
   };
 });
 

--- a/apps/backend/handlers/tts.handler.ts
+++ b/apps/backend/handlers/tts.handler.ts
@@ -5,10 +5,10 @@
 
 import fs from "node:fs";
 import { TTS_VOICES, getVoiceScenes } from "@/constants/voices.js";
+import type { TTSFactory } from "@/services/tts.factory.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { VoiceInfo, VoicesResponse } from "@xiaozhi-client/shared-types";
-import { TTS } from "@xiaozhi-client/tts";
 import type { Context } from "hono";
 import { BaseHandler } from "./base.handler.js";
 
@@ -36,8 +36,11 @@ interface TTSRequestBody {
  * TTS API 路由处理器类
  */
 export class TTSApiHandler extends BaseHandler {
-  constructor() {
+  private ttsFactory: TTSFactory;
+
+  constructor(ttsFactory: TTSFactory) {
     super();
+    this.ttsFactory = ttsFactory;
   }
 
   /**
@@ -104,22 +107,14 @@ export class TTSApiHandler extends BaseHandler {
         );
       }
 
-      // 创建 TTS 客户端
-      const ttsClient = new TTS({
-        bytedance: {
-          v1: {
-            app: {
-              appid: appid!,
-              accessToken: accessToken!,
-            },
-            audio: {
-              voice_type: voice_type!,
-              encoding: encoding || "wav",
-            },
-            cluster,
-            endpoint,
-          },
-        },
+      // 通过工厂获取或创建 TTS 客户端
+      const ttsClient = this.ttsFactory.getOrCreateClient({
+        appid: appid!,
+        accessToken: accessToken!,
+        voice_type: voice_type!,
+        encoding: encoding || "wav",
+        cluster,
+        endpoint,
       });
 
       c.get("logger").info(

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -6,10 +6,11 @@
  * - NotificationService: 通知服务，处理系统通知和消息推送
  * - EventBus / getEventBus: 事件总线服务，提供发布-订阅模式的事件处理机制
  * - CustomMCPHandler: 自定义 MCP 处理器（重新导出，保持向后兼容性）
+ * - TTSFactory: TTS 客户端工厂，管理 TTS 客户端实例的创建和复用
  *
  * @example
  * ```typescript
- * import { StatusService, NotificationService, getEventBus } from '@/services';
+ * import { StatusService, NotificationService, getEventBus, TTSFactory } from '@/services';
  *
  * // 使用状态服务
  * const statusService = new StatusService();
@@ -20,6 +21,10 @@
  * eventBus.onEvent('event-name', (data) => {
  *   console.log('Event received:', data);
  * });
+ *
+ * // 使用 TTS 工厂
+ * const ttsFactory = new TTSFactory();
+ * const ttsClient = ttsFactory.getOrCreateClient(config);
  * ```
  */
 export * from "./status.service.js";
@@ -27,6 +32,7 @@ export * from "./notification.service.js";
 export * from "./event-bus.service.js";
 export * from "./device-registry.service.js";
 export * from "./esp32.service.js";
+export * from "./tts.factory.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";

--- a/apps/backend/services/tts.factory.ts
+++ b/apps/backend/services/tts.factory.ts
@@ -1,0 +1,284 @@
+/**
+ * TTS 客户端工厂
+ * 管理 TTS 客户端实例的创建和复用
+ */
+
+import { logger } from "@/Logger.js";
+import type { ByteDanceTTSConfig } from "@xiaozhi-client/tts";
+import { TTS } from "@xiaozhi-client/tts";
+
+/**
+ * TTS 配置键
+ * 用于标识和缓存 TTS 客户端实例
+ */
+interface TTSConfigKey {
+  appid: string;
+  accessToken: string;
+  voice_type: string;
+  encoding: string;
+  cluster?: string;
+  endpoint?: string;
+}
+
+/**
+ * TTS 客户端实例缓存
+ */
+interface TTSCacheEntry {
+  client: TTS;
+  config: TTSConfigKey;
+  lastUsed: number;
+}
+
+/**
+ * TTS 工厂选项
+ */
+interface TTSFactoryOptions {
+  /** 是否启用客户端缓存（默认启用） */
+  enableCache?: boolean;
+  /** 缓存过期时间（毫秒，默认 5 分钟） */
+  cacheExpiryMs?: number;
+  /** 最大缓存实例数（默认 10） */
+  maxCacheSize?: number;
+}
+
+/**
+ * TTS 客户端工厂
+ * 负责创建和管理 TTS 客户端实例
+ */
+export class TTSFactory {
+  /** TTS 客户端缓存 */
+  private readonly cache = new Map<string, TTSCacheEntry>();
+
+  /** 工厂配置 */
+  private readonly options: Required<TTSFactoryOptions>;
+
+  /** 清理定时器 */
+  private cleanupTimer?: NodeJS.Timeout;
+
+  constructor(options: TTSFactoryOptions = {}) {
+    this.options = {
+      enableCache: options.enableCache ?? true,
+      cacheExpiryMs: options.cacheExpiryMs ?? 5 * 60 * 1000, // 5 分钟
+      maxCacheSize: options.maxCacheSize ?? 10,
+    };
+
+    // 启动缓存清理定时器
+    if (this.options.enableCache) {
+      this.startCleanupTimer();
+    }
+
+    logger.debug("TTS 工厂初始化完成", {
+      enableCache: this.options.enableCache,
+      cacheExpiryMs: this.options.cacheExpiryMs,
+      maxCacheSize: this.options.maxCacheSize,
+    });
+  }
+
+  /**
+   * 获取或创建 TTS 客户端
+   * @param config - TTS 配置
+   * @returns TTS 客户端实例
+   */
+  getOrCreateClient(config: TTSConfigKey): TTS {
+    // 如果禁用缓存，直接创建新实例
+    if (!this.options.enableCache) {
+      return this.createClient(config);
+    }
+
+    // 生成配置键
+    const key = this.generateConfigKey(config);
+
+    // 检查缓存中是否存在
+    const cached = this.cache.get(key);
+    if (cached) {
+      // 更新最后使用时间
+      cached.lastUsed = Date.now();
+      logger.debug("复用缓存的 TTS 客户端", { key });
+      return cached.client;
+    }
+
+    // 创建新客户端
+    const client = this.createClient(config);
+
+    // 添加到缓存
+    this.addToCache(key, client, config);
+
+    logger.debug("创建新的 TTS 客户端", { key });
+    return client;
+  }
+
+  /**
+   * 创建新的 TTS 客户端
+   * @param config - TTS 配置
+   * @returns TTS 客户端实例
+   */
+  private createClient(config: TTSConfigKey): TTS {
+    const ttsConfig: ByteDanceTTSConfig = {
+      app: {
+        appid: config.appid,
+        accessToken: config.accessToken,
+      },
+      audio: {
+        voice_type: config.voice_type,
+        encoding: config.encoding,
+      },
+      cluster: config.cluster,
+      endpoint: config.endpoint,
+    };
+
+    return new TTS({
+      bytedance: {
+        v1: ttsConfig,
+      },
+    });
+  }
+
+  /**
+   * 生成配置键
+   * @param config - TTS 配置
+   * @returns 配置键字符串
+   */
+  private generateConfigKey(config: TTSConfigKey): string {
+    return `${config.appid}:${config.accessToken}:${config.voice_type}:${config.encoding}:${config.cluster || ""}:${config.endpoint || ""}`;
+  }
+
+  /**
+   * 添加客户端到缓存
+   * @param key - 配置键
+   * @param client - TTS 客户端
+   * @param config - 配置信息
+   */
+  private addToCache(key: string, client: TTS, config: TTSConfigKey): void {
+    // 如果缓存已满，清理最旧的实例
+    if (this.cache.size >= this.options.maxCacheSize) {
+      this.evictOldest();
+    }
+
+    this.cache.set(key, {
+      client,
+      config,
+      lastUsed: Date.now(),
+    });
+  }
+
+  /**
+   * 清理最旧的缓存实例
+   */
+  private evictOldest(): void {
+    let oldestKey: string | null = null;
+    let oldestTime = Number.POSITIVE_INFINITY;
+
+    for (const [key, entry] of this.cache) {
+      if (entry.lastUsed < oldestTime) {
+        oldestTime = entry.lastUsed;
+        oldestKey = key;
+      }
+    }
+
+    if (oldestKey) {
+      const entry = this.cache.get(oldestKey);
+      if (entry) {
+        entry.client.close();
+        this.cache.delete(oldestKey);
+        logger.debug("清理最旧的 TTS 客户端缓存", { key: oldestKey });
+      }
+    }
+  }
+
+  /**
+   * 清理过期缓存
+   */
+  private cleanupExpired(): void {
+    const now = Date.now();
+    const expiredKeys: string[] = [];
+
+    for (const [key, entry] of this.cache) {
+      if (now - entry.lastUsed > this.options.cacheExpiryMs) {
+        expiredKeys.push(key);
+      }
+    }
+
+    for (const key of expiredKeys) {
+      const entry = this.cache.get(key);
+      if (entry) {
+        entry.client.close();
+        this.cache.delete(key);
+        logger.debug("清理过期 TTS 客户端缓存", { key });
+      }
+    }
+  }
+
+  /**
+   * 启动缓存清理定时器
+   */
+  private startCleanupTimer(): void {
+    // 每分钟清理一次过期缓存
+    this.cleanupTimer = setInterval(() => {
+      this.cleanupExpired();
+    }, 60 * 1000);
+  }
+
+  /**
+   * 停止缓存清理定时器
+   */
+  private stopCleanupTimer(): void {
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = undefined;
+    }
+  }
+
+  /**
+   * 清理指定配置的客户端
+   * @param config - TTS 配置
+   */
+  removeClient(config: TTSConfigKey): void {
+    const key = this.generateConfigKey(config);
+    const entry = this.cache.get(key);
+    if (entry) {
+      entry.client.close();
+      this.cache.delete(key);
+      logger.debug("移除 TTS 客户端", { key });
+    }
+  }
+
+  /**
+   * 清理所有缓存
+   */
+  clearCache(): void {
+    for (const entry of this.cache.values()) {
+      entry.client.close();
+    }
+    this.cache.clear();
+    logger.debug("清理所有 TTS 客户端缓存");
+  }
+
+  /**
+   * 获取缓存统计信息
+   */
+  getCacheStats(): {
+    size: number;
+    maxSize: number;
+    entries: Array<{ key: string; lastUsed: number }>;
+  } {
+    const entries = Array.from(this.cache.entries()).map(([key, entry]) => ({
+      key,
+      lastUsed: entry.lastUsed,
+    }));
+
+    return {
+      size: this.cache.size,
+      maxSize: this.options.maxCacheSize,
+      entries,
+    };
+  }
+
+  /**
+   * 销毁工厂
+   */
+  destroy(): void {
+    this.stopCleanupTimer();
+    this.clearCache();
+    logger.debug("TTS 工厂已销毁");
+  }
+}


### PR DESCRIPTION
## 问题
TTSApiHandler 的 synthesize 方法中直接创建 TTS 客户端实例，
违反了依赖注入原则。每次调用 /api/tts 端点都会创建一个新的
TTS 客户端，可能导致性能问题和资源浪费。

## 解决方案
1. 创建 TTSFactory 服务管理 TTS 客户端实例的创建和复用
2. 通过构造函数注入 TTSFactory 到 TTSApiHandler
3. TTSFactory 支持：
   - 客户端缓存和复用
   - 缓存过期自动清理
   - 最大缓存实例数限制
   - 优雅的资源清理

## 修改文件
- 新增 apps/backend/services/tts.factory.ts
- 修改 apps/backend/handlers/tts.handler.ts
- 修改 apps/backend/WebServer.ts
- 修改 apps/backend/services/index.ts
- 更新测试 mock

Closes #2906

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2906