### PR TITLE
fix(cli): 替换 ServiceCommandHandler 中的 getService<any> 为具体类型

### DIFF
--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -3,6 +3,7 @@
  */
 
 import consola from "consola";
+import type { DaemonManager, ServiceManager } from "../interfaces/Service";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
@@ -89,7 +90,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
         consola.level = 5; // debug 级别
       }
 
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
 
       if (options.stdio) {
         // stdio 模式已迁移到 HTTP 方式
@@ -99,7 +100,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
 
       // 传统模式
       await serviceManager.start({
-        daemon: options.daemon || false,
+        daemon: Boolean(options.daemon),
       });
     } catch (error) {
       this.handleError(error as Error);
@@ -111,7 +112,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStop(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       await serviceManager.stop();
     } catch (error) {
       this.handleError(error as Error);
@@ -123,7 +124,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleStatus(): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       const status = await serviceManager.getStatus();
 
       if (status.running) {
@@ -147,9 +148,9 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleRestart(options: CommandOptions): Promise<void> {
     try {
-      const serviceManager = this.getService<any>("serviceManager");
+      const serviceManager = this.getService<ServiceManager>("serviceManager");
       await serviceManager.restart({
-        daemon: options.daemon || false,
+        daemon: Boolean(options.daemon),
       });
     } catch (error) {
       this.handleError(error as Error);
@@ -161,7 +162,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
    */
   private async handleAttach(): Promise<void> {
     try {
-      const daemonManager = this.getService<any>("daemonManager");
+      const daemonManager = this.getService<DaemonManager>("daemonManager");
       await daemonManager.attachToLogs();
     } catch (error) {
       this.handleError(error as Error);

--- a/packages/cli/src/interfaces/Service.ts
+++ b/packages/cli/src/interfaces/Service.ts
@@ -78,6 +78,8 @@ export interface DaemonManager {
   startDaemon(serverFactory: () => Promise<any>): Promise<void>;
   /** 停止守护进程 */
   stopDaemon(): Promise<void>;
+  /** 连接到守护进程日志 */
+  attachToLogs(logFileName?: string): Promise<void>;
 }
 
 /**


### PR DESCRIPTION
- 导入 ServiceManager 和 DaemonManager 类型
- 替换 5 处 getService<any> 为 getService<ServiceManager> 和 getService<DaemonManager>
- 添加 attachToLogs 方法到 DaemonManager 接口
- 使用 Boolean(options.daemon) 确保 daemon 参数类型安全

修复 Issue #3009 中记录的类型安全问题

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3009