### PR TITLE
fix(frontend): 将 pagination.tsx 中的 aria-label 改为中文

### DIFF
--- a/apps/frontend/src/components/ui/pagination.tsx
+++ b/apps/frontend/src/components/ui/pagination.tsx
@@ -6,7 +6,7 @@ import { type ButtonProps, buttonVariants } from "./button";
 
 const Pagination = ({ className, ...props }: React.ComponentProps<"nav">) => (
   <nav
-    aria-label="pagination"
+    aria-label="分页导航"
     className={cn("mx-auto flex w-full justify-center", className)}
     {...props}
   />
@@ -63,7 +63,7 @@ const PaginationPrevious = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to previous page"
+    aria-label="上一页"
     size="default"
     className={cn("gap-1 pl-2.5", className)}
     {...props}
@@ -79,7 +79,7 @@ const PaginationNext = ({
   ...props
 }: React.ComponentProps<typeof PaginationLink>) => (
   <PaginationLink
-    aria-label="Go to next page"
+    aria-label="下一页"
     size="default"
     className={cn("gap-1 pr-2.5", className)}
     {...props}


### PR DESCRIPTION
修复 aria-label 属性使用英文而非中文的问题，保持与页面可见文本一致：
- 分页导航区域 aria-label: "pagination" → "分页导航"
- 上一页按钮 aria-label: "Go to previous page" → "上一页"
- 下一页按钮 aria-label: "Go to next page" → "下一页"

符合项目本地化规范要求。

Fixes #3003

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3003