### PR TITLE
refactor(frontend): 拆分 ToolDebugDialog 主组件职责 (#3089)

### DIFF
--- a/apps/frontend/src/components/form-field-renderer/index.ts
+++ b/apps/frontend/src/components/form-field-renderer/index.ts
@@ -1,0 +1,11 @@
+/**
+ * 工具调试对话框组件模块
+ *
+ * @description 该模块包含工具调试对话框及其相关的子组件和辅助函数
+ */
+
+export {
+  createFormFieldRenderer,
+  getTypeBadgeColor,
+} from "./render-form-field";
+export type { FormFieldRenderer } from "./render-form-field";

--- a/apps/frontend/src/components/form-field-renderer/render-form-field.tsx
+++ b/apps/frontend/src/components/form-field-renderer/render-form-field.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import { FormControl } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import type React from "react";
+import { Controller, type useForm } from "react-hook-form";
+
+/**
+ * 表单字段渲染辅助模块
+ *
+ * @description 为 ToolDebugDialog 提供表单字段渲染功能
+ * 根据 JSON Schema 字段类型渲染对应的表单控件
+ */
+
+/**
+ * 获取类型徽章的颜色样式
+ *
+ * @param type - JSON Schema 字段类型
+ * @returns Tailwind CSS 类名字符串
+ */
+export function getTypeBadgeColor(type: string): string {
+  const colors: Record<string, string> = {
+    string: "bg-blue-100 text-blue-800",
+    number: "bg-green-100 text-green-800",
+    integer: "bg-green-100 text-green-800",
+    boolean: "bg-purple-100 text-purple-800",
+    array: "bg-orange-100 text-orange-800",
+    object: "bg-gray-100 text-gray-800",
+  };
+
+  return colors[type] || "bg-gray-100 text-gray-800";
+}
+
+/**
+ * 表单字段渲染器类型定义
+ *
+ * @description 渲染单个表单字段，支持各种 JSON Schema 类型
+ */
+export type FormFieldRenderer = (
+  fieldName: string,
+  fieldSchema: any
+) => React.ReactElement | null;
+
+/**
+ * 创建表单字段渲染器
+ *
+ * @description 根据 JSON Schema 字段类型创建对应的表单控件渲染器
+ * 支持嵌套的数组和对象类型，通过递归调用渲染器实现
+ *
+ * @param form - react-hook-form 的表单实例
+ * @param ArrayFieldComponent - 数组字段渲染组件
+ * @param ObjectFieldComponent - 对象字段渲染组件
+ * @returns 表单字段渲染函数
+ *
+ * @example
+ * ```tsx
+ * const form = useForm({ resolver: zodResolver(schema) });
+ * const renderFormField = createFormFieldRenderer(form, ArrayField, ObjectField);
+ *
+ * // 在 JSX 中使用
+ * {renderFormField("fieldName", { type: "string" })}
+ * ```
+ */
+export function createFormFieldRenderer(
+  form: ReturnType<typeof useForm>,
+  ArrayFieldComponent: React.ComponentType<{
+    name: string;
+    schema: any;
+    form: ReturnType<typeof useForm>;
+    renderFormField: FormFieldRenderer;
+  }>,
+  ObjectFieldComponent: React.ComponentType<{
+    name: string;
+    schema: any;
+    form: ReturnType<typeof useForm>;
+    renderFormField: FormFieldRenderer;
+    getTypeBadge: (type: string) => string;
+  }>
+): FormFieldRenderer {
+  const renderFormField: FormFieldRenderer = (
+    fieldName: string,
+    fieldSchema: any
+  ): React.ReactElement | null => {
+    switch (fieldSchema.type) {
+      case "string":
+        if (fieldSchema.enum) {
+          return (
+            <Controller
+              name={fieldName as any}
+              control={form.control}
+              render={({ field }) => (
+                <Select value={field.value} onValueChange={field.onChange}>
+                  <FormControl>
+                    <SelectTrigger>
+                      <SelectValue placeholder={`选择${fieldName}`} />
+                    </SelectTrigger>
+                  </FormControl>
+                  <SelectContent>
+                    {fieldSchema.enum.map((option: string) => (
+                      <SelectItem key={option} value={option}>
+                        {option}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              )}
+            />
+          );
+        }
+        return (
+          <Controller
+            name={fieldName as any}
+            control={form.control}
+            render={({ field }) => (
+              <FormControl>
+                <Input
+                  {...field}
+                  placeholder={`输入${fieldName}`}
+                  type={fieldSchema.format === "password" ? "password" : "text"}
+                />
+              </FormControl>
+            )}
+          />
+        );
+
+      case "number":
+      case "integer":
+        return (
+          <Controller
+            name={fieldName as any}
+            control={form.control}
+            render={({ field }) => (
+              <FormControl>
+                <Input
+                  {...field}
+                  type="number"
+                  placeholder={`输入${fieldName}`}
+                  step={fieldSchema.type === "integer" ? "1" : "0.1"}
+                  onChange={(e) => {
+                    const value = e.target.value;
+                    field.onChange(value === "" ? "" : Number(value));
+                  }}
+                />
+              </FormControl>
+            )}
+          />
+        );
+
+      case "boolean":
+        return (
+          <Controller
+            name={fieldName as any}
+            control={form.control}
+            render={({ field }) => (
+              <Select
+                value={field.value?.toString()}
+                onValueChange={(value) => field.onChange(value === "true")}
+              >
+                <FormControl>
+                  <SelectTrigger>
+                    <SelectValue placeholder={`选择${fieldName}`} />
+                  </SelectTrigger>
+                </FormControl>
+                <SelectContent>
+                  <SelectItem value="true">true</SelectItem>
+                  <SelectItem value="false">false</SelectItem>
+                </SelectContent>
+              </Select>
+            )}
+          />
+        );
+
+      case "array":
+        return (
+          <ArrayFieldComponent
+            name={fieldName}
+            schema={fieldSchema}
+            form={form}
+            renderFormField={renderFormField}
+          />
+        );
+
+      case "object":
+        return (
+          <ObjectFieldComponent
+            name={fieldName}
+            schema={fieldSchema}
+            form={form}
+            renderFormField={renderFormField}
+            getTypeBadge={getTypeBadgeColor}
+          />
+        );
+
+      default:
+        return (
+          <Controller
+            name={fieldName as any}
+            control={form.control}
+            render={({ field }) => (
+              <FormControl>
+                <Input {...field} placeholder={`输入${fieldName}`} />
+              </FormControl>
+            )}
+          />
+        );
+    }
+  };
+
+  return renderFormField;
+}

--- a/apps/frontend/src/components/tool-debug-dialog.tsx
+++ b/apps/frontend/src/components/tool-debug-dialog.tsx
@@ -12,22 +12,13 @@ import {
 } from "@/components/ui/dialog";
 import {
   Form,
-  FormControl,
   FormDescription,
   FormField,
   FormItem,
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { Input } from "@/components/ui/input";
 import { ScrollArea } from "@/components/ui/scroll-area";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -36,6 +27,7 @@ import {
   TooltipProvider,
   TooltipTrigger,
 } from "@/components/ui/tooltip";
+import { useToolShortcut } from "@/hooks/use-tool-shortcut";
 import {
   createDefaultValues,
   createZodSchemaFromJsonSchema,
@@ -57,9 +49,13 @@ import {
 } from "lucide-react";
 import type React from "react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { Controller, useFieldArray, useForm } from "react-hook-form";
+import { useFieldArray, useForm } from "react-hook-form";
 import { toast } from "sonner";
 import { z } from "zod";
+import {
+  createFormFieldRenderer,
+  getTypeBadgeColor,
+} from "./form-field-renderer";
 
 /**
  * 数组字段渲染器组件
@@ -221,7 +217,6 @@ interface ObjectFieldProps {
     fieldName: string,
     fieldSchema: any
   ) => React.ReactElement | null;
-  getTypeBadge: (type: string) => string;
 }
 
 const ObjectField = memo(function ObjectField({
@@ -229,7 +224,6 @@ const ObjectField = memo(function ObjectField({
   schema,
   form,
   renderFormField,
-  getTypeBadge,
 }: ObjectFieldProps) {
   if (!schema.properties || Object.keys(schema.properties).length === 0) {
     return (
@@ -262,7 +256,7 @@ const ObjectField = memo(function ObjectField({
                     </FormLabel>
                     <Badge
                       variant="secondary"
-                      className={`text-xs ${getTypeBadge(fieldSchema.type)}`}
+                      className={`text-xs ${getTypeBadgeColor(fieldSchema.type)}`}
                     >
                       {fieldSchema.type}
                     </Badge>
@@ -648,149 +642,11 @@ export function ToolDebugDialog({
     }
   }, [inputMode, tool?.inputSchema, defaultValues, form]);
 
-  // 渲染表单字段的辅助函数 - 使用 useMemo 优化性能
-  const renderFormField = useMemo(() => {
-    const getTypeBadge = (type: string) => {
-      const colors: Record<string, string> = {
-        string: "bg-blue-100 text-blue-800",
-        number: "bg-green-100 text-green-800",
-        integer: "bg-green-100 text-green-800",
-        boolean: "bg-purple-100 text-purple-800",
-        array: "bg-orange-100 text-orange-800",
-        object: "bg-gray-100 text-gray-800",
-      };
-
-      return colors[type] || "bg-gray-100 text-gray-800";
-    };
-
-    return (fieldName: string, fieldSchema: any): React.ReactElement | null => {
-      switch (fieldSchema.type) {
-        case "string":
-          if (fieldSchema.enum) {
-            return (
-              <Controller
-                name={fieldName as any}
-                control={form.control}
-                render={({ field }) => (
-                  <Select value={field.value} onValueChange={field.onChange}>
-                    <FormControl>
-                      <SelectTrigger>
-                        <SelectValue placeholder={`选择${fieldName}`} />
-                      </SelectTrigger>
-                    </FormControl>
-                    <SelectContent>
-                      {fieldSchema.enum.map((option: string) => (
-                        <SelectItem key={option} value={option}>
-                          {option}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
-                )}
-              />
-            );
-          }
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input
-                    {...field}
-                    placeholder={`输入${fieldName}`}
-                    type={
-                      fieldSchema.format === "password" ? "password" : "text"
-                    }
-                  />
-                </FormControl>
-              )}
-            />
-          );
-
-        case "number":
-        case "integer":
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input
-                    {...field}
-                    type="number"
-                    placeholder={`输入${fieldName}`}
-                    step={fieldSchema.type === "integer" ? "1" : "0.1"}
-                    onChange={(e) => {
-                      const value = e.target.value;
-                      field.onChange(value === "" ? "" : Number(value));
-                    }}
-                  />
-                </FormControl>
-              )}
-            />
-          );
-
-        case "boolean":
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <Select
-                  value={field.value?.toString()}
-                  onValueChange={(value) => field.onChange(value === "true")}
-                >
-                  <FormControl>
-                    <SelectTrigger>
-                      <SelectValue placeholder={`选择${fieldName}`} />
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    <SelectItem value="true">true</SelectItem>
-                    <SelectItem value="false">false</SelectItem>
-                  </SelectContent>
-                </Select>
-              )}
-            />
-          );
-
-        case "array":
-          return (
-            <ArrayField
-              name={fieldName}
-              schema={fieldSchema}
-              form={form}
-              renderFormField={renderFormField}
-            />
-          );
-
-        case "object":
-          return (
-            <ObjectField
-              name={fieldName}
-              schema={fieldSchema}
-              form={form}
-              renderFormField={renderFormField}
-              getTypeBadge={getTypeBadge}
-            />
-          );
-
-        default:
-          return (
-            <Controller
-              name={fieldName as any}
-              control={form.control}
-              render={({ field }) => (
-                <FormControl>
-                  <Input {...field} placeholder={`输入${fieldName}`} />
-                </FormControl>
-              )}
-            />
-          );
-      }
-    };
-  }, [form]);
+  // 渲染表单字段 - 使用提取的渲染器创建函数
+  const renderFormField = useMemo(
+    () => createFormFieldRenderer(form, ArrayField, ObjectField),
+    [form]
+  );
 
   // 格式化结果显示
   const formatResult = useCallback((data: any) => {
@@ -808,52 +664,16 @@ export function ToolDebugDialog({
     return isMac ? "⌘+Enter" : "Ctrl+Enter";
   }, []);
 
-  // 处理键盘事件
-  const handleKeyDown = useCallback(
-    async (event: KeyboardEvent) => {
-      // 检查是否是 Command+Enter (Mac) 或 Ctrl+Enter (Windows/Linux)
-      const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
-      const isShortcutKey = isMac
-        ? event.metaKey && event.key === "Enter"
-        : event.ctrlKey && event.key === "Enter";
-
-      if (isShortcutKey && open && !loading) {
-        // 阻止默认行为
-        event.preventDefault();
-
-        // 检查是否无参数工具，或者是有参数工具且JSON模式时验证格式
-        const hasNoParams =
-          !tool?.inputSchema?.properties ||
-          Object.keys(tool.inputSchema.properties).length === 0;
-        if (!hasNoParams && inputMode === "json" && !validateJSON(jsonInput)) {
-          toast.error("输入参数不是有效的JSON格式");
-          return;
-        }
-
-        // 调用工具
-        await handleCallTool();
-      }
-    },
-    [
-      open,
-      loading,
-      inputMode,
-      jsonInput,
-      validateJSON,
-      handleCallTool,
-      tool?.inputSchema?.properties,
-    ]
-  );
-
-  // 添加键盘事件监听器
-  useEffect(() => {
-    if (open) {
-      window.addEventListener("keydown", handleKeyDown);
-      return () => {
-        window.removeEventListener("keydown", handleKeyDown);
-      };
-    }
-  }, [open, handleKeyDown]);
+  // 使用快捷键 Hook 处理 Cmd/Ctrl+Enter
+  useToolShortcut({
+    open,
+    loading,
+    tool,
+    inputMode,
+    jsonInput,
+    validateJSON,
+    handleCallTool,
+  });
 
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>

--- a/apps/frontend/src/hooks/use-tool-shortcut.ts
+++ b/apps/frontend/src/hooks/use-tool-shortcut.ts
@@ -1,0 +1,113 @@
+"use client";
+
+import { useCallback, useEffect } from "react";
+import { toast } from "sonner";
+
+/**
+ * 工具调用快捷键 Hook
+ *
+ * @description 处理工具调试对话框的 Cmd/Ctrl+Enter 快捷键
+ * 在对话框打开且不在加载状态时，允许用户通过快捷键快速调用工具
+ */
+
+interface UseToolShortcutOptions {
+  /** 对话框是否打开 */
+  open: boolean;
+  /** 是否正在加载 */
+  loading: boolean;
+  /** 当前工具信息 */
+  tool: {
+    name: string;
+    serverName: string;
+    toolName: string;
+    description?: string;
+    inputSchema?: any;
+  } | null;
+  /** 当前输入模式 */
+  inputMode: "form" | "json";
+  /** JSON 输入内容 */
+  jsonInput: string;
+  /** JSON 验证函数 */
+  validateJSON: (jsonString: string) => boolean;
+  /** 调用工具的回调函数 */
+  handleCallTool: () => Promise<void>;
+}
+
+/**
+ * 使用工具快捷键
+ *
+ * @description 在对话框打开时添加键盘事件监听器，处理 Cmd/Ctrl+Enter 快捷键
+ *
+ * @param options - 快捷键配置选项
+ *
+ * @example
+ * ```tsx
+ * useToolShortcut({
+ *   open: dialogOpen,
+ *   loading: isLoading,
+ *   tool: currentTool,
+ *   inputMode: "form",
+ *   jsonInput: "{}",
+ *   validateJSON: (str) => { try { JSON.parse(str); return true; } catch { return false; } },
+ *   handleCallTool: async () => { await callTool(); }
+ * });
+ * ```
+ */
+export function useToolShortcut(options: UseToolShortcutOptions) {
+  const {
+    open,
+    loading,
+    tool,
+    inputMode,
+    jsonInput,
+    validateJSON,
+    handleCallTool,
+  } = options;
+
+  const handleKeyDown = useCallback(
+    async (event: KeyboardEvent) => {
+      // 检查是否是 Command+Enter (Mac) 或 Ctrl+Enter (Windows/Linux)
+      const isMac = /Mac|iPhone|iPad|iPod/.test(navigator.platform);
+      const isShortcutKey = isMac
+        ? event.metaKey && event.key === "Enter"
+        : event.ctrlKey && event.key === "Enter";
+
+      if (isShortcutKey && open && !loading) {
+        // 阻止默认行为
+        event.preventDefault();
+
+        // 检查是否无参数工具，或者是有参数工具且JSON模式时验证格式
+        const hasNoParams =
+          !tool?.inputSchema?.properties ||
+          Object.keys(tool.inputSchema.properties).length === 0;
+
+        if (!hasNoParams && inputMode === "json" && !validateJSON(jsonInput)) {
+          toast.error("输入参数不是有效的JSON格式");
+          return;
+        }
+
+        // 调用工具
+        await handleCallTool();
+      }
+    },
+    [
+      open,
+      loading,
+      inputMode,
+      jsonInput,
+      validateJSON,
+      handleCallTool,
+      tool?.inputSchema?.properties,
+    ]
+  );
+
+  // 添加键盘事件监听器
+  useEffect(() => {
+    if (open) {
+      window.addEventListener("keydown", handleKeyDown);
+      return () => {
+        window.removeEventListener("keydown", handleKeyDown);
+      };
+    }
+  }, [open, handleKeyDown]);
+}


### PR DESCRIPTION
按照 Issue #3089 的建议，将主组件的过多职责拆分到独立模块：

1. 提取 renderFormField 函数（~140行）到 form-field-renderer 模块
   - 创建 createFormFieldRenderer 工厂函数
   - 导出 getTypeBadgeColor 辅助函数
   - 保持递归渲染逻辑完整性

2. 提取键盘事件处理（~45行）到 useToolShortcut Hook
   - 封装 Cmd/Ctrl+Enter 快捷键处理
   - 统一事件监听器生命周期管理

3. 主组件简化效果：
   - 从 ~635 行降至 ~490 行
   - 职责更加清晰：状态管理、表单逻辑、事件处理、UI渲染

遵循项目"务实开发"理念，渐进式优化而非预防性重构。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3089