### PR TITLE
fix(frontend): 使用 JSONSchema 类型替代 any 提升类型安全性

### DIFF
--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -28,7 +28,7 @@ import { useToolSearch } from "@/hooks/useToolSearch";
 import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
-import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
+import type { CustomMCPToolWithStats, JSONSchema } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { toast } from "sonner";
@@ -48,7 +48,7 @@ export interface ToolRowData {
   enabled: boolean;
   usageCount: number;
   lastUsedTime: string;
-  inputSchema: any;
+  inputSchema: JSONSchema;
 }
 
 interface McpToolTableProps {
@@ -109,7 +109,7 @@ export function McpToolTable({
       serverName: string;
       toolName: string;
       description?: string;
-      inputSchema?: any;
+      inputSchema?: JSONSchema;
     };
   }>({ open: false });
 

--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -41,6 +41,7 @@ import {
   createZodSchemaFromJsonSchema,
 } from "@/lib/schema-utils";
 import { apiClient } from "@/services/api";
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
 import { zodResolver } from "@hookform/resolvers/zod";
 import {
   AlertCircle,
@@ -57,7 +58,7 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { Controller, useFieldArray, useForm, type UseFormReturn } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
 
@@ -75,11 +76,11 @@ import { z } from "zod";
  */
 interface ArrayFieldProps {
   name: string;
-  schema: any;
-  form: any;
+  schema: JSONSchema;
+  form: UseFormReturn;
   renderFormField: (
     fieldName: string,
-    fieldSchema: any
+    fieldSchema: JSONSchema
   ) => React.ReactElement | null;
 }
 
@@ -96,27 +97,31 @@ const ArrayField = memo(function ArrayField({
 
   const addItem = () => {
     const itemSchema = schema.items;
-    let newItem: any;
+    let newItem: unknown;
 
-    switch (itemSchema.type) {
-      case "string":
-        newItem = itemSchema.enum ? itemSchema.enum[0] : "";
-        break;
-      case "number":
-      case "integer":
-        newItem = 0;
-        break;
-      case "boolean":
-        newItem = false;
-        break;
-      case "array":
-        newItem = [];
-        break;
-      case "object":
-        newItem = {};
-        break;
-      default:
-        newItem = "";
+    if (!itemSchema) {
+      newItem = "";
+    } else {
+      switch (itemSchema.type) {
+        case "string":
+          newItem = itemSchema.enum ? itemSchema.enum[0] : "";
+          break;
+        case "number":
+        case "integer":
+          newItem = 0;
+          break;
+        case "boolean":
+          newItem = false;
+          break;
+        case "array":
+          newItem = [];
+          break;
+        case "object":
+          newItem = {};
+          break;
+        default:
+          newItem = "";
+      }
     }
 
     append(newItem);
@@ -177,14 +182,14 @@ const ArrayField = memo(function ArrayField({
                         ) {
                           return (
                             <div className="ml-6 border-l-2 border-muted pl-4">
-                              {renderFormField(
+                              {schema.items && renderFormField(
                                 `${name}.${index}`,
                                 schema.items
                               )}
                             </div>
                           );
                         }
-                        return renderFormField(
+                        return schema.items && renderFormField(
                           `${name}.${index}`,
                           schema.items
                         );
@@ -215,11 +220,11 @@ const ArrayField = memo(function ArrayField({
  */
 interface ObjectFieldProps {
   name: string;
-  schema: any;
-  form: any;
+  schema: JSONSchema;
+  form: UseFormReturn;
   renderFormField: (
     fieldName: string,
-    fieldSchema: any
+    fieldSchema: JSONSchema
   ) => React.ReactElement | null;
   getTypeBadge: (type: string) => string;
 }
@@ -243,7 +248,7 @@ const ObjectField = memo(function ObjectField({
     <div className="space-y-4">
       <span className="text-sm font-medium">对象字段</span>
       {Object.entries(schema.properties).map(
-        ([fieldName, fieldSchema]: [string, any]) => (
+        ([fieldName, fieldSchema]: [string, JSONSchema]) => (
           <div
             key={`${name}-${fieldName}`}
             className="ml-6 border-l-2 border-muted pl-4"
@@ -262,9 +267,9 @@ const ObjectField = memo(function ObjectField({
                     </FormLabel>
                     <Badge
                       variant="secondary"
-                      className={`text-xs ${getTypeBadge(fieldSchema.type)}`}
+                      className={`text-xs ${getTypeBadge(Array.isArray(fieldSchema.type) ? fieldSchema.type[0] ?? "unknown" : fieldSchema.type ?? "unknown")}`}
                     >
-                      {fieldSchema.type}
+                      {Array.isArray(fieldSchema.type) ? fieldSchema.type.join("|") : fieldSchema.type ?? "unknown"}
                     </Badge>
                     {fieldSchema.description && (
                       <Tooltip>
@@ -339,10 +344,10 @@ const NoParamsMessage = memo(function NoParamsMessage() {
  */
 interface FormRendererProps {
   tool: ToolDebugDialogProps["tool"];
-  form: any;
+  form: UseFormReturn;
   renderFormField: (
     fieldName: string,
-    fieldSchema: any
+    fieldSchema: JSONSchema
   ) => React.ReactElement | null;
 }
 
@@ -351,7 +356,9 @@ const FormRenderer = memo(function FormRenderer({
   form,
   renderFormField,
 }: FormRendererProps) {
-  if (!tool?.inputSchema?.properties) {
+  const inputSchema = tool?.inputSchema;
+
+  if (!inputSchema?.properties) {
     return (
       <div className="text-center py-8">
         <Code className="h-8 w-8 mx-auto mb-2 opacity-50" />
@@ -364,17 +371,17 @@ const FormRenderer = memo(function FormRenderer({
     <Form {...form}>
       <ScrollArea className="h-full">
         <div className="space-y-4 p-2">
-          {Object.entries(tool.inputSchema.properties).map(
-            ([fieldName, fieldSchema]: [string, any]) => (
+          {Object.entries(inputSchema.properties).map(
+            ([fieldName, fieldSchema]: [string, JSONSchema]) => (
               <FormField
-                key={`${tool.name}-${fieldName}`} // 添加工具名称作为前缀，确保 key 的唯一性和稳定性
+                key={`${tool?.name ?? "unknown"}-${fieldName}`} // 添加工具名称作为前缀，确保 key 的唯一性和稳定性
                 control={form.control}
                 name={fieldName as any}
                 render={() => (
                   <FormItem>
                     <div className="flex items-center gap-2">
                       <FormLabel>
-                        {tool.inputSchema.required?.includes(fieldName) && (
+                        {inputSchema.required?.includes(fieldName) && (
                           <span className="text-red-500 mr-1">*</span>
                         )}
                         {fieldName}
@@ -432,7 +439,7 @@ interface ToolDebugDialogProps {
     serverName: string;
     toolName: string;
     description?: string;
-    inputSchema?: any;
+    inputSchema?: JSONSchema;
   } | null;
 }
 
@@ -663,7 +670,7 @@ export function ToolDebugDialog({
       return colors[type] || "bg-gray-100 text-gray-800";
     };
 
-    return (fieldName: string, fieldSchema: any): React.ReactElement | null => {
+    return (fieldName: string, fieldSchema: JSONSchema): React.ReactElement | null => {
       switch (fieldSchema.type) {
         case "string":
           if (fieldSchema.enum) {
@@ -679,7 +686,7 @@ export function ToolDebugDialog({
                       </SelectTrigger>
                     </FormControl>
                     <SelectContent>
-                      {fieldSchema.enum.map((option: string) => (
+                      {(fieldSchema.enum as string[]).map((option) => (
                         <SelectItem key={option} value={option}>
                           {option}
                         </SelectItem>

--- a/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-pagination.test.ts
@@ -14,7 +14,7 @@ describe("useToolPagination", () => {
       enabled: i % 2 === 0,
       usageCount: i * 10,
       lastUsedTime: `2024-01-${(i % 28) + 1}T00:00:00Z`,
-      inputSchema: null,
+      inputSchema: {},
     }));
   };
 

--- a/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
+++ b/apps/frontend/src/hooks/__tests__/use-tool-search.test.ts
@@ -13,7 +13,7 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 10,
       lastUsedTime: "2024-01-01T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
     {
       name: "tool2",
@@ -23,7 +23,7 @@ describe("useToolSearch", () => {
       enabled: false,
       usageCount: 5,
       lastUsedTime: "2024-01-02T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
     {
       name: "tool3",
@@ -33,7 +33,7 @@ describe("useToolSearch", () => {
       enabled: true,
       usageCount: 3,
       lastUsedTime: "2024-01-03T00:00:00Z",
-      inputSchema: null,
+      inputSchema: {},
     },
   ];
 
@@ -176,7 +176,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
       ];
 
@@ -206,7 +206,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
         {
           name: "tool2",
@@ -216,7 +216,7 @@ describe("useToolSearch", () => {
           enabled: true,
           usageCount: 0,
           lastUsedTime: "",
-          inputSchema: null,
+          inputSchema: {},
         },
       ] as ToolRowData[];
 

--- a/apps/frontend/src/lib/__tests__/schema-utils.test.ts
+++ b/apps/frontend/src/lib/__tests__/schema-utils.test.ts
@@ -1,0 +1,379 @@
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
+import { describe, expect, it } from "vitest";
+import {
+  createDefaultValues,
+  createZodSchemaFromJsonSchema,
+  getDefaultValueForSchema,
+} from "../schema-utils";
+
+describe("schema-utils", () => {
+  describe("createZodSchemaFromJsonSchema", () => {
+    describe("基础类型", () => {
+      it("应该为 string 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "string" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("test").success).toBe(true);
+        expect(zodSchema.safeParse(123).success).toBe(false);
+      });
+
+      it("应该为带 enum 的 string 类型创建正确的 schema", () => {
+        const schema: JSONSchema = {
+          type: "string",
+          enum: ["option1", "option2", "option3"],
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("option1").success).toBe(true);
+        expect(zodSchema.safeParse("option2").success).toBe(true);
+        expect(zodSchema.safeParse("invalid").success).toBe(false);
+      });
+
+      it("应该为带 minLength 的 string 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "string", minLength: 3 };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("abc").success).toBe(true);
+        expect(zodSchema.safeParse("ab").success).toBe(false);
+      });
+
+      it("应该为带 maxLength 的 string 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "string", maxLength: 5 };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("abc").success).toBe(true);
+        expect(zodSchema.safeParse("abcdef").success).toBe(false);
+      });
+
+      it("应该为带 pattern 的 string 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "string", pattern: "^\\d+$" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("123").success).toBe(true);
+        expect(zodSchema.safeParse("abc").success).toBe(false);
+      });
+
+      it("应该为 number 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "number" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(123).success).toBe(true);
+        expect(zodSchema.safeParse(123.45).success).toBe(true);
+        expect(zodSchema.safeParse("123").success).toBe(false);
+      });
+
+      it("应该为 integer 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "integer" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(123).success).toBe(true);
+        expect(zodSchema.safeParse(123.45).success).toBe(false);
+      });
+
+      it("应该为带 minimum 的 number 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "number", minimum: 10 };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(10).success).toBe(true);
+        expect(zodSchema.safeParse(5).success).toBe(false);
+      });
+
+      it("应该为带 maximum 的 number 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "number", maximum: 100 };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(50).success).toBe(true);
+        expect(zodSchema.safeParse(150).success).toBe(false);
+      });
+
+      it("应该为 boolean 类型创建正确的 schema", () => {
+        const schema: JSONSchema = { type: "boolean" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(true).success).toBe(true);
+        expect(zodSchema.safeParse(false).success).toBe(true);
+        expect(zodSchema.safeParse("true").success).toBe(false);
+      });
+
+      it("应该为 array 类型创建正确的 schema", () => {
+        const schema: JSONSchema = {
+          type: "array",
+          items: { type: "string" },
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(["a", "b", "c"]).success).toBe(true);
+        expect(zodSchema.safeParse([1, 2, 3]).success).toBe(false);
+        expect(zodSchema.safeParse("not-array").success).toBe(false);
+      });
+
+      it("应该为带 minItems 的 array 类型创建正确的 schema", () => {
+        const schema: JSONSchema = {
+          type: "array",
+          items: { type: "string" },
+          minItems: 2,
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(["a", "b"]).success).toBe(true);
+        expect(zodSchema.safeParse(["a"]).success).toBe(false);
+      });
+
+      it("应该为带 maxItems 的 array 类型创建正确的 schema", () => {
+        const schema: JSONSchema = {
+          type: "array",
+          items: { type: "string" },
+          maxItems: 3,
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse(["a", "b"]).success).toBe(true);
+        expect(zodSchema.safeParse(["a", "b", "c", "d"]).success).toBe(false);
+      });
+
+      it("应该为 object 类型创建正确的 schema", () => {
+        const schema: JSONSchema = {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            age: { type: "number" },
+          },
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse({ name: "test", age: 25 }).success).toBe(
+          true
+        );
+        expect(zodSchema.safeParse({ name: 123 }).success).toBe(false);
+      });
+
+      it("应该正确处理 required 字段", () => {
+        const schema: JSONSchema = {
+          type: "object",
+          properties: {
+            name: { type: "string" },
+            optionalField: { type: "string" },
+          },
+          required: ["name"],
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        // name 是必填的
+        const result1 = zodSchema.safeParse({ name: "test" });
+        expect(result1.success).toBe(true);
+
+        // optionalField 是可选的
+        const result2 = zodSchema.safeParse({ name: "test", optionalField: "value" });
+        expect(result2.success).toBe(true);
+      });
+
+      it("应该处理嵌套对象", () => {
+        const schema: JSONSchema = {
+          type: "object",
+          properties: {
+            user: {
+              type: "object",
+              properties: {
+                name: { type: "string" },
+                email: { type: "string" },
+              },
+            },
+          },
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(
+          zodSchema.safeParse({ user: { name: "test", email: "test@example.com" } }).success
+        ).toBe(true);
+      });
+
+      it("应该处理嵌套数组", () => {
+        const schema: JSONSchema = {
+          type: "array",
+          items: {
+            type: "object",
+            properties: {
+              id: { type: "number" },
+              name: { type: "string" },
+            },
+          },
+        };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(
+          zodSchema.safeParse([{ id: 1, name: "item1" }, { id: 2, name: "item2" }]).success
+        ).toBe(true);
+      });
+    });
+
+    describe("边界情况", () => {
+      it("应该为空或无效的 schema 返回 z.any()", () => {
+        const nullSchema = createZodSchemaFromJsonSchema(null as unknown as JSONSchema);
+        expect(nullSchema.safeParse("anything").success).toBe(true);
+        expect(nullSchema.safeParse(null).success).toBe(true);
+
+        const undefinedSchema = createZodSchemaFromJsonSchema(undefined as unknown as JSONSchema);
+        expect(undefinedSchema.safeParse("anything").success).toBe(true);
+
+        const emptySchema = createZodSchemaFromJsonSchema({} as JSONSchema);
+        expect(emptySchema.safeParse("anything").success).toBe(true);
+      });
+
+      it("应该为未知类型返回 z.any()", () => {
+        const schema: JSONSchema = { type: "unknown" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse("anything").success).toBe(true);
+      });
+
+      it("应该处理没有 items 的 array 类型", () => {
+        const schema: JSONSchema = { type: "array" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse([1, "a", true]).success).toBe(true);
+      });
+
+      it("应该处理没有 properties 的 object 类型", () => {
+        const schema: JSONSchema = { type: "object" };
+        const zodSchema = createZodSchemaFromJsonSchema(schema);
+
+        expect(zodSchema.safeParse({ anyKey: "anyValue" }).success).toBe(true);
+      });
+    });
+  });
+
+  describe("getDefaultValueForSchema", () => {
+    it("应该为 string 类型返回空字符串", () => {
+      const schema: JSONSchema = { type: "string" };
+      expect(getDefaultValueForSchema(schema)).toBe("");
+    });
+
+    it("应该为带 enum 的 string 类型返回第一个 enum 值", () => {
+      const schema: JSONSchema = {
+        type: "string",
+        enum: ["option1", "option2"],
+      };
+      expect(getDefaultValueForSchema(schema)).toBe("option1");
+    });
+
+    it("应该为 number 类型返回 0", () => {
+      const schema: JSONSchema = { type: "number" };
+      expect(getDefaultValueForSchema(schema)).toBe(0);
+    });
+
+    it("应该为 integer 类型返回 0", () => {
+      const schema: JSONSchema = { type: "integer" };
+      expect(getDefaultValueForSchema(schema)).toBe(0);
+    });
+
+    it("应该为 boolean 类型返回 false", () => {
+      const schema: JSONSchema = { type: "boolean" };
+      expect(getDefaultValueForSchema(schema)).toBe(false);
+    });
+
+    it("应该为 array 类型返回空数组", () => {
+      const schema: JSONSchema = { type: "array" };
+      expect(getDefaultValueForSchema(schema)).toEqual([]);
+    });
+
+    it("应该为 object 类型返回默认值对象", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+          active: { type: "boolean" },
+        },
+      };
+      expect(getDefaultValueForSchema(schema)).toEqual({
+        name: "",
+        age: 0,
+        active: false,
+      });
+    });
+
+    it("应该为没有 properties 的 object 类型返回空对象", () => {
+      const schema: JSONSchema = { type: "object" };
+      expect(getDefaultValueForSchema(schema)).toEqual({});
+    });
+
+    it("应该为空或无效的 schema 返回 undefined", () => {
+      expect(getDefaultValueForSchema(null as unknown as JSONSchema)).toBeUndefined();
+      expect(getDefaultValueForSchema(undefined as unknown as JSONSchema)).toBeUndefined();
+    });
+
+    it("应该处理嵌套对象", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          user: {
+            type: "object",
+            properties: {
+              name: { type: "string" },
+            },
+          },
+        },
+      };
+      expect(getDefaultValueForSchema(schema)).toEqual({
+        user: {
+          name: "",
+        },
+      });
+    });
+  });
+
+  describe("createDefaultValues", () => {
+    it("应该为必填字段创建默认值", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+        required: ["name", "age"],
+      };
+      expect(createDefaultValues(schema)).toEqual({
+        name: "",
+        age: 0,
+      });
+    });
+
+    it("应该只对有有意义默认值的可选字段设置默认值", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+          active: { type: "boolean" },
+        },
+        required: ["name"],
+      };
+      expect(createDefaultValues(schema)).toEqual({
+        name: "",
+        age: 0, // number 默认值 0
+        active: false, // boolean 默认值 false
+      });
+    });
+
+    it("应该为空或无效的 schema 返回空对象", () => {
+      expect(createDefaultValues(null as unknown as JSONSchema)).toEqual({});
+      expect(createDefaultValues(undefined as unknown as JSONSchema)).toEqual({});
+      expect(createDefaultValues({} as JSONSchema)).toEqual({});
+    });
+
+    it("应该处理没有 required 字段的 schema", () => {
+      const schema: JSONSchema = {
+        type: "object",
+        properties: {
+          name: { type: "string" },
+          age: { type: "number" },
+        },
+      };
+      // 没有 required 字段时，所有字段都是可选的
+      // 可选字段只有非空字符串的默认值才会被设置
+      expect(createDefaultValues(schema)).toEqual({
+        age: 0, // number 默认值 0 被包含
+      });
+    });
+  });
+});

--- a/apps/frontend/src/lib/schema-utils.ts
+++ b/apps/frontend/src/lib/schema-utils.ts
@@ -1,9 +1,10 @@
+import type { JSONSchema } from "@xiaozhi-client/shared-types";
 import { z } from "zod";
 
 /**
  * 根据 JSON Schema 动态生成 Zod schema
  */
-export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
+export function createZodSchemaFromJsonSchema(jsonSchema: JSONSchema): z.ZodTypeAny {
   if (!jsonSchema || typeof jsonSchema !== "object") {
     return z.any();
   }
@@ -92,7 +93,7 @@ export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
 /**
  * 获取字段的默认值
  */
-export function getDefaultValueForSchema(schema: any): any {
+export function getDefaultValueForSchema(schema: JSONSchema): unknown {
   if (!schema) return undefined;
 
   switch (schema.type) {
@@ -112,7 +113,7 @@ export function getDefaultValueForSchema(schema: any): any {
 
     case "object":
       if (schema.properties) {
-        const defaults: Record<string, any> = {};
+        const defaults: Record<string, unknown> = {};
         for (const [key, propSchema] of Object.entries(schema.properties)) {
           defaults[key] = getDefaultValueForSchema(propSchema);
         }
@@ -128,10 +129,10 @@ export function getDefaultValueForSchema(schema: any): any {
 /**
  * 根据 JSON Schema 生成默认值对象
  */
-export function createDefaultValues(jsonSchema: any): Record<string, any> {
+export function createDefaultValues(jsonSchema: JSONSchema): Record<string, unknown> {
   if (!jsonSchema || !jsonSchema.properties) return {};
 
-  const defaults: Record<string, any> = {};
+  const defaults: Record<string, unknown> = {};
   const requiredFields = jsonSchema.required || [];
 
   for (const [key, propSchema] of Object.entries(jsonSchema.properties)) {

--- a/packages/shared-types/src/mcp/schema.ts
+++ b/packages/shared-types/src/mcp/schema.ts
@@ -16,6 +16,20 @@ export interface JSONSchema {
   description?: string;
   enum?: unknown[];
   const?: unknown;
+  // 字符串类型约束
+  minLength?: number;
+  maxLength?: number;
+  pattern?: string;
+  format?: string;
+  // 数值类型约束
+  minimum?: number;
+  maximum?: number;
+  multipleOf?: number;
+  // 数组类型约束
+  minItems?: number;
+  maxItems?: number;
+  // 其他属性
+  default?: unknown;
   [key: string]: unknown;
 }
 


### PR DESCRIPTION
- 在 shared-types 中扩展 JSONSchema 类型定义，添加常用约束属性
- 修复 tool-debug-dialog.tsx 中的 any 类型，使用 JSONSchema 和 UseFormReturn
- 修复 mcp-tool-table.tsx 中的 inputSchema 类型
- 修复 schema-utils.ts 函数参数类型，使用 JSONSchema 替代 any
- 创建 schema-utils.test.ts 测试文件，覆盖关键功能场景
- 更新相关测试文件中的 inputSchema 类型

Closes #3019

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3019