### PR TITLE
refactor(handler): 使用工厂模式改进 MCPRouteHandler 的依赖注入

### DIFF
--- a/apps/backend/handlers/__tests__/mcp.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp.handler.test.ts
@@ -1,29 +1,40 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPRouteHandler } from "../mcp.handler.js";
+import type { MCPMessageHandler, MCPServiceManager } from "@/lib/mcp";
 
 // 模拟 MCPServiceManager - 在 Context 中提供
-const mockServiceManager = {
-  // 模拟服务管理器
-};
+const mockServiceManager = {} as MCPServiceManager;
 
-// 模拟 MCPMessageHandler
-vi.mock("@/lib/mcp", () => ({
-  MCPMessageHandler: vi.fn().mockImplementation(() => ({
+// 创建模拟的 MCPMessageHandler
+function createMockMCPMessageHandler(): MCPMessageHandler {
+  return {
     handleMessage: vi.fn().mockResolvedValue({
       jsonrpc: "2.0",
       result: { test: "response" },
       id: 1,
     }),
-  })),
-}));
+  } as unknown as MCPMessageHandler;
+}
 
 describe("MCPRouteHandler", () => {
   let handler: MCPRouteHandler;
+  let mockMessageHandler: MCPMessageHandler;
+  let mockMessageHandlerFactory: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    // 重置 mock
+    vi.clearAllMocks();
+
+    // 每次测试创建新的 mock 消息处理器和工厂函数
+    mockMessageHandler = createMockMCPMessageHandler();
+
+    mockMessageHandlerFactory = vi.fn().mockReturnValue(mockMessageHandler);
+
+    // 使用工厂函数创建 handler，便于测试依赖注入
     handler = new MCPRouteHandler({
       maxMessageSize: 1024 * 1024,
       enableMetrics: true,
+      mcpMessageHandlerFactory: mockMessageHandlerFactory,
     });
   });
 
@@ -43,6 +54,19 @@ describe("MCPRouteHandler", () => {
     expect(status).toHaveProperty("config");
     expect(status.isInitialized).toBe(false);
     expect(status.config.maxMessageSize).toBe(1024 * 1024);
+  });
+
+  it("应该接受自定义的 MCPMessageHandler 工厂函数", () => {
+    // 创建另一个 mock 消息处理器
+    const anotherMockHandler = createMockMCPMessageHandler();
+
+    const customFactory = vi.fn().mockReturnValue(anotherMockHandler);
+    const customHandler = new MCPRouteHandler({
+      mcpMessageHandlerFactory: customFactory,
+    });
+
+    expect(customHandler).toBeInstanceOf(MCPRouteHandler);
+    customHandler.destroy();
   });
 
   it("应该处理有效的 JSON-RPC 消息的 POST 请求", async () => {
@@ -68,12 +92,12 @@ describe("MCPRouteHandler", () => {
           })
         ),
       },
-      json: vi.fn((data: unknown, status?: number, headers?: any) => {
+      json: vi.fn((data: unknown, status?: number, headers?: Record<string, string>) => {
         return new Response(JSON.stringify(data), {
           status: status || 200,
           headers: {
             "Content-Type": "application/json",
-            ...headers,
+            ...(headers || {}),
           },
         });
       }),
@@ -93,9 +117,14 @@ describe("MCPRouteHandler", () => {
       }),
     };
 
-    const response = await handler.handlePost(mockContext as any);
+    const response = await handler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(200);
+
+    // 验证工厂函数被调用（消息处理器初始化）
+    expect(mockMessageHandlerFactory).toHaveBeenCalledWith(mockServiceManager);
+    // 验证 MCPMessageHandler.handleMessage 被调用
+    expect(mockMessageHandler.handleMessage).toHaveBeenCalled();
   });
 
   it("应该拒绝无效 content-type 的 POST 请求", async () => {
@@ -120,7 +149,7 @@ describe("MCPRouteHandler", () => {
       }),
     };
 
-    const response = await handler.handlePost(mockContext as any);
+    const response = await handler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
   });
@@ -151,7 +180,7 @@ describe("MCPRouteHandler", () => {
       }),
     };
 
-    const response = await handler.handlePost(mockContext as any);
+    const response = await handler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
   });
@@ -187,7 +216,7 @@ describe("MCPRouteHandler", () => {
       }),
     };
 
-    const response = await handler.handlePost(mockContext as any);
+    const response = await handler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
   });
@@ -220,12 +249,114 @@ describe("MCPRouteHandler", () => {
       }),
     };
 
