### PR TITLE
refactor(asr): 提取 ByteDance 配置类型中的公共定义

### DIFF
--- a/packages/asr/src/platforms/bytedance/types.ts
+++ b/packages/asr/src/platforms/bytedance/types.ts
@@ -6,6 +6,40 @@ import type { AudioFormat } from "@/audio";
 import type { AuthMethod } from "@/auth";
 
 /**
+ * ByteDance 音频配置
+ */
+export interface ByteDanceAudioConfig {
+  /** 音频格式 */
+  format?: AudioFormat;
+  /** 采样率 */
+  sampleRate?: number;
+  /** 位深 */
+  bits?: number;
+  /** 声道数 */
+  channel?: number;
+  /** 编解码器 */
+  codec?: string;
+}
+
+/**
+ * ByteDance 请求配置
+ */
+export interface ByteDanceRequestConfig {
+  /** 分片时长 (ms) */
+  segDuration?: number;
+  /** N-best 数量 */
+  nbest?: number;
+  /** 工作流 */
+  workflow?: string;
+  /** 显示语言 */
+  showLanguage?: boolean;
+  /** 显示分句 */
+  showUtterances?: boolean;
+  /** 结果类型 */
+  resultType?: string;
+}
+
+/**
  * ByteDance 平台配置
  */
 export interface ByteDancePlatformConfig {
@@ -36,34 +70,10 @@ export interface ByteDancePlatformConfig {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 
   /** 认证配置 */
   auth?: {
@@ -98,34 +108,10 @@ export interface ByteDanceV2Config {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 }
 
 /**
@@ -148,34 +134,10 @@ export interface ByteDanceV3Config {
   };
 
   /** 音频配置 */
-  audio?: {
-    /** 音频格式 */
-    format?: AudioFormat;
-    /** 采样率 */
-    sampleRate?: number;
-    /** 位深 */
-    bits?: number;
-    /** 声道数 */
-    channel?: number;
-    /** 编解码器 */
-    codec?: string;
-  };
+  audio?: ByteDanceAudioConfig;
 
   /** 请求配置 */
-  request?: {
-    /** 分片时长 (ms) */
-    segDuration?: number;
-    /** N-best 数量 */
-    nbest?: number;
-    /** 工作流 */
-    workflow?: string;
-    /** 显示语言 */
-    showLanguage?: boolean;
-    /** 显示分句 */
-    showUtterances?: boolean;
-    /** 结果类型 */
-    resultType?: string;
-  };
+  request?: ByteDanceRequestConfig;
 }
 
 /**


### PR DESCRIPTION
解决 packages/asr/src/platforms/bytedance/types.ts 文件中的代码重复问题：
- 提取 ByteDanceAudioConfig 和 ByteDanceRequestConfig 公共类型
- 更新 ByteDancePlatformConfig、ByteDanceV2Config 和 ByteDanceV3Config 使用公共类型
- 减少约 38 行重复代码，遵循 DRY 原则

修复 #3090

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3090