### PR TITLE
fix(handler): 替换双重类型断言为公共方法调用以修复类型安全问题

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
@@ -27,7 +27,8 @@ const createMockMCPServiceManager = (): Partial<MCPServiceManager> => ({
   startService: vi.fn(),
   stopService: vi.fn(),
   removeServiceConfig: vi.fn(),
-  // MCPServiceManager 的其他模拟方法将在后续里程碑中添加
+  getService: vi.fn().mockReturnValue(undefined),
+  hasService: vi.fn().mockReturnValue(false),
 });
 
 const createMockEventBus = (): Partial<EventBus> => ({
@@ -260,9 +261,7 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["new-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 修复 mock 配置 - 确保初始配置不包含新服务，但 updateMcpServer 后包含
     const currentConfig = {
@@ -430,9 +429,7 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["disconnected-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.addMCPServer(mockContext as Context);
 
@@ -547,9 +544,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -619,9 +614,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 模拟服务停止失败
     mockMCPServiceManager.stopService = vi
@@ -654,9 +647,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 修改配置管理器让它认为这个服务存在
     const originalGetConfig = mockConfigManager.getConfig;
@@ -705,9 +696,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -960,9 +949,7 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -984,9 +971,7 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -1125,10 +1110,11 @@ describe("listMCPServers", () => {
       getTools: vi.fn().mockReturnValue([]),
     };
     // service3 不在 services Map 中（未启动）
-    (mockMCPServiceManager as any).services = new Map([
-      ["service1", mockService1],
-      ["service2", mockService2],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockImplementation((name: string) => {
+      if (name === "service1") return mockService1;
+      if (name === "service2") return mockService2;
+      return undefined; // service3 未启动
+    });
 
     const response = await handler.listMCPServers(mockContext as Context);
 
@@ -1316,9 +1302,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1356,9 +1340,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1396,9 +1378,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -25,13 +25,6 @@ import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
 
-/**
- * MCPServiceManager 扩展接口，用于访问私有属性
- * 这个接口定义了我们需要访问但实际上是私有的属性
- */
-interface MCPServiceManagerAccess {
-  services: Map<string, MCPService>;
-}
 
 /**
  * 配置详情接口，包含时间戳
@@ -421,9 +414,7 @@ export class MCPHandler {
 
     // 尝试从 MCPServiceManager 获取实际状态
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.isConnected?.()) {
         const currentTools = service.getTools().map((tool: Tool) => tool.name);
@@ -530,9 +521,7 @@ export class MCPHandler {
    */
   private getServiceTools(serverName: string): Tool[] {
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.getTools) {
         return service.getTools();

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1080,6 +1080,13 @@ export class MCPServiceManager extends EventEmitter {
   }
 
   /**
+   * 检查服务是否存在
+   */
+  hasService(name: string): boolean {
+    return this.services.has(name);
+  }
+
+  /**
    * 获取所有已连接的服务名称
    */
   getConnectedServices(): string[] {


### PR DESCRIPTION
问题：mcp-manage.handler.ts 使用 `as unknown as MCPServiceManagerAccess`
双重类型断言来访问 MCPServiceManager 的私有属性 services，绕过了
TypeScript 类型检查，违反类型安全原则。

修复：
- 在 MCPServiceManager 中添加 hasService() 公共方法
- 替换 handler 中的双重类型断言为 getService() 公共方法调用
- 更新测试文件使用 getService mock 替代直接访问 services
- 移除 MCPServiceManagerAccess 接口定义（不再需要）

影响范围：
- apps/backend/handlers/mcp-manage.handler.ts
- apps/backend/lib/mcp/manager.ts
- apps/backend/handlers/__tests__/mcp-manage.handler.test.ts

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3117