### PR TITLE
chore: 更新 Claude Code 归属设置配置

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,5 +46,9 @@
     ],
     "deny": [],
     "ask": []
+  },
+  "attribution": {
+    "commit": "🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nCo-Authored-By: GLM-5.1 <noreply@bigmodel.cn>",
+    "pr": ""
   }
 }


### PR DESCRIPTION
## Summary
- 在 `.claude/settings.json` 中添加 `attribution` 配置项
- 配置 commit 归属信息，包含 Claude Code 生成标记和协作者信息
- PR 归属设置为空（使用默认行为）

## Test plan
- [ ] 验证 `.claude/settings.json` 格式正确
- [ ] 确认配置项不影响现有功能