### PR TITLE
refactor: 提取 ASR/TTS 包共享的平台抽象类型到 shared-types

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -47,6 +47,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@xiaozhi-client/shared-types": "workspace:*",
     "@discordjs/opus": "^0.10.0",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",

--- a/packages/asr/src/core/ASRPlatform.ts
+++ b/packages/asr/src/core/ASRPlatform.ts
@@ -2,11 +2,11 @@
  * ASR 平台抽象接口
  */
 
+import { SimplePlatformRegistry } from "@xiaozhi-client/shared-types";
 import type {
   ASRController,
   ASRPlatform,
   PlatformConfig,
-  PlatformRegistry,
 } from "./types.js";
 
 /**
@@ -16,27 +16,14 @@ export type ASRPlatformFactory = (config: PlatformConfig) => ASRPlatform;
 
 /**
  * 简单平台注册表实现
+ * 使用共享的 SimplePlatformRegistry 类型
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, ASRPlatform> = new Map();
-
-  get(platform: string): ASRPlatform | undefined {
-    return this.platforms.get(platform);
-  }
-
-  register(platform: ASRPlatform): void {
-    this.platforms.set(platform.platform, platform);
-  }
-
-  list(): string[] {
-    return Array.from(this.platforms.keys());
-  }
-}
+export class SimpleASRPlatformRegistry extends SimplePlatformRegistry<ASRPlatform> {}
 
 /**
  * 全局平台注册表
  */
-export const platformRegistry = new SimplePlatformRegistry();
+export const platformRegistry = new SimpleASRPlatformRegistry();
 
 /**
  * 注册平台装饰器

--- a/packages/asr/src/core/index.ts
+++ b/packages/asr/src/core/index.ts
@@ -7,7 +7,7 @@ export type {
   ASRController,
   PlatformConfig,
   ASRPlatform,
-  PlatformRegistry,
+  ASRPlatformRegistry,
   CommonASROptions,
   ASREventType,
   ASREventData,
@@ -15,7 +15,7 @@ export type {
 
 // 平台接口导出
 export {
-  SimplePlatformRegistry,
+  SimpleASRPlatformRegistry,
   platformRegistry,
   registerPlatform,
 } from "./ASRPlatform.js";

--- a/packages/asr/src/core/types.ts
+++ b/packages/asr/src/core/types.ts
@@ -3,6 +3,10 @@
  */
 
 import type { Readable } from "node:stream";
+import type {
+  PlatformDefinition,
+  PlatformRegistry,
+} from "@xiaozhi-client/shared-types";
 
 /**
  * 音频输入类型
@@ -55,12 +59,9 @@ export interface ASRController {
 
 /**
  * 平台配置泛型接口
+ * 使用共享的 PlatformDefinition 类型
  */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
+export type PlatformConfig = PlatformDefinition;
 
 /**
  * ASR 平台接口
@@ -101,18 +102,9 @@ export interface ASRPlatform {
 
 /**
  * 平台注册表
- * 存储所有已注册的平台
+ * 使用共享的 PlatformRegistry 泛型类型
  */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): ASRPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: ASRPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
-}
+export type ASRPlatformRegistry = PlatformRegistry<ASRPlatform>;
 
 /**
  * 通用 ASR 选项

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -29,6 +29,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js"
+    },
+    "./platforms": {
+      "types": "./dist/platforms/index.d.ts",
+      "import": "./dist/platforms/index.js"
     }
   },
   "files": [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -57,3 +57,7 @@ export { TimeoutError } from "./utils";
 
 // TTS 相关类型
 export type { VoiceInfo, VoicesResponse } from "./tts";
+
+// 平台相关类型
+export type { PlatformDefinition, PlatformRegistry } from "./platforms";
+export { SimplePlatformRegistry } from "./platforms";

--- a/packages/shared-types/src/platforms/index.ts
+++ b/packages/shared-types/src/platforms/index.ts
@@ -1,0 +1,9 @@
+/**
+ * 平台抽象类型导出
+ */
+
+// 类型定义
+export type { PlatformDefinition, PlatformRegistry } from "./types.js";
+
+// 注册表实现
+export { SimplePlatformRegistry } from "./registry.js";

