### PR TITLE
refactor(esp32): 修复 ESP32Service 依赖注入问题

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -54,8 +54,10 @@ import {
 } from "@/middlewares/index.js";
 import type { EventBus, EventBusEvents } from "@/services/index.js";
 import {
+  ASRService,
   DeviceRegistryService,
   ESP32Service,
+  LLMService,
   NotificationService,
   StatusService,
   destroyEventBus,
@@ -188,8 +190,15 @@ export class WebServer {
     this.statusService = new StatusService();
     this.notificationService = new NotificationService();
     this.deviceRegistryService = new DeviceRegistryService();
-    // 创建 ESP32 服务
-    this.esp32Service = new ESP32Service(this.deviceRegistryService);
+    // 初始化语音服务
+    const llmService = new LLMService();
+    const asrService = new ASRService();
+    // 创建 ESP32 服务（依赖注入）
+    this.esp32Service = new ESP32Service(
+      this.deviceRegistryService,
+      llmService,
+      asrService
+    );
     // 设置 TTS 服务的获取连接回调
     this.esp32Service.setupTTSGetConnection();
 

--- a/apps/backend/services/__tests__/esp32.service.test.ts
+++ b/apps/backend/services/__tests__/esp32.service.test.ts
@@ -5,8 +5,10 @@
 
 import type { ESP32DeviceReport } from "@/types/esp32.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { ASRService } from "../asr.service.js";
 import { DeviceRegistryService } from "../device-registry.service.js";
 import { ESP32Service } from "../esp32.service.js";
+import { LLMService } from "../llm.service.js";
 
 // Mock dependencies
 vi.mock("../../Logger.js", () => ({
@@ -51,8 +53,12 @@ describe("ESP32Service", () => {
     // 创建设备注册服务
     deviceRegistry = new DeviceRegistryService();
 
-    // 创建ESP32服务（使用默认的空实现语音服务）
-    esp32Service = new ESP32Service(deviceRegistry);
+    // 创建语音服务（依赖注入）
+    const llmService = new LLMService();
+    const asrService = new ASRService();
+
+    // 创建ESP32服务（依赖注入）
+    esp32Service = new ESP32Service(deviceRegistry, llmService, asrService);
 
     // Mock WebSocket
     mockWebSocket = {

--- a/apps/backend/services/esp32.service.ts
+++ b/apps/backend/services/esp32.service.ts
@@ -44,15 +44,19 @@ export class ESP32Service {
   /**
    * 构造函数
    * @param deviceRegistry - 设备注册服务
+   * @param llmService - LLM 服务实例
+   * @param asrService - ASR 服务实例
    */
-  constructor(deviceRegistry: DeviceRegistryService) {
+  constructor(
+    deviceRegistry: DeviceRegistryService,
+    llmService: LLMService,
+    asrService: ASRService
+  ) {
     this.deviceRegistry = deviceRegistry;
+    this.llmService = llmService;
+    this.asrService = asrService;
     this.connections = new Map();
     this.clientIdToDeviceId = new Map();
-
-    // 初始化语音服务
-    this.llmService = new LLMService();
-    this.asrService = new ASRService();
     this.ttsService = this.createTTSService();
     this.setupTTSGetConnection();
   }

--- a/apps/backend/services/index.ts
+++ b/apps/backend/services/index.ts
@@ -27,6 +27,8 @@ export * from "./notification.service.js";
 export * from "./event-bus.service.js";
 export * from "./device-registry.service.js";
 export * from "./esp32.service.js";
+export * from "./llm.service.js";
+export * from "./asr.service.js";
 
 // CustomMCPHandler 重新导出 - 保持向后兼容性
 export { CustomMCPHandler } from "@/lib/mcp/custom.js";


### PR DESCRIPTION
将 LLMService 和 ASRService 通过构造函数参数注入，而不是在构造函数中直接创建实例。

修改内容：
- ESP32Service 构造函数现在接受 llmService 和 asrService 参数
- WebServer.ts 在创建 ESP32Service 时注入相应的服务实例
- 更新测试文件以使用依赖注入方式创建服务
- 在 services/index.ts 中导出 LLMService 和 ASRService

这样修复的好处：
- 遵循依赖注入原则，提高可测试性
- 可以在测试中注入 mock 服务实例
- 保持与其他服务的依赖注入模式一致

Fixes #3049

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3049