### PR TITLE
perf(config): 添加 getConfigReadOnly() 方法避免不必要的深拷贝开销

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -308,7 +308,7 @@ export class WebServer {
     // 确保 mcpServerConfig 与 mcpServers 保持同步
     configManager.cleanupInvalidServerToolsConfig();
 
-    const config = configManager.getConfig();
+    const config = configManager.getConfigReadOnly();
 
     return {
       mcpEndpoint: config.mcpEndpoint,

--- a/apps/backend/handlers/config.handler.ts
+++ b/apps/backend/handlers/config.handler.ts
@@ -31,7 +31,7 @@ export class ConfigApiHandler extends BaseHandler {
     const logger = c.get("logger");
     try {
       logger.debug("处理获取配置请求");
-      const config = configManager.getConfig();
+      const config = configManager.getConfigReadOnly();
       logger.debug("获取配置成功");
       return c.success(config);
     } catch (error) {
@@ -180,7 +180,7 @@ export class ConfigApiHandler extends BaseHandler {
     try {
       c.get("logger").info("处理重新加载配置请求");
       configManager.reloadConfig();
-      const config = configManager.getConfig();
+      const config = configManager.getConfigReadOnly();
       c.get("logger").info("重新加载配置成功");
       return c.success(config, "配置重新加载成功");
     } catch (error) {

--- a/apps/backend/handlers/heartbeat.handler.ts
+++ b/apps/backend/handlers/heartbeat.handler.ts
@@ -84,7 +84,7 @@ export class HeartbeatHandler {
    */
   private async sendLatestConfig(ws: any, clientId: string): Promise<void> {
     try {
-      const latestConfig = configManager.getConfig();
+      const latestConfig = configManager.getConfigReadOnly();
       const message = {
         type: "configUpdate",
         data: latestConfig,

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -406,7 +406,7 @@ export class MCPHandler {
    * 获取服务状态信息
    */
   private getServiceStatus(serverName: string): MCPServerStatus {
-    const config = this.configManager.getConfig();
+    const config = this.configManager.getConfigReadOnly();
     const serverConfig = config.mcpServers[serverName];
 
     if (!serverConfig) {
@@ -739,8 +739,8 @@ export class MCPHandler {
    */
   async listMCPServers(c: Context<AppContext>): Promise<Response> {
     try {
-      // 1. 获取所有配置的 MCP 服务
-      const config = this.configManager.getConfig();
+      // 1. 获取所有配置的 MCP 服务（使用只读引用，避免深拷贝开销）
+      const config = this.configManager.getConfigReadOnly();
       const mcpServers = config.mcpServers || {};
 
       // 2. 构建服务列表
@@ -1106,7 +1106,7 @@ export namespace MCPServerConfigValidator {
     name: string,
     configManager: ConfigManager
   ): boolean {
-    const config = configManager.getConfig();
+    const config = configManager.getConfigReadOnly();
     return config.mcpServers && name in config.mcpServers;
   }
 }

--- a/apps/backend/handlers/realtime-notification.handler.ts
+++ b/apps/backend/handlers/realtime-notification.handler.ts
@@ -117,7 +117,7 @@ export class RealtimeNotificationHandler {
     this.logDeprecationWarning("WebSocket getConfig", "GET /api/config");
 
     try {
-      const config = configManager.getConfig();
+      const config = configManager.getConfigReadOnly();
       this.logger.debug("WebSocket: getConfig 请求处理成功", { clientId });
       ws.send(JSON.stringify({ type: "config", data: config }));
     } catch (error) {
@@ -258,8 +258,8 @@ export class RealtimeNotificationHandler {
     try {
       this.logger.debug("发送初始数据给客户端", { clientId });
 
-      // 发送当前配置
-      const config = configManager.getConfig();
+      // 发送当前配置（使用只读引用，避免深拷贝开销）
+      const config = configManager.getConfigReadOnly();
       ws.send(JSON.stringify({ type: "configUpdate", data: config }));
 
       // 发送当前状态

--- a/apps/backend/lib/mcp/custom.ts
+++ b/apps/backend/lib/mcp/custom.ts
@@ -93,7 +93,7 @@ export class CustomMCPHandler {
    * 获取 CozeApiService 实例
    */
   private getCozeApiService(): CozeApiService {
-    const token = configManager.getConfig().platforms?.coze?.token;
+    const token = configManager.getConfigReadOnly().platforms?.coze?.token;
 
     if (!token) {
       throw new Error("Coze Token 配置不存在");

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -89,8 +89,8 @@ export class NotificationService {
   private setupEventListeners(): void {
     // 监听配置更新事件
     this.eventBus.onEvent("config:updated", (data) => {
-      // 获取最新的配置
-      const config = configManager.getConfig();
+      // 获取最新的配置（使用只读引用，避免深拷贝开销）
+      const config = configManager.getConfigReadOnly();
       this.broadcastConfigUpdate(config);
     });
 

--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -139,7 +139,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
       }
 
       const configManager = this.getService<any>("configManager");
-      const config = configManager.getConfig();
+      const config = configManager.getConfigReadOnly();
 
       switch (key) {
         case "mcpEndpoint": {

--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -207,7 +207,7 @@ export class ServiceManagerImpl implements IServiceManager {
 
     // 验证配置文件
     try {
-      const config = this.configManager.getConfig();
+      const config = this.configManager.getConfigReadOnly();
       if (!config) {
         throw new ConfigError("配置文件无效");
       }

--- a/packages/config/src/index.ts
+++ b/packages/config/src/index.ts
@@ -14,8 +14,8 @@
  * ```typescript
  * import { configManager } from '@xiaozhi-client/config';
  *
- * // 获取配置
- * const config = configManager.getConfig();
+ * // 获取配置只读引用（适用于只读场景，性能更好）
+ * const config = configManager.getConfigReadOnly();
  *
  * // 更新 MCP 端点配置
  * configManager.updateMcpEndpoint('wss://api.example.com/mcp');

--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -12,8 +12,11 @@
  * ```typescript
  * import { configManager } from '@xiaozhi-client/config';
  *
- * // 获取配置
+ * // 获取配置（深拷贝，适用于需要独立副本的场景）
  * const config = configManager.getConfig();
+ *
+ * // 获取配置只读引用（适用于 JSON 序列化等只读场景，性能更好）
+ * const configReadOnly = configManager.getConfigReadOnly();
  *
  * // 更新配置
  * configManager.updateConfig({ mcpEndpoint: 'wss://...' });
@@ -29,8 +32,8 @@
  *   // }
  *   console.log('配置已更新事件:', payload);
  *
- *   // 如果需要获取最新的完整配置对象，可在回调中调用 getConfig()
- *   const latestConfig = configManager.getConfig();
+ *   // 如果只需要读取最新配置，推荐使用 getConfigReadOnly() 避免深拷贝开销
+ *   const latestConfig = configManager.getConfigReadOnly();
  *   console.log('最新配置对象:', latestConfig);
  * });
  * ```
@@ -558,6 +561,9 @@ export class ConfigManager {
   /**
    * 获取配置（只读）
    * 使用缓存机制避免频繁的文件 I/O 操作
+   *
+   * 注意：此方法返回配置的深拷贝，以防止外部修改影响内部缓存。
+   * 如果只需要只读访问且不需要独立副本，请使用 getConfigReadOnly()。
    */
   public getConfig(): Readonly<AppConfig> {
     // 使用缓存，避免每次都重新加载文件
@@ -568,6 +574,34 @@ export class ConfigManager {
     // 使用 structuredClone 进行更高效的深拷贝
     // 如果不支持则降级到 JSON.parse(JSON.stringify())
     return structuredClone(this.config);
+  }
+
+  /**
+   * 获取配置的只读引用（不进行深拷贝）
+   *
+   * 适用于只需要读取配置值的场景，避免深拷贝的性能开销。
+   *
+   * **使用场景**：
+   * - HTTP API 返回配置数据（会被 JSON 序列化）
+   * - WebSocket 心跳响应中发送配置
+   * - 事件回调中广播配置更新
+   * - 检查配置属性是否存在
+   *
+   * **注意事项**：
+   * - 返回的对象是内部缓存的直接引用，不应被修改
+   * - 如需修改配置，请使用 updateConfig 等专用方法
+   * - 如需独立的可修改副本，请使用 getConfig()
+   *
+   * @returns 配置对象的只读引用
+   */
+  public getConfigReadOnly(): Readonly<AppConfig> {
+    // 使用缓存，避免每次都重新加载文件
+    if (!this.config) {
+      this.config = this.loadConfig();
+    }
+
+    // 直接返回引用，不进行深拷贝
+    return this.config;
   }
 
   /**
@@ -585,7 +619,7 @@ export class ConfigManager {
    * @deprecated 使用 getMcpEndpoints() 获取所有端点
    */
   public getMcpEndpoint(): string {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     if (Array.isArray(config.mcpEndpoint)) {
       return config.mcpEndpoint[0] || "";
     }
@@ -596,7 +630,7 @@ export class ConfigManager {
    * 获取所有 MCP 端点
    */
   public getMcpEndpoints(): string[] {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     if (Array.isArray(config.mcpEndpoint)) {
       return [...config.mcpEndpoint];
     }
@@ -607,7 +641,7 @@ export class ConfigManager {
    * 获取 MCP 服务配置
    */
   public getMcpServers(): Readonly<Record<string, MCPServerConfig>> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.mcpServers;
   }
 
@@ -615,7 +649,7 @@ export class ConfigManager {
    * 获取 MCP 服务工具配置
    */
   public getMcpServerConfig(): Readonly<Record<string, MCPServerToolsConfig>> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.mcpServerConfig || {};
   }
 
@@ -920,14 +954,13 @@ export class ConfigManager {
    * 删除指定服务器的工具配置
    */
   public removeServerToolsConfig(serverName: string): void {
-    const config = this.getConfig();
-    const newConfig = { ...config };
+    const config = this.getMutableConfig();
 
     // 确保 mcpServerConfig 存在
-    if (newConfig.mcpServerConfig) {
+    if (config.mcpServerConfig) {
       // 删除指定服务的工具配置
-      delete newConfig.mcpServerConfig[serverName];
-      this.saveConfig(newConfig);
+      delete config.mcpServerConfig[serverName];
+      this.saveConfig(config);
     }
   }
 
@@ -1113,7 +1146,7 @@ export class ConfigManager {
    * 获取连接配置（包含默认值）
    */
   public getConnectionConfig(): Required<ConnectionConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     const connectionConfig = config.connection || {};
 
     return {
@@ -1302,7 +1335,7 @@ export class ConfigManager {
    * 获取 ModelScope 配置
    */
   public getModelScopeConfig(): Readonly<ModelScopeConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.modelscope || {};
   }
 
@@ -1353,7 +1386,7 @@ export class ConfigManager {
    * 获取 customMCP 配置
    */
   public getCustomMCPConfig(): CustomMCPConfig | null {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.customMCP || null;
   }
 
@@ -1867,7 +1900,7 @@ export class ConfigManager {
    * 获取 Web UI 配置
    */
   public getWebUIConfig(): Readonly<WebUIConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.webUI || {};
   }
 
@@ -1959,7 +1992,7 @@ export class ConfigManager {
    * 获取扣子平台配置
    */
   public getCozePlatformConfig(): CozePlatformConfig | null {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     const cozeConfig = config.platforms?.coze;
 
     if (!cozeConfig || !cozeConfig.token) {
@@ -2309,7 +2342,7 @@ export class ConfigManager {
    * 获取工具调用日志配置
    */
   public getToolCallLogConfig(): Readonly<ToolCallLogConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.toolCallLog || {};
   }
 
@@ -2343,7 +2376,7 @@ export class ConfigManager {
    * 获取 TTS 配置
    */
   public getTTSConfig(): Readonly<TTSConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.tts || {};
   }
 
@@ -2351,7 +2384,7 @@ export class ConfigManager {
    * 获取 ASR 配置
    */
   public getASRConfig(): Readonly<ASRConfig> {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.asr || {};
   }
 
@@ -2359,7 +2392,7 @@ export class ConfigManager {
    * 获取 LLM 配置
    */
   public getLLMConfig(): LLMConfig | null {
-    const config = this.getConfig();
+    const config = this.getConfigReadOnly();
     return config.llm || null;
   }
 


### PR DESCRIPTION
问题：configManager.getConfig() 每次调用都使用 structuredClone 进行深拷贝，
在配置对象较大或调用频繁时会有性能开销（约 31 处调用点）。

解决方案：
1. 新增 getConfigReadOnly() 方法，返回配置对象的直接引用（不深拷贝）
   - 适用于 JSON 序列化、属性检查等只读场景
   - 在事件回调、WebSocket 心跳响应中避免深拷贝开销

2. 保留 getConfig() 方法用于需要独立副本的场景
   - 更新文档说明两种方法的适用场景

3. 更新所有只读访问场景使用 getConfigReadOnly()
   - manager.ts 内部 13 个 getter 方法
   - 修复 removeServerToolsConfig() 使用 getMutableConfig()
   - 11 个外部调用点（handlers、services、WebServer、CLI）

影响：
- 减少 JSON 序列化场景下的深拷贝开销
- 保持 getConfig() 的安全语义不变（仍返回独立副本）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3080