### PR TITLE
fix(frontend): 使用统一日志系统替代 console.log/error/warn

### DIFF
--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -26,6 +26,7 @@ import {
   formToJson,
   jsonToFormData,
 } from "@/utils/mcpFormConverter";
+import { createLogger } from "@/utils/logger";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon } from "lucide-react";
@@ -33,6 +34,8 @@ import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
+
+const logger = createLogger("AddMcpServerButton");
 
 // 高级模式的 JSON 表单 schema
 const jsonFormSchema = z.object({
@@ -135,7 +138,7 @@ export function AddMcpServerButton() {
         form.reset();
         setOpen(false);
       } catch (error) {
-        console.error("更新配置失败:", error);
+        logger.error("更新配置失败:", error);
         toast.error(error instanceof Error ? error.message : "更新配置失败");
       } finally {
         setIsLoading(false);
@@ -193,7 +196,7 @@ export function AddMcpServerButton() {
         advancedForm.reset();
         setOpen(false);
       } catch (error) {
-        console.error("更新配置失败:", error);
+        logger.error("更新配置失败:", error);
         toast.error(error instanceof Error ? error.message : "更新配置失败");
       } finally {
         setIsLoading(false);

--- a/apps/frontend/src/components/common/collapsible-text.tsx
+++ b/apps/frontend/src/components/common/collapsible-text.tsx
@@ -1,8 +1,11 @@
 "use client";
 
 import { cn } from "@/lib/utils";
+import { createLogger } from "@/utils/logger";
 import { ChevronDownIcon, ChevronUpIcon } from "lucide-react";
 import { useEffect, useState } from "react";
+
+const logger = createLogger("CollapsibleText");
 
 /**
  * CollapsibleText 组件属性
@@ -60,7 +63,7 @@ export function CollapsibleText({
     try {
       localStorage.setItem(storageKey, String(isExpanded));
     } catch (error) {
-      console.warn("无法写入 localStorage:", error);
+      logger.warn("无法写入 localStorage:", error);
     }
   }, [isExpanded, storageKey]);
 

--- a/apps/frontend/src/components/install-log-dialog.tsx
+++ b/apps/frontend/src/components/install-log-dialog.tsx
@@ -21,6 +21,7 @@ import {
 import { Progress } from "@/components/ui/progress";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useNPMInstall } from "@/hooks/useNPMInstall";
+import { createLogger } from "@/utils/logger";
 import {
   CheckCircleIcon,
   ChevronDownIcon,
@@ -31,6 +32,8 @@ import {
 import type React from "react";
 import { useEffect, useRef, useState } from "react";
 import { toast } from "sonner";
+
+const logger = createLogger("InstallLogDialog");
 
 // 单个正则表达式匹配所有 ANSI 颜色转义序列，避免每次渲染时创建多个正则表达式
 const ANSI_PATTERN = /\[(0|31|32|33|34|35|36|37|90|91|92|93|94|95|96|97)m/g;
@@ -60,10 +63,10 @@ export function InstallLogDialog({
   // 对话框打开时开始安装
   useEffect(() => {
     if (isOpen && version) {
-      console.log("[InstallLogDialog] 对话框打开，开始安装版本:", version);
+      logger.info("[InstallLogDialog] 对话框打开，开始安装版本:", version);
       clearStatus();
       startInstall(version).catch((error) => {
-        console.error("[InstallLogDialog] 启动安装失败:", error);
+        logger.error("[InstallLogDialog] 启动安装失败:", error);
       });
     }
   }, [isOpen, version, startInstall, clearStatus]);

--- a/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-endpoint-setting-button.tsx
@@ -25,6 +25,7 @@ import { Input } from "@/components/ui/input";
 import { type EndpointStatusResponse, apiClient } from "@/services/api";
 import { webSocketManager } from "@/services/websocket";
 import { useConfig, useConfigActions, useMcpEndpoint } from "@/stores/config";
+import { createLogger } from "@/utils/logger";
 import {
   BadgeInfoIcon,
   CopyIcon,
@@ -37,6 +38,8 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { toast } from "sonner";
+
+const logger = createLogger("McpEndpointSettingButton");
 
 // 接入点状态接口
 interface EndpointState {
@@ -100,7 +103,7 @@ export function McpEndpointSettingButton() {
       try {
         return await apiClient.getEndpointStatus(endpoint);
       } catch (error) {
-        console.error(`获取接入点状态失败: ${endpoint}`, error);
+        logger.error(`获取接入点状态失败: ${endpoint}`, error);
         // 返回默认状态
         return {
           endpoint,
@@ -251,7 +254,7 @@ export function McpEndpointSettingButton() {
         }
       }
     } catch (error) {
-      console.error("复制失败:", error);
+      logger.error("复制失败:", error);
       toast.error("复制失败，请手动复制");
     }
   };
@@ -277,7 +280,7 @@ export function McpEndpointSettingButton() {
       setDeleteConfirmOpen(false);
       setEndpointToDelete("");
     } catch (error) {
-      console.error("删除接入点失败:", error);
+      logger.error("删除接入点失败:", error);
       toast.error(error instanceof Error ? error.message : "删除接入点失败");
     } finally {
       setIsDeleting(false);
@@ -334,7 +337,7 @@ export function McpEndpointSettingButton() {
       setNewEndpoint("");
       setValidationError("");
     } catch (error) {
-      console.error("添加接入点失败:", error);
+      logger.error("添加接入点失败:", error);
       toast.error(error instanceof Error ? error.message : "添加接入点失败");
     } finally {
       setIsAdding(false);
@@ -389,7 +392,7 @@ export function McpEndpointSettingButton() {
         (event: any) => {
           // 只处理当前端点的事件
           if (event.endpoint === endpoint) {
-            console.log(
+            logger.info(
               `[McpEndpointSettingButton] 接收到端点 ${endpoint} 状态变更:`,
               event
             );

--- a/apps/frontend/src/components/mcp-server-list.tsx
+++ b/apps/frontend/src/components/mcp-server-list.tsx
@@ -31,6 +31,7 @@ import {
   useMcpServers,
 } from "@/stores/config";
 import { getMcpServerCommunicationType } from "@/utils/mcpServerUtils";
+import { createLogger } from "@/utils/logger";
 import type {
   AppConfig,
   CozeWorkflow,
@@ -48,6 +49,8 @@ import { McpServerSettingButton } from "./mcp-server-setting-button";
 import { RemoveMcpServerButton } from "./remove-mcp-server-button";
 import { RestartButton } from "./restart-button";
 import { ToolDebugDialog } from "./tool-debug-dialog";
+
+const logger = createLogger("McpServerList");
 
 // 服务名称常量
 const UNKNOWN_SERVICE_NAME = "未知服务";
@@ -159,7 +162,7 @@ export function McpServerList({
       setEnabledTools(formattedEnabledTools);
       setDisabledTools(formattedDisabledTools);
     } catch (error) {
-      console.error("获取工具列表失败:", error);
+      logger.error("获取工具列表失败:", error);
       const errorMessage =
         error instanceof Error ? error.message : "获取工具列表失败";
       toast.error(errorMessage);
@@ -199,7 +202,7 @@ export function McpServerList({
       // 并行刷新配置数据和工具列表
       await Promise.all([refreshConfig(), fetchTools()]);
     } catch (error) {
-      console.error("刷新数据失败:", error);
+      logger.error("刷新数据失败:", error);
       toast.error("刷新数据失败");
     } finally {
       setIsRefreshing(false);
@@ -227,7 +230,7 @@ export function McpServerList({
       setEnabledTools(formattedEnabledTools);
       setDisabledTools(formattedDisabledTools);
     } catch (error) {
-      console.error("刷新工具列表失败:", error);
+      logger.error("刷新工具列表失败:", error);
       toast.error("刷新工具列表失败");
     }
   }, [formatTool]);
@@ -306,7 +309,7 @@ export function McpServerList({
       // 重新获取工具列表以更新状态
       await refreshToolLists();
     } catch (error) {
-      console.error("切换工具状态失败:", error);
+      logger.error("切换工具状态失败:", error);
       toast.error(error instanceof Error ? error.message : "切换工具状态失败");
     }
   };
@@ -322,7 +325,7 @@ export function McpServerList({
       toast.success(`删除工具 ${cozeToolToRemove} 成功`);
       await refreshToolLists();
     } catch (error) {
-      console.error("删除 Coze 工具失败:", error);
+      logger.error("删除 Coze 工具失败:", error);
       toast.error(
         error instanceof Error ? error.message : "删除 Coze 工具失败"
       );
@@ -453,7 +456,7 @@ export function McpServerList({
       // 刷新工具列表
       await refreshToolLists();
     } catch (error) {
-      console.error("更新工具参数配置失败:", error);
+      logger.error("更新工具参数配置失败:", error);
 
       let errorMessage = "更新工具参数配置失败，请重试";
       if (error instanceof Error) {

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -28,6 +28,7 @@ import {
   formToJson,
   jsonToFormData,
 } from "@/utils/mcpFormConverter";
+import { createLogger } from "@/utils/logger";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
@@ -36,6 +37,8 @@ import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
+
+const logger = createLogger("McpServerSettingButton");
 
 // 高级模式的 JSON 表单 schema
 const jsonFormSchema = z.object({
@@ -164,7 +167,7 @@ export function McpServerSettingButton({
 
         setOpen(false);
       } catch (error) {
-        console.error("更新配置失败:", error);
+        logger.error("更新配置失败:", error);
         toast.error(error instanceof Error ? error.message : "更新配置失败");
       } finally {
         setIsLoading(false);
@@ -235,7 +238,7 @@ export function McpServerSettingButton({
 
         setOpen(false);
       } catch (error) {
-        console.error("更新配置失败:", error);
+        logger.error("更新配置失败:", error);
         toast.error(error instanceof Error ? error.message : "更新配置失败");
       } finally {
         setIsLoading(false);

--- a/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
+++ b/apps/frontend/src/components/mcp-tool/mcp-tool-table.tsx
@@ -28,6 +28,7 @@ import { useToolSearch } from "@/hooks/useToolSearch";
 import { useToolSortPersistence } from "@/hooks/useToolSortPersistence";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
+import { createLogger } from "@/utils/logger";
 import type { CustomMCPToolWithStats } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon, Loader2, ZapIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
@@ -35,6 +36,8 @@ import { toast } from "sonner";
 import { ToolPagination } from "./tool-pagination";
 import { ToolSearchInput } from "./tool-search-input";
 import { ToolSortSelector } from "./tool-sort-selector";
+
+const logger = createLogger("McpToolTable");
 
 // 服务名称常量
 const UNKNOWN_SERVICE_NAME = "未知服务";
@@ -174,7 +177,7 @@ export function McpToolTable({
     try {
       await loadToolsData();
     } catch (err) {
-      console.error("获取工具列表失败:", err);
+      logger.error("获取工具列表失败:", err);
       setError(err instanceof Error ? err.message : "获取工具列表失败");
       toast.error("获取工具列表失败");
     } finally {
@@ -187,7 +190,7 @@ export function McpToolTable({
     try {
       await loadToolsData();
     } catch (err) {
-      console.error("刷新工具列表失败:", err);
+      logger.error("刷新工具列表失败:", err);
       toast.error("刷新工具列表失败");
     }
   }, [loadToolsData]);
@@ -250,7 +253,7 @@ export function McpToolTable({
 
         await refreshToolLists();
       } catch (err) {
-        console.error("切换工具状态失败:", err);
+        logger.error("切换工具状态失败:", err);
         toast.error(err instanceof Error ? err.message : "切换工具状态失败");
       }
     },
@@ -266,7 +269,7 @@ export function McpToolTable({
       toast.success(`删除工具 ${cozeToolToRemove} 成功`);
       await refreshToolLists();
     } catch (err) {
-      console.error("删除 Coze 工具失败:", err);
+      logger.error("删除 Coze 工具失败:", err);
       toast.error(err instanceof Error ? err.message : "删除 Coze 工具失败");
     } finally {
       setCozeToolToRemove(null);

--- a/apps/frontend/src/components/remove-mcp-server-button.tsx
+++ b/apps/frontend/src/components/remove-mcp-server-button.tsx
@@ -20,9 +20,12 @@ import {
 } from "@/components/ui/alert-dialog";
 import { cn } from "@/lib/utils";
 import { apiClient } from "@/services/api";
+import { createLogger } from "@/utils/logger";
 import { TrashIcon } from "lucide-react";
 import { useState } from "react";
 import { toast } from "sonner";
+
+const logger = createLogger("RemoveMcpServerButton");
 
 export function RemoveMcpServerButton({
   mcpServerName,
@@ -53,7 +56,7 @@ export function RemoveMcpServerButton({
         await onRemoveSuccess();
       }
     } catch (error) {
-      console.error("删除 MCP 服务失败:", error);
+      logger.error("删除 MCP 服务失败:", error);
       toast.error(
         `删除 MCP 服务失败: ${error instanceof Error ? error.message : "未知错误"}`
       );

--- a/apps/frontend/src/components/restart-button.tsx
+++ b/apps/frontend/src/components/restart-button.tsx
@@ -1,7 +1,10 @@
 import { Button } from "@/components/ui/button";
 import { useRestartPollingStatus, useStatusStore } from "@/stores/status";
+import { createLogger } from "@/utils/logger";
 import clsx from "clsx";
 import { LoaderCircleIcon, PowerIcon } from "lucide-react";
+
+const logger = createLogger("RestartButton");
 
 /**
  * RestartButton 组件属性接口
@@ -50,7 +53,7 @@ export function RestartButton({
     try {
       await restartService();
     } catch (error) {
-      console.error("[RestartButton] 重启失败:", error);
+      logger.error("重启失败:", error);
     }
   };
 

--- a/apps/frontend/src/components/system-setting-dialog.tsx
+++ b/apps/frontend/src/components/system-setting-dialog.tsx
@@ -26,6 +26,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { useWebSocketActions } from "@/providers/WebSocketProvider";
 import { useConfig } from "@/stores/config";
+import { createLogger } from "@/utils/logger";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import { SettingsIcon } from "lucide-react";
@@ -33,6 +34,8 @@ import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
+
+const logger = createLogger("SystemSettingDialog");
 
 const formSchema = z.object({
   modelscope: z.object({
@@ -131,7 +134,7 @@ export function SystemSettingDialog() {
       toast.success("配置已更新");
       setOpen(false);
     } catch (error) {
-      console.error("更新配置失败:", error);
+      logger.error("更新配置失败:", error);
       toast.error(error instanceof Error ? error.message : "更新配置失败");
     } finally {
       setIsLoading(false);

--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -40,6 +40,7 @@ import {
   formatTimestamp,
   generateStableKey,
 } from "@/utils/formatUtils";
+import { createLogger } from "@/utils/logger";
 import type {
   ApiResponse,
   ToolCallLogsResponse,
@@ -57,6 +58,8 @@ import {
   XCircle,
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
+
+const logger = createLogger("ToolCallLogsDialog");
 
 export function ToolCallLogsDialog() {
   const [open, setOpen] = useState(false);
@@ -90,7 +93,7 @@ export function ToolCallLogsDialog() {
         }
       } catch (err) {
         setError("网络请求失败");
-        console.error("获取工具调用日志失败:", err);
+        logger.error("获取工具调用日志失败:", err);
       } finally {
         if (isRefresh) {
           setRefreshing(false);
@@ -353,7 +356,7 @@ function CopyButton({
         setCopied(false);
       }, 3000);
     } catch (error) {
-      console.error("复制失败:", error);
+      logger.error("复制失败:", error);
     }
   };
 

--- a/apps/frontend/src/components/version-display.tsx
+++ b/apps/frontend/src/components/version-display.tsx
@@ -19,9 +19,12 @@ import {
 } from "@/components/ui/tooltip";
 import type { VersionInfo } from "@/services/api";
 import { apiClient } from "@/services/api";
+import { createLogger } from "@/utils/logger";
 import { CopyIcon, InfoIcon, RocketIcon } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import { VersionUpgradeDialog } from "./version-upgrade-dialog";
+
+const logger = createLogger("VersionDisplay");
 
 interface VersionDisplayProps {
   className?: string;
@@ -53,7 +56,7 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         setVersionInfo(info);
       } catch (err) {
         setError(err instanceof Error ? err.message : "获取版本信息失败");
-        console.error("获取版本信息失败:", err);
+        logger.error("获取版本信息失败:", err);
       } finally {
         setLoading(false);
       }
@@ -77,7 +80,7 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         const updateInfo = await apiClient.getLatestVersion();
         setLatestVersionInfo(updateInfo);
       } catch (err) {
-        console.error("检查更新失败:", err);
+        logger.error("检查更新失败:", err);
         // 设置默认值，不显示错误给用户
         setLatestVersionInfo({
           currentVersion: versionInfo?.version || "unknown",
@@ -106,7 +109,7 @@ export function VersionDisplay({ className }: VersionDisplayProps) {
         }
         copiedTimerRef.current = setTimeout(() => setCopied(false), 2000);
       } catch (err) {
-        console.error("复制版本号失败:", err);
+        logger.error("复制版本号失败:", err);
       }
     }
   };

--- a/apps/frontend/src/components/version-manager.tsx
+++ b/apps/frontend/src/components/version-manager.tsx
@@ -18,6 +18,7 @@ import {
   CardTitle,
 } from "@/components/ui/card";
 import { apiClient } from "@/services/api";
+import { createLogger } from "@/utils/logger";
 import {
   AlertCircle,
   Calendar,
@@ -30,6 +31,8 @@ import {
 import { useCallback, useEffect, useRef, useState } from "react";
 import { InstallLogDialog } from "./install-log-dialog";
 import { VersionDisplay } from "./version-display";
+
+const logger = createLogger("VersionManager");
 
 interface VersionInfo {
   name: string;
@@ -65,12 +68,12 @@ export function VersionManager() {
       setError(null);
       const versionInfo = await apiClient.getVersion();
       setCurrentVersion(versionInfo);
-      console.log("[VersionManager] 当前版本信息:", versionInfo);
+      logger.info("[VersionManager] 当前版本信息:", versionInfo);
     } catch (err) {
       const errorMessage =
         err instanceof Error ? err.message : "获取版本信息失败";
       setError(errorMessage);
-      console.error("[VersionManager] 获取版本信息失败:", err);
+      logger.error("[VersionManager] 获取版本信息失败:", err);
     }
   }, []);
 
@@ -84,7 +87,7 @@ export function VersionManager() {
 
       // 这里可以调用检查更新的 API
       // 暂时模拟一个检查更新的过程
-      console.log("[VersionManager] 检查更新...");
+      logger.info("[VersionManager] 检查更新...");
 
       // 模拟 API 调用延迟
       await new Promise((resolve) => setTimeout(resolve, 1000));
@@ -100,11 +103,11 @@ export function VersionManager() {
       };
 
       setUpdateInfo(mockUpdateInfo);
-      console.log("[VersionManager] 更新检查结果:", mockUpdateInfo);
+      logger.info("[VersionManager] 更新检查结果:", mockUpdateInfo);
     } catch (err) {
       const errorMessage = err instanceof Error ? err.message : "检查更新失败";
       setError(errorMessage);
-      console.error("[VersionManager] 检查更新失败:", err);
+      logger.error("[VersionManager] 检查更新失败:", err);
     } finally {
       setIsLoading(false);
     }
@@ -112,7 +115,7 @@ export function VersionManager() {
 
   // 开始更新
   const startUpdate = (version: string) => {
-    console.log("[VersionManager] 开始更新到版本:", version);
+    logger.info("[VersionManager] 开始更新到版本:", version);
     setTargetVersion(version);
     setShowInstallDialog(true);
   };

--- a/apps/frontend/src/components/version-upgrade-dialog.tsx
+++ b/apps/frontend/src/components/version-upgrade-dialog.tsx
@@ -26,10 +26,13 @@ import {
 } from "@/components/ui/select";
 import { useNPMInstall } from "@/hooks/useNPMInstall";
 import { apiClient } from "@/services/api";
+import { createLogger } from "@/utils/logger";
 import { DownloadIcon, ShieldAlertIcon } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import semver from "semver";
 import { InstallLogDialog } from "./install-log-dialog";
+
+const logger = createLogger("VersionUpgradeDialog");
 
 interface VersionUpgradeDialogProps {
   children?: React.ReactNode;
@@ -73,7 +76,7 @@ export function VersionUpgradeDialog({
           label: `v${version}`,
         }));
         setAvailableVersions(versions);
-        console.log(
+        logger.info(
           `[VersionUpgradeDialog] 获取到 ${response.total} 个${type}版本`
         );
         if (
@@ -83,7 +86,7 @@ export function VersionUpgradeDialog({
           setSelectedVersion(defaultSelectedVersion || "");
         }
       } catch (error) {
-        console.error("[VersionUpgradeDialog] 获取版本列表失败:", error);
+        logger.error("[VersionUpgradeDialog] 获取版本列表失败:", error);
         // 如果获取失败，使用默认版本列表
         const defaultVersions = [] as { value: string; label: string }[];
         setAvailableVersions(defaultVersions);
@@ -119,7 +122,7 @@ export function VersionUpgradeDialog({
     }
 
     try {
-      console.log("[VersionUpgradeDialog] 开始安装版本:", selectedVersion);
+      logger.info("[VersionUpgradeDialog] 开始安装版本:", selectedVersion);
 
       // 关闭版本选择对话框
       setIsOpen(false);
@@ -130,7 +133,7 @@ export function VersionUpgradeDialog({
       // 开始安装
       await startInstall(selectedVersion);
     } catch (error) {
-      console.error("[VersionUpgradeDialog] 安装失败:", error);
+      logger.error("[VersionUpgradeDialog] 安装失败:", error);
       // 如果安装失败，关闭安装日志对话框
       setShowInstallDialog(false);
     }

--- a/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
+++ b/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
@@ -39,6 +39,7 @@ import { Separator } from "@/components/ui/separator";
 import { useWebSocketActions } from "@/providers/WebSocketProvider";
 import { type PromptFileInfo, apiClient } from "@/services/api";
 import { useConfig } from "@/stores/config";
+import { createLogger } from "@/utils/logger";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type {
   ASRConfig,
@@ -52,6 +53,8 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
+
+const logger = createLogger("VoiceInteractionSettingDialog");
 
 /**
  * 语音交互配置表单 Schema
@@ -156,7 +159,7 @@ export function VoiceInteractionSettingDialog() {
       const files = await apiClient.getPromptFiles();
       setPromptFiles(files);
     } catch (error) {
-      console.error("加载提示词文件列表失败:", error);
+      logger.error("加载提示词文件列表失败:", error);
       setPromptFiles([]);
     } finally {
       setIsLoadingPrompts(false);
@@ -170,7 +173,7 @@ export function VoiceInteractionSettingDialog() {
       const response = await apiClient.getTTSVoices();
       setVoices(response.voices);
     } catch (error) {
-      console.error("加载音色列表失败:", error);
+      logger.error("加载音色列表失败:", error);
       setVoices([]);
     } finally {
       setIsLoadingVoices(false);
@@ -270,7 +273,7 @@ export function VoiceInteractionSettingDialog() {
       toast.success("语音交互配置已更新");
       setOpen(false);
     } catch (error) {
-      console.error("更新语音交互配置失败:", error);
+      logger.error("更新语音交互配置失败:", error);
       toast.error(error instanceof Error ? error.message : "更新配置失败");
     } finally {
       setIsLoading(false);

--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -23,12 +23,15 @@ import {
   useWebSocketConnected,
   useWebSocketPortChangeStatus,
 } from "@/stores/websocket";
+import { createLogger } from "@/utils/logger";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { SettingsIcon } from "lucide-react";
 import { useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
 import z from "zod";
+
+const logger = createLogger("WebUrlSettingButton");
 
 const formSchema = z.object({
   port: z
@@ -101,7 +104,7 @@ export function WebUrlSettingButton() {
       return;
     }
 
-    console.log(
+    logger.info(
       `[WebUrlSettingButton] 开始端口切换: ${currentPort} -> ${newPort}`
     );
     setIsLoading(true);
@@ -124,7 +127,7 @@ export function WebUrlSettingButton() {
       );
       setOpen(false);
     } catch (error) {
-      console.error("端口切换失败:", error);
+      logger.error("端口切换失败:", error);
       const errorMessage =
         error instanceof Error ? error.message : "端口切换失败";
       toast.error(`端口切换失败: ${errorMessage}`);

--- a/apps/frontend/src/providers/WebSocketProvider.tsx
+++ b/apps/frontend/src/providers/WebSocketProvider.tsx
@@ -31,6 +31,7 @@
  */
 import { useNetworkService } from "@/hooks/useNetworkService";
 import { initializeStores } from "@/stores/index";
+import { createLogger } from "@/utils/logger";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
 import {
   type ReactNode,
@@ -39,6 +40,8 @@ import {
   useEffect,
   useState,
 } from "react";
+
+const logger = createLogger("WebSocketProvider");
 
 interface NetworkServiceContextType {
   // HTTP API 方法
@@ -88,15 +91,15 @@ export function NetworkServiceProvider({
 
     const initStores = async () => {
       try {
-        console.log("[WebSocketProvider] 开始初始化 stores");
+        logger.info("开始初始化 stores");
         await initializeStores();
 
         if (mounted) {
           setStoresInitialized(true);
-          console.log("[WebSocketProvider] Stores 初始化完成");
+          logger.info("Stores 初始化完成");
         }
       } catch (error) {
-        console.error("[WebSocketProvider] Stores 初始化失败:", error);
+        logger.error("Stores 初始化失败:", error);
         // 即使初始化失败，也允许应用继续运行
         if (mounted) {
           setStoresInitialized(true);

--- a/apps/frontend/src/utils/logger.ts
+++ b/apps/frontend/src/utils/logger.ts
@@ -1,0 +1,222 @@
+/**
+ * 前端统一日志服务
+ *
+ * 提供统一的日志接口，替代 console.log/error/warn
+ * 支持日志级别控制和环境区分
+ */
+
+/**
+ * 日志级别枚举
+ */
+export enum LogLevel {
+  TRACE = "trace",
+  DEBUG = "debug",
+  INFO = "info",
+  WARN = "warn",
+  ERROR = "error",
+  FATAL = "fatal",
+}
+
+/**
+ * 日志配置
+ */
+interface LoggerConfig {
+  /** 当前日志级别，低于此级别的日志不会输出 */
+  level: LogLevel;
+  /** 是否在生产环境输出日志 */
+  enableInProduction: boolean;
+  /** 日志前缀 */
+  prefix?: string;
+}
+
+/**
+ * 判断是否为开发环境
+ * 在 Vite 项目中，import.meta.env.DEV 在开发模式下为 true
+ */
+const isDev = typeof import.meta !== "undefined" && (import.meta as { env?: { DEV?: boolean } }).env?.DEV;
+
+/**
+ * 默认配置
+ * 开发环境: DEBUG 级别，允许输出
+ * 生产环境: WARN 级别，默认禁止输出（可通过配置开启）
+ */
+const defaultConfig: LoggerConfig = {
+  level: isDev ? LogLevel.DEBUG : LogLevel.WARN,
+  enableInProduction: false,
+};
+
+/**
+ * 日志级别优先级映射
+ */
+const levelPriority: Record<LogLevel, number> = {
+  [LogLevel.TRACE]: 0,
+  [LogLevel.DEBUG]: 1,
+  [LogLevel.INFO]: 2,
+  [LogLevel.WARN]: 3,
+  [LogLevel.ERROR]: 4,
+  [LogLevel.FATAL]: 5,
+};
+
+/**
+ * 日志级别对应的 console 方法
+ */
+const levelToConsole: Record<LogLevel, "log" | "info" | "warn" | "error"> = {
+  [LogLevel.TRACE]: "log",
+  [LogLevel.DEBUG]: "log",
+  [LogLevel.INFO]: "info",
+  [LogLevel.WARN]: "warn",
+  [LogLevel.ERROR]: "error",
+  [LogLevel.FATAL]: "error",
+};
+
+/**
+ * 日志级别对应的样式
+ */
+const levelStyles: Record<LogLevel, string> = {
+  [LogLevel.TRACE]: "color: gray",
+  [LogLevel.DEBUG]: "color: cyan",
+  [LogLevel.INFO]: "color: blue",
+  [LogLevel.WARN]: "color: orange",
+  [LogLevel.ERROR]: "color: red",
+  [LogLevel.FATAL]: "color: red; font-weight: bold",
+};
+
+/**
+ * 判断是否为生产环境
+ */
+const isProduction = !isDev;
+
+/**
+ * 创建 Logger 实例
+ */
+class Logger {
+  private config: LoggerConfig;
+
+  constructor(config: Partial<LoggerConfig> = {}) {
+    this.config = { ...defaultConfig, ...config };
+  }
+
+  /**
+   * 更新配置
+   */
+  updateConfig(config: Partial<LoggerConfig>): void {
+    this.config = { ...this.config, ...config };
+  }
+
+  /**
+   * 检查是否应该输出日志
+   */
+  private shouldLog(level: LogLevel): boolean {
+    // 生产环境检查
+    if (!this.config.enableInProduction && isProduction) {
+      return false;
+    }
+
+    // 级别检查
+    return levelPriority[level] >= levelPriority[this.config.level];
+  }
+
+  /**
+   * 格式化日志消息
+   */
+  private formatMessage(level: LogLevel, message: string): string {
+    const timestamp = new Date().toISOString();
+    const levelStr = level.toUpperCase();
+    const prefix = this.config.prefix ? `[${this.config.prefix}] ` : "";
+
+    return `${prefix}${timestamp} [${levelStr}] ${message}`;
+  }
+
+  /**
+   * 输出日志
+   */
+  private log(
+    level: LogLevel,
+    message: string,
+    ...args: unknown[]
+  ): void {
+    if (!this.shouldLog(level)) {
+      return;
+    }
+
+    const consoleMethod = levelToConsole[level];
+    const formattedMessage = this.formatMessage(level, message);
+
+    // 开发环境使用彩色输出
+    if (isDev) {
+      console[consoleMethod](
+        `%c${formattedMessage}`,
+        levelStyles[level],
+        ...args
+      );
+    } else {
+      console[consoleMethod](formattedMessage, ...args);
+    }
+  }
+
+  /**
+   * 输出 TRACE 级别日志
+   */
+  trace(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.TRACE, message, ...args);
+  }
+
+  /**
+   * 输出 DEBUG 级别日志
+   */
+  debug(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.DEBUG, message, ...args);
+  }
+
+  /**
+   * 输出 INFO 级别日志
+   */
+  info(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.INFO, message, ...args);
+  }
+
+  /**
+   * 输出 WARN 级别日志
+   */
+  warn(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.WARN, message, ...args);
+  }
+
+  /**
+   * 输出 ERROR 级别日志
+   */
+  error(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.ERROR, message, ...args);
+  }
+
+  /**
+   * 输出 FATAL 级别日志
+   */
+  fatal(message: string, ...args: unknown[]): void {
+    this.log(LogLevel.FATAL, message, ...args);
+  }
+}
+
+/**
+ * 默认 Logger 实例
+ */
+export const logger = new Logger();
+
+/**
+ * 创建带前缀的 Logger 实例
+ * @param prefix 日志前缀，用于区分不同模块
+ * @returns Logger 实例
+ */
+export function createLogger(prefix: string): Logger {
+  return new Logger({ prefix });
+}
+
+/**
+ * 配置全局 Logger
+ */
+export function configureLogger(config: Partial<LoggerConfig>): void {
+  logger.updateConfig(config);
+}
+
+// 导出 Logger 类以供高级使用
+export { Logger };


### PR DESCRIPTION
修复 Issue #3032：apps/frontend/src/components 和 providers 目录下约40处 console 使用违反项目日志规范

主要更改：
- 创建 apps/frontend/src/utils/logger.ts 统一日志服务
- 支持 DEBUG/INFO/WARN/ERROR/FATAL 日志级别
- 开发环境彩色输出，生产环境可配置
- 替换所有 console.log -> logger.info/debug
- 替换所有 console.error -> logger.error
- 替换所有 console.warn -> logger.warn

修改文件：
- providers/WebSocketProvider.tsx (3处)
- components/restart-button.tsx (1处)
- components/mcp-server-setting-button.tsx (2处)
- components/common/collapsible-text.tsx (1处)
- components/mcp-server-list.tsx (7处)
- components/version-manager.tsx (7处)
- components/voice-interaction-setting-dialog.tsx (3处)
- components/add-mcp-server-button.tsx (2处)
- components/install-log-dialog.tsx (2处)
- components/mcp-tool/mcp-tool-table.tsx (4处)
- components/system-setting-dialog.tsx (1处)
- components/version-display.tsx (3处)
- components/mcp-endpoint-setting-button.tsx (4处)
- components/tool-call-logs-dialog.tsx (2处)
- components/version-upgrade-dialog.tsx (4处)
- components/remove-mcp-server-button.tsx (1处)
- components/web-url-setting-button.tsx (2处)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3032