-    const response = await handler.handlePost(mockContext as any);
+    const response = await handler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
     expect(response).toBeInstanceOf(Response);
     expect(response.status).toBe(400);
   });
 
   it("应该正确处理 destroy 方法", () => {
     expect(() => handler.destroy()).not.toThrow();
+  });
+
+  it("应该使用注入的工厂函数创建 MCPMessageHandler（依赖注入验证）", async () => {
+    // 创建一个全新的 handler 来验证工厂函数被调用
+    const newMockHandler = createMockMCPMessageHandler();
+
+    const newFactory = vi.fn().mockReturnValue(newMockHandler);
+    const newHandler = new MCPRouteHandler({
+      mcpMessageHandlerFactory: newFactory,
+    });
+
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          // 注意：HTTP_HEADERS.CONTENT_TYPE 是 "Content-Type"，需要处理两种大小写
+          if (name === "content-type" || name === "Content-Type")
+            return "application/json";
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "initialize",
+            id: 1,
+          })
+        ),
+      },
+      json: vi.fn((data: unknown) => new Response(JSON.stringify(data))),
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") return mockServiceManager;
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    await newHandler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
+
+    // 验证工厂函数被正确调用
+    expect(newFactory).toHaveBeenCalledTimes(1);
+    expect(newFactory).toHaveBeenCalledWith(mockServiceManager);
+
+    newHandler.destroy();
+  });
+
+  it("应该在多次请求中只初始化一次消息处理器（懒加载验证）", async () => {
+    // 创建一个全新的 handler 来验证懒加载特性
+    const newMockHandler = createMockMCPMessageHandler();
+
+    const newFactory = vi.fn().mockReturnValue(newMockHandler);
+    const newHandler = new MCPRouteHandler({
+      mcpMessageHandlerFactory: newFactory,
+    });
+
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          // 注意：HTTP_HEADERS.CONTENT_TYPE 是 "Content-Type"，需要处理两种大小写
+          if (name === "content-type" || name === "Content-Type")
+            return "application/json";
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "initialize",
+            id: 1,
+          })
+        ),
+      },
+      json: vi.fn((data: unknown) => new Response(JSON.stringify(data))),
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") return mockServiceManager;
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    // 第一次请求
+    await newHandler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
+    // 第二次请求
+    await newHandler.handlePost(mockContext as unknown as Parameters<typeof handler.handlePost>[0]);
+
+    // 工厂函数应该只被调用一次（懒加载特性）
+    expect(newFactory).toHaveBeenCalledTimes(1);
+
+    newHandler.destroy();
   });
 });

--- a/apps/backend/handlers/mcp.handler.ts
+++ b/apps/backend/handlers/mcp.handler.ts
@@ -23,11 +23,21 @@ import type { MCPMessage } from "@/types/mcp.js";
 import type { Context } from "hono";
 
 /**
+ * MCP 消息处理器工厂函数类型
+ * 用于依赖注入，避免直接创建 MCPMessageHandler 实例
+ */
+type MCPMessageHandlerFactory = (
+  serviceManager: MCPServiceManager
+) => MCPMessageHandler;
+
+/**
  * MCP 路由处理器配置接口
  */
 interface MCPRouteHandlerConfig {
   maxMessageSize?: number;
   enableMetrics?: boolean;
+  /** MCP 消息处理器工厂函数（可选，用于依赖注入） */
+  mcpMessageHandlerFactory?: MCPMessageHandlerFactory;
 }
 
 /**
@@ -46,6 +56,8 @@ interface ConnectionMetrics {
 export class MCPRouteHandler {
   private logger: Logger;
   private mcpMessageHandler: MCPMessageHandler | null = null;
+  /** MCP 消息处理器工厂函数（用于依赖注入） */
+  private mcpMessageHandlerFactory: MCPMessageHandlerFactory;
   private config: {
     maxMessageSize: number;
     enableMetrics: boolean;
@@ -54,6 +66,9 @@ export class MCPRouteHandler {
 
   constructor(config: MCPRouteHandlerConfig = {}) {
     this.logger = logger;
+    // 默认工厂函数：直接创建 MCPMessageHandler 实例
+    this.mcpMessageHandlerFactory =
+      config.mcpMessageHandlerFactory ?? ((sm) => new MCPMessageHandler(sm));
     this.config = {
       maxMessageSize: config.maxMessageSize ?? MESSAGE_SIZE_LIMITS.DEFAULT,
       enableMetrics: config.enableMetrics ?? true,
@@ -98,6 +113,7 @@ export class MCPRouteHandler {
 
   /**
    * 初始化 MCP 消息处理器
+   * 使用注入的工厂函数创建 MCPMessageHandler 实例
    */
   private async initializeMessageHandler(c: Context): Promise<void> {
     if (this.mcpMessageHandler) {
@@ -106,7 +122,7 @@ export class MCPRouteHandler {
 
     try {
       const serviceManager = this.getMCPServiceManager(c);
-      this.mcpMessageHandler = new MCPMessageHandler(serviceManager);
+      this.mcpMessageHandler = this.mcpMessageHandlerFactory(serviceManager);
       this.logger.debug("MCP 消息处理器初始化成功");
     } catch (error) {
       this.logger.error("MCP 消息处理器初始化失败:", error);


### PR DESCRIPTION
修复 #3085 - MCPRouteHandler 在 initializeMessageHandler 方法中直接创建
MCPMessageHandler 实例违反依赖注入原则的问题。

修改内容：
- 添加 MCPMessageHandlerFactory 类型定义
- 在 MCPRouteHandlerConfig 中添加可选的 mcpMessageHandlerFactory 参数
- 构造函数接受工厂函数，默认使用直接创建实例的方式
- initializeMessageHandler 方法使用注入的工厂函数创建实例

架构改进：
- 符合依赖注入原则：不再在方法中直接创建实例
- 保持懒加载特性：工厂函数在首次请求时调用
- 提高可测试性：可以轻松注入 mock 工厂函数
- 向后兼容：默认工厂函数保持原有行为

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3085