### PR TITLE
fix(esp32): 在 close() 方法中移除事件监听器防止内存泄漏

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -430,6 +430,9 @@ export class ESP32Connection {
    * 关闭连接
    */
   async close(): Promise<void> {
+    // 先移除所有事件监听器，防止内存泄漏
+    this.ws.removeAllListeners();
+
     if (this.state === "disconnected") {
       return;
     }
@@ -449,20 +452,16 @@ export class ESP32Connection {
 
     // 等待实际的 close 事件，而不是依赖 setTimeout
     return new Promise<void>((resolve) => {
-      // 监听 close 事件
-      const onClose = () => {
-        this.ws.removeListener("close", onClose);
+      // 监听 close 事件（此时 listeners 已被移除，所以使用 once）
+      this.ws.once("close", () => {
         resolve();
-      };
-
-      this.ws.once("close", onClose);
+      });
 
       // 发起关闭
       this.ws.close(1000, "Normal closure");
 
       // 设置超时以防 close 事件未触发
       setTimeout(() => {
-        this.ws.removeListener("close", onClose);
         resolve();
       }, 1000);
     });


### PR DESCRIPTION
在 ESP32Connection.close() 方法开始时调用 removeAllListeners()
移除 setupWebSocket() 中注册的 4 个事件监听器（message、close、error、pong），
防止在高频设备连接/断开场景下出现监听器累积导致的内存泄漏。

同时简化了 close 事件处理逻辑，因为监听器已在方法开始时移除。

Fixes #2954

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2954