### PR TITLE
fix(cli): 信号处理器 async 函数添加 try-catch 错误处理

### DIFF
--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -282,8 +282,15 @@ export class ServiceManagerImpl implements IServiceManager {
 
       // 处理退出信号
       const cleanup = async () => {
-        await server.stop();
-        process.exit(0);
+        try {
+          await server.stop();
+        } catch (error) {
+          consola.error(
+            `停止服务时出错: ${error instanceof Error ? error.message : String(error)}`
+          );
+        } finally {
+          process.exit(0);
+        }
       };
 
       process.once("SIGINT", cleanup);
@@ -341,9 +348,16 @@ export class ServiceManagerImpl implements IServiceManager {
 
     // 处理退出信号
     const cleanup = async () => {
-      await server.stop();
-      this.processManager.cleanupPidFile();
-      process.exit(0);
+      try {
+        await server.stop();
+      } catch (error) {
+        consola.error(
+          `停止服务时出错: ${error instanceof Error ? error.message : String(error)}`
+        );
+      } finally {
+        this.processManager.cleanupPidFile();
+        process.exit(0);
+      }
     };
 
     process.once("SIGINT", cleanup);


### PR DESCRIPTION
修复 ServiceManager 中两个信号处理器的 async 函数缺少 try-catch
导致的未捕获 Promise rejection 问题：
- startMcpServerMode 中的 cleanup 函数
- startWebServerInForeground 中的 cleanup 函数

关闭 #2935

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2935