### PR TITLE
fix(cli): McpCommandHandler 使用依赖注入获取 ProcessManager

### DIFF
--- a/packages/cli/src/commands/McpCommandHandler.ts
+++ b/packages/cli/src/commands/McpCommandHandler.ts
@@ -16,7 +16,7 @@ import type {
   ListOptions,
 } from "../interfaces/CommandTypes";
 import { isLocalMCPServerConfig } from "../interfaces/CommandTypes";
-import { ProcessManagerImpl } from "../services/ProcessManager";
+import type { ProcessManager } from "../interfaces/Service";
 
 // 工具调用结果接口
 interface ToolCallResult {
@@ -31,12 +31,10 @@ interface ToolCallResult {
  * MCP管理命令处理器
  */
 export class McpCommandHandler extends BaseCommandHandler {
-  private processManager: ProcessManagerImpl;
   private baseUrl: string;
 
   constructor(...args: ConstructorParameters<typeof BaseCommandHandler>) {
     super(...args);
-    this.processManager = new ProcessManagerImpl();
 
     // 获取 Web 服务器的端口
     try {
@@ -45,6 +43,13 @@ export class McpCommandHandler extends BaseCommandHandler {
     } catch {
       this.baseUrl = "http://localhost:9999";
     }
+  }
+
+  /**
+   * 获取进程管理器实例（通过依赖注入容器）
+   */
+  private get processManager(): ProcessManager {
+    return this.getService<ProcessManager>("processManager");
   }
 
   /**

--- a/packages/cli/src/commands/__tests__/mcp-command-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/mcp-command-handler.test.ts
@@ -138,16 +138,14 @@ vi.mock("@xiaozhi-client/config", () => ({
   },
 }));
 
-// Mock ProcessManager
+// Mock ProcessManager for DI container
 const mockGetServiceStatus = vi
   .fn()
   .mockReturnValue({ running: false, pid: null });
 
-vi.mock("../../services/ProcessManager.js", () => ({
-  ProcessManagerImpl: vi.fn().mockImplementation(() => ({
-    getServiceStatus: mockGetServiceStatus,
-  })),
-}));
+const mockProcessManager = {
+  getServiceStatus: mockGetServiceStatus,
+};
 
 // Mock fetch for HTTP API calls
 global.fetch = vi.fn();
@@ -173,7 +171,12 @@ describe("McpCommandHandler", () => {
   };
 
   const mockContainer: IDIContainer = {
-    get: vi.fn(),
+    get: vi.fn((key: string) => {
+      if (key === "processManager") {
+        return mockProcessManager;
+      }
+      return undefined;
+    }),
     has: vi.fn(),
     register: vi.fn(),
   };


### PR DESCRIPTION
修复 McpCommandHandler 在构造函数中直接创建 ProcessManagerImpl 实例的问题，
改为通过依赖注入容器获取 processManager 服务，与项目其他 Handler 保持一致。

变更：
- 移除构造函数中直接创建 ProcessManagerImpl 的代码
- 使用 getter 通过容器获取 processManager
- 更新测试文件以适配新的依赖注入模式

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2959