### PR TITLE
fix(security): add pnpm override for path-to-regexp CVE-2026-4926, CVE-2026-4923

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,7 +134,8 @@
       "rollup@<5.0.0": ">=4.59.0",
       "express-rate-limit@<9.0.0": ">=8.2.2",
       "dompurify@<4.0.0": ">=3.3.2",
-      "immutable@<6.0.0": ">=5.1.5"
+      "immutable@<6.0.0": ">=5.1.5",
+      "path-to-regexp@>=8.0.0 <8.4.0": ">=8.4.0"
     }
   },
   "packageManager": "pnpm@10.13.1"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -27,6 +27,7 @@ overrides:
   express-rate-limit@<9.0.0: '>=8.2.2'
   dompurify@<4.0.0: '>=3.3.2'
   immutable@<6.0.0: '>=5.1.5'
+  path-to-regexp@>=8.0.0 <8.4.0: '>=8.4.0'
 
 importers:
 
@@ -6061,8 +6062,8 @@ packages:
     resolution: {integrity: sha512-oWyT4gICAu+kaA7QWk/jvCHWarMKNs6pXOGWKDTr7cw4IGcUbW+PeTfbaQiLGheFRpjo6O9J0PmyMfQPjH71oA==}
     engines: {node: 20 || >=22}
 
-  path-to-regexp@8.3.0:
-    resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   path-type@4.0.0:
     resolution: {integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==}
@@ -13434,7 +13435,7 @@ snapshots:
       lru-cache: 11.2.5
       minipass: 7.1.2
 
-  path-to-regexp@8.3.0: {}
+  path-to-regexp@8.4.2: {}
 
   path-type@4.0.0: {}
 
@@ -14115,7 +14116,7 @@ snapshots:
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
-      path-to-regexp: 8.3.0
+      path-to-regexp: 8.4.2
     transitivePeerDependencies:
       - supports-color
 


### PR DESCRIPTION
Add override to force path-to-regexp to >=8.4.0 to fix:
- CVE-2026-4926 (High): DoS via consecutive optional groups
- CVE-2026-4923 (Moderate): ReDoS via multiple wildcards

Closes #2964

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2964