### PR TITLE
fix(tts): 修复 WebSocket 消息处理器中未捕获异常问题

### DIFF
--- a/packages/tts/src/platforms/bytedance/protocol/protocols.ts
+++ b/packages/tts/src/platforms/bytedance/protocol/protocols.ts
@@ -607,7 +607,11 @@ function setupMessageHandler(ws: WebSocket) {
           queue.push(msg);
         }
       } catch (error) {
-        throw new Error(`Error processing message: ${error}`);
+        // 使用 WebSocket 的 error 事件传播错误，避免未捕获异常
+        ws.emit(
+          "error",
+          error instanceof Error ? error : new Error(String(error))
+        );
       }
     });
 


### PR DESCRIPTION
将 message 事件处理器中的 throw 替换为 ws.emit('error')，
确保错误通过 WebSocket 的 error 事件正确传播，避免
Node.js 进程出现未捕获异常。

修复 issue #3006

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3006