### PR TITLE
fix(asr): 为 WebSocket 消息处理器添加 try-catch 错误处理

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -764,7 +764,18 @@ export class ASR extends EventEmitter {
       // Register global message handler for event-driven mode
       // In streaming mode, this enables result/vad_end events via on()
       this.ws.on("message", (data: Buffer) => {
-        this.handleMessage(data);
+        try {
+          this.handleMessage(data);
+        } catch (error) {
+          const err = error instanceof Error ? error : new Error(String(error));
+          this.emit("error", err);
+
+          // 记录错误日志
+          console.error(`ASR WebSocket 消息处理失败: ${err.message}`, {
+            dataLength: data.length,
+            error: err.stack,
+          });
+        }
       });
     });
   }


### PR DESCRIPTION
修复 packages/asr/src/client/ASR.ts 中 WebSocket "message" 事件处理器
缺少 try-catch 导致未捕获异常的问题。

当 parseResponse 方法因数据格式错误或 Buffer 解析失败抛出异常时，
会导致未捕获的异常，可能导致应用崩溃或 ASR 连接异常断开。

变更内容：
- 在消息处理器中添加 try-catch 包装
- 捕获异常后通过 emit("error") 通知监听者
- 记录详细的错误日志便于调试

Issue: #3082

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3082