### PR TITLE
fix(cli): 添加缺失的 @xiaozhi-client/version 依赖声明

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -22,6 +22,7 @@
   },
   "dependencies": {
     "@xiaozhi-client/config": "workspace:*",
+    "@xiaozhi-client/version": "workspace:*",
     "chalk": "^5.6.0",
     "cli-table3": "^0.6.5",
     "commander": "^14.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -597,6 +597,9 @@ importers:
       '@xiaozhi-client/config':
         specifier: workspace:*
         version: link:../config
+      '@xiaozhi-client/version':
+        specifier: workspace:*
+        version: link:../version
       chalk:
         specifier: ^5.6.0
         version: 5.6.2


### PR DESCRIPTION
packages/cli/package.json 中未声明 @xiaozhi-client/version 依赖，
但 Container.ts 中实际导入了 VersionUtils，导致发布后可能无法正常使用。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2982