### PR TITLE
fix(coze): 修复 getCozeApiService() 每次创建新实例导致缓存功能失效

### DIFF
--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -51,7 +51,14 @@ function isErrorWithCode(error: unknown): error is ErrorWithCode {
 }
 
 /**
- * 获取扣子 API 服务实例
+ * 扣子 API 服务单例实例
+ * 用于缓存管理，确保所有操作使用同一个实例
+ */
+let cozeApiServiceInstance: CozeApiService | null = null;
+
+/**
+ * 获取扣子 API 服务实例（单例模式）
+ * 如果实例不存在或 token 变化，则创建新实例
  */
 function getCozeApiService(): CozeApiService {
   const token = configManager.getCozeToken();
@@ -62,7 +69,12 @@ function getCozeApiService(): CozeApiService {
     );
   }
 
-  return new CozeApiService(token);
+  // 如果实例不存在或 token 变化，创建新实例
+  if (!cozeApiServiceInstance || cozeApiServiceInstance.getToken() !== token) {
+    cozeApiServiceInstance = new CozeApiService(token);
+  }
+
+  return cozeApiServiceInstance;
 }
 
 /**

--- a/apps/backend/lib/coze/service.ts
+++ b/apps/backend/lib/coze/service.ts
@@ -113,6 +113,14 @@ export class CozeApiService {
   }
 
   /**
+   * 获取当前使用的 Token
+   * 用于检查 token 是否变化，决定是否需要重新创建实例
+   */
+  getToken(): string {
+    return this.token;
+  }
+
+  /**
    * 清除缓存
    * @param pattern 可选的模式字符串，清除所有以该模式开头的缓存键
    */


### PR DESCRIPTION
问题：getCozeApiService() 每次调用都创建新的 CozeApiService 实例，
导致缓存操作（clearCache 和 getCacheStats）完全失效。

修复方案：
- 在 coze.handler.ts 中实现单例模式，保持同一个实例
- 在 CozeApiService 中添加 getToken() 方法，用于检测 token 变化
- 当 token 变化时才创建新实例，否则复用现有实例

影响：
- 缓存清除和统计功能现在能正确操作正在使用的缓存
- 多次调用不同方法时共享同一个实例，缓存可复用

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3113