--- a/packages/shared-types/src/platforms/registry.ts
+++ b/packages/shared-types/src/platforms/registry.ts
@@ -1,0 +1,27 @@
+/**
+ * 平台注册表实现
+ */
+
+import type { PlatformRegistry } from "./types.js";
+
+/**
+ * 简单平台注册表实现
+ * 提供基于 Map 的平台注册和查找功能
+ */
+export class SimplePlatformRegistry<T extends { platform: string }>
+  implements PlatformRegistry<T>
+{
+  private platforms: Map<string, T> = new Map();
+
+  get(platform: string): T | undefined {
+    return this.platforms.get(platform);
+  }
+
+  register(platform: T): void {
+    this.platforms.set(platform.platform, platform);
+  }
+
+  list(): string[] {
+    return Array.from(this.platforms.keys());
+  }
+}

--- a/packages/shared-types/src/platforms/types.ts
+++ b/packages/shared-types/src/platforms/types.ts
@@ -1,0 +1,28 @@
+/**
+ * 平台定义相关共享类型
+ */
+
+/**
+ * 平台定义泛型接口
+ * 用于 ASR/TTS 等平台的配置定义
+ */
+export interface PlatformDefinition {
+  /** 平台类型 */
+  platform: string;
+  [key: string]: unknown;
+}
+
+/**
+ * 平台注册表接口
+ * 用于管理平台实例的注册和查找
+ */
+export interface PlatformRegistry<T extends { platform: string }> {
+  /** 获取平台 */
+  get(platform: string): T | undefined;
+
+  /** 注册平台 */
+  register(platform: T): void;
+
+  /** 获取所有已注册的平台 */
+  list(): string[];
+}

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     api: "src/api/index.ts",
     config: "src/config/index.ts",
     utils: "src/utils/index.ts",
+    platforms: "src/platforms/index.ts",
   },
   format: ["esm"],
   target: "node20",

--- a/packages/tts/package.json
+++ b/packages/tts/package.json
@@ -49,6 +49,7 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
+    "@xiaozhi-client/shared-types": "workspace:*",
     "ws": "^8.16.0",
     "zod": "^3.23.8"
   },

--- a/packages/tts/src/__tests__/core/registry.test.ts
+++ b/packages/tts/src/__tests__/core/registry.test.ts
@@ -1,21 +1,21 @@
 /**
- * SimplePlatformRegistry 测试
+ * SimpleTTSPlatformRegistry 测试
  */
 
-import { SimplePlatformRegistry, type TTSPlatform } from "@/core/index.js";
+import { SimpleTTSPlatformRegistry, type TTSPlatform } from "@/core/index.js";
 import { describe, expect, it, vi } from "vitest";
 
