### PR TITLE
fix: 使用 logger 替代 console 输出日志

### DIFF
--- a/apps/backend/lib/mcp/__tests__/utils.test.ts
+++ b/apps/backend/lib/mcp/__tests__/utils.test.ts
@@ -7,26 +7,25 @@ import {
   inferTransportTypeFromUrl,
 } from "../utils.js";
 
-// Mock console 方法
-let mockConsoleInfo: Mock;
-let mockConsoleWarn: Mock;
+// Mock logger 模块
+vi.mock("@/Logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// 导入 mock 后的 logger 以获取 mock 函数
+import { logger } from "@/Logger.js";
+
+// Mock logger 方法
+let mockLoggerInfo: Mock;
+let mockLoggerWarn: Mock;
 
 beforeEach(() => {
   vi.clearAllMocks();
-  mockConsoleInfo = vi.fn();
-  mockConsoleWarn = vi.fn();
-
-  // Mock console 方法
-  const originalConsoleInfo = console.info;
-  const originalConsoleWarn = console.warn;
-  console.info = mockConsoleInfo;
-  console.warn = mockConsoleWarn;
-
-  // 恢复原始方法（在测试结束时）
-  return () => {
-    console.info = originalConsoleInfo;
-    console.warn = originalConsoleWarn;
-  };
+  mockLoggerInfo = logger.info as Mock;
+  mockLoggerWarn = logger.warn as Mock;
 });
 
 describe("MCP 传输类型推断工具", () => {
@@ -290,7 +289,7 @@ describe("MCP 传输类型推断工具", () => {
           serviceName,
         });
 
-        expect(mockConsoleInfo).toHaveBeenCalledWith(
+        expect(mockLoggerInfo).toHaveBeenCalledWith(
           `[MCP-${serviceName}] URL 路径 /api/v1/tools 不匹配特定规则，默认推断为 http 类型`
         );
       });
@@ -303,7 +302,7 @@ describe("MCP 传输类型推断工具", () => {
           serviceName,
         });
 
-        expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
           `[MCP-${serviceName}] URL 解析失败，默认推断为 http 类型`,
           expect.any(Error)
         );
@@ -321,8 +320,8 @@ describe("MCP 传输类型推断工具", () => {
           serviceName: "test-service",
         });
 
-        expect(mockConsoleInfo).not.toHaveBeenCalled();
-        expect(mockConsoleWarn).not.toHaveBeenCalled();
+        expect(mockLoggerInfo).not.toHaveBeenCalled();
+        expect(mockLoggerWarn).not.toHaveBeenCalled();
       });
     });
   });
@@ -439,7 +438,7 @@ describe("MCP 传输类型推断工具", () => {
         inferTransportTypeFromConfig(config, "test-service");
 
         // 验证是否用正确的参数调用了日志记录
-        expect(mockConsoleWarn).toHaveBeenCalledWith(
+        expect(mockLoggerWarn).toHaveBeenCalledWith(
           "[MCP-test-service] URL 解析失败，默认推断为 http 类型",
           expect.any(Error)
         );

--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -6,6 +6,7 @@
  * - 工具调用参数验证
  */
 
+import { logger } from "@/Logger.js";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
@@ -41,16 +42,16 @@ export function inferTransportTypeFromUrl(
       return MCPTransportType.HTTP;
     }
 
-    // 默认类型 - 使用 console 输出
+    // 默认类型 - 使用 logger 输出
     if (options?.serviceName) {
-      console.info(
+      logger.info(
         `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
       );
     }
     return MCPTransportType.HTTP;
   } catch (error) {
     if (options?.serviceName) {
-      console.warn(
+      logger.warn(
         `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
         error
       );


### PR DESCRIPTION
- 在 lib/mcp/utils.ts 中导入 logger 模块
- 替换 console.info/warn 为 logger.info/warn
- 更新测试文件使用 logger mock 替代 console mock

修复 #2940

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2940