### PR TITLE
fix: WebServer.destroy() 移除 endpointManager 事件监听器防止内存泄漏

### DIFF
--- a/apps/backend/WebServer.ts
+++ b/apps/backend/WebServer.ts
@@ -381,20 +381,28 @@ export class WebServer {
         await this.endpointManager.connect();
 
         // 设置端点添加事件监听器
-        this.endpointManager.on(
-          "endpointAdded",
-          (event: { endpoint: string }) => {
-            this.logger.debug(`端点已添加: ${event.endpoint}`);
-          }
-        );
+        const endpointAddedListener = (event: { endpoint: string }) => {
+          this.logger.debug(`端点已添加: ${event.endpoint}`);
+        };
+
+        this.endpointManager.on("endpointAdded", endpointAddedListener);
+
+        // 存储清理函数，防止内存泄漏
+        this.eventListenerUnsubscribers.push(() => {
+          this.endpointManager?.off("endpointAdded", endpointAddedListener);
+        });
 
         // 设置端点移除事件监听器
-        this.endpointManager.on(
-          "endpointRemoved",
-          (event: { endpoint: string }) => {
-            this.logger.debug(`端点已移除: ${event.endpoint}`);
-          }
-        );
+        const endpointRemovedListener = (event: { endpoint: string }) => {
+          this.logger.debug(`端点已移除: ${event.endpoint}`);
+        };
+
+        this.endpointManager.on("endpointRemoved", endpointRemovedListener);
+
+        // 存储清理函数，防止内存泄漏
+        this.eventListenerUnsubscribers.push(() => {
+          this.endpointManager?.off("endpointRemoved", endpointRemovedListener);
+        });
 
         this.logger.debug(
           `小智接入点连接管理器初始化完成，管理 ${validEndpoints.length} 个端点`


### PR DESCRIPTION
将 endpointAdded 和 endpointRemoved 事件监听器的清理函数添加到
eventListenerUnsubscribers 数组，确保 destroy() 方法正确移除所有监听器。

Fixes #3103

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.ai/code)\n\nFixes issue: #3103