### PR TITLE
fix(endpoint): 在 cleanup 方法中移除事件监听器防止内存泄漏

### DIFF
--- a/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
+++ b/packages/endpoint/src/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      removeAllListeners: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);
@@ -355,6 +356,20 @@ describe("InternalMCPManagerAdapter", () => {
       await adapter.cleanup();
 
       expect(mockMCPManager.disconnect).toHaveBeenCalled();
+    });
+
+    it("应该移除事件监听器防止内存泄漏", async () => {
+      const adapter = new InternalMCPManagerAdapter({
+        mcpServers: {
+          "test-service": { command: "node", args: ["server.js"] },
+        },
+      });
+
+      await adapter.initialize();
+      await adapter.cleanup();
+
+      expect(mockMCPManager.removeAllListeners).toHaveBeenCalledWith("connected");
+      expect(mockMCPManager.removeAllListeners).toHaveBeenCalledWith("error");
     });
 
     it("清理后应该清空工具列表", async () => {

--- a/packages/endpoint/src/internal-mcp-manager.ts
+++ b/packages/endpoint/src/internal-mcp-manager.ts
@@ -88,6 +88,10 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
    * 清理资源
    */
   async cleanup(): Promise<void> {
+    // 移除事件监听器，防止内存泄漏
+    this.mcpManager.removeAllListeners("connected");
+    this.mcpManager.removeAllListeners("error");
+
     await this.mcpManager.disconnect();
     this.tools.clear();
     this.isInitialized = false;


### PR DESCRIPTION
在 InternalMCPManagerAdapter.cleanup() 方法中添加事件监听器移除逻辑，
防止 cleanup 后 MCPManager 对象仍持有对 adapter 的引用导致的内存泄漏。

修复内容：
- 在 cleanup 方法开始时调用 removeAllListeners("connected")
- 在 cleanup 方法开始时调用 removeAllListeners("error")
- 添加测试验证 cleanup 时正确移除监听器

相关问题：#3021

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3021