### PR TITLE
refactor(types): 消除跨包重复类型定义，统一使用 shared-types (#3077)

### DIFF
--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -1877,7 +1877,7 @@ export class MCPToolHandler {
   private generateInputSchemaFromConfig(
     parameterConfig: WorkflowParameterConfig
   ): JSONSchema {
-    const properties: Record<string, unknown> = {};
+    const properties: Record<string, object> = {};
     const required: string[] = [];
 
     for (const param of parameterConfig.parameters) {

--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -7,6 +7,26 @@ import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  JSONSchema,
+  CustomMCPTool as SharedCustomMCPTool,
+} from "@xiaozhi-client/shared-types";
+
+// 重新导出 JSONSchema 和 CustomMCPTool 以保持向后兼容
+export type { JSONSchema } from "@xiaozhi-client/shared-types";
+
+// 重新导出 CustomMCPTool，使用本地扩展定义以保持兼容性
+// 注意：shared-types 的 CustomMCPTool 使用严格的 handler 类型定义
+// 本地版本保持宽松的 handler 类型以向后兼容
+export interface CustomMCPTool {
+  name: string;
+  description?: string;
+  inputSchema: JSONSchema;
+  handler?: {
+    type: string;
+    config?: Record<string, unknown>;
+  };
+}
 
 // =========================
 // 1. 基础传输类型
@@ -128,26 +148,10 @@ export interface ToolCallResult {
 }
 
 /**
- * JSON Schema 类型定义
- * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
- */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>; // 允许更宽松的格式以保持向后兼容
-
-/**
  * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
  */
-export function isValidToolJSONSchema(obj: unknown): obj is {
+export function isValidToolJSONSchema(obj: unknown): obj is JSONSchema & {
   type: "object";
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
 } {
   return (
     typeof obj === "object" &&
@@ -161,41 +165,19 @@ export function isValidToolJSONSchema(obj: unknown): obj is {
  * 确保对象符合 MCP Tool JSON Schema 格式
  * 如果不符合，会返回一个默认的空对象 schema
  */
-export function ensureToolJSONSchema(schema: JSONSchema): {
+export function ensureToolJSONSchema(schema: JSONSchema): JSONSchema & {
   type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
 } {
   if (isValidToolJSONSchema(schema)) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
+    return schema as JSONSchema & { type: "object" };
   }
 
   // 如果不符合标准格式，返回默认的空对象 schema
   return {
     type: "object",
-    properties: {} as Record<string, object>,
+    properties: {},
     required: [],
     additionalProperties: true,
-  };
-}
-
-/**
- * CustomMCP 工具类型定义
- * 统一了 manager.ts 和 configManager.ts 中的定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
   };
 }
 

--- a/apps/backend/types/toolApi.ts
+++ b/apps/backend/types/toolApi.ts
@@ -1,299 +1,50 @@
 /**
  * 工具添加 API 相关类型定义
- * 支持多种工具类型的添加，包括 MCP 工具、Coze 工作流等
- */
-
-import type { JSONSchema as LibJSONSchema } from "@/lib/mcp/types.js";
-import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
-
-/**
- * JSON Schema 类型
- * 重新导出 @/lib/mcp/types.js 中的 JSONSchema
  *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 JSONSchema 相同
- * TODO：将来应从 shared-types 导入 JSONSchema 以消除重复定义
- */
-export type JSONSchema = LibJSONSchema;
-
-/**
- * 工具处理器配置相关类型
+ * 此文件从 @xiaozhi-client/shared-types 重新导出所有类型
+ * 以消除跨包重复定义（DRY 原则）
  *
- * 注意：这些类型与 @xiaozhi-client/shared-types/src/mcp/tool-definition.ts 中定义的类型相同
- * TODO：将 toolApi.ts 的类型迁移为从 shared-types 导入，消除重复定义
- * 目前保持本地定义以避免 TypeScript 子路径解析问题（影响 tts、asr 等其他包）
- *
- * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts
+ * 权威定义位置：
+ * - packages/shared-types/src/api/toolApi.ts
+ * - packages/shared-types/src/mcp/tool-definition.ts
+ * - packages/shared-types/src/mcp/schema.ts
  */
-export type ToolHandlerConfig =
-  | MCPHandlerConfig
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig;
 
-/**
- * MCP 处理器配置
- * 用于标准 MCP 服务中的工具
- */
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
+// 从 shared-types 导入所有工具 API 类型
+export {
+  ToolType,
+  ToolValidationError,
+} from "@xiaozhi-client/shared-types";
 
-/**
- * 代理处理器配置
- * 用于第三方平台代理（如 Coze、OpenAI 等）
- */
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: Record<string, unknown>;
-}
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ExtendedCustomMCPTool,
+  ToolValidationErrorDetail,
+} from "@xiaozhi-client/shared-types";
 
-/**
- * HTTP 处理器配置
- * 用于 HTTP API 工具
- */
-export interface HttpHandlerConfig {
-  type: "http";
-  config: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
-  };
-}
+// 从 shared-types 导入工具处理器配置类型
+export type {
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+} from "@xiaozhi-client/shared-types";
 
-/**
- * 函数处理器配置
- * 用于自定义函数工具
- */
-export interface FunctionHandlerConfig {
-  type: "function";
-  config: {
-    module: string;
-    function: string;
-  };
-}
+// 从 shared-types 导入 CustomMCP 工具类型和 JSONSchema
+export type {
+  CustomMCPTool,
+  CustomMCPToolWithStats,
+  CustomMCPToolConfig,
+  JSONSchema,
+} from "@xiaozhi-client/shared-types";
 
-/**
- * CustomMCP 工具基础接口
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPTool 相同
- * TODO：将来应从 shared-types 导入 CustomMCPTool 以消除重复定义
- */
-export interface CustomMCPToolBase {
-  /** 工具唯一标识符 */
-  name: string;
-  /** 工具描述信息 */
-  description: string;
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-  /** 处理器配置 */
-  handler: ToolHandlerConfig;
-}
-
-/**
- * 带统计信息的 CustomMCP 工具
- * 用于 API 响应，使用扁平的统计信息结构
- *
- * 注意：此类型与 @xiaozhi-client/shared-types 中的 CustomMCPToolWithStats 类似
- * 但不包含 `enabled` 字段。如需完整功能，请从 shared-types 导入
- */
-export interface CustomMCPToolWithStats extends CustomMCPToolBase {
-  /** 工具使用次数（扁平结构，与 API 响应格式一致） */
-  usageCount?: number;
-  /** 最后使用时间（ISO 8601 格式） */
-  lastUsedTime?: string;
-}
-
-/**
- * 工具类型枚举
- */
-export enum ToolType {
-  /** MCP 工具（标准 MCP 服务中的工具） */
-  MCP = "mcp",
-  /** Coze 工作流工具 */
-  COZE = "coze",
-  /** HTTP API 工具（预留） */
-  HTTP = "http",
-  /** 自定义函数工具（预留） */
-  FUNCTION = "function",
-}
-
-/**
- * MCP 工具数据
- * 用于将标准 MCP 服务中的工具添加到 customMCP.tools 配置中
- */
-export interface MCPToolData {
-  /** MCP 服务名称 */
-  serviceName: string;
-  /** 工具名称 */
-  toolName: string;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * Coze 工作流数据
- * 保持与现有格式的兼容性
- */
-export interface CozeWorkflowData {
-  /** Coze 工作流信息 */
-  workflow: CozeWorkflow;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-  /** 可选的参数配置 */
-  parameterConfig?: WorkflowParameterConfig;
-}
-
-/**
- * HTTP API 工具数据（预留）
- */
-export interface HttpApiToolData {
-  /** API 地址 */
-  url: string;
-  /** HTTP 方法 */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  /** API 描述 */
-  description: string;
-  /** 请求头 */
-  headers?: Record<string, string>;
-  /** 请求体模板 */
-  bodyTemplate?: string;
-  /** 认证配置 */
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    apiKey?: string;
-    apiKeyHeader?: string;
-  };
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 函数工具数据（预留）
- */
-export interface FunctionToolData {
-  /** 模块路径 */
-  module: string;
-  /** 函数名 */
-  function: string;
-  /** 函数描述 */
-  description: string;
-  /** 函数执行上下文 */
-  context?: Record<string, any>;
-  /** 超时时间 */
-  timeout?: number;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 添加自定义工具的统一请求接口
- */
-export interface AddCustomToolRequest {
-  /** 工具类型 */
-  type: ToolType;
-  /** 工具数据（根据类型不同而不同） */
-  data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
-}
-
-/**
- * 工具验证错误类型
- */
-export enum ToolValidationError {
-  /** 无效的工具类型 */
-  INVALID_TOOL_TYPE = "INVALID_TOOL_TYPE",
-  /** 缺少必需字段 */
-  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
-  /** 服务不存在 */
-  SERVICE_NOT_FOUND = "SERVICE_NOT_FOUND",
-  /** 工具名称冲突 */
-  TOOL_NAME_CONFLICT = "TOOL_NAME_CONFLICT",
-  /** 配置验证失败 */
-  CONFIG_VALIDATION_FAILED = "CONFIG_VALIDATION_FAILED",
-  /** 系统配置错误 */
-  SYSTEM_CONFIG_ERROR = "SYSTEM_CONFIG_ERROR",
-  /** 资源限制超出 */
-  RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED",
-}
-
-/**
- * 工具验证错误详情
- */
-export interface ToolValidationErrorDetail {
-  /** 错误类型 */
-  error: ToolValidationError;
-  /** 错误消息 */
-  message: string;
-  /** 错误详情 */
-  details?: any;
-  /** 建议的解决方案 */
-  suggestions?: string[];
-}
-
-/**
- * 添加工具的响应数据
- */
-export interface AddToolResponse {
-  /** 成功添加的工具 */
-  tool: any;
-  /** 工具名称 */
-  toolName: string;
-  /** 工具类型 */
-  toolType: ToolType;
-  /** 添加时间戳 */
-  addedAt: string;
-}
-
-/**
- * 工具元数据信息
- */
-export interface ToolMetadata {
-  /** 工具原始来源 */
-  source: {
-    type: "mcp" | "coze" | "http" | "function";
-    serviceName?: string;
-    toolName?: string;
-    url?: string;
-  };
-  /** 添加时间 */
-  addedAt: string;
-  /** 最后更新时间 */
-  updatedAt?: string;
-  /** 版本信息 */
-  version?: string;
-}
-
-/**
- * 工具配置选项
- */
-export interface ToolConfigOptions {
-  /** 是否启用工具（默认 true） */
-  enabled?: boolean;
-  /** 超时时间（毫秒） */
-  timeout?: number;
-  /** 重试次数 */
-  retryCount?: number;
-  /** 重试间隔（毫秒） */
-  retryDelay?: number;
-  /** 自定义标签 */
-  tags?: string[];
-  /** 工具分组 */
-  group?: string;
-}
+// CustomMCPToolBase 作为 CustomMCPTool 的别名（向后兼容）
+export type { CustomMCPTool as CustomMCPToolBase } from "@xiaozhi-client/shared-types";

--- a/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
+++ b/apps/frontend/src/components/common/workflow-parameter-config-dialog.tsx
@@ -114,24 +114,24 @@ function extractParametersFromSchema(
   const properties = inputSchema.properties;
   const required = inputSchema.required || [];
 
-  return Object.entries(properties).map(
-    ([fieldName, schema]: [string, JSONSchema]) => {
-      let type: "string" | "number" | "boolean" = "string";
+  return Object.entries(properties).map(([fieldName, schema]) => {
+    // schema 从 properties 中取出，类型为 unknown，需要类型检查
+    const schemaObj = schema as JSONSchema;
+    let type: "string" | "number" | "boolean" = "string";
 
-      if (schema.type === "integer" || schema.type === "number") {
-        type = "number";
-      } else if (schema.type === "boolean") {
-        type = "boolean";
-      }
-
-      return {
-        fieldName,
-        description: schema.description || "",
-        type,
-        required: required.includes(fieldName),
-      };
+    if (schemaObj.type === "integer" || schemaObj.type === "number") {
+      type = "number";
+    } else if (schemaObj.type === "boolean") {
+      type = "boolean";
     }
-  );
+
+    return {
+      fieldName,
+      description: schemaObj.description || "",
+      type,
+      required: required.includes(fieldName),
+    };
+  });
 }
 
 /**

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -13,7 +13,7 @@ export type {
   CozeWorkflowsParams,
 } from "./coze";
 
-// MCP 相关类型
+// MCP 相关类型 - 包括工具处理器配置和 CustomMCP 工具类型
 export type {
   ExtendedMCPToolsCache,
   EnhancedToolResultCache,
@@ -25,10 +25,35 @@ export type {
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
   JSONSchema,
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
 } from "./mcp";
 
-// 工具API相关类型
-export type { ToolType, MCPToolData } from "./api";
+// 工具API相关类型 - 导出所有类型以消除跨包重复定义
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ExtendedCustomMCPTool,
+  ToolValidationErrorDetail,
+} from "./api";
+
+export {
+  ToolType,
+  // 注意：ToolValidationError 在 api/index.ts 中被重命名为 ApiToolValidationError
+  // 如果需要原始名称，可以使用 ApiToolValidationError 并重命名
+} from "./api";
+
+// 导出 ToolValidationError 作为别名（向后兼容）
+export { ApiToolValidationError as ToolValidationError } from "./api";
 
 // 配置相关类型
 export type {

--- a/packages/shared-types/src/mcp/schema.ts
+++ b/packages/shared-types/src/mcp/schema.ts
@@ -1,26 +1,32 @@
 /**
  * JSON Schema 类型定义
  * 用于 MCP 工具的 inputSchema 字段
+ *
+ * 使用宽松的类型定义以保持向后兼容性
+ * 兼容 MCP SDK 的 JSON Schema 格式
  */
 
 /**
  * JSON Schema 类型
- * 带类型守卫的严格 JSON Schema 类型定义
+ * 使用宽松的类型定义，兼容 MCP SDK 和现有代码
+ * 同时保留常用属性的类型信息
+ *
+ * 注意：properties 使用 object 类型以兼容 MCP SDK 的 AssertObjectSchema
  */
-export interface JSONSchema {
+export type JSONSchema = Record<string, unknown> & {
   type?: string | string[];
-  properties?: Record<string, JSONSchema>;
+  properties?: Record<string, object>;
   required?: string[];
-  items?: JSONSchema;
-  additionalProperties?: boolean | JSONSchema;
+  items?: object;
+  additionalProperties?: boolean | object;
   description?: string;
   enum?: unknown[];
   const?: unknown;
-  [key: string]: unknown;
-}
+  default?: unknown;
+};
 
 /**
- * 检查值是否为有效的 JSON Schema
+ * 检查值是否为有效的 Json Schema（类型守卫）
  */
 export function isJSONSchema(value: unknown): value is JSONSchema {
   if (typeof value !== "object" || value === null) {


### PR DESCRIPTION
- 将 apps/backend/types/toolApi.ts 从 300+ 行减少到 45 行
- 统一 JSONSchema 类型定义，兼容 MCP SDK 格式
- 更新 shared-types 导出所有工具 API 类型
- 修复相关文件的类型兼容性问题

修改文件:
- packages/shared-types/src/index.ts - 导出所有工具 API 类型
- packages/shared-types/src/mcp/schema.ts - 统一 JSONSchema 类型定义
- apps/backend/types/toolApi.ts - 重新导出 shared-types 类型
- apps/backend/lib/mcp/types.ts - 导入 JSONSchema 从 shared-types
- apps/frontend/.../workflow-parameter-config-dialog.tsx - 修复类型兼容性
- apps/backend/handlers/mcp-tool.handler.ts - 修复类型兼容性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3077