### PR TITLE
fix(log): 将 console.log 替换为 logger.info

### DIFF
--- a/apps/backend/lib/mcp/log.ts
+++ b/apps/backend/lib/mcp/log.ts
@@ -105,9 +105,9 @@ export class ToolCallLogger {
           try {
             const logObj = JSON.parse(chunk);
             const message = this.formatConsoleMessage(logObj);
-            console.log("[工具调用]", { message });
+            logger.info("[工具调用]", { message });
           } catch {
-            console.log("[工具调用]", { chunk: chunk.trim() });
+            logger.info("[工具调用]", { chunk: chunk.trim() });
           }
         },
       },


### PR DESCRIPTION
修复 apps/backend/lib/mcp/log.ts 中 createPinoLogger 方法的控制台流
使用 console.log 而非已导入 logger 的问题，符合项目日志规范。

Closes #3014

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3014