### PR TITLE
refactor(frontend): 提取工作流错误处理函数消除重复代码

### DIFF
--- a/apps/frontend/src/components/coze-workflow-integration.tsx
+++ b/apps/frontend/src/components/coze-workflow-integration.tsx
@@ -28,6 +28,7 @@ import {
 import { Skeleton } from "@/components/ui/skeleton";
 import { useCozeWorkflows } from "@/hooks/useCozeWorkflows";
 import { apiClient } from "@/services/api";
+import { extractWorkflowErrorMessage } from "@/utils/workflowErrorUtils";
 import type {
   CozeWorkflow,
   WorkflowParameter,
@@ -224,41 +225,7 @@ export function CozeWorkflowIntegration({
       // 刷新工作流列表以确保状态同步
       await refreshWorkflows();
     } catch (error) {
-      // 根据错误类型显示不同的错误信息
-      let errorMessage = "添加工作流失败，请重试";
-
-      if (error instanceof Error) {
-        if (
-          error.message.includes("已存在") ||
-          error.message.includes("冲突")
-        ) {
-          errorMessage = `工作流 "${workflow.workflow_name}" 已存在，请勿重复添加`;
-        } else if (
-          error.message.includes("配置") ||
-          error.message.includes("token")
-        ) {
-          errorMessage = "系统配置错误，请检查扣子API配置";
-        } else if (
-          error.message.includes("验证失败") ||
-          error.message.includes("格式")
-        ) {
-          errorMessage = "工作流数据格式错误，请联系管理员";
-        } else if (
-          error.message.includes("网络") ||
-          error.message.includes("超时") ||
-          error.message.includes("连接")
-        ) {
-          errorMessage = "网络连接失败，请检查网络后重试";
-        } else if (error.message.includes("权限")) {
-          errorMessage = "权限不足，请检查API权限配置";
-        } else if (error.message.includes("频繁")) {
-          errorMessage = "操作过于频繁，请稍后重试";
-        } else {
-          errorMessage = error.message;
-        }
-      }
-
-      toast.error(errorMessage);
+      toast.error(extractWorkflowErrorMessage(error, workflow.workflow_name));
     } finally {
       setIsAddingWorkflow(false);
       setPendingOperations((prev) => {
@@ -331,41 +298,7 @@ export function CozeWorkflowIntegration({
       // 刷新工作流列表以确保状态同步
       await refreshWorkflows();
     } catch (error) {
-      // 根据错误类型显示不同的错误信息
-      let errorMessage = "添加工作流失败，请重试";
-
-      if (error instanceof Error) {
-        if (
-          error.message.includes("已存在") ||
-          error.message.includes("冲突")
-        ) {
-          errorMessage = `工作流 "${workflow.workflow_name}" 已存在，请勿重复添加`;
-        } else if (
-          error.message.includes("配置") ||
-          error.message.includes("token")
-        ) {
-          errorMessage = "系统配置错误，请检查扣子API配置";
-        } else if (
-          error.message.includes("验证失败") ||
-          error.message.includes("格式")
-        ) {
-          errorMessage = "工作流数据格式错误，请联系管理员";
-        } else if (
-          error.message.includes("网络") ||
-          error.message.includes("超时") ||
-          error.message.includes("连接")
-        ) {
-          errorMessage = "网络连接失败，请检查网络后重试";
-        } else if (error.message.includes("权限")) {
-          errorMessage = "权限不足，请检查API权限配置";
-        } else if (error.message.includes("频繁")) {
-          errorMessage = "操作过于频繁，请稍后重试";
-        } else {
-          errorMessage = error.message;
-        }
-      }
-
-      toast.error(errorMessage);
+      toast.error(extractWorkflowErrorMessage(error, workflow.workflow_name));
     } finally {
       setIsAddingWorkflow(false);
       setPendingOperations((prev) => {

--- a/apps/frontend/src/utils/workflowErrorUtils.ts
+++ b/apps/frontend/src/utils/workflowErrorUtils.ts
@@ -1,0 +1,58 @@
+/**
+ * 工作流错误处理工具函数
+ *
+ * 提供工作流操作相关的错误信息提取和格式化功能
+ *
+ * @module workflowErrorUtils
+ */
+
+/**
+ * 根据错误类型生成用户友好的错误信息
+ *
+ * @param error - 捕获的错误对象
+ * @param workflowName - 工作流名称，用于个性化错误信息
+ * @returns 格式化后的用户友好错误信息
+ *
+ * @example
+ * ```typescript
+ * try {
+ *   await addWorkflow(workflow);
+ * } catch (error) {
+ *   toast.error(extractWorkflowErrorMessage(error, workflow.workflow_name));
+ * }
+ * ```
+ */
+export function extractWorkflowErrorMessage(
+  error: unknown,
+  workflowName: string
+): string {
+  const defaultMessage = "添加工作流失败，请重试";
+
+  if (error instanceof Error) {
+    if (error.message.includes("已存在") || error.message.includes("冲突")) {
+      return `工作流 "${workflowName}" 已存在，请勿重复添加`;
+    }
+    if (error.message.includes("配置") || error.message.includes("token")) {
+      return "系统配置错误，请检查扣子API配置";
+    }
+    if (error.message.includes("验证失败") || error.message.includes("格式")) {
+      return "工作流数据格式错误，请联系管理员";
+    }
+    if (
+      error.message.includes("网络") ||
+      error.message.includes("超时") ||
+      error.message.includes("连接")
+    ) {
+      return "网络连接失败，请检查网络后重试";
+    }
+    if (error.message.includes("权限")) {
+      return "权限不足，请检查API权限配置";
+    }
+    if (error.message.includes("频繁")) {
+      return "操作过于频繁，请稍后重试";
+    }
+    return error.message;
+  }
+
+  return defaultMessage;
+}


### PR DESCRIPTION
修复 coze-workflow-integration.tsx 中的 DRY 原则违规问题：
- 创建 workflowErrorUtils.ts 包含 extractWorkflowErrorMessage 函数
- 将两处约 35 行重复的错误处理代码替换为函数调用
- 组件从 662 行减少到 595 行

采用务实的方案二（提取函数），而非过度拆分组件：
- 组件职责虽多，但各部分逻辑紧密关联
- 提取函数解决了最明显的 DRY 违规
- 避免为"可能的需要"而增加复杂度

Closes #3109

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3109