### PR TITLE
fix(security): 升级 axios 至 1.15.0+ 修复 CVE-2025-62718

### DIFF
--- a/package.json
+++ b/package.json
@@ -117,7 +117,7 @@
       "form-data": "^4.0.4",
       "braces": ">=3.0.3",
       "micromatch": ">=4.0.8",
-      "axios": ">=1.13.5",
+      "axios": ">=1.15.0",
       "@conventional-changelog/git-client": ">=2.0.0",
       "hono@>=1.1.0 <4.10.3": ">=4.10.3",
       "js-yaml@<4.1.1": ">=4.1.1",


### PR DESCRIPTION
修复严重的 SSRF 漏洞 (CVSS 9.3/10):
- 更新 pnpm overrides 中 axios 版本从 >=1.13.5 到 >=1.15.0
- 解决 NO_PROXY 绕过漏洞，防止内部服务数据泄露
- 强制所有 axios 依赖升级至安全版本

Fixes #3111

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3111