### PR TITLE
refactor(asr): 简化 ASR 服务为单会话模式

### DIFF
--- a/apps/backend/lib/esp32/connection.ts
+++ b/apps/backend/lib/esp32/connection.ts
@@ -12,7 +12,6 @@ import {
   parseBinaryProtocol2,
   parseBinaryProtocol3,
 } from "@/lib/esp32/audio-protocol.js";
-import type { ASRService } from "@/services/asr.service.js";
 import {
   type ESP32ConnectionState,
   ESP32ErrorCode,
@@ -35,8 +34,6 @@ interface ESP32ConnectionConfig {
   onError: (error: Error) => void;
   /** 心跳超时时间（毫秒），默认30秒 */
   heartbeatTimeoutMs?: number;
-  /** ASR 服务获取函数（用于获取最新的实例） */
-  getASRService: () => ASRService;
 }
 
 /**
@@ -71,9 +68,6 @@ export class ESP32Connection {
   /** 是否已完成Hello握手 */
   private helloCompleted = false;
 
-  /** ASR 服务获取函数（用于获取最新的实例） */
-  private getASRService: () => ASRService;
-
   /**
    * 构造函数
    * @param deviceId - 设备ID
@@ -92,7 +86,6 @@ export class ESP32Connection {
     this.ws = ws;
     this.lastActivity = new Date();
     this.sessionId = this.generateSessionId();
-    this.getASRService = config.getASRService;
 
     this.heartbeatTimeoutMs = config.heartbeatTimeoutMs ?? 30_000;
 
@@ -101,7 +94,6 @@ export class ESP32Connection {
       onClose: config.onClose,
       onError: config.onError,
       heartbeatTimeoutMs: this.heartbeatTimeoutMs,
-      getASRService: config.getASRService,
     };
 
     this.setupWebSocket();
@@ -287,14 +279,6 @@ export class ESP32Connection {
     logger.info(`[HELLO] 准备发送ServerHello响应: sessionId=${this.sessionId}`);
     await this.send(serverHello);
     logger.info("[HELLO] ServerHello响应已发送");
-
-    // 在 Hello 阶段只准备 ASR 服务（不建立连接）
-    // 连接会在 start 阶段建立，以支持多次语音交互
-    const asrService = this.getASRService();
-    if (asrService) {
-      logger.info(`[HELLO] 准备 ASR 服务: deviceId=${this.deviceId}`);
-      await asrService.prepare(this.deviceId);
-    }
 
     this.helloCompleted = true;
     this.state = "connected";

--- a/apps/backend/services/asr.interface.ts
+++ b/apps/backend/services/asr.interface.ts
@@ -1,6 +1,6 @@
 /**
  * ASR 服务接口
- * 定义语音识别服务的方法和事件
+ * 定义单会话语音识别服务的方法和事件
  */
 
 /**
@@ -9,24 +9,16 @@
 export interface ASRServiceEvents {
   /**
    * 识别结果回调
-   * @param deviceId - 设备 ID
    * @param text - 识别文本
    * @param isFinal - 是否为最终结果
    */
-  onResult?: (deviceId: string, text: string, isFinal: boolean) => void;
+  onResult?: (text: string, isFinal: boolean) => void;
 
   /**
    * 错误回调
-   * @param deviceId - 设备 ID
    * @param error - 错误对象
    */
-  onError?: (deviceId: string, error: Error) => void;
-
-  /**
-   * 连接关闭回调
-   * @param deviceId - 设备 ID
-   */
-  onClose?: (deviceId: string) => void;
+  onError?: (error: Error) => void;
 }
 
 /**
@@ -41,58 +33,31 @@ export interface ASRServiceOptions {
 
 /**
  * ASR 服务接口
- * 定义语音识别所需的方法
+ * 单会话模式：每个实例只管理一次语音识别
  */
 export interface IASRService {
   /**
-   * 准备 ASR 服务
-   * 只准备配置和缓冲区，不建立连接
-   * 用于在连接建立前缓存音频数据
-   * @param deviceId - 设备 ID
+   * 启动 ASR 识别会话
+   * 建立 ASR 连接并开始处理音频流
    */
-  prepare(deviceId: string): Promise<void>;
-
-  /**
-   * 建立 ASR 连接
-   * 建立 WebSocket 连接并开始处理音频流
-   * @param deviceId - 设备 ID
-   */
-  connect(deviceId: string): Promise<void>;
-
-  /**
-   * 初始化 ASR 语音识别服务（已弃用，请使用 prepare + connect）
-   * 如果已存在 ASR 客户端且已连接，则跳过初始化
-   * @param deviceId - 设备 ID
-   * @deprecated 使用 prepare() + connect() 替代
-   */
-  init(deviceId: string): Promise<void>;
+  start(): Promise<void>;
 
   /**
    * 处理音频数据
-   * 将音频数据推入队列，由 listen() 异步生成器消费
-   * 如果连接未建立，数据会被缓存直到连接建立
-   * @param deviceId - 设备 ID
+   * 将 Opus 音频数据推入流中，由 ASR 引擎消费
    * @param audioData - 裸 Opus 音频数据
    */
-  handleAudioData(deviceId: string, audioData: Uint8Array): Promise<void>;
+  handleAudioData(audioData: Uint8Array): Promise<void>;
 
   /**
-   * 结束 ASR 语音识别
-   * 标记音频结束，由 listen() 任务自动处理关闭
-   * @param deviceId - 设备 ID
+   * 结束 ASR 识别会话
+   * 结束音频流并等待识别完成
    */
-  end(deviceId: string): Promise<void>;
-
-  /**
-   * 重置 ASR 服务状态
-   * 清理资源但保留配置，准备下一次语音交互
-   * @param deviceId - 设备 ID
-   */
-  reset(deviceId: string): Promise<void>;
+  end(): Promise<void>;
 
   /**
    * 销毁服务
-   * 清理所有设备资源
+   * 清理所有资源
    */
   destroy(): void;
 }

