### PR TITLE
fix(handler): MCPToolLogHandler 使用依赖注入而非直接实例化

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -40,6 +40,7 @@ import {
   VersionApiHandler,
 } from "@/handlers/index.js";
 import { MCPServiceManager } from "@/lib/mcp";
+import { ToolCallLogService } from "@/lib/mcp/log.js";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
 import {
@@ -198,7 +199,7 @@ export class WebServer {
     this.statusApiHandler = new StatusApiHandler(this.statusService);
     this.serviceApiHandler = new ServiceApiHandler(this.statusService);
     this.mcpToolHandler = new MCPToolHandler();
-    this.mcpToolLogHandler = new MCPToolLogHandler();
+    this.mcpToolLogHandler = new MCPToolLogHandler(new ToolCallLogService());
     this.versionApiHandler = new VersionApiHandler();
     this.staticFileHandler = new StaticFileHandler();
     this.mcpRouteHandler = new MCPRouteHandler();

--- a/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool-log.handler.test.ts
@@ -4,18 +4,21 @@
  */
 
 import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
-import { describe, expect, it } from "vitest";
+import { ToolCallLogService } from "@/lib/mcp/log.js";
+import { describe, expect, it, vi } from "vitest";
 import { MCPToolLogHandler } from "../mcp-tool-log.handler.js";
 
 describe("MCPToolLogHandler - 基本功能测试", () => {
   it("应该能够创建处理器实例", () => {
-    const handler = new MCPToolLogHandler();
+    const toolCallLogService = new ToolCallLogService();
+    const handler = new MCPToolLogHandler(toolCallLogService);
     expect(handler).toBeDefined();
     expect(handler).toBeInstanceOf(MCPToolLogHandler);
   });
 
   it("应该能够解析和验证查询参数", () => {
-    const handler = new MCPToolLogHandler();
+    const toolCallLogService = new ToolCallLogService();
+    const handler = new MCPToolLogHandler(toolCallLogService);
     const parseAndValidateQueryParams = (
       handler as any
     ).parseAndValidateQueryParams.bind(handler);

--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -5,7 +5,7 @@
 
 import { PAGINATION_CONSTANTS } from "@/constants/api.constants.js";
 import type { ToolCallQuery } from "@/lib/mcp/log.js";
-import { ToolCallLogService } from "@/lib/mcp/log.js";
+import type { ToolCallLogService } from "@/lib/mcp/log.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
 import { z } from "zod";
@@ -85,9 +85,9 @@ const ToolCallQuerySchema = z
 export class MCPToolLogHandler extends BaseHandler {
   private toolCallLogService: ToolCallLogService;
 
-  constructor() {
+  constructor(toolCallLogService: ToolCallLogService) {
     super();
-    this.toolCallLogService = new ToolCallLogService();
+    this.toolCallLogService = toolCallLogService;
   }
 
   /**


### PR DESCRIPTION
将 ToolCallLogService 通过构造函数注入，遵循项目其他 handler 的依赖注入模式。

变更：
- MCPToolLogHandler 构造函数接受 ToolCallLogService 参数
- WebServer.ts 创建并注入 ToolCallLogService 实例
- 更新测试文件以匹配新的构造函数签名

修复 #2968

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2968