### PR TITLE
fix(types): 使用具体类型替换 event-bus.service.ts 中的 any 类型

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -14,8 +14,10 @@
 import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
+import type { MCPServerAddResult } from "@/handlers/mcp-manage.handler.js";
 import type { ClientInfo } from "@/services/status.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
 
 /**
  * 事件类型定义
@@ -126,7 +128,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };
@@ -160,7 +162,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {


### PR DESCRIPTION
- 将 `mcp:server:added` 事件的 `config: any` 替换为 `MCPServerConfig`
- 将 `mcp:server:batch_added` 事件的 `results: any[]` 替换为 `MCPServerAddResult[]`
- 使用 `@xiaozhi-client/config` 的 MCPServerConfig 类型以保持与 backend 类型系统的兼容性
- 使用本地 handler 的 MCPServerAddResult 类型以避免类型冲突

Closes #3035

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3035