### PR TITLE
fix(cli): 修复 DaemonManager.attachToLogs SIGINT 处理器泄漏问题

### DIFF
--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -43,6 +43,8 @@ export interface DaemonOptions {
  */
 export class DaemonManagerImpl implements IDaemonManager {
   private currentDaemon: ChildProcess | null = null;
+  /** SIGINT 处理器引用，用于清理 */
+  private sigintHandler: (() => void) | null = null;
 
   constructor(private processManager: ProcessManager) {}
 
@@ -161,21 +163,39 @@ export class DaemonManagerImpl implements IDaemonManager {
       const { command, args } = PlatformUtils.getTailCommand(logFilePath);
       const tail = spawn(command, args, { stdio: "inherit" });
 
-      // 处理中断信号
-      process.once("SIGINT", () => {
+      // 创建处理器函数并保存引用
+      this.sigintHandler = () => {
         console.log("\n断开连接，服务继续在后台运行");
         tail.kill();
         process.exit(0);
-      });
+      };
+
+      // 注册 SIGINT 处理器
+      process.on("SIGINT", this.sigintHandler);
+
+      // 移除 SIGINT 处理器的辅助函数
+      const removeSigintHandler = () => {
+        if (this.sigintHandler) {
+          process.removeListener("SIGINT", this.sigintHandler);
+          this.sigintHandler = null;
+        }
+      };
 
       tail.on("exit", () => {
+        removeSigintHandler();
         process.exit(0);
       });
 
       tail.on("error", (error) => {
+        removeSigintHandler();
         throw new ServiceError(`连接日志失败: ${error.message}`);
       });
     } catch (error) {
+      // 在异常时移除处理器
+      if (this.sigintHandler) {
+        process.removeListener("SIGINT", this.sigintHandler);
+        this.sigintHandler = null;
+      }
       throw new ServiceError(
         `连接日志失败: ${error instanceof Error ? error.message : String(error)}`
       );
@@ -315,6 +335,12 @@ export class DaemonManagerImpl implements IDaemonManager {
    * 清理守护进程资源
    */
   cleanup(): void {
+    // 清理 SIGINT 处理器
+    if (this.sigintHandler) {
+      process.removeListener("SIGINT", this.sigintHandler);
+      this.sigintHandler = null;
+    }
+
     if (this.currentDaemon) {
       try {
         this.currentDaemon.kill("SIGTERM");


### PR DESCRIPTION
每次调用 attachToLogs 都会注册新的 SIGINT 处理器但未正确清理，
导致 MaxListenersExceededWarning 和潜在的内存泄漏。

修复方案：
- 添加 sigintHandler 属性保存处理器引用
- 使用 process.on() 替代 process.once() 以便主动清理
- 在 tail exit/error/catch 和 cleanup() 中移除处理器

关闭 #3048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3048