### PR TITLE
perf(tts): 使用 for...of 循环替代 while + Array.shift() 处理音频包队列

### DIFF
--- a/apps/backend/services/tts.service.ts
+++ b/apps/backend/services/tts.service.ts
@@ -250,7 +250,7 @@ export class TTSService implements ITTSService {
     this.isProcessingBuffer.set(deviceId, true);
 
     try {
-      while (buffer.length > 0) {
+      for (const opusPacket of buffer) {
         // 首次收到 Opus 包时发送 start 消息
         if (!this.ttsStarted.get(deviceId)) {
           await connection.send({
@@ -261,9 +261,6 @@ export class TTSService implements ITTSService {
           this.ttsStarted.set(deviceId, true);
           logger.info(`[TTSService] 发送 TTS start 消息: deviceId=${deviceId}`);
         }
-
-        // 从缓冲区取出第一个包
-        const opusPacket = buffer.shift()!;
 
         // 计算时间戳和时长
         const timestamp = this.cumulativeTimestamps.get(deviceId) || 0;
@@ -284,6 +281,8 @@ export class TTSService implements ITTSService {
         // 流控：等待硬件处理
         await new Promise((resolve) => setTimeout(resolve, duration * 0.8));
       }
+      // 清空缓冲区
+      buffer.splice(0, buffer.length);
     } finally {
       this.isProcessingBuffer.set(deviceId, false);
     }
@@ -451,10 +450,10 @@ export class TTSService implements ITTSService {
         if (isProcessing || packetQueue.length === 0) return;
 
         isProcessing = true;
-        while (packetQueue.length > 0) {
-          const packet = packetQueue.shift()!;
+        for (const packet of packetQueue) {
           await processPacket(packet);
         }
+        packetQueue.splice(0, packetQueue.length);
         isProcessing = false;
       };
 


### PR DESCRIPTION
修复 TTSService 中两处 Array.shift() 在循环中的使用，将 O(n²) 性能开销降低为 O(n)。

变更内容：
1. processBuffer 方法：将 while + buffer.shift() 改为 for...of + splice
2. processAudioBuffer 方法：将 while + packetQueue.shift() 改为 for...of + splice

Array.shift() 每次调用需要重新索引所有剩余元素，在循环中处理大量音频包时会导致 O(n²) 时间复杂度。
使用 for...of 循环遍历后一次性 splice 清空，将整体时间复杂度降低为 O(n)。

相关 Issue: #3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3086