### PR TITLE
fix(endpoint): 修复 EndpointManager.disconnect() 未正确等待 Promise 的问题

### DIFF
--- a/packages/endpoint/src/manager.ts
+++ b/packages/endpoint/src/manager.ts
@@ -290,7 +290,7 @@ export class EndpointManager extends EventEmitter {
         throw new Error(`接入点不存在: ${sliceEndpoint(endpoint)}`);
       }
 
-      endpointInstance.disconnect();
+      await endpointInstance.disconnect();
 
       const status = this.connectionStates.get(endpoint);
       if (status) {
@@ -310,11 +310,7 @@ export class EndpointManager extends EventEmitter {
     const promises: Promise<void>[] = [];
 
     for (const endpoint of this.endpoints.values()) {
-      promises.push(
-        Promise.resolve().then(() => {
-          endpoint.disconnect();
-        })
-      );
+      promises.push(endpoint.disconnect());
     }
 
     await Promise.allSettled(promises);


### PR DESCRIPTION
问题：在 disconnect() 方法中，Endpoint.disconnect() 异步方法调用
没有正确等待其 Promise 完成，可能导致：
1. 未捕获的 Promise rejection
2. 资源清理不完整
3. 竞态条件风险

修复：
- 第293行：添加 await 等待单个端点断开连接
- 第314-316行：简化 Promise 处理，直接添加 disconnect() Promise

Closes #3001

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3001