### PR TITLE
fix: 修复 NotificationService.destroy() 未移除事件监听器的内存泄漏

### DIFF
--- a/apps/backend/services/__tests__/notification.service.test.ts
+++ b/apps/backend/services/__tests__/notification.service.test.ts
@@ -9,6 +9,7 @@ vi.mock("../event-bus.service.js", () => ({
   getEventBus: vi.fn().mockReturnValue({
     onEvent: vi.fn(),
     emitEvent: vi.fn(),
+    offEvent: vi.fn(),
   }),
 }));
 
@@ -85,6 +86,7 @@ describe("NotificationService", () => {
     mockEventBus = {
       onEvent: vi.fn(),
       emitEvent: vi.fn(),
+      offEvent: vi.fn(),
     };
     const { getEventBus } = await import("../event-bus.service.js");
     (getEventBus as any).mockReturnValue(mockEventBus);

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -76,6 +76,8 @@ export class NotificationService {
   private clients: Map<string, WebSocketClient> = new Map();
   private messageQueue: Map<string, NotificationMessage[]> = new Map();
   private maxQueueSize = 100;
+  // 事件监听器清理函数数组
+  private eventListenerUnsubscribers: Array<() => void> = [];
 
   constructor() {
     this.logger = logger;
@@ -88,54 +90,162 @@ export class NotificationService {
    */
   private setupEventListeners(): void {
     // 监听配置更新事件
-    this.eventBus.onEvent("config:updated", (data) => {
+    const configUpdatedListener = (data: {
+      type: string;
+      serviceName?: string;
+      platformName?: string;
+      timestamp: Date;
+    }) => {
       // 获取最新的配置
       const config = configManager.getConfig();
       this.broadcastConfigUpdate(config);
+    };
+    this.eventBus.onEvent("config:updated", configUpdatedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("config:updated", configUpdatedListener);
     });
 
     // 监听状态更新事件
-    this.eventBus.onEvent("status:updated", (data) => {
+    const statusUpdatedListener = (data: {
+      status: import("@/services/status.service.js").ClientInfo;
+      source: string;
+    }) => {
       this.broadcastStatusUpdate(data.status);
+    };
+    this.eventBus.onEvent("status:updated", statusUpdatedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("status:updated", statusUpdatedListener);
     });
 
     // 监听重启状态事件
-    this.eventBus.onEvent("service:restart:started", (data) => {
+    const restartStartedListener = (data: {
+      serviceName: string;
+      reason?: string;
+      attempt: number;
+      timestamp: number;
+    }) => {
       this.broadcastRestartStatus("restarting", undefined, data.timestamp);
+    };
+    this.eventBus.onEvent("service:restart:started", restartStartedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("service:restart:started", restartStartedListener);
     });
 
-    this.eventBus.onEvent("service:restart:completed", (data) => {
+    const restartCompletedListener = (data: {
+      serviceName: string;
+      reason?: string;
+      attempt: number;
+      timestamp: number;
+    }) => {
       this.broadcastRestartStatus("completed", undefined, data.timestamp);
+    };
+    this.eventBus.onEvent(
+      "service:restart:completed",
+      restartCompletedListener
+    );
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent(
+        "service:restart:completed",
+        restartCompletedListener
+      );
     });
 
-    this.eventBus.onEvent("service:restart:failed", (data) => {
+    const restartFailedListener = (data: {
+      serviceName: string;
+      error: Error;
+      attempt: number;
+      timestamp: number;
+    }) => {
       this.broadcastRestartStatus("failed", data.error.message, data.timestamp);
+    };
+    this.eventBus.onEvent("service:restart:failed", restartFailedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("service:restart:failed", restartFailedListener);
     });
 
     // 监听 NPM 安装事件
-    this.eventBus.onEvent("npm:install:started", (data) => {
+    const npmInstallStartedListener = (data: {
+      version: string;
+      installId: string;
+      timestamp: number;
+    }) => {
       this.broadcast("npm:install:started", data);
+    };
+    this.eventBus.onEvent("npm:install:started", npmInstallStartedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("npm:install:started", npmInstallStartedListener);
     });
 
-    this.eventBus.onEvent("npm:install:log", (data) => {
+    const npmInstallLogListener = (data: {
+      version: string;
+      installId: string;
+      type: "stdout" | "stderr";
+      message: string;
+      timestamp: number;
+    }) => {
       this.broadcast("npm:install:log", data);
+    };
+    this.eventBus.onEvent("npm:install:log", npmInstallLogListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("npm:install:log", npmInstallLogListener);
     });
 
-    this.eventBus.onEvent("npm:install:completed", (data) => {
+    const npmInstallCompletedListener = (data: {
+      version: string;
+      installId: string;
+      success: boolean;
+      duration: number;
+      timestamp: number;
+    }) => {
       this.broadcast("npm:install:completed", data);
+    };
+    this.eventBus.onEvent("npm:install:completed", npmInstallCompletedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent(
+        "npm:install:completed",
+        npmInstallCompletedListener
+      );
     });
 
-    this.eventBus.onEvent("npm:install:failed", (data) => {
+    const npmInstallFailedListener = (data: {
+      version: string;
+      installId: string;
+      error: string;
+      duration: number;
+      timestamp: number;
+    }) => {
       this.broadcast("npm:install:failed", data);
+    };
+    this.eventBus.onEvent("npm:install:failed", npmInstallFailedListener);
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("npm:install:failed", npmInstallFailedListener);
     });
 
     // 监听通知广播事件
-    this.eventBus.onEvent("notification:broadcast", (data) => {
+    const notificationBroadcastListener = (data: {
+      type: string;
+      data: unknown;
+      target?: string;
+    }) => {
       if (data.target) {
-        this.sendToClient(data.target, data.type, data.data);
+        this.sendToClient(
+          data.target,
+          data.type,
+          data.data as NotificationData
+        );
       } else {
-        this.broadcast(data.type, data.data);
+        this.broadcast(data.type, data.data as NotificationData);
       }
+    };
+    this.eventBus.onEvent(
+      "notification:broadcast",
+      notificationBroadcastListener
+    );
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent(
+        "notification:broadcast",
+        notificationBroadcastListener
+      );
     });
   }
 
@@ -388,6 +498,14 @@ export class NotificationService {
    */
   destroy(): void {
     this.logger.debug("销毁通知服务");
+
+    // 移除所有事件监听器，防止内存泄漏
+    for (const unsubscribe of this.eventListenerUnsubscribers) {
+      unsubscribe();
+    }
+    this.eventListenerUnsubscribers = [];
+    this.logger.debug("已移除所有事件总线监听器");
+
     this.clients.clear();
     this.messageQueue.clear();
   }


### PR DESCRIPTION
在 setupEventListeners() 中注册的 10 个事件监听器现在会在 destroy() 中正确移除：
- 使用 eventListenerUnsubscribers 数组保存清理函数
- destroy() 时遍历所有清理函数并调用 offEvent 移除监听器
- 同步更新测试文件的 mock EventBus 包含 offEvent 方法

修复的事件监听器：
- config:updated
- status:updated
- service:restart:started/completed/failed
- npm:install:started/log/completed/failed
- notification:broadcast

参考 WebServer.ts 的正确实现模式。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2946