-describe("SimplePlatformRegistry", () => {
+describe("SimpleTTSPlatformRegistry", () => {
   describe("构造函数", () => {
     it("应创建空的平台注册表", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
       expect(registry.list()).toEqual([]);
     });
   });
 
   describe("register 方法", () => {
     it("应注册平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const mockPlatform: TTSPlatform = {
         platform: "test-platform",
@@ -31,7 +31,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应允许注册多个平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const mockPlatform1: TTSPlatform = {
         platform: "platform-1",
@@ -58,7 +58,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应覆盖已存在的平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const mockPlatform1: TTSPlatform = {
         platform: "duplicate-platform",
@@ -85,7 +85,7 @@ describe("SimplePlatformRegistry", () => {
 
   describe("get 方法", () => {
     it("应返回已注册的平台", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const mockPlatform: TTSPlatform = {
         platform: "test-platform",
@@ -104,7 +104,7 @@ describe("SimplePlatformRegistry", () => {
     });
 
     it("应返回 undefined 当平台不存在时", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const result = registry.get("non-existent");
 
@@ -114,13 +114,13 @@ describe("SimplePlatformRegistry", () => {
 
   describe("list 方法", () => {
     it("应返回空数组当没有注册平台时", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       expect(registry.list()).toEqual([]);
     });
 
     it("应返回所有已注册的平台名称", () => {
-      const registry = new SimplePlatformRegistry();
+      const registry = new SimpleTTSPlatformRegistry();
 
       const mockPlatform1: TTSPlatform = {
         platform: "platform-a",

--- a/packages/tts/src/core/TTSPlatform.ts
+++ b/packages/tts/src/core/TTSPlatform.ts
@@ -2,9 +2,9 @@
  * TTS 平台抽象接口
  */
 
+import { SimplePlatformRegistry } from "@xiaozhi-client/shared-types";
 import type {
   PlatformConfig,
-  PlatformRegistry,
   TTSController,
   TTSPlatform,
 } from "./types.js";
@@ -16,27 +16,14 @@ export type TTSPlatformFactory = (config: PlatformConfig) => TTSPlatform;
 
 /**
  * 简单平台注册表实现
+ * 使用共享的 SimplePlatformRegistry 类型
  */
-export class SimplePlatformRegistry implements PlatformRegistry {
-  private platforms: Map<string, TTSPlatform> = new Map();
-
-  get(platform: string): TTSPlatform | undefined {
-    return this.platforms.get(platform);
-  }
-
-  register(platform: TTSPlatform): void {
-    this.platforms.set(platform.platform, platform);
-  }
-
-  list(): string[] {
-    return Array.from(this.platforms.keys());
-  }
-}
+export class SimpleTTSPlatformRegistry extends SimplePlatformRegistry<TTSPlatform> {}
 
 /**
  * 全局平台注册表
  */
-export const platformRegistry = new SimplePlatformRegistry();
+export const platformRegistry = new SimpleTTSPlatformRegistry();
 
 /**
  * 注册平台装饰器

--- a/packages/tts/src/core/types.ts
+++ b/packages/tts/src/core/types.ts
@@ -2,6 +2,11 @@
  * TTS 核心类型定义
  */
 
+import type {
+  PlatformDefinition,
+  PlatformRegistry,
+} from "@xiaozhi-client/shared-types";
+
 /**
  * 音频块回调类型
  * @param chunk - 音频数据块
@@ -54,12 +59,9 @@ export interface TTSController {
 
 /**
  * 平台配置泛型接口
+ * 使用共享的 PlatformDefinition 类型
  */
-export interface PlatformConfig {
-  /** 平台类型 */
-  platform: string;
-  [key: string]: unknown;
-}
+export type PlatformConfig = PlatformDefinition;
 
 /**
  * TTS 平台接口
@@ -100,18 +102,9 @@ export interface TTSPlatform {
 
 /**
  * 平台注册表
- * 存储所有已注册的平台
+ * 使用共享的 PlatformRegistry 泛型类型
  */
-export interface PlatformRegistry {
-  /** 获取平台 */
-  get(platform: string): TTSPlatform | undefined;
-
-  /** 注册平台 */
-  register(platform: TTSPlatform): void;
-
-  /** 获取所有已注册的平台 */
-  list(): string[];
-}
+export type TTSPlatformRegistry = PlatformRegistry<TTSPlatform>;
 
 /**
  * 通用 TTS 选项

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -554,6 +554,9 @@ importers:
       '@discordjs/opus':
         specifier: ^0.10.0
         version: 0.10.0
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       prism-media:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)
@@ -724,6 +727,9 @@ importers:
 
   packages/tts:
     dependencies:
+      '@xiaozhi-client/shared-types':
+        specifier: workspace:*
+        version: link:../shared-types
       ws:
         specifier: ^8.16.0
         version: 8.19.0


### PR DESCRIPTION
将 PlatformConfig、PlatformRegistry 和 SimplePlatformRegistry
从 ASR 和 TTS 包中提取到 shared-types 包，消除约 40 行重复代码。

变更：
- 在 shared-types/src/platforms/ 创建共享类型文件
- ASR/TTS 包改用 PlatformDefinition 和 PlatformRegistry 泛型
- 重命名 SimplePlatformRegistry 为 SimpleASRPlatformRegistry/SimpleTTSPlatformRegistry

解决 issue #2995 中报告的 DRY 原则违反问题。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2995