### PR TITLE
refactor(handler): 将 VersionApiHandler 改为依赖注入模式

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -42,6 +42,7 @@ import {
 import { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import { ensureToolJSONSchema } from "@/lib/mcp/types.js";
+import { NPMManager } from "@/lib/npm";
 import {
   corsMiddleware,
   endpointManagerMiddleware,
@@ -199,7 +200,9 @@ export class WebServer {
     this.serviceApiHandler = new ServiceApiHandler(this.statusService);
     this.mcpToolHandler = new MCPToolHandler();
     this.mcpToolLogHandler = new MCPToolLogHandler();
-    this.versionApiHandler = new VersionApiHandler();
+    this.versionApiHandler = new VersionApiHandler(
+      new NPMManager(this.eventBus)
+    );
     this.staticFileHandler = new StaticFileHandler();
     this.mcpRouteHandler = new MCPRouteHandler();
     this.updateApiHandler = new UpdateApiHandler();

--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -3,6 +3,7 @@
  * 提供版本信息查询、可用版本列表获取、版本检查等相关的 RESTful API 接口
  */
 import { NPMManager } from "@/lib/npm";
+import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { VersionUtils } from "@xiaozhi-client/version";
 import type { Context } from "hono";
@@ -12,6 +13,17 @@ import { BaseHandler } from "./base.handler.js";
  * 版本 API 处理器
  */
 export class VersionApiHandler extends BaseHandler {
+  private npmManager: NPMManager;
+
+  /**
+   * 构造函数
+   * @param npmManager - NPM 管理器实例（可选，用于依赖注入）
+   */
+  constructor(npmManager?: NPMManager) {
+    super();
+    // 使用传入的实例或创建新实例（向后兼容）
+    this.npmManager = npmManager || new NPMManager(getEventBus());
+  }
   /**
    * 获取版本信息
    * GET /api/version
@@ -87,8 +99,10 @@ export class VersionApiHandler extends BaseHandler {
         );
       }
 
-      const npmManager = new NPMManager();
-      const versions = await npmManager.getAvailableVersions(type as string);
+      // 使用注入的 NPMManager 实例
+      const versions = await this.npmManager.getAvailableVersions(
+        type as string
+      );
 
       c.get("logger").debug(
         `获取到 ${versions.length} 个可用版本 (类型: ${type})`
@@ -117,8 +131,8 @@ export class VersionApiHandler extends BaseHandler {
     try {
       c.get("logger").debug("处理检查最新版本请求");
 
-      const npmManager = new NPMManager();
-      const result = await npmManager.checkForLatestVersion();
+      // 使用注入的 NPMManager 实例
+      const result = await this.npmManager.checkForLatestVersion();
 
       c.get("logger").debug("版本检查结果:", result);
 


### PR DESCRIPTION
修复 Issue #3073：version.handler.ts 在方法中直接创建 NPMManager 实例违反依赖注入原则

**变更内容**:
- VersionApiHandler 添加构造函数接受可选的 NPMManager 参数
- 将 NPMManager 实例存储为私有属性，而非每次调用创建新实例
- WebServer.ts 在创建 VersionApiHandler 时注入 NPMManager 实例

**效果**:
- 单元测试可以 Mock NPMManager 进行测试
- 与其他 handler 的依赖注入模式保持一致
- 支持状态隔离和实例共享

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3073