### PR TITLE
fix(endpoint): 使用统一 logger 替代 console

### DIFF
--- a/packages/endpoint/src/endpoint.ts
+++ b/packages/endpoint/src/endpoint.ts
@@ -27,6 +27,7 @@ import {
 } from "./types.js";
 import { validateToolCallParams } from "./utils.js";
 import { sliceEndpoint } from "./utils.js";
+import { logger } from "./logger.js";
 
 // 导出错误类型供外部使用
 export {
@@ -182,7 +183,7 @@ export class Endpoint {
         inputSchema: ensureToolJSONSchemaFn(toolInfo.inputSchema),
       }));
     } catch (error) {
-      console.error(
+      logger.error(
         `获取工具列表失败: ${error instanceof Error ? error.message : String(error)}`
       );
       return [];
@@ -212,7 +213,7 @@ export class Endpoint {
    */
   private async attemptConnection(): Promise<void> {
     this.connectionState = ConnectionState.CONNECTING;
-    console.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     return new Promise((resolve, reject) => {
       // 设置连接超时
@@ -234,7 +235,7 @@ export class Endpoint {
           const message: MCPMessage = JSON.parse(data.toString());
           this.handleMessage(message);
         } catch (error) {
-          console.error("MCP 消息解析错误:", error);
+          logger.error("MCP 消息解析错误:", error);
         }
       });
 
@@ -262,7 +263,7 @@ export class Endpoint {
     this.connectionStatus = true;
     this.connectionState = ConnectionState.CONNECTED;
 
-    console.debug("MCP WebSocket 连接已建立");
+    logger.debug("MCP WebSocket 连接已建立");
   }
 
   /**
@@ -278,7 +279,7 @@ export class Endpoint {
       this.connectionTimeout = null;
     }
 
-    console.error("MCP WebSocket 错误:", error.message);
+    logger.error("MCP WebSocket 错误:", error.message);
 
     // 清理当前连接
     this.cleanupConnection();
@@ -291,7 +292,7 @@ export class Endpoint {
     this.connectionStatus = false;
     this.serverInitialized = false;
     this.connectionState = ConnectionState.DISCONNECTED;
-    console.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
+    logger.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
   }
 
   /**
@@ -309,7 +310,7 @@ export class Endpoint {
           this.ws.terminate();
         }
       } catch (error) {
-        console.debug("WebSocket 关闭时出现错误（已忽略）:", error);
+        logger.debug("WebSocket 关闭时出现错误（已忽略）:", error);
       }
 
       this.ws = null;
@@ -336,7 +337,7 @@ export class Endpoint {
     // console.debug("收到 MCP 消息:", JSON.stringify(message, null, 2));
 
     if (!message.method) {
-      console.debug("收到没有 method 字段的消息，忽略");
+      logger.debug("收到没有 method 字段的消息，忽略");
       return;
     }
 
@@ -355,19 +356,19 @@ export class Endpoint {
           },
         });
         this.serverInitialized = true;
-        console.debug("MCP 服务器初始化完成");
+        logger.debug("MCP 服务器初始化完成");
         break;
 
       case "tools/list": {
         const toolsList = this.getTools();
         this.sendResponse(message.id, { tools: toolsList });
-        console.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
+        logger.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
         break;
       }
 
       case "tools/call": {
         this.handleToolCall(message).catch((error) => {
-          console.error("处理工具调用时发生未捕获错误:", error);
+          logger.error("处理工具调用时发生未捕获错误:", error);
         });
         break;
       }
@@ -378,7 +379,7 @@ export class Endpoint {
         break;
 
       default:
-        console.warn(`未知的 MCP 请求: ${message.method}`);
+        logger.warn(`未知的 MCP 请求: ${message.method}`);
     }
   }
 
@@ -399,18 +400,18 @@ export class Endpoint {
 
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("响应已发送", {
+        logger.debug("响应已发送", {
           id,
           responseSize: JSON.stringify(response).length,
         });
       } catch (error) {
-        console.error("发送响应失败", {
+        logger.error("发送响应失败", {
           id,
           error,
         });
       }
     } else {
-      console.error("无法发送响应", {
+      logger.error("无法发送响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,
@@ -445,7 +446,7 @@ export class Endpoint {
    * 主动断开小智连接
    */
   public async disconnect(): Promise<void> {
-    console.info("主动断开小智连接");
+    logger.info("主动断开小智连接");
 
     // 清理 MCP 适配器
     await this.mcpAdapter.cleanup();
@@ -458,7 +459,7 @@ export class Endpoint {
    * 重连小智接入点
    */
   public async reconnect(): Promise<void> {
-    console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     // 先断开连接
     this.disconnect();
@@ -487,7 +488,7 @@ export class Endpoint {
     try {
       const params = validateToolCallParams(request.params);
 
-      console.info("开始处理工具调用", {
+      logger.info("开始处理工具调用", {
         requestId,
         toolName: params.name,
         hasArguments: !!params.arguments,
@@ -506,7 +507,7 @@ export class Endpoint {
         isError: result.isError || false,
       });
 
-      console.info("工具调用成功", {
+      logger.info("工具调用成功", {
         requestId,
         toolName: params.name,
         duration: `${Date.now() - startTime}ms`,
@@ -596,7 +597,7 @@ export class Endpoint {
 
     this.sendErrorResponse(requestId, errorResponse);
 
-    console.error("工具调用失败", {
+    logger.error("工具调用失败", {
       requestId,
       duration: `${duration}ms`,
       error: errorResponse,
@@ -618,10 +619,10 @@ export class Endpoint {
       };
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("已发送错误响应:", response);
+        logger.debug("已发送错误响应:", response);
       } catch (sendError) {
         // 发送错误响应失败，记录日志但不抛出异常
-        console.error("发送错误响应失败:", {
+        logger.error("发送错误响应失败:", {
           id,
           errorResponse: error,
           sendError: sendError instanceof Error
@@ -630,7 +631,7 @@ export class Endpoint {
         });
       }
     } else {
-      console.error("无法发送错误响应", {
+      logger.error("无法发送错误响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -9,6 +9,7 @@ import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { logger } from "./logger.js";
 
 /**
  * 内部 MCP 服务管理器适配器
@@ -32,13 +33,13 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
 
     // 设置事件监听
     this.mcpManager.on("connected", (data) => {
-      console.info(
+      logger.info(
         `MCP 服务 ${data.serverName} 已连接，工具数: ${data.tools.length}`
       );
     });
 
     this.mcpManager.on("error", (data) => {
-      console.error(`MCP 服务 ${data.serverName} 出错:`, data.error);
+      logger.error(`MCP 服务 ${data.serverName} 出错:`, data.error);
     });
   }
 

--- a/packages/endpoint/src/logger.ts
+++ b/packages/endpoint/src/logger.ts
@@ -1,0 +1,97 @@
+/**
+ * Endpoint 包日志模块
+ * 提供统一的日志记录接口，与项目主 logger 保持一致的 API
+ *
+ * 使用方式：
+ * ```typescript
+ * import { logger } from "./logger.js";
+ *
+ * logger.info("[EndpointManager] 实例已创建");
+ * logger.error(`[EndpointManager] 连接失败: ${url}`, error);
+ * logger.debug("[Endpoint] MCP 服务器初始化完成");
+ * ```
+ */
+
+/**
+ * 日志级别类型
+ */
+type LogLevel = "debug" | "info" | "warn" | "error";
+
+/**
+ * Logger 接口，与项目主 logger 保持一致
+ */
+export interface Logger {
+  info(message: string, ...args: unknown[]): void;
+  info(obj: object, message?: string): void;
+  debug(message: string, ...args: unknown[]): void;
+  debug(obj: object, message?: string): void;
+  warn(message: string, ...args: unknown[]): void;
+  warn(obj: object, message?: string): void;
+  error(message: string, ...args: unknown[]): void;
+  error(obj: object, message?: string): void;
+}
+
+/**
+ * 简单 Logger 实现
+ * 使用 console 作为底层输出，但提供统一的 API
+ * 未来可轻松替换为更完善的日志系统
+ */
+class SimpleLogger implements Logger {
+  private formatMessage(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    return `[${timestamp}] [${level.toUpperCase()}] ${message}`;
+  }
+
+  info(messageOrObj: string | object, ...args: unknown[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        console.info(this.formatMessage("info", messageOrObj));
+      } else {
+        console.info(this.formatMessage("info", messageOrObj), ...args);
+      }
+    } else {
+      console.info(this.formatMessage("info", args[0] as string || ""), messageOrObj);
+    }
+  }
+
+  debug(messageOrObj: string | object, ...args: unknown[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        console.debug(this.formatMessage("debug", messageOrObj));
+      } else {
+        console.debug(this.formatMessage("debug", messageOrObj), ...args);
+      }
+    } else {
+      console.debug(this.formatMessage("debug", args[0] as string || ""), messageOrObj);
+    }
+  }
+
+  warn(messageOrObj: string | object, ...args: unknown[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        console.warn(this.formatMessage("warn", messageOrObj));
+      } else {
+        console.warn(this.formatMessage("warn", messageOrObj), ...args);
+      }
+    } else {
+      console.warn(this.formatMessage("warn", args[0] as string || ""), messageOrObj);
+    }
+  }
+
+  error(messageOrObj: string | object, ...args: unknown[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        console.error(this.formatMessage("error", messageOrObj));
+      } else {
+        console.error(this.formatMessage("error", messageOrObj), ...args);
+      }
+    } else {
+      console.error(this.formatMessage("error", args[0] as string || ""), messageOrObj);
+    }
+  }
+}
+
+/**
+ * 导出默认 logger 实例
+ */
+export const logger: Logger = new SimpleLogger();

--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -29,6 +29,7 @@ import type {
   SimpleConnectionStatus,
 } from "./types.js";
 import { sliceEndpoint } from "./utils.js";
+import { logger } from "./logger.js";
 
 /**
  * MCP 服务连接事件数据
@@ -66,7 +67,7 @@ export class EndpointManager extends EventEmitter {
    */
   constructor(private config?: EndpointManagerConfig) {
     super();
-    console.debug("[EndpointManager] 实例已创建");
+    logger.debug("[EndpointManager] 实例已创建");
   }
 
   /**
@@ -88,13 +89,13 @@ export class EndpointManager extends EventEmitter {
     if ("on" in mcpManager && typeof mcpManager.on === "function") {
       const connectedHandler = (...args: unknown[]) => {
         const data = args[0] as MCPConnectedEvent;
-        console.info(
+        logger.info(
           `[EndpointManager] MCP 服务已连接: ${data.serverName}, 工具数: ${data.tools?.length || 0}`
         );
       };
       const errorHandler = (...args: unknown[]) => {
         const data = args[0] as MCPErrorEvent;
-        console.error(
+        logger.error(
           `[EndpointManager] MCP 服务连接失败: ${data.serverName}`,
           data.error
         );
@@ -107,7 +108,7 @@ export class EndpointManager extends EventEmitter {
       this.mcpEventListeners.push(connectedHandler, errorHandler);
     }
 
-    console.info("[EndpointManager] MCPManager 已设置");
+    logger.info("[EndpointManager] MCPManager 已设置");
   }
 
   /**
@@ -153,13 +154,13 @@ export class EndpointManager extends EventEmitter {
     const url = endpoint.getUrl();
 
     if (this.endpoints.has(url)) {
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点 ${sliceEndpoint(url)} 已存在，跳过添加`
       );
       return;
     }
 
-    console.debug(`[EndpointManager] 添加接入点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 添加接入点: ${sliceEndpoint(url)}`);
 
     this.endpoints.set(url, endpoint);
     this.connectionStates.set(url, {
@@ -181,13 +182,13 @@ export class EndpointManager extends EventEmitter {
     const url = endpoint.getUrl();
 
     if (!this.endpoints.has(url)) {
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点 ${sliceEndpoint(url)} 不存在，跳过移除`
       );
       return;
     }
 
-    console.debug(`[EndpointManager] 移除接入点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 移除接入点: ${sliceEndpoint(url)}`);
 
     // 断开连接
     await endpoint.disconnect();
@@ -217,7 +218,7 @@ export class EndpointManager extends EventEmitter {
 
       const status = this.connectionStates.get(endpoint);
       if (status?.connected) {
-        console.debug(
+        logger.debug(
           `[EndpointManager] 接入点已连接，跳过: ${sliceEndpoint(endpoint)}`
         );
         return;
@@ -228,7 +229,7 @@ export class EndpointManager extends EventEmitter {
     }
 
     // 连接所有未连接的 Endpoint
-    console.debug(
+    logger.debug(
       `[EndpointManager] 开始连接接入点，总数: ${this.endpoints.size}`
     );
 
@@ -239,7 +240,7 @@ export class EndpointManager extends EventEmitter {
 
       // 跳过已连接的端点
       if (status?.connected) {
-        console.debug(
+        logger.debug(
           `[EndpointManager] 接入点已连接，跳过: ${sliceEndpoint(url)}`
         );
         continue;
@@ -247,7 +248,7 @@ export class EndpointManager extends EventEmitter {
 
       promises.push(
         this.connectSingleEndpoint(url, endpoint).catch((error) => {
-          console.error(
+          logger.error(
             `[EndpointManager] 连接失败: ${sliceEndpoint(url)}`,
             error
           );
@@ -270,7 +271,7 @@ export class EndpointManager extends EventEmitter {
       (s) => s.connected
     ).length;
 
-    console.info(
+    logger.info(
       `[EndpointManager] 连接完成: 成功 ${connectedCount}/${this.endpoints.size}`
     );
   }
@@ -298,14 +299,14 @@ export class EndpointManager extends EventEmitter {
         status.initialized = false;
       }
 
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点已断开: ${sliceEndpoint(endpoint)}`
       );
       return;
     }
 
     // 断开所有连接
-    console.debug("[EndpointManager] 开始断开所有连接");
+    logger.debug("[EndpointManager] 开始断开所有连接");
 
     const promises: Promise<void>[] = [];
 
@@ -325,7 +326,7 @@ export class EndpointManager extends EventEmitter {
       status.initialized = false;
     }
 
-    console.debug("[EndpointManager] 所有接入点已断开连接");
+    logger.debug("[EndpointManager] 所有接入点已断开连接");
   }
 
   /**
@@ -390,33 +391,33 @@ export class EndpointManager extends EventEmitter {
    *               注意：此参数只控制断开和重新连接之间的等待时间，不影响底层 Endpoint 实例的重连延迟
    */
   async reconnect(endpoint?: string, delay = 1000): Promise<void> {
-    console.info("[EndpointManager] 开始重连");
+    logger.info("[EndpointManager] 开始重连");
 
     // 先断开连接
     await this.disconnect(endpoint);
 
     // 等待一段时间
-    console.debug(`[EndpointManager] 等待 ${delay}ms 后重连`);
+    logger.debug(`[EndpointManager] 等待 ${delay}ms 后重连`);
     await new Promise((resolve) => setTimeout(resolve, delay));
 
     // 再重新连接
     await this.connect(endpoint);
 
-    console.info("[EndpointManager] 重连完成");
+    logger.info("[EndpointManager] 重连完成");
   }
 
   /**
    * 重连所有端点
    */
   async reconnectAll(): Promise<void> {
-    console.info("[EndpointManager] 开始重连所有接入点");
+    logger.info("[EndpointManager] 开始重连所有接入点");
 
     const promises: Promise<void>[] = [];
 
     for (const [url, endpoint] of this.endpoints) {
       promises.push(
         this.reconnectSingleEndpoint(url, endpoint).catch((error) => {
-          console.error(
+          logger.error(
             `[EndpointManager] 重连失败: ${sliceEndpoint(url)}`,
             error
           );
@@ -447,7 +448,7 @@ export class EndpointManager extends EventEmitter {
    * 注意：此方法不会清理 MCPManager，MCPManager 的生命周期由外部管理
    */
   async clearEndpoints(): Promise<void> {
-    console.debug("[EndpointManager] 清除所有接入点");
+    logger.debug("[EndpointManager] 清除所有接入点");
 
     await this.disconnect();
 
@@ -458,7 +459,7 @@ export class EndpointManager extends EventEmitter {
     // this.mcpManager = null;
     // this.sharedMCPAdapter = null;
 
-    console.info("[EndpointManager] 所有接入点已清除");
+    logger.info("[EndpointManager] 所有接入点已清除");
   }
 
   /**
@@ -467,7 +468,7 @@ export class EndpointManager extends EventEmitter {
    * 注意：此方法不会清理 MCPManager，MCPManager 的生命周期由外部管理
    */
   async cleanup(): Promise<void> {
-    console.debug("[EndpointManager] 开始清理资源");
+    logger.debug("[EndpointManager] 开始清理资源");
 
     // 移除 MCP 服务事件监听器
     if (
@@ -484,7 +485,7 @@ export class EndpointManager extends EventEmitter {
 
     await this.clearEndpoints();
 
-    console.debug("[EndpointManager] 资源清理完成");
+    logger.debug("[EndpointManager] 资源清理完成");
   }
 
   // ==================== 私有方法 ====================
@@ -501,7 +502,7 @@ export class EndpointManager extends EventEmitter {
       throw new Error(`端点状态不存在: ${sliceEndpoint(url)}`);
     }
 
-    console.debug(`[EndpointManager] 连接端点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 连接端点: ${sliceEndpoint(url)}`);
 
     // 更新状态为连接中
     status.connected = false;
@@ -516,7 +517,7 @@ export class EndpointManager extends EventEmitter {
     status.lastConnected = new Date();
     status.lastError = undefined;
 
-    console.info(`[EndpointManager] 端点连接成功: ${sliceEndpoint(url)}`);
+    logger.info(`[EndpointManager] 端点连接成功: ${sliceEndpoint(url)}`);
   }
 
   /**
@@ -531,7 +532,7 @@ export class EndpointManager extends EventEmitter {
       throw new Error(`端点状态不存在: ${sliceEndpoint(url)}`);
     }
 
-    console.debug(`[EndpointManager] 重连端点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 重连端点: ${sliceEndpoint(url)}`);
 
     // 执行重连
     await endpoint.reconnect();
@@ -542,6 +543,6 @@ export class EndpointManager extends EventEmitter {
     status.lastConnected = new Date();
     status.lastError = undefined;
 
-    console.info(`[EndpointManager] 端点重连成功: ${sliceEndpoint(url)}`);
+    logger.info(`[EndpointManager] 端点重连成功: ${sliceEndpoint(url)}`);
   }
 }


### PR DESCRIPTION
- 新增 logger.ts 模块，提供与项目 logger 一致的 API
- 替换 manager.ts 中 29 处 console 调用为 logger
- 替换 endpoint.ts 中 26 处 console 调用为 logger
- 替换 internal-mcp-manager.ts 中 2 处 console 调用为 logger

修复 #3000

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3000