--- a/apps/backend/services/asr.service.ts
+++ b/apps/backend/services/asr.service.ts
@@ -1,8 +1,9 @@
 /**
- * ASR 服务实现
- * 处理语音识别功能，使用 univoice SDK
+ * ASR 服务实现（单会话模式）
+ * 每个实例管理一次语音识别会话，使用 univoice SDK
  */
 
+import { Readable } from "node:stream";
 import { logger } from "@/Logger.js";
 import { configManager } from "@xiaozhi-client/config";
 import { createASR, decodeOpusStream } from "univoice/asr";
@@ -15,39 +16,21 @@ import type {
 } from "./asr.interface.js";
 
 /**
- * 设备 ASR 状态
- */
-interface DeviceASRState {
-  /** 是否已准备（缓冲区已初始化） */
-  prepared: boolean;
-  /** 是否正在连接 */
-  connecting: boolean;
-  /** 连接 Promise（用于等待连接完成） */
-  connectPromise?: Promise<void>;
-}
-
-/**
- * ASR 服务
- * 处理语音识别功能，通过回调通知识别结果
+ * ASR 服务（单会话模式）
+ * 每个实例只管理一次语音识别，ESP32Service 每次识别时创建新实例
  */
 export class ASRService implements IASRService {
   /** 事件回调 */
   private events: ASRServiceEvents;
 
-  /** 每个设备的 ASR 状态 */
-  private readonly deviceStates = new Map<string, DeviceASRState>();
+  /** ASR 连接实例 */
+  private connection?: ASRConnection;
 
-  /** 每个设备的 ASR 连接（预建立连接模式） */
-  private readonly asrConnections = new Map<string, ASRConnection>();
+  /** 音频数据输入流（替代队列轮询） */
+  private feedingStream?: Readable;
 
-  /** 每个设备的 Opus 音频数据队列 */
-  private readonly opusQueues = new Map<string, Buffer[]>();
-
-  /** 每个设备是否已结束音频输入 */
-  private readonly audioEnded = new Map<string, boolean>();
-
-  /** 每个设备的 listen 任务 */
-  private readonly listenTasks = new Map<string, Promise<void>>();
+  /** listen 任务 */
+  private listenTask?: Promise<void>;
 
   /**
    * 构造函数
@@ -58,105 +41,22 @@ export class ASRService implements IASRService {
   }
 
   /**
-   * 准备 ASR 服务
-   * 只准备配置和缓冲区，不建立连接
-   * 用于在连接建立前缓存音频数据
-   * @param deviceId - 设备 ID
+   * 启动 ASR 识别会话
+   * 创建 ASR 连接并开始处理音频流
    */
-  async prepare(deviceId: string): Promise<void> {
-    const state = this.getOrCreateDeviceState(deviceId);
-
-    // 如果已经准备好，跳过
-    if (state.prepared) {
-      logger.debug(`[ASRService] ASR 已准备好，跳过: deviceId=${deviceId}`);
-      return;
-    }
-
-    // 初始化音频队列
-    this.opusQueues.set(deviceId, []);
-    this.audioEnded.set(deviceId, false);
-    state.prepared = true;
-
-    logger.info(`[ASRService] ASR 服务已准备: deviceId=${deviceId}`);
-  }
-
-  /**
-   * 建立 ASR 连接
-   * 使用 univoice 的 connect() 预建立 WebSocket 连接
-   * @param deviceId - 设备 ID
-   */
-  async connect(deviceId: string): Promise<void> {
-    const state = this.getOrCreateDeviceState(deviceId);
-
-    // 如果已有连接，跳过
-    const existingConnection = this.asrConnections.get(deviceId);
-    if (existingConnection && existingConnection.state === "connected") {
-      logger.debug(`[ASRService] ASR 已连接，跳过: deviceId=${deviceId}`);
-      return;
-    }
-
-    // 如果正在连接，等待连接完成
-    if (state.connecting && state.connectPromise) {
-      logger.debug(`[ASRService] ASR 正在连接，等待: deviceId=${deviceId}`);
-      await state.connectPromise;
-      return;
-    }
-
-    // 标记正在连接
-    state.connecting = true;
-    state.connectPromise = this.doConnect(deviceId);
-
-    try {
-      await state.connectPromise;
-    } finally {
-      state.connecting = false;
-      state.connectPromise = undefined;
-    }
-  }
-
-  /**
-   * 执行实际的连接
-   * @param deviceId - 设备 ID
-   */
-  private async doConnect(deviceId: string): Promise<void> {
-    // 如果已存在连接，先关闭
-    const existingConnection = this.asrConnections.get(deviceId);
-    if (existingConnection) {
-      logger.warn(
-        `[ASRService] ASR 连接存在但状态异常，关闭旧的: deviceId=${deviceId}`
-      );
-      existingConnection.close();
-      this.asrConnections.delete(deviceId);
-    }
-
-    // 确保已准备
-    await this.prepare(deviceId);
-
-    // 创建 ASR 实例并建立连接
-    await this.createASRConnection(deviceId);
-
-    const connection = this.asrConnections.get(deviceId);
-    if (!connection || connection.state !== "connected") {
-      throw new Error(`[ASRService] ASR 连接建立失败: deviceId=${deviceId}`);
-    }
-
-    logger.info(`[ASRService] ASR 连接已建立: deviceId=${deviceId}`);
-  }
-
-  /**
-   * 创建 ASR 实例并建立连接
-   * @param deviceId - 设备 ID
-   */
-  private async createASRConnection(deviceId: string): Promise<void> {
+  async start(): Promise<void> {
     const asrConfig = configManager.getASRConfig();
 
     if (!asrConfig.appid || !asrConfig.accessToken) {
       throw new Error("[ASRService] ASR 配置不完整，请检查配置文件");
     }
 
-    // 创建 ASR 实例，配置字段映射：
-    // asrConfig.appid → appKey
-    // asrConfig.accessToken → accessKey
+    // 创建音频数据输入流
+    this.feedingStream = new Readable({
+      read() {},
+    });
+
+    // 创建 ASR 实例
     const asr = createASR({
       provider: "doubao",
       appKey: asrConfig.appid,
@@ -166,270 +66,120 @@ export class ASRService implements IASRService {
       codec: "raw",
     });
 
-    // 使用 connect() 预建立连接
     try {
-      const connection = await asr.connect();
-      this.asrConnections.set(deviceId, connection);
+      // 建立 ASR 连接
+      this.connection = await asr.connect();
 
-      // 启动 listen 任务处理音频流
-      const listenTask = this.startListenTask(deviceId, connection);
-      this.listenTasks.set(deviceId, listenTask);
+      // 将 feedingStream 转为 AsyncIterable 供 decodeOpusStream 使用
+      const pcmStream = decodeOpusStream(Readable.from(this.feedingStream), {
+        sampleRate: 24000,
+        channels: 1,
+      });
 
-      logger.info(
-        `[ASRService] ASR 连接已创建（univoice doubao）: deviceId=${deviceId}`
-      );
+      // 启动 listen 任务
+      this.listenTask = this.startListen(pcmStream);
+
+      logger.info("[ASRService] ASR 会话已启动");
     } catch (error) {
-      logger.error(
-        `[ASRService] ASR 连接建立失败: deviceId=${deviceId}`,
-        error
-      );
-      this.events.onError?.(deviceId, error as Error);
+      logger.error("[ASRService] ASR 连接建立失败", error);
+      this.events.onError?.(error as Error);
       throw error;
     }
   }
 
   /**
-   * 初始化 ASR 语音识别服务（已弃用，请使用 prepare + connect）
-   * 如果已存在 ASR 客户端且已连接，则跳过初始化
-   * @param deviceId - 设备 ID
-   * @deprecated 使用 prepare() + connect() 替代
-   */
-  async init(deviceId: string): Promise<void> {
-    // 兼容旧接口：准备 + 连接
-    await this.prepare(deviceId);
-    await this.connect(deviceId);
-  }
-
-  /**
    * 处理音频数据
-   * 将 Opus 音频数据推入队列，由 listen 任务通过 decodeOpusStream 消费
-   * 如果连接未建立，数据会被缓存直到连接建立
-   * @param deviceId - 设备 ID
+   * 将 Opus 音频数据推入流中
    * @param audioData - 裸 Opus 音频数据
    */
-  async handleAudioData(
-    deviceId: string,
-    audioData: Uint8Array
-  ): Promise<void> {
-    const audioBuffer = Buffer.from(audioData);
-    logger.debug(
-      `[ASRService] 收到音频数据: deviceId=${deviceId}, size=${audioData.length}`
-    );
-
-    const state = this.getOrCreateDeviceState(deviceId);
-
-    // 检查是否已准备好
-    if (!state.prepared) {
-      logger.warn(`[ASRService] ASR 未准备好，自动准备: deviceId=${deviceId}`);
-      await this.prepare(deviceId);
-    }
-
-    // 检查是否已经结束
-    if (this.audioEnded.get(deviceId)) {
-      logger.debug(`[ASRService] 音频已结束，忽略新数据: deviceId=${deviceId}`);
+  async handleAudioData(audioData: Uint8Array): Promise<void> {
+    if (!this.feedingStream) {
+      logger.warn("[ASRService] 流未初始化，忽略音频数据");
       return;
     }
 
-    // 获取或创建队列，直接缓存 Opus 数据
-    let queue = this.opusQueues.get(deviceId);
-    if (!queue) {
-      queue = [];
-      this.opusQueues.set(deviceId, queue);
-    }
-
-    queue.push(audioBuffer);
-    logger.debug(
-      `[ASRService] 已将 Opus 数据推入队列: deviceId=${deviceId}, queueLength=${queue.length}`
-    );
+    this.feedingStream.push(Buffer.from(audioData));
   }
 
   /**
-   * 获取或创建设备状态
+   * 结束 ASR 识别会话
+   * 结束音频流并等待识别完成
    */
-  private getOrCreateDeviceState(deviceId: string): DeviceASRState {
-    let state = this.deviceStates.get(deviceId);
-    if (!state) {
-      state = { prepared: false, connecting: false };
-      this.deviceStates.set(deviceId, state);
-    }
-    return state;
-  }
+  async end(): Promise<void> {
+    // 结束音频输入流
+    this.feedingStream?.push(null);
 
-  /**
-   * 创建异步生成器，从队列中读取 Opus 数据
-   * @param deviceId - 设备 ID
-   * @returns 异步生成器
-   */
-  private async *createOpusStream(
-    deviceId: string
-  ): AsyncGenerator<Buffer, void, unknown> {
-    let queue = this.opusQueues.get(deviceId);
-    if (!queue) {
-      queue = [];
-      this.opusQueues.set(deviceId, queue);
-    }
-
-    while (true) {
-      // 等待队列中有数据
-      while (queue.length === 0) {
-        // 检查是否已结束
-        if (this.audioEnded.get(deviceId)) {
-          logger.debug(`[ASRService] Opus 流结束: deviceId=${deviceId}`);
-          return;
-        }
-        // 短暂等待
-        await new Promise((resolve) => setTimeout(resolve, 50));
+    // 等待 listen 任务完成
+    if (this.listenTask) {
+      try {
+        await this.listenTask;
+      } catch (error) {
+        logger.error("[ASRService] 等待 listen 任务失败", error);
       }
-
-      // 从队列取出数据
-      const opusData = queue.shift()!;
-      yield opusData;
     }
+
+    // 关闭连接
+    this.connection?.close();
+
+    logger.info("[ASRService] ASR 会话已结束");
   }
 
   /**
    * 启动 listen 任务
-   * 使用 univoice 的 connection.listen() 处理音频流
-   * @param deviceId - 设备 ID
-   * @param connection - ASR 连接
+   * 使用 ASR 连接处理音频流并回调识别结果
+   * @param pcmStream - PCM 音频流
    */
-  private async startListenTask(
-    deviceId: string,
-    connection: ASRConnection
-  ): Promise<void> {
+  private async startListen(pcmStream: AsyncIterable<Buffer>): Promise<void> {
+    if (!this.connection) return;
+
     try {
-      // 创建 Opus 数据流
-      const opusStream = this.createOpusStream(deviceId);
-
-      // 使用 univoice 的 decodeOpusStream 将 Opus 解码为 PCM
-      const pcmStream = decodeOpusStream(opusStream, {
-        sampleRate: 24000,
-        channels: 1,
-      });
-
-      // 使用 connection.listen() 进行流式识别
-      for await (const result of connection.listen(pcmStream, {
+      for await (const result of this.connection.listen(pcmStream, {
         stream: true,
       })) {
         logger.info(
-          `[ASRService] ASR 识别结果: deviceId=${deviceId}, isFinal=${result.isFinal}, text=${result.text}`
+          `[ASRService] ASR 识别结果: isFinal=${result.isFinal}, text=${result.text}`
         );
 
-        // isFinal 时标记音频结束，停止 listen 循环，避免重复触发 LLM
+        // isFinal 时标记结束，避免重复触发 LLM
         if (result.isFinal) {
-          this.audioEnded.set(deviceId, true);
-          logger.info(
-            `[ASRService] ASR 识别完成，停止 listen: deviceId=${deviceId}`
-          );
+          logger.info("[ASRService] ASR 识别完成");
         }
 
-        // 触发结果回调，使用异常隔离避免回调抛错导致整条链路终止
+        // 触发结果回调
         try {
-          this.events.onResult?.(deviceId, result.text || "", result.isFinal);
+          this.events.onResult?.(result.text || "", result.isFinal);
         } catch (callbackError) {
-          logger.error(
-            `[ASRService] onResult 回调执行失败: deviceId=${deviceId}`,
-            callbackError
-          );
+          logger.error("[ASRService] onResult 回调执行失败", callbackError);
         }
 
-        // isFinal 时 break 停止 listen 循环
         if (result.isFinal) {
           break;
         }
       }
 
-      logger.info(`[ASRService] listen 任务完成: deviceId=${deviceId}`);
+      logger.info("[ASRService] listen 任务完成");
     } catch (error) {
-      logger.error(`[ASRService] listen 任务出错: deviceId=${deviceId}`, error);
-      this.events.onError?.(deviceId, error as Error);
+      logger.error("[ASRService] listen 任务出错", error);
+      this.events.onError?.(error as Error);
     }
-  }
-
-  /**
-   * 结束 ASR 语音识别
-   * 标记音频结束，由 listen() 任务自动处理关闭
-   * @param deviceId - 设备 ID
-   */
-  async end(deviceId: string): Promise<void> {
-    // 标记音频已结束
-    this.audioEnded.set(deviceId, true);
-
-    // 等待 listen 任务完成
-    const listenTask = this.listenTasks.get(deviceId);
-    if (listenTask) {
-      try {
-        await listenTask;
-        logger.info(`[ASRService] ASR listen 任务已结束: deviceId=${deviceId}`);
-      } catch (error) {
-        logger.error(
-          `[ASRService] 等待 listen 任务失败: deviceId=${deviceId}`,
-          error
-        );
-      }
-    }
-
-    // 关闭 ASR 连接
-    const connection = this.asrConnections.get(deviceId);
-    if (connection) {
-      try {
-        connection.close();
-      } catch (error) {
-        logger.error(
-          `[ASRService] ASR 连接关闭失败: deviceId=${deviceId}`,
-          error
-        );
-      }
-    }
-
-    // 清理资源
-    this.asrConnections.delete(deviceId);
-    this.opusQueues.delete(deviceId);
-    this.audioEnded.delete(deviceId);
-    this.listenTasks.delete(deviceId);
-
-    logger.info(`[ASRService] ASR 资源已清理: deviceId=${deviceId}`);
-  }
-
-  /**
-   * 重置 ASR 服务状态
-   * 清理资源但保留配置，准备下一次语音交互
-   * @param deviceId - 设备 ID
-   */
-  async reset(deviceId: string): Promise<void> {
-    logger.info(`[ASRService] 重置 ASR 服务状态: deviceId=${deviceId}`);
-
-    // 先结束当前会话
-    await this.end(deviceId);
-
-    // 重置状态
-    const state = this.deviceStates.get(deviceId);
-    if (state) {
-      state.prepared = false;
-      state.connecting = false;
-      state.connectPromise = undefined;
-    }
-
-    // 重新准备
-    await this.prepare(deviceId);
-
-    logger.info(`[ASRService] ASR 服务已重置: deviceId=${deviceId}`);
   }
 
   /**
    * 销毁服务
+   * 清理所有资源
    */
   destroy(): void {
-    // 关闭所有 ASR 连接
-    for (const connection of this.asrConnections.values()) {
-      connection.close();
-    }
-    this.asrConnections.clear();
-    // 清理音频队列相关状态
-    this.opusQueues.clear();
-    this.audioEnded.clear();
-    this.listenTasks.clear();
-    this.deviceStates.clear();
+    // 结束音频流
+    this.feedingStream?.push(null);
+    this.feedingStream?.destroy();
+    this.feedingStream = undefined;
+
+    // 关闭连接
+    this.connection?.close();
+    this.connection = undefined;
+
+    this.listenTask = undefined;
+
     logger.debug("[ASRService] 服务已销毁");
   }
 }

--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -52,19 +52,20 @@ export class ESP32Service {
 
     // 初始化语音服务
     this.llmService = new LLMService();
-    this.asrService = this.createASRService();
+    this.asrService = new ASRService();
     this.ttsService = this.createTTSService();
     this.setupTTSGetConnection();
   }
 
   /**
    * 创建 ASR 服务实例
+   * @param deviceId - 设备 ID（通过闭包绑定到回调中）
    * @returns ASR 服务实例
    */
-  private createASRService(): ASRService {
+  private createASRService(deviceId: string): ASRService {
     return new ASRService({
       events: {
-        onResult: async (deviceId, text, isFinal) => {
+        onResult: async (text, isFinal) => {
           // 如果是最终结果，触发 LLM 和 TTS
           if (isFinal && text) {
             const connection = this.connections.get(deviceId);
@@ -106,7 +107,7 @@ export class ESP32Service {
             this.recreateASRService();
           }
         },
-        onError: (deviceId, error) => {
+        onError: (error) => {
           logger.error(`[ESP32Service] ASR 错误: deviceId=${deviceId}`, error);
         },
       },
@@ -115,14 +116,16 @@ export class ESP32Service {
 
   /**
    * 重建 ASR 服务实例
-   * 销毁当前实例并创建新实例，确保每次识别都从干净的状态开始
+   * 销毁当前实例并创建新的空实例
+   * 下次 detect 时会通过 createASRService(deviceId) 创建绑定设备的实例
    */
   private recreateASRService(): void {
     logger.info("[ESP32Service] 重建 ASR 服务实例");
     if (this.asrService) {
       this.asrService.destroy();
     }
-    this.asrService = this.createASRService();
+    // 创建不绑定设备的空实例，等下次 detect 时再绑定
+    this.asrService = new ASRService();
     logger.info("[ESP32Service] ASR 服务实例已重建");
   }
 
@@ -161,14 +164,6 @@ export class ESP32Service {
     logger.info("[ESP32Service] 重建 LLM 服务实例");
     this.llmService = new LLMService();
     logger.info("[ESP32Service] LLM 服务实例已重建");
-  }
-
-  /**
-   * 获取 ASR 服务实例
-   * @returns ASR 服务实例
-   */
-  getASRService(): ASRService {
-    return this.asrService;
   }
 
   /**
@@ -323,8 +318,6 @@ export class ESP32Service {
           error
         );
       },
-      // 使用 getter 函数获取最新的 ASR 服务实例
-      getASRService: () => this.asrService,
     });
 
     this.connections.set(deviceId, connection);
@@ -352,8 +345,7 @@ export class ESP32Service {
     // 根据消息类型处理
     switch (message.type) {
       case "hello":
-        // ASR 初始化现在在 ESP32Connection.handleHello() 中处理
-        // 这里不再需要重复调用
+        // Hello 握手由 ESP32Connection 处理
         break;
       case "listen":
         // Listen消息处理（唤醒词检测和监听状态）
@@ -397,13 +389,15 @@ export class ESP32Service {
 
     switch (state) {
       case "detect":
-        // 检测到唤醒词，初始化 ASR
+        // 检测到唤醒词，创建绑定设备的 ASR 实例并启动会话
         if (text) {
           logger.info(
             `[ESP32Service] 处理唤醒词检测: deviceId=${deviceId}, word="${text}"`
           );
-          // 初始化 ASR 服务
-          await this.asrService.init(deviceId);
+          // 销毁旧实例，创建绑定当前设备的新实例
+          this.asrService.destroy();
+          this.asrService = this.createASRService(deviceId);
+          await this.asrService.start();
         } else {
           logger.warn(
             `[ESP32Service] 唤醒词消息缺少必要字段: text="${text}", mode=${mode}`
@@ -411,18 +405,14 @@ export class ESP32Service {
         }
         break;
       case "start":
+        // 连接已在 detect 阶段建立，无需额外操作
         logger.info(
           `[ESP32Service] 收到start消息: message=${JSON.stringify(message)}`
         );
-        // 开始监听，建立 ASR 连接
-        // 注意：硬件端会在发送 start 消息后立刻发送音频数据
-        // 所以这里需要尽快建立连接，音频数据会在缓冲区中等待
-        await this.asrService.connect(deviceId);
         if (mode === "manual" || mode === "realtime") {
           logger.info(
             `[ESP32Service] 开始手动/实时监听会话: deviceId=${deviceId}, mode=${mode}`
           );
-          // 开始会话
           const sessionId = `session_${deviceId}_${Date.now()}`;
           logger.info(
             `[ESP32Service] 语音会话已开始: deviceId=${deviceId}, sessionId=${sessionId}`
@@ -434,9 +424,9 @@ export class ESP32Service {
         }
         break;
       case "stop":
-        // 停止监听，中断当前会话
+        // 停止监听，结束当前会话
         logger.info(`[ESP32Service] 停止监听，中断会话: deviceId=${deviceId}`);
-        await this.asrService.end(deviceId);
+        await this.asrService.end();
         break;
       default:
         logger.warn(`[ESP32Service] 未知的监听状态: ${state}`);
@@ -482,7 +472,7 @@ export class ESP32Service {
     }
 
     // 交给 ASR 服务处理
-    await this.asrService.handleAudioData(deviceId, audioData);
+    await this.asrService.handleAudioData(audioData);
   }
 
   /**


### PR DESCRIPTION
## Summary
- 将 ASRService 从多设备管理简化为单会话服务，消除与 ESP32Service 的职责重复
- ASRService 代码从 435 行降至 185 行（-57%），净减 311 行
- 移除 connection.ts 中 ASR 耦合，Hello 阶段不再需要 prepare 调用

## Changes
- **asr.service.ts**: 移除 5 个 per-device Map，用 Readable stream push 模式替代 50ms 轮询，接口简化为 `start/handleAudioData/end/destroy`
- **asr.interface.ts**: 移除 deviceId 参数，删除已废弃的 init/prepare/connect/reset 方法声明
- **esp32.service.ts**: deviceId 通过闭包绑定到 ASR 回调，detect 阶段直接创建绑定设备的实例
- **connection.ts**: 移除 `getASRService` 配置和 Hello 阶段的 ASR prepare 调用

## Test plan
- [x] `pnpm check:type` — TypeScript 类型检查通过
- [x] `pnpm lint` — 代码规范检查通过
- [x] `pnpm test` — 944 个测试全通过
- [x] `pnpm build` — 构建验证通过
- [ ] 手动测试：连接 ESP32 设备，验证完整语音交互流程（唤醒 → 识别 → LLM → TTS）