### PR TITLE
fix(nx): 添加 backend type-check 缺失的构建依赖

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["shared-types:build", "config:build", "endpoint:build", "version:build", "tts:build", "asr:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
在 backend 的 type-check 目标中添加了缺失的构建依赖：
- shared-types:build
- tts:build
- asr:build

这些依赖确保在运行 TypeScript 类型检查之前，相关包已经构建完成，
避免模块解析错误。

修复 GitHub Issue #2916

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2916