### PR TITLE
fix: 为 WebSocket 事件订阅添加取消订阅逻辑

### DIFF
--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -113,6 +113,11 @@ const initialState: ConfigState = {
 };
 
 /**
+ * WebSocket 事件取消订阅函数
+ */
+let configUpdateUnsubscribe: (() => void) | null = null;
+
+/**
  * 创建配置 Store
  */
 export const useConfigStore = create<ConfigStore>()(
@@ -316,6 +321,13 @@ export const useConfigStore = create<ConfigStore>()(
 
       reset: () => {
         console.log("[ConfigStore] 重置状态");
+
+        // 取消 WebSocket 事件订阅
+        if (configUpdateUnsubscribe) {
+          configUpdateUnsubscribe();
+          configUpdateUnsubscribe = null;
+        }
+
         set(initialState, false, "reset");
       },
 
@@ -326,11 +338,14 @@ export const useConfigStore = create<ConfigStore>()(
           setLoading({ isLoading: true });
           console.log("[ConfigStore] 初始化配置 Store");
 
-          // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:configUpdate", (config) => {
-            console.log("[ConfigStore] 收到 WebSocket 配置更新");
-            get().setConfig(config, "websocket");
-          });
+          // 设置 WebSocket 事件监听，保存取消订阅函数
+          configUpdateUnsubscribe = webSocketManager.subscribe(
+            "data:configUpdate",
+            (config) => {
+              console.log("[ConfigStore] 收到 WebSocket 配置更新");
+              get().setConfig(config, "websocket");
+            }
+          );
 
           // 获取初始配置
           await refreshConfig();

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -211,6 +211,12 @@ let pollingTimer: NodeJS.Timeout | null = null;
 let restartPollingTimer: NodeJS.Timeout | null = null;
 
 /**
+ * WebSocket 事件取消订阅函数
+ */
+let statusUpdateUnsubscribe: (() => void) | null = null;
+let restartStatusUnsubscribe: (() => void) | null = null;
+
+/**
  * 创建状态 Store
  */
 export const useStatusStore = create<StatusStore>()(
@@ -677,6 +683,16 @@ export const useStatusStore = create<StatusStore>()(
       reset: () => {
         console.log("[StatusStore] 重置状态");
 
+        // 取消 WebSocket 事件订阅
+        if (statusUpdateUnsubscribe) {
+          statusUpdateUnsubscribe();
+          statusUpdateUnsubscribe = null;
+        }
+        if (restartStatusUnsubscribe) {
+          restartStatusUnsubscribe();
+          restartStatusUnsubscribe = null;
+        }
+
         // 停止所有轮询
         get().stopPolling();
         get().stopRestartPolling();
@@ -692,16 +708,22 @@ export const useStatusStore = create<StatusStore>()(
           setLoading({ isLoading: true });
           console.log("[StatusStore] 初始化状态 Store");
 
-          // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:statusUpdate", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 状态更新");
-            get().setClientStatus(status, "websocket");
-          });
+          // 设置 WebSocket 事件监听，保存取消订阅函数
+          statusUpdateUnsubscribe = webSocketManager.subscribe(
+            "data:statusUpdate",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 状态更新");
+              get().setClientStatus(status, "websocket");
+            }
+          );
 
-          webSocketManager.subscribe("data:restartStatus", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 重启状态更新");
-            get().setRestartStatus(status, "websocket");
-          });
+          restartStatusUnsubscribe = webSocketManager.subscribe(
+            "data:restartStatus",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 重启状态更新");
+              get().setRestartStatus(status, "websocket");
+            }
+          );
 
           // 获取初始状态
           await refreshStatus();

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -135,6 +135,16 @@ const initialState: WebSocketState = {
 };
 
 /**
+ * WebSocket 事件取消订阅函数
+ */
+let unsubscribeConnecting: (() => void) | null = null;
+let unsubscribeConnected: (() => void) | null = null;
+let unsubscribeDisconnected: (() => void) | null = null;
+let unsubscribeReconnecting: (() => void) | null = null;
+let unsubscribeError: (() => void) | null = null;
+let unsubscribeHeartbeat: (() => void) | null = null;
+
+/**
  * 创建 WebSocket Store（重构版）
  */
 export const useWebSocketStore = create<WebSocketStore>()(
@@ -258,6 +268,33 @@ export const useWebSocketStore = create<WebSocketStore>()(
 
       reset: () => {
         console.log("[WebSocketStore] 重置状态");
+
+        // 取消 WebSocket 事件订阅
+        if (unsubscribeConnecting) {
+          unsubscribeConnecting();
+          unsubscribeConnecting = null;
+        }
+        if (unsubscribeConnected) {
+          unsubscribeConnected();
+          unsubscribeConnected = null;
+        }
+        if (unsubscribeDisconnected) {
+          unsubscribeDisconnected();
+          unsubscribeDisconnected = null;
+        }
+        if (unsubscribeReconnecting) {
+          unsubscribeReconnecting();
+          unsubscribeReconnecting = null;
+        }
+        if (unsubscribeError) {
+          unsubscribeError();
+          unsubscribeError = null;
+        }
+        if (unsubscribeHeartbeat) {
+          unsubscribeHeartbeat();
+          unsubscribeHeartbeat = null;
+        }
+
         set(initialState, false, "reset");
       },
 
@@ -266,33 +303,51 @@ export const useWebSocketStore = create<WebSocketStore>()(
       initialize: () => {
         console.log("[WebSocketStore] 初始化 WebSocket Store");
 
-        // 设置 WebSocket 事件监听
-        webSocketManager.subscribe("connection:connecting", () => {
-          get().setConnectionState(ConnectionState.CONNECTING);
-        });
+        // 设置 WebSocket 事件监听，保存取消订阅函数
+        unsubscribeConnecting = webSocketManager.subscribe(
+          "connection:connecting",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTING);
+          }
+        );
 
-        webSocketManager.subscribe("connection:connected", () => {
-          get().setConnectionState(ConnectionState.CONNECTED);
-        });
+        unsubscribeConnected = webSocketManager.subscribe(
+          "connection:connected",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:disconnected", () => {
-          get().setConnectionState(ConnectionState.DISCONNECTED);
-        });
+        unsubscribeDisconnected = webSocketManager.subscribe(
+          "connection:disconnected",
+          () => {
+            get().setConnectionState(ConnectionState.DISCONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:reconnecting", () => {
-          get().setConnectionState(ConnectionState.RECONNECTING);
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        unsubscribeReconnecting = webSocketManager.subscribe(
+          "connection:reconnecting",
+          () => {
+            get().setConnectionState(ConnectionState.RECONNECTING);
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
-        webSocketManager.subscribe("connection:error", ({ error }) => {
-          get().setLastError(error);
-        });
+        unsubscribeError = webSocketManager.subscribe(
+          "connection:error",
+          ({ error }) => {
+            get().setLastError(error);
+          }
+        );
 
-        webSocketManager.subscribe("system:heartbeat", () => {
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        unsubscribeHeartbeat = webSocketManager.subscribe(
+          "system:heartbeat",
+          () => {
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
         // 初始化连接状态
         const initialStats = webSocketManager.getConnectionStats();


### PR DESCRIPTION
修复三个 Zustand store（status.ts、websocket.ts、config.ts）
在 initialize() 方法中订阅 WebSocket 事件但未保存取消订阅函数的问题。

修改内容：
- 添加模块级变量保存取消订阅函数
- 在 initialize() 中保存 subscribe() 返回的取消函数
- 在 reset() 中调用取消函数并清理变量

这防止了多次调用 initialize() 时事件监听器累积和潜在的内存泄漏。

Closes #2948

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2948