### PR TITLE
fix(tts): 使用路径别名替代相对路径导入

### DIFF
--- a/packages/tts/src/platforms/bytedance/TTSController.ts
+++ b/packages/tts/src/platforms/bytedance/TTSController.ts
@@ -8,7 +8,7 @@ import type {
   AudioChunkCallback,
   PlatformConfig,
   TTSController,
-} from "../../core/index.js";
+} from "@/core/index.js";
 import {
   FullClientRequest,
   MsgType,

--- a/packages/tts/src/platforms/bytedance/index.ts
+++ b/packages/tts/src/platforms/bytedance/index.ts
@@ -2,7 +2,7 @@
  * 字节跳动 TTS 平台模块导出
  */
 
-import { platformRegistry } from "../../core/index.js";
+import { platformRegistry } from "@/core/index.js";
 import { ByteDanceTTSPlatform } from "./TTSController.js";
 
 // 注册字节跳动平台


### PR DESCRIPTION
修复 packages/tts/src/platforms/bytedance 目录下的两个文件使用相对路径
而非 @/ 路径别名导入的问题，与 packages/asr 包保持一致性。

更改:
- index.ts: 将 ../../core/index.js 替换为 @/core/index.js
- TTSController.ts: 将 ../../core/index.js 替换为 @/core/index.js

Fixes #2966

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2966