### PR TITLE
fix(middleware): 使用 logger.debug 替代 console.error 打印开发环境错误信息

### DIFF
--- a/apps/backend/middlewares/error.middleware.ts
+++ b/apps/backend/middlewares/error.middleware.ts
@@ -67,9 +67,9 @@ export const errorHandlerMiddleware = (err: Error, c: Context) => {
   // 使用 Context 上的 logger 属性
   c.logger.error("HTTP request error:", err);
 
-  // 在开发环境中打印详细错误信息
+  // 在开发环境中使用 logger.debug 打印详细错误信息
   if (process.env.NODE_ENV === "development") {
-    console.error("HTTP Request Error:", {
+    c.logger.debug("HTTP Request Error Details:", {
       error: err.message,
       stack: err.stack,
       path: c.req.path,


### PR DESCRIPTION
- 将 error.middleware.ts 中的 console.error 替换为 c.logger.debug
- 保持日志输出统一，遵循项目日志规范
- 更新注释说明以反映正确的日志使用方式

Fixes #2997

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #2997