### PR TITLE
fix(npm): 将进程启动失败日志从 console.log 改为 logger.error

### DIFF
--- a/apps/backend/lib/npm/manager.ts
+++ b/apps/backend/lib/npm/manager.ts
@@ -71,7 +71,7 @@ export class NPMManager {
       // 监听进程启动失败事件
       npmProcess.on("error", (error) => {
         const errorMessage = `进程启动失败: ${error.message}`;
-        console.log(errorMessage, { error });
+        logger.error(errorMessage, { error });
 
         // 清理资源
         cleanup();


### PR DESCRIPTION
修复 apps/backend/lib/npm/manager.ts 第 74 行违反日志规范的问题。
该文件已导入 logger 但在处理 npm 进程启动失败时使用 console.log。

变更：
- 将 console.log(errorMessage, { error }) 改为 logger.error(errorMessage, { error })

相关 Issues: #3062, #3014, #2940, #2937

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3062