### PR TITLE
fix(shared-types): 移除重复的 ApiResponse 类型定义并修复 any 类型

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -27,7 +27,7 @@ export type CustomMCPTool = CustomMCPToolWithStats;
 /**
  * API 响应格式
  */
-interface ApiResponse<T = any> {
+interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: {

--- a/packages/shared-types/src/api/common.ts
+++ b/packages/shared-types/src/api/common.ts
@@ -1,50 +1,10 @@
 /**
- * 通用 API 响应类型定义
+ * API 通用类型定义
+ * 注意：ApiResponse、ApiSuccessResponse、ApiErrorResponse 已移除
+ * 实际使用的 API 响应类型请参考：
+ * - 前端：packages/shared-types/src/frontend/api.ts
+ * - 后端：apps/backend/types/api.response.ts
  */
-
-/**
- * 通用 API 响应接口
- */
-export interface ApiResponse<T = any> {
-  /** 响应状态码，0表示成功 */
-  code: number;
-  /** 响应数据 */
-  data: T;
-  /** 响应消息 */
-  message: string;
-  /** 请求时间戳 */
-  timestamp: number;
-}
-
-/**
- * 成功响应接口
- */
-export interface ApiSuccessResponse<T = any> {
-  /** 响应状态码，固定为0 */
-  code: 0;
-  /** 响应数据 */
-  data: T;
-  /** 响应消息 */
-  message: string;
-  /** 请求时间戳 */
-  timestamp: number;
-}
-
-/**
- * 错误响应接口
- */
-export interface ApiErrorResponse {
-  /** 响应状态码，非0值 */
-  code: number;
-  /** 错误数据 */
-  data: null;
-  /** 错误消息 */
-  message: string;
-  /** 错误详情 */
-  error?: string;
-  /** 请求时间戳 */
-  timestamp: number;
-}
 
 /**
  * 分页请求参数

--- a/packages/shared-types/src/api/index.ts
+++ b/packages/shared-types/src/api/index.ts
@@ -2,14 +2,8 @@
  * API 相关类型导出
  */
 
-// 通用 API 响应类型
-export type {
-  ApiResponse,
-  ApiSuccessResponse,
-  ApiErrorResponse,
-  PaginationParams,
-  PaginatedResponse,
-} from "./common";
+// 分页相关类型（保留用于未来扩展）
+export type { PaginationParams, PaginatedResponse } from "./common";
 
 // 工具 API 相关类型
 export type {

--- a/packages/shared-types/src/frontend/api.ts
+++ b/packages/shared-types/src/frontend/api.ts
@@ -65,7 +65,7 @@ export interface MCPServerListResponse {
 /**
  * API 统一响应格式接口
  */
-export interface ApiSuccessResponse<T = any> {
+export interface ApiSuccessResponse<T = unknown> {
   success: boolean;
   data?: T;
   message?: string;
@@ -77,7 +77,7 @@ export interface ApiErrorResponse {
     message: string;
     details?: {
       serverName?: string;
-      config?: any;
+      config?: unknown;
       tools?: string[];
       timestamp: string;
     };
@@ -120,9 +120,9 @@ export interface ToolCallRecord {
   /** 服务器名称 */
   serverName?: string;
   /** 调用参数 */
-  arguments?: any;
+  arguments?: Record<string, unknown>;
   /** 调用结果 */
-  result?: any;
+  result?: unknown;
   /** 是否成功 */
   success: boolean;
   /** 调用耗时（毫秒） */
@@ -148,12 +148,12 @@ export interface ToolCallLogsResponse {
 /**
  * API通用响应格式
  */
-export interface ApiResponse<T = any> {
+export interface ApiResponse<T = unknown> {
   success: boolean;
   data?: T;
   error?: {
     code: string;
     message: string;
-    details?: any;
+    details?: unknown;
   };
 }


### PR DESCRIPTION
问题分析:
- packages/shared-types/src/api/common.ts 中定义了使用 code: number 格式的 ApiResponse，完全未被使用（僵尸代码）
- packages/shared-types/src/frontend/api.ts 中定义了使用 success: boolean 格式的 ApiResponse，使用 any 类型
- apps/frontend/src/services/api.ts 中有本地 ApiResponse 定义
- apps/backend/types/api.response.ts 中有最完整的联合类型定义
- 同名类型在不同路径下有不同结构，造成类型混淆风险

修复内容:
- 移除 api/common.ts 中的僵尸 ApiResponse、ApiSuccessResponse、ApiErrorResponse 定义
- 更新 api/index.ts 移除僵尸类型导出，保留 PaginationParams 和 PaginatedResponse
- 修复 frontend/api.ts 中所有 any 类型为 unknown
- 修复 apps/frontend/src/services/api.ts 中 T = any 为 T = unknown

影响范围:
- 类型定义统一，减少维护混乱
- 修复 any 类型滥用，提升类型安全性
- 保留分页类型供未来扩展

相关问题: #3116

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3116