### PR TITLE
fix(frontend): 使用 @/ 路径别名替换相对路径导入

### DIFF
--- a/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
+++ b/apps/frontend/src/components/mcp-server/mcp-server-table.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { McpServerSettingButton } from "@/components/mcp-server-setting-button";
+import { RemoveMcpServerButton } from "@/components/remove-mcp-server-button";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import {
@@ -19,8 +21,6 @@ import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
 import { CoffeeIcon } from "lucide-react";
 import { useCallback, useEffect, useMemo } from "react";
 import { toast } from "sonner";
-import { McpServerSettingButton } from "../mcp-server-setting-button";
-import { RemoveMcpServerButton } from "../remove-mcp-server-button";
 import { ServerPagination } from "./server-pagination";
 import { ServerSearchInput } from "./server-search-input";
 import { ServerSortSelector } from "./server-sort-selector";


### PR DESCRIPTION
将 mcp-server-table.tsx 中的相对路径导入替换为 @/ 路径别名：
- McpServerSettingButton: ../mcp-server-setting-button -> @/components/mcp-server-setting-button
- RemoveMcpServerButton: ../remove-mcp-server-button -> @/components/remove-mcp-server-button

修复了同一文件中导入路径风格不一致的问题，符合项目路径别名使用规范。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3098