### PR TITLE
fix(endpoint): 在 reconnect() 中正确 await disconnect() 调用

### DIFF
--- a/packages/endpoint/src/endpoint.ts
+++ b/packages/endpoint/src/endpoint.ts
@@ -460,8 +460,8 @@ export class Endpoint {
   public async reconnect(): Promise<void> {
     console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
-    // 先断开连接
-    this.disconnect();
+    // 先断开连接（使用 await 确保完成）
+    await this.disconnect();
 
     // 等待可配置的时间确保连接完全断开
     await new Promise((resolve) => setTimeout(resolve, this.reconnectDelay));


### PR DESCRIPTION
修复 Endpoint.reconnect() 方法中未 await disconnect() 调用的问题。
这可能导致：
- 未捕获的 Promise rejection
- 资源清理不完整
- 重连状态不一致

修复后将确保 disconnect() 完全完成后再执行后续重连逻辑。

相关问题：#3053

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3053