### PR TITLE
fix(cli): 为相对路径导入添加 .js 后缀以符合 ESM 规范

### DIFF
--- a/packages/cli/src/errors/ErrorMessages.ts
+++ b/packages/cli/src/errors/ErrorMessages.ts
@@ -2,7 +2,7 @@
  * 错误消息管理
  */
 
-import { ERROR_CODES } from "../Constants";
+import { ERROR_CODES } from "../Constants.js";
 
 /**
  * 错误消息映射

--- a/packages/cli/src/errors/index.ts
+++ b/packages/cli/src/errors/index.ts
@@ -2,7 +2,7 @@
  * 统一错误处理系统
  */
 
-import { ERROR_CODES } from "../Constants";
+import { ERROR_CODES } from "../Constants.js";
 
 /**
  * CLI 基础错误类

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -15,14 +15,14 @@ import { spawn } from "node:child_process";
 import fs from "node:fs";
 import type { WebServer } from "@/WebServer";
 import consola from "consola";
-import { RETRY_CONSTANTS } from "../Constants";
-import { ProcessError, ServiceError } from "../errors/index";
+import { RETRY_CONSTANTS } from "../Constants.js";
+import { ProcessError, ServiceError } from "../errors/index.js";
 import type {
   DaemonManager as IDaemonManager,
   ProcessManager,
-} from "../interfaces/Service";
-import { PathUtils } from "../utils/PathUtils";
-import { PlatformUtils } from "../utils/PlatformUtils";
+} from "../interfaces/Service.js";
+import { PathUtils } from "../utils/PathUtils.js";
+import { PlatformUtils } from "../utils/PlatformUtils.js";
 
 /**
  * 守护进程选项

--- a/packages/cli/src/services/ProcessManager.ts
+++ b/packages/cli/src/services/ProcessManager.ts
@@ -10,15 +10,15 @@
  * @module packages/cli/src/services/ProcessManager
  */
 
-import { FileError, ProcessError } from "../errors/index";
+import { FileError, ProcessError } from "../errors/index.js";
 import type {
   ProcessManager as IProcessManager,
   ServiceStatus,
-} from "../interfaces/Service";
-import { FileUtils } from "../utils/FileUtils";
-import { FormatUtils } from "../utils/FormatUtils";
-import { PathUtils } from "../utils/PathUtils";
-import { PlatformUtils } from "../utils/PlatformUtils";
+} from "../interfaces/Service.js";
+import { FileUtils } from "../utils/FileUtils.js";
+import { FormatUtils } from "../utils/FormatUtils.js";
+import { PathUtils } from "../utils/PathUtils.js";
+import { PlatformUtils } from "../utils/PlatformUtils.js";
 
 /**
  * PID 文件信息接口

--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -13,16 +13,16 @@
 import type { ConfigManager } from "@xiaozhi-client/config";
 import { ConfigInitializer } from "@xiaozhi-client/config";
 import consola from "consola";
-import { RETRY_CONSTANTS } from "../Constants";
-import { ConfigError, ServiceError } from "../errors/index";
+import { RETRY_CONSTANTS } from "../Constants.js";
+import { ConfigError, ServiceError } from "../errors/index.js";
 import type {
   ServiceManager as IServiceManager,
   ProcessManager,
   ServiceStartOptions,
   ServiceStatus,
-} from "../interfaces/Service";
-import { PathUtils } from "../utils/PathUtils";
-import { Validation } from "../utils/Validation";
+} from "../interfaces/Service.js";
+import { PathUtils } from "../utils/PathUtils.js";
+import { Validation } from "../utils/Validation.js";
 
 /**
  * 服务管理器实现

--- a/packages/cli/src/services/TemplateManager.ts
+++ b/packages/cli/src/services/TemplateManager.ts
@@ -13,15 +13,15 @@
 
 import fs from "node:fs";
 import path from "node:path";
-import { FileError, ValidationError } from "../errors/index";
+import { FileError, ValidationError } from "../errors/index.js";
 import type {
   TemplateManager as ITemplateManager,
   TemplateCreateOptions,
   TemplateInfo,
-} from "../interfaces/Service";
-import { FileUtils } from "../utils/FileUtils";
-import { PathUtils } from "../utils/PathUtils";
-import { Validation } from "../utils/Validation";
+} from "../interfaces/Service.js";
+import { FileUtils } from "../utils/FileUtils.js";
+import { PathUtils } from "../utils/PathUtils.js";
+import { Validation } from "../utils/Validation.js";
 
 // 重新导出类型以保持向后兼容
 export type { TemplateInfo, TemplateCreateOptions };

--- a/packages/cli/src/utils/FileUtils.ts
+++ b/packages/cli/src/utils/FileUtils.ts
@@ -5,8 +5,8 @@
 import fs from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
-import type { FileOperationOptions } from "../Types";
-import { FileError } from "../errors/index";
+import type { FileOperationOptions } from "../Types.js";
+import { FileError } from "../errors/index.js";
 
 /**
  * 文件工具类

--- a/packages/cli/src/utils/PathUtils.ts
+++ b/packages/cli/src/utils/PathUtils.ts
@@ -10,8 +10,8 @@ import {
   CONFIG_CONSTANTS,
   PATH_CONSTANTS,
   SERVICE_CONSTANTS,
-} from "../Constants";
-import { FileUtils } from "./FileUtils";
+} from "../Constants.js";
+import { FileUtils } from "./FileUtils.js";
 
 /**
  * 路径工具类

--- a/packages/cli/src/utils/PlatformUtils.ts
+++ b/packages/cli/src/utils/PlatformUtils.ts
@@ -3,9 +3,9 @@
  */
 
 import { execSync } from "node:child_process";
-import { TIMEOUT_CONSTANTS } from "../Constants";
-import type { Platform } from "../Types";
-import { ProcessError } from "../errors/index";
+import { TIMEOUT_CONSTANTS } from "../Constants.js";
+import type { Platform } from "../Types.js";
+import { ProcessError } from "../errors/index.js";
 
 /**
  * 平台工具类

--- a/packages/cli/src/utils/Validation.ts
+++ b/packages/cli/src/utils/Validation.ts
@@ -2,8 +2,8 @@
  * 输入验证工具
  */
 
-import type { ConfigFormat } from "../Types";
-import { ValidationError } from "../errors/index";
+import type { ConfigFormat } from "../Types.js";
+import { ValidationError } from "../errors/index.js";
 
 /**
  * 验证工具类


### PR DESCRIPTION
修复 packages/cli/src 目录下 10 个文件中的相对路径导入，添加 .js 后缀以符合 ESM 模块规范要求：

- errors/index.ts: Constants → Constants.js
- errors/ErrorMessages.ts: Constants → Constants.js
- utils/Validation.ts: Types → Types.js, errors/index → errors/index.js
- utils/PathUtils.ts: Constants → Constants.js, FileUtils → FileUtils.js
- utils/PlatformUtils.ts: Constants → Constants.js, Types → Types.js, errors/index → errors/index.js
- utils/FileUtils.ts: Types → Types.js, errors/index → errors/index.js
- services/ServiceManager.ts: Constants, errors, interfaces, utils 全部添加 .js
- services/DaemonManager.ts: Constants, errors, interfaces, utils 全部添加 .js
- services/ProcessManager.ts: errors, interfaces, utils 全部添加 .js
- services/TemplateManager.ts: errors, interfaces, utils 全部添加 .js

Fixes #2976

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2976