### PR TITLE
fix(arch): UpdateApiHandler 依赖注入重构

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -42,6 +42,7 @@ import {
 import { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
+import { NPMManager } from "@/lib/npm";
 import {
   corsMiddleware,
   endpointManagerMiddleware,
@@ -202,7 +203,7 @@ export class WebServer {
     this.versionApiHandler = new VersionApiHandler();
     this.staticFileHandler = new StaticFileHandler();
     this.mcpRouteHandler = new MCPRouteHandler();
-    this.updateApiHandler = new UpdateApiHandler();
+    this.updateApiHandler = new UpdateApiHandler(new NPMManager(this.eventBus));
     this.cozeHandler = new CozeHandler();
     this.ttsApiHandler = new TTSApiHandler();
     this.esp32Handler = new ESP32Handler(this.esp32Service);

--- a/apps/backend/handlers/__tests__/update.handler.test.ts
+++ b/apps/backend/handlers/__tests__/update.handler.test.ts
@@ -1,11 +1,10 @@
-import { NPMManager } from "@/lib/npm";
+import type { NPMManager } from "@/lib/npm";
 import type { Context } from "hono";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
 import { logger } from "../../Logger.js";
 import { UpdateApiHandler } from "../update.handler.js";
 
 // 模拟依赖
-vi.mock("@/lib/npm");
 vi.mock("../../Logger.js");
 vi.mock("@/services/event-bus.service.js");
 
@@ -99,16 +98,11 @@ describe("UpdateApiHandler", () => {
     mockNPMManager = {
       installVersion: vi.fn(),
     };
-    vi.mocked(NPMManager).mockImplementation(
-      () => mockNPMManager as unknown as NPMManager
+
+    // 创建处理器实例（通过构造函数注入 mock NPMManager）
+    updateApiHandler = new UpdateApiHandler(
+      mockNPMManager as unknown as NPMManager
     );
-
-    // 创建处理器实例
-    updateApiHandler = new UpdateApiHandler();
-  });
-
-  afterEach(() => {
-    vi.restoreAllMocks();
   });
 
   describe("performUpdate", () => {

--- a/apps/backend/handlers/update.handler.ts
+++ b/apps/backend/handlers/update.handler.ts
@@ -2,7 +2,7 @@
  * 更新 API HTTP 路由处理器
  * 提供版本更新和 NPM 包安装相关的 RESTful API 接口
  */
-import { NPMManager } from "@/lib/npm";
+import type { NPMManager } from "@/lib/npm";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
@@ -22,9 +22,9 @@ export class UpdateApiHandler extends BaseHandler {
   private eventBus = getEventBus();
   private activeInstalls: Map<string, boolean> = new Map();
 
-  constructor() {
+  constructor(npmManager: NPMManager) {
     super();
-    this.npmManager = new NPMManager(this.eventBus);
+    this.npmManager = npmManager;
   }
 
   /**


### PR DESCRIPTION
将 UpdateApiHandler 的 NPMManager 从构造函数内直接创建改为通过构造函数参数注入，
遵循依赖注入原则，与项目中其他 handler 的设计模式保持一致。

变更内容：
- update.handler.ts: NPMManager 改为构造函数参数注入
- WebServer.ts: 创建 NPMManager 实例并传递给 UpdateApiHandler
- update.handler.test.ts: 使用构造函数注入 mock NPMManager

修复 #3008

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3008