### PR TITLE
fix(ui): sr-only 辅助文本本地化为中文

### DIFF
--- a/apps/frontend/src/components/ui/breadcrumb.tsx
+++ b/apps/frontend/src/components/ui/breadcrumb.tsx
@@ -100,7 +100,7 @@ const BreadcrumbEllipsis = ({
     {...props}
   >
     <MoreHorizontal className="h-4 w-4" />
-    <span className="sr-only">More</span>
+    <span className="sr-only">更多</span>
   </span>
 );
 BreadcrumbEllipsis.displayName = "BreadcrumbElipssis";

--- a/apps/frontend/src/components/ui/dialog.tsx
+++ b/apps/frontend/src/components/ui/dialog.tsx
@@ -44,7 +44,7 @@ const DialogContent = React.forwardRef<
       {children}
       <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">关闭</span>
       </DialogPrimitive.Close>
     </DialogPrimitive.Content>
   </DialogPortal>

--- a/apps/frontend/src/components/ui/sheet.tsx
+++ b/apps/frontend/src/components/ui/sheet.tsx
@@ -67,7 +67,7 @@ const SheetContent = React.forwardRef<
       {children}
       <SheetPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
         <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
+        <span className="sr-only">关闭</span>
       </SheetPrimitive.Close>
     </SheetPrimitive.Content>
   </SheetPortal>


### PR DESCRIPTION
修复 UI 组件中 sr-only 屏幕阅读器辅助文本的本地化问题：
- sheet.tsx: "Close" → "关闭"
- dialog.tsx: "Close" → "关闭"
- breadcrumb.tsx: "More" → "更多"

符合项目本地化规范：面向用户的文本必须使用中文。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2974