### PR TITLE
fix(arch): 解决 MCPCacheManager 依赖注入违规和定时器泄漏问题

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
@@ -26,6 +26,10 @@ vi.mock("@xiaozhi-client/config", () => ({
 }));
 
 // 模拟 MCPServiceManager - 在 Context 中提供
+const mockCacheManager = {
+  getAllCachedTools: vi.fn().mockResolvedValue([]),
+};
+
 const mockServiceManager = {
   hasTool: vi.fn(() => false),
   hasCustomMCPTool: vi.fn(() => false),
@@ -41,6 +45,7 @@ const mockServiceManager = {
   getConnectedServices: vi.fn(() => []),
   stopService: vi.fn(),
   startService: vi.fn(),
+  getCacheManager: vi.fn(() => mockCacheManager),
 };
 
 // 模拟 MCPCacheManager
@@ -237,21 +242,14 @@ describe("MCPToolHandler - 核心功能测试", () => {
         () => {}
       );
 
-      // 模拟 MCPCacheManager
-      const { MCPCacheManager } = await import("@/lib/mcp");
-      const mockMCPCacheManager = vi.mocked(MCPCacheManager);
-      mockMCPCacheManager.mockImplementation(
-        () =>
-          ({
-            getAllCachedTools: vi.fn().mockResolvedValue([
-              {
-                name: "test-service__test-tool",
-                description: "测试工具",
-                inputSchema: { type: "object", properties: {} },
-              },
-            ]),
-          }) as any
-      );
+      // 模拟缓存管理器返回缓存的工具列表
+      mockCacheManager.getAllCachedTools.mockResolvedValue([
+        {
+          name: "test-service__test-tool",
+          description: "测试工具",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
 
       await handler.addCustomTool(mockContext as Context);
 

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -7,7 +7,6 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import { HTTP_TIMEOUTS } from "@/constants/timeout.constants.js";
 import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
-import { MCPCacheManager } from "@/lib/mcp";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
@@ -666,8 +665,8 @@ export class MCPToolHandler {
       return c.fail("SERVICE_OR_TOOL_NOT_FOUND", errorMessage, undefined, 404);
     }
 
-    // 从缓存中获取工具信息
-    const cacheManager = new MCPCacheManager();
+    // 从 MCPServiceManager 获取缓存管理器实例，避免重复创建和定时器泄漏
+    const cacheManager = serviceManager.getCacheManager();
     const cachedTools = await cacheManager.getAllCachedTools();
 
     // 查找对应的工具

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1811,12 +1811,23 @@ export class MCPServiceManager extends EventEmitter {
   }
 
   /**
+   * 获取缓存管理器
+   * 提供对 MCPCacheManager 实例的访问，避免重复创建实例
+   */
+  getCacheManager(): MCPCacheManager {
+    return this.cacheManager;
+  }
+
+  /**
    * 清理资源（实现 IMCPServiceManager 接口）
    *
-   * 注意：此方法会停止所有 MCP 服务
+   * 注意：此方法会停止所有 MCP 服务并清理缓存管理器
    */
   async cleanup(): Promise<void> {
     await this.stopAllServices();
+
+    // 清理缓存管理器，停止清理定时器
+    this.cacheManager.cleanup();
 
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(


### PR DESCRIPTION
问题：
- mcp-tool.handler.ts 在方法中直接创建 MCPCacheManager 实例
- 每次调用都启动新的清理定时器，导致资源泄漏
- 无法进行单元测试 mock

修复：
- 在 MCPServiceManager 添加 getCacheManager() getter 方法
- 在 MCPServiceManager.cleanup() 中清理 cacheManager 资源
- 修改 mcp-tool.handler.ts 使用 serviceManager.getCacheManager()
- 更新测试用例适配新的依赖注入模式

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2923