### PR TITLE
feat(mcp-core): 添加 MCPLogger 接口支持统一日志系统

### DIFF
--- a/packages/mcp-core/examples/http.ts
+++ b/packages/mcp-core/examples/http.ts
@@ -51,29 +51,33 @@ async function main(): Promise<void> {
   console.log("=== http MCP 连接示例 ===\n");
 
   // 1. 创建连接实例
-  const connection = new MCPConnection("12306-mcp", {
-    type: "http",
-    url: "https://mcp.api-inference.modelscope.net/7521b0f1413b49/mcp",
-  }, {
-    // 连接成功回调
-    onConnected: (data) => {
-      console.log(`✅ 服务 ${data.serviceName} 已连接`);
-      console.log(`   发现 ${data.tools.length} 个工具`);
-      console.log();
+  const connection = new MCPConnection(
+    "12306-mcp",
+    {
+      type: "http",
+      url: "https://mcp.api-inference.modelscope.net/7521b0f1413b49/mcp",
     },
+    {
+      // 连接成功回调
+      onConnected: (data) => {
+        console.log(`✅ 服务 ${data.serviceName} 已连接`);
+        console.log(`   发现 ${data.tools.length} 个工具`);
+        console.log();
+      },
 
-    // 连接失败回调
-    onConnectionFailed: (data) => {
-      console.error(`❌ 服务 ${data.serviceName} 连接失败`);
-      console.error(`   错误: ${data.error.message}`);
-    },
+      // 连接失败回调
+      onConnectionFailed: (data) => {
+        console.error(`❌ 服务 ${data.serviceName} 连接失败`);
+        console.error(`   错误: ${data.error.message}`);
+      },
 
-    // 断开连接回调
-    onDisconnected: (data) => {
-      console.log(`👋 服务 ${data.serviceName} 已断开`);
-      console.log(`   原因: ${data.reason || "正常关闭"}`);
-    },
-  });
+      // 断开连接回调
+      onDisconnected: (data) => {
+        console.log(`👋 服务 ${data.serviceName} 已断开`);
+        console.log(`   原因: ${data.reason || "正常关闭"}`);
+      },
+    }
+  );
 
   try {
     // 3. 建立连接

--- a/packages/mcp-core/examples/sse.ts
+++ b/packages/mcp-core/examples/sse.ts
@@ -51,29 +51,33 @@ async function main(): Promise<void> {
   console.log("=== SSE MCP 连接示例 ===\n");
 
   // 1. 创建连接实例
-  const connection = new MCPConnection("12306-mcp", {
-    type: "sse",
-    url: "https://mcp.api-inference.modelscope.net/ed2b195cc8f94d/sse",
-  }, {
-    // 连接成功回调
-    onConnected: (data) => {
-      console.log(`✅ 服务 ${data.serviceName} 已连接`);
-      console.log(`   发现 ${data.tools.length} 个工具`);
-      console.log();
+  const connection = new MCPConnection(
+    "12306-mcp",
+    {
+      type: "sse",
+      url: "https://mcp.api-inference.modelscope.net/ed2b195cc8f94d/sse",
     },
+    {
+      // 连接成功回调
+      onConnected: (data) => {
+        console.log(`✅ 服务 ${data.serviceName} 已连接`);
+        console.log(`   发现 ${data.tools.length} 个工具`);
+        console.log();
+      },
 
-    // 连接失败回调
-    onConnectionFailed: (data) => {
-      console.error(`❌ 服务 ${data.serviceName} 连接失败`);
-      console.error(`   错误: ${data.error.message}`);
-    },
+      // 连接失败回调
+      onConnectionFailed: (data) => {
+        console.error(`❌ 服务 ${data.serviceName} 连接失败`);
+        console.error(`   错误: ${data.error.message}`);
+      },
 
-    // 断开连接回调
-    onDisconnected: (data) => {
-      console.log(`👋 服务 ${data.serviceName} 已断开`);
-      console.log(`   原因: ${data.reason || "正常关闭"}`);
-    },
-  });
+      // 断开连接回调
+      onDisconnected: (data) => {
+        console.log(`👋 服务 ${data.serviceName} 已断开`);
+        console.log(`   原因: ${data.reason || "正常关闭"}`);
+      },
+    }
+  );
 
   try {
     // 3. 建立连接

--- a/packages/mcp-core/examples/streamable-http.ts
+++ b/packages/mcp-core/examples/streamable-http.ts
@@ -36,10 +36,10 @@ import { MCPConnection } from "@xiaozhi-client/mcp-core";
  * 这些格式都会被 TypeFieldNormalizer 自动转换为标准的 "http" 类型
  */
 const typeVariants = [
-	"streamable-http", // MCP 官方格式（推荐使用）
-	"streamableHttp", // camelCase 格式
-	"streamable_http", // snake_case 格式
-	"http", // 标准格式
+  "streamable-http", // MCP 官方格式（推荐使用）
+  "streamableHttp", // camelCase 格式
+  "streamable_http", // snake_case 格式
+  "http", // 标准格式
 ] as const;
 
 /**
@@ -47,7 +47,8 @@ const typeVariants = [
  *
  * 使用 ModelScope 托管的 12306-mcp 服务作为示例
  */
-const serviceUrl = "https://mcp.api-inference.modelscope.net/f0fd106773fa4e/mcp";
+const serviceUrl =
+  "https://mcp.api-inference.modelscope.net/f0fd106773fa4e/mcp";
 
 /**
  * 测试单个 type 格式的连接
@@ -57,97 +58,97 @@ const serviceUrl = "https://mcp.api-inference.modelscope.net/f0fd106773fa4e/mcp"
  * @param total - 总测试数量
  */
 async function testConnection(
-	typeVariant: (typeof typeVariants)[number],
-	index: number,
-	total: number,
+  typeVariant: (typeof typeVariants)[number],
+  index: number,
+  total: number
 ): Promise<void> {
-	const serviceName = `12306-mcp-${typeVariant}`;
-	console.log(`\n测试 ${index}/${total}: type = "${typeVariant}"`);
-	console.log(`服务名称: ${serviceName}`);
-	console.log("正在连接...");
+  const serviceName = `12306-mcp-${typeVariant}`;
+  console.log(`\n测试 ${index}/${total}: type = "${typeVariant}"`);
+  console.log(`服务名称: ${serviceName}`);
+  console.log("正在连接...");
 
-	const connection = new MCPConnection(
-		serviceName,
-		{
-			type: typeVariant,
-			url: serviceUrl,
-		},
-		{
-			// 连接成功回调
-			onConnected: (data) => {
-				console.log(`✅ 服务 ${data.serviceName} 已连接`);
-				console.log(`   发现 ${data.tools.length} 个工具`);
-			},
+  const connection = new MCPConnection(
+    serviceName,
+    {
+      type: typeVariant,
+      url: serviceUrl,
+    },
+    {
+      // 连接成功回调
+      onConnected: (data) => {
+        console.log(`✅ 服务 ${data.serviceName} 已连接`);
+        console.log(`   发现 ${data.tools.length} 个工具`);
+      },
 
-			// 连接失败回调
-			onConnectionFailed: (data) => {
-				console.error(`❌ 服务 ${data.serviceName} 连接失败`);
-				console.error(`   错误: ${data.error.message}`);
-			},
+      // 连接失败回调
+      onConnectionFailed: (data) => {
+        console.error(`❌ 服务 ${data.serviceName} 连接失败`);
+        console.error(`   错误: ${data.error.message}`);
+      },
 
-			// 断开连接回调
-			onDisconnected: (data) => {
-				console.log(`👋 服务 ${data.serviceName} 已断开`);
-			},
-		},
-	);
+      // 断开连接回调
+      onDisconnected: (data) => {
+        console.log(`👋 服务 ${data.serviceName} 已断开`);
+      },
+    }
+  );
 
-	try {
-		await connection.connect();
+  try {
+    await connection.connect();
 
-		// 获取工具列表
-		const tools = connection.getTools();
-		console.log("可用工具:");
-		for (const tool of tools) {
-			console.log(`  - ${tool.name}`);
-			if (tool.description) {
-				console.log(`    描述: ${tool.description}`);
-			}
-		}
+    // 获取工具列表
+    const tools = connection.getTools();
+    console.log("可用工具:");
+    for (const tool of tools) {
+      console.log(`  - ${tool.name}`);
+      if (tool.description) {
+        console.log(`    描述: ${tool.description}`);
+      }
+    }
 
-		// 检查连接状态
-		const isConnected = connection.isConnected();
-		const status = connection.getStatus();
-		console.log("连接状态:");
-		console.log(`  是否已连接: ${isConnected}`);
-		console.log(`  状态: ${status.connectionState}`);
-	} catch (error) {
-		console.error("执行过程中出错:");
-		if (error instanceof Error) {
-			console.error(`  ${error.message}`);
-		}
-	} finally {
-		// 断开连接
-		await connection.disconnect();
-	}
+    // 检查连接状态
+    const isConnected = connection.isConnected();
+    const status = connection.getStatus();
+    console.log("连接状态:");
+    console.log(`  是否已连接: ${isConnected}`);
+    console.log(`  状态: ${status.connectionState}`);
+  } catch (error) {
+    console.error("执行过程中出错:");
+    if (error instanceof Error) {
+      console.error(`  ${error.message}`);
+    }
+  } finally {
+    // 断开连接
+    await connection.disconnect();
+  }
 }
 
 /**
  * 主函数
  */
 async function main(): Promise<void> {
-	console.log("=== streamable-http MCP 连接示例 - Type 格式兼容性演示 ===");
-	console.log("\n服务 URL:", serviceUrl);
-	console.log("\n将依次测试以下 type 格式:");
-	typeVariants.forEach((variant, index) => {
-		console.log(`  ${index + 1}. "${variant}"`);
-	});
+  console.log("=== streamable-http MCP 连接示例 - Type 格式兼容性演示 ===");
+  console.log("\n服务 URL:", serviceUrl);
+  console.log("\n将依次测试以下 type 格式:");
+  typeVariants.forEach((variant, index) => {
+    console.log(`  ${index + 1}. "${variant}"`);
+  });
 
-	const totalTests = typeVariants.length;
+  const totalTests = typeVariants.length;
 
-	// 按顺序测试每种格式
-	for (let i = 0; i < typeVariants.length; i++) {
-		await testConnection(typeVariants[i], i + 1, totalTests);
-	}
+  // 按顺序测试每种格式
+  for (let i = 0; i < typeVariants.length; i++) {
+    await testConnection(typeVariants[i], i + 1, totalTests);
+  }
 
-	console.log("\n=== 所有格式兼容性测试完成 ===");
-	console.log("\n结论:");
-	console.log("  所有 type 格式变体都已成功规范化并正常连接");
-	console.log("  推荐使用 'http' 作为标准 type 值");
+  console.log("\n=== 所有格式兼容性测试完成 ===");
+  console.log("\n结论:");
+  console.log("  所有 type 格式变体都已成功规范化并正常连接");
+  console.log("  推荐使用 'http' 作为标准 type 值");
 }
 
 // 运行主函数
 main().catch((error) => {
-	console.error("未捕获的错误:", error);
-	process.exit(1);
+  console.error("未捕获的错误:", error);
+  process.exit(1);
 });

--- a/packages/mcp-core/src/__tests__/connection.test.ts
+++ b/packages/mcp-core/src/__tests__/connection.test.ts
@@ -1,10 +1,18 @@
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { afterEach, beforeAll, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { MCPConnection } from "../connection.js";
 import { ConnectionState } from "../types.js";
 import { MCPTransportType } from "../types.js";
 import type { MCPServerTransport, MCPServiceConfig } from "../types.js";
-import { MCPConnection } from "../connection.js";
 
 // Mock 接口定义
 interface MockClient {
@@ -25,11 +33,7 @@ vi.mock("../transport-factory.js", () => {
   const mockTransportFactory = {
     validateConfig: vi.fn(),
     create: vi.fn(),
-    getSupportedTypes: vi.fn().mockReturnValue([
-      "stdio",
-      "sse",
-      "http",
-    ]),
+    getSupportedTypes: vi.fn().mockReturnValue(["stdio", "sse", "http"]),
   };
 
   return {
@@ -48,13 +52,15 @@ let mockTransportFactory: {
 // 使用 beforeAll 来获取 mock 函数
 beforeAll(async () => {
   const module = await import("../transport-factory.js");
-  mockTransportFactory = (module as unknown as {
-    __mockTransportFactory: {
-      validateConfig: ReturnType<typeof vi.fn>;
-      create: ReturnType<typeof vi.fn>;
-      getSupportedTypes: ReturnType<typeof vi.fn>;
-    };
-  }).__mockTransportFactory;
+  mockTransportFactory = (
+    module as unknown as {
+      __mockTransportFactory: {
+        validateConfig: ReturnType<typeof vi.fn>;
+        create: ReturnType<typeof vi.fn>;
+        getSupportedTypes: ReturnType<typeof vi.fn>;
+      };
+    }
+  ).__mockTransportFactory;
 });
 
 describe("MCPConnection", () => {
@@ -330,9 +336,9 @@ describe("MCPConnection", () => {
     it("未连接时应该抛出错误", async () => {
       await connection.disconnect();
 
-      await expect(
-        connection.callTool("test-tool", {})
-      ).rejects.toThrow("服务 test-service 未连接");
+      await expect(connection.callTool("test-tool", {})).rejects.toThrow(
+        "服务 test-service 未连接"
+      );
     });
 
     it("工具不存在时应该抛出错误", async () => {
@@ -420,7 +426,11 @@ describe("MCPConnection", () => {
 
   describe("error handling", () => {
     it("连接失败时应该设置 DISCONNECTED 状态", async () => {
-      const testConnection = new MCPConnection("test-service", config, mockCallbacks);
+      const testConnection = new MCPConnection(
+        "test-service",
+        config,
+        mockCallbacks
+      );
       mockClient.connect.mockRejectedValue(new Error("Connection failed"));
 
       await testConnection.connect().catch(() => {});
@@ -431,7 +441,11 @@ describe("MCPConnection", () => {
     });
 
     it("应该正确处理连接失败", async () => {
-      const testConnection = new MCPConnection("test-service", config, mockCallbacks);
+      const testConnection = new MCPConnection(
+        "test-service",
+        config,
+        mockCallbacks
+      );
       mockClient.connect.mockRejectedValue(new Error("Connection failed"));
 
       await expect(testConnection.connect()).rejects.toThrow(
@@ -460,9 +474,7 @@ describe("MCPConnection", () => {
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockRejectedValue(new Error("Failed to get tools"));
 
-      await expect(connection.connect()).rejects.toThrow(
-        "Failed to get tools"
-      );
+      await expect(connection.connect()).rejects.toThrow("Failed to get tools");
     });
 
     it("断开连接后工具列表应该被保留", async () => {
@@ -491,7 +503,11 @@ describe("MCPConnection", () => {
         apiKey: "test-key",
       };
 
-      const sseConnection = new MCPConnection("test-sse-service", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse-service",
+        sseConfig,
+        mockCallbacks
+      );
       const status = sseConnection.getStatus();
 
       expect(status.name).toBe("test-sse-service");
@@ -505,7 +521,11 @@ describe("MCPConnection", () => {
         headers: { "Custom-Header": "value" },
       };
 
-      const httpConnection = new MCPConnection("test-http-service", httpConfig, mockCallbacks);
+      const httpConnection = new MCPConnection(
+        "test-http-service",
+        httpConfig,
+        mockCallbacks
+      );
       const status = httpConnection.getStatus();
 
       expect(status.name).toBe("test-http-service");
@@ -562,9 +582,9 @@ describe("MCPConnection", () => {
       const invalidConfig = {
         type: MCPTransportType.SSE,
       } as MCPServiceConfig;
-      expect(() => new MCPConnection("test", invalidConfig, mockCallbacks)).toThrow(
-        "sse 类型需要 url 字段"
-      );
+      expect(
+        () => new MCPConnection("test", invalidConfig, mockCallbacks)
+      ).toThrow("sse 类型需要 url 字段");
     });
 
     it("缺少 command 时应该抛出错误", () => {
@@ -577,9 +597,9 @@ describe("MCPConnection", () => {
         type: MCPTransportType.STDIO,
         command: undefined,
       } as MCPServiceConfig;
-      expect(() => new MCPConnection("test", invalidConfig, mockCallbacks)).toThrow(
-        "stdio 类型需要 command 字段"
-      );
+      expect(
+        () => new MCPConnection("test", invalidConfig, mockCallbacks)
+      ).toThrow("stdio 类型需要 command 字段");
     });
   });
 
@@ -598,7 +618,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 
@@ -620,7 +644,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
       mockClient.close.mockResolvedValue(undefined);
@@ -653,7 +681,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const stdioConnection = new MCPConnection("test-stdio", stdioConfig, mockCallbacks);
+      const stdioConnection = new MCPConnection(
+        "test-stdio",
+        stdioConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 
@@ -674,7 +706,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 
@@ -694,7 +730,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 
@@ -716,7 +756,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 
@@ -742,7 +786,11 @@ describe("MCPConnection", () => {
         },
       };
 
-      const sseConnection = new MCPConnection("test-sse", sseConfig, mockCallbacks);
+      const sseConnection = new MCPConnection(
+        "test-sse",
+        sseConfig,
+        mockCallbacks
+      );
       mockClient.connect.mockResolvedValue(undefined);
       mockClient.listTools.mockResolvedValue({ tools: [] });
 

--- a/packages/mcp-core/src/__tests__/transport-factory.test.ts
+++ b/packages/mcp-core/src/__tests__/transport-factory.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
+import { TransportFactory } from "../transport-factory.js";
 import { MCPTransportType } from "../types.js";
 import type { InternalMCPServiceConfig } from "../types.js";
-import { TransportFactory } from "../transport-factory.js";
 
 describe("TransportFactory", () => {
   describe("validateConfig", () => {
@@ -225,9 +225,7 @@ describe("TransportFactory", () => {
         type: "unsupported" as MCPTransportType,
       } as InternalMCPServiceConfig;
 
-      expect(() => TransportFactory.create(config)).toThrow(
-        "不支持的传输类型"
-      );
+      expect(() => TransportFactory.create(config)).toThrow("不支持的传输类型");
     });
   });
 

--- a/packages/mcp-core/src/connection.ts
+++ b/packages/mcp-core/src/connection.ts
@@ -9,11 +9,25 @@
 
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import type { MCPServerTransport, MCPServiceConfig, MCPServiceStatus, ToolCallResult } from "./types.js";
-import { ConnectionState, MCPTransportType } from "./types.js";
 import { TransportFactory } from "./transport-factory.js";
+import type {
+  MCPServerTransport,
+  MCPServiceConfig,
+  MCPServiceStatus,
+  ToolCallResult,
+} from "./types.js";
+import {
+  ConnectionState,
+  type MCPLogger,
+  MCPTransportType,
+  createConsoleLogger,
+} from "./types.js";
+import type {
+  HeartbeatConfig,
+  InternalMCPServiceConfig,
+  MCPServiceEventCallbacks,
+} from "./types.js";
 import { inferTransportTypeFromConfig } from "./utils/index.js";
-import type { HeartbeatConfig, MCPServiceEventCallbacks, InternalMCPServiceConfig } from './types.js';
 
 /**
  * MCP 连接类
@@ -32,20 +46,25 @@ export class MCPConnection {
   // 心跳检测相关
   private heartbeatTimer: NodeJS.Timeout | null = null;
   private heartbeatConfig?: HeartbeatConfig;
+  // 日志系统
+  private logger: MCPLogger;
 
   constructor(
     name: string,
     config: MCPServiceConfig,
-    callbacks?: MCPServiceEventCallbacks
+    callbacks?: MCPServiceEventCallbacks,
+    logger?: MCPLogger
   ) {
     this.name = name;
-    // 使用工具方法推断服务类型（传递服务名称用于日志）
-    this.config = inferTransportTypeFromConfig(config, name);
+    // 使用注入的 logger 或默认 console logger
+    this.logger = logger ?? createConsoleLogger();
+    // 使用工具方法推断服务类型（传递服务名称和 logger 用于日志）
+    this.config = inferTransportTypeFromConfig(config, name, this.logger);
     this.callbacks = callbacks;
     // 保存心跳配置 - 优先使用用户配置
     this.heartbeatConfig = {
-      enabled: config.heartbeat?.enabled ?? true,  // 默认启用
-      interval: config.heartbeat?.interval ?? 30 * 1000,  // 默认 30 秒
+      enabled: config.heartbeat?.enabled ?? true, // 默认启用
+      interval: config.heartbeat?.interval ?? 30 * 1000, // 默认 30 秒
     };
 
     // 验证配置
@@ -88,9 +107,7 @@ export class MCPConnection {
    */
   private async attemptConnection(): Promise<void> {
     this.connectionState = ConnectionState.CONNECTING;
-    console.debug(
-      `[MCP-${this.name}] 正在连接 MCP 服务: ${this.name}`
-    );
+    this.logger.debug(`[MCP-${this.name}] 正在连接 MCP 服务: ${this.name}`);
 
     return new Promise((resolve, reject) => {
       // 设置连接超时（使用固定默认值 30 秒）
@@ -161,9 +178,7 @@ export class MCPConnection {
     this.connectionState = ConnectionState.CONNECTED;
     this.initialized = true;
 
-    console.info(
-      `[MCP-${this.name}] MCP 服务 ${this.name} 连接已建立`
-    );
+    this.logger.info(`[MCP-${this.name}] MCP 服务 ${this.name} 连接已建立`);
 
     // 启动心跳检测
     this.startHeartbeat();
@@ -176,7 +191,7 @@ export class MCPConnection {
     this.connectionState = ConnectionState.DISCONNECTED;
     this.initialized = false;
 
-    console.debug(`MCP 服务 ${this.name} 连接错误:`, error.message);
+    this.logger.debug(`MCP 服务 ${this.name} 连接错误:`, error.message);
 
     // 清理连接超时定时器
     if (this.connectionTimeout) {
@@ -247,13 +262,13 @@ export class MCPConnection {
         this.tools.set(tool.name, tool);
       }
 
-      console.debug(
+      this.logger.debug(
         `${this.name} 服务加载了 ${tools.length} 个工具: ${tools
           .map((t) => t.name)
           .join(", ")}`
       );
     } catch (error) {
-      console.error(
+      this.logger.error(
         `${this.name} 获取工具列表失败:`,
         error instanceof Error ? error.message : String(error)
       );
@@ -265,7 +280,7 @@ export class MCPConnection {
    * 断开连接
    */
   async disconnect(): Promise<void> {
-    console.info(`主动断开 MCP 服务 ${this.name} 连接`);
+    this.logger.info(`主动断开 MCP 服务 ${this.name} 连接`);
 
     // 清理连接资源
     this.cleanupConnection();
@@ -309,9 +324,7 @@ export class MCPConnection {
    */
   private async reconnect(): Promise<void> {
     this.connectionState = ConnectionState.RECONNECTING;
-    console.debug(
-      `[MCP-${this.name}] 检测到会话过期，正在重新连接...`
-    );
+    this.logger.debug(`[MCP-${this.name}] 检测到会话过期，正在重新连接...`);
 
     // 清理旧连接
     this.cleanupConnection();
@@ -336,16 +349,14 @@ export class MCPConnection {
 
     this.heartbeatTimer = setInterval(() => {
       this.performHeartbeat().catch((error) => {
-        console.error(
+        this.logger.error(
           `[MCP-${this.name}] 心跳检测执行异常：`,
           error instanceof Error ? error.message : String(error)
         );
       });
     }, interval);
 
-    console.debug(
-      `[MCP-${this.name}] 心跳检测已启动，间隔: ${interval}ms`
-    );
+    this.logger.debug(`[MCP-${this.name}] 心跳检测已启动，间隔: ${interval}ms`);
   }
 
   /**
@@ -359,9 +370,9 @@ export class MCPConnection {
     try {
       // 调用 MCP SDK 的 ping() 方法
       await this.client.ping();
-      console.debug(`[MCP-${this.name}] 心跳检测成功`);
+      this.logger.debug(`[MCP-${this.name}] 心跳检测成功`);
     } catch (error) {
-      console.warn(
+      this.logger.warn(
         `[MCP-${this.name}] 心跳检测失败，尝试重连...`,
         error instanceof Error ? error.message : String(error)
       );
@@ -377,7 +388,7 @@ export class MCPConnection {
     if (this.heartbeatTimer) {
       clearInterval(this.heartbeatTimer);
       this.heartbeatTimer = null;
-      console.debug(`[MCP-${this.name}] 心跳检测已停止`);
+      this.logger.debug(`[MCP-${this.name}] 心跳检测已停止`);
     }
   }
 
@@ -396,7 +407,7 @@ export class MCPConnection {
       throw new Error(`工具 ${name} 在服务 ${this.name} 中不存在`);
     }
 
-    console.debug(
+    this.logger.debug(
       `调用 ${this.name} 服务的工具 ${name}，参数:`,
       JSON.stringify(arguments_)
     );
@@ -407,7 +418,7 @@ export class MCPConnection {
         arguments: arguments_ || {},
       });
 
-      console.debug(
+      this.logger.debug(
         `工具 ${name} 调用成功，结果:`,
         `${JSON.stringify(result).substring(0, 500)}...`
       );
@@ -416,7 +427,7 @@ export class MCPConnection {
     } catch (error) {
       // 检测是否为会话过期错误
       if (this.isSessionExpiredError(error)) {
-        console.warn(
+        this.logger.warn(
           `[MCP-${this.name}] 检测到会话过期，尝试重新连接并重试...`
         );
 
@@ -431,7 +442,7 @@ export class MCPConnection {
       }
 
       // 其他错误正常抛出
-      console.error(
+      this.logger.error(
         `工具 ${name} 调用失败:`,
         error instanceof Error ? error.message : String(error)
       );

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -32,6 +32,8 @@ export type {
   MCPServerTransport,
   // 事件相关
   MCPServiceEventCallbacks,
+  // 日志相关
+  MCPLogger,
 } from "./types.js";
 
 // =========================
@@ -42,6 +44,7 @@ export {
   MCPTransportType,
   ConnectionState,
   ToolCallErrorCode,
+  createConsoleLogger,
 } from "./types.js";
 
 // =========================

--- a/packages/mcp-core/src/manager.ts
+++ b/packages/mcp-core/src/manager.ts
@@ -67,10 +67,7 @@ export class MCPManager extends EventEmitter {
    * });
    * ```
    */
-  addServer(
-    name: string,
-    config: MCPServiceConfig
-  ): void {
+  addServer(name: string, config: MCPServiceConfig): void {
     if (this.configs.has(name)) {
       throw new Error(`服务 ${name} 已存在`);
     }

--- a/packages/mcp-core/src/types.ts
+++ b/packages/mcp-core/src/types.ts
@@ -3,10 +3,10 @@
  * 统一管理所有 MCP 相关的类型定义
  */
 
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
 import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
 import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 
 // =========================
 // 1. 基础传输类型
@@ -43,7 +43,49 @@ export type MCPTransportTypeString = "stdio" | "sse" | "http";
 export type MCPTransportTypeInput = MCPTransportType | MCPTransportTypeString;
 
 // =========================
-// 1.1 事件回调接口
+// 1.1 日志接口
+// =========================
+
+/**
+ * MCP 日志接口
+ * 定义 MCPConnection 所需的最低日志功能
+ *
+ * @description
+ * 此接口允许注入任何符合规范的日志实现（如 Pino、console 等），
+ * 保持 packages/mcp-core 的独立性和向后兼容性。
+ */
+export interface MCPLogger {
+  /** 信息级别日志 */
+  info(message: string, ...args: unknown[]): void;
+  /** 调试级别日志 */
+  debug(message: string, ...args: unknown[]): void;
+  /** 警告级别日志 */
+  warn(message: string, ...args: unknown[]): void;
+  /** 错误级别日志 */
+  error(message: string, ...args: unknown[]): void;
+}
+
+/**
+ * 创建基于 console 的默认日志实现
+ * 用于向后兼容，当未提供 logger 时使用
+ *
+ * @returns 符合 MCPLogger 接口的 console 实现
+ */
+export function createConsoleLogger(): MCPLogger {
+  return {
+    info: (message: string, ...args: unknown[]) =>
+      console.info(message, ...args),
+    debug: (message: string, ...args: unknown[]) =>
+      console.debug(message, ...args),
+    warn: (message: string, ...args: unknown[]) =>
+      console.warn(message, ...args),
+    error: (message: string, ...args: unknown[]) =>
+      console.error(message, ...args),
+  };
+}
+
+// =========================
+// 1.2 事件回调接口
 // =========================
 
 /**

--- a/packages/mcp-core/src/utils/type-normalizer.ts
+++ b/packages/mcp-core/src/utils/type-normalizer.ts
@@ -59,7 +59,11 @@ export namespace TypeFieldNormalizer {
     const originalType = (config as Record<string, unknown>).type;
 
     // 如果已经是标准格式，直接返回原始对象（无需拷贝）
-    if (originalType === "stdio" || originalType === "sse" || originalType === "http") {
+    if (
+      originalType === "stdio" ||
+      originalType === "sse" ||
+      originalType === "http"
+    ) {
       return config;
     }
 
@@ -67,7 +71,11 @@ export namespace TypeFieldNormalizer {
     const normalizedType = normalizeTypeValue(originalType as string);
 
     // 验证转换后的类型是否有效
-    if (normalizedType === "stdio" || normalizedType === "sse" || normalizedType === "http") {
+    if (
+      normalizedType === "stdio" ||
+      normalizedType === "sse" ||
+      normalizedType === "http"
+    ) {
       // 只在需要修改时创建浅拷贝，使用展开运算符只修改 type 字段
       return {
         ...config,
@@ -135,9 +143,7 @@ export namespace TypeFieldNormalizer {
 /**
  * 导出便捷函数
  */
-export function normalizeTypeField<T extends MCPBaseConfig>(
-  config: T
-): T;
+export function normalizeTypeField<T extends MCPBaseConfig>(config: T): T;
 export function normalizeTypeField(config: unknown): unknown;
 export function normalizeTypeField<T extends MCPBaseConfig>(
   config: T | unknown

--- a/packages/mcp-core/src/utils/validators.ts
+++ b/packages/mcp-core/src/utils/validators.ts
@@ -9,29 +9,37 @@
  * @module validators
  */
 
-import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "../types.js";
-import { TypeFieldNormalizer } from "./type-normalizer.js";
+import {
+  type MCPLogger,
+  MCPTransportType,
+  ToolCallError,
+  ToolCallErrorCode,
+  createConsoleLogger,
+} from "../types.js";
 import type {
   MCPServiceConfig,
   ToolCallParams,
   ToolCallValidationOptions,
   ValidatedToolCallParams,
 } from "../types.js";
+import { TypeFieldNormalizer } from "./type-normalizer.js";
 
 /**
  * 根据 URL 路径推断传输类型
  * 基于路径末尾推断，支持包含多个 / 的复杂路径
  *
  * @param url - 要推断的 URL
- * @param options - 可选配置项
+ * @param options - 可选配置项（包括 serviceName 和 logger）
  * @returns 推断出的传输类型
  */
 export function inferTransportTypeFromUrl(
   url: string,
   options?: {
     serviceName?: string;
+    logger?: MCPLogger;
   }
 ): MCPTransportType {
+  const logger = options?.logger ?? createConsoleLogger();
   try {
     const parsedUrl = new URL(url);
     const pathname = parsedUrl.pathname;
@@ -44,16 +52,16 @@ export function inferTransportTypeFromUrl(
       return MCPTransportType.HTTP;
     }
 
-    // 默认类型 - 使用 console 输出
+    // 默认类型 - 使用 logger 输出
     if (options?.serviceName) {
-      console.info(
+      logger.info(
         `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
       );
     }
     return MCPTransportType.HTTP;
   } catch (error) {
     if (options?.serviceName) {
-      console.warn(
+      logger.warn(
         `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
         error
       );
@@ -67,11 +75,13 @@ export function inferTransportTypeFromUrl(
  *
  * @param config - MCP 服务配置
  * @param serviceName - 服务名称（用于日志输出）
+ * @param logger - 日志实现（可选，默认使用 console）
  * @returns 完整的配置对象，包含推断出的类型
  */
 export function inferTransportTypeFromConfig(
   config: MCPServiceConfig,
-  serviceName?: string
+  serviceName?: string,
+  logger?: MCPLogger
 ): MCPServiceConfig {
   // 如果已显式指定类型，先标准化然后返回
   if (config.type) {
@@ -91,6 +101,7 @@ export function inferTransportTypeFromConfig(
   if (config.url !== undefined && config.url !== null) {
     const inferredType = inferTransportTypeFromUrl(config.url, {
       serviceName,
+      logger,
     });
     return {
       ...config,


### PR DESCRIPTION
修复 packages/mcp-core 使用 console 而非统一日志系统的问题：

- 定义 MCPLogger 接口，支持 info/debug/warn/error 方法
- 添加 createConsoleLogger 函数，提供向后兼容的默认实现
- MCPConnection 构造函数新增可选 logger 参数
- inferTransportTypeFromUrl 和 inferTransportTypeFromConfig 支持 logger 参数
- 导出 MCPLogger 类型和 createConsoleLogger 函数

保持向后兼容：当未提供 logger 时，使用 console 作为默认实现。

Fixes #3093

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3093