### PR TITLE
fix(utils): prompt-utils.ts 使用 logger 替代 console

### DIFF
--- a/apps/backend/utils/prompt-utils.ts
+++ b/apps/backend/utils/prompt-utils.ts
@@ -16,6 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
+import { logger } from "@/Logger.js";
 import { configManager } from "@xiaozhi-client/config";
 
 // 默认系统提示词
@@ -73,7 +74,7 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件是否存在
     if (!existsSync(resolvedPath)) {
-      console.warn(
+      logger.warn(
         `[prompt-utils] 提示词文件不存在: ${resolvedPath}，将使用默认提示词`
       );
       return null;
@@ -84,16 +85,16 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件内容是否为空
     if (!content) {
-      console.warn(
+      logger.warn(
         `[prompt-utils] 提示词文件内容为空: ${resolvedPath}，将使用默认提示词`
       );
       return null;
     }
 
-    console.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
+    logger.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
     return content;
   } catch (error) {
-    console.error(
+    logger.error(
       `[prompt-utils] 读取提示词文件失败: ${promptPath}`,
       error instanceof Error ? error.message : String(error)
     );
@@ -178,7 +179,7 @@ export function listPromptFiles(): PromptFileInfo[] {
 
     return promptFiles;
   } catch (error) {
-    console.error(
+    logger.error(
       "[prompt-utils] 获取提示词文件列表失败:",
       error instanceof Error ? error.message : String(error)
     );


### PR DESCRIPTION
将 prompt-utils.ts 文件中的 5 处 console 调用替换为 logger 方法，
符合项目统一日志规范。

修改内容：
- 导入 logger: import { logger } from "@/Logger.js"
- 第 76 行: console.warn → logger.warn
- 第 87 行: console.warn → logger.warn
- 第 93 行: console.info → logger.info
- 第 96 行: console.error → logger.error
- 第 181 行: console.error → logger.error

参考 Issue #3067

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3067