### PR TITLE
fix(cli): 替换 any 类型为具体类型定义

### DIFF
--- a/packages/cli/src/commands/ProjectCommandHandler.ts
+++ b/packages/cli/src/commands/ProjectCommandHandler.ts
@@ -4,7 +4,7 @@
 
 import path from "node:path";
 import chalk from "chalk";
-import ora from "ora";
+import ora, { type Ora } from "ora";
 import type { CommandOption } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
@@ -12,6 +12,7 @@ import type {
   CommandOptions,
 } from "../interfaces/CommandTypes";
 import type { IDIContainer } from "../interfaces/Config";
+import type { TemplateManager } from "../interfaces/Service";
 
 /**
  * 项目管理命令处理器
@@ -102,8 +103,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
     projectName: string,
     templateName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: Ora,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = "检查模板...";
 
@@ -176,8 +177,8 @@ export class ProjectCommandHandler extends BaseCommandHandler {
   private async createBasicProject(
     projectName: string,
     targetPath: string,
-    spinner: any,
-    templateManager: any
+    spinner: Ora,
+    templateManager: TemplateManager
   ): Promise<void> {
     spinner.text = `创建基本项目 "${projectName}"...`;
 


### PR DESCRIPTION
修复 ProjectCommandHandler.ts 中的类型安全问题：
- spinner 参数：从 any 改为 Ora 类型（ora 包的 spinner 类型）
- templateManager 参数：从 any 改为 TemplateManager 接口

相关问题: #3017

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3017