### PR TITLE
fix(asr): 移除事件监听器避免内存泄漏

### DIFF
--- a/apps/backend/services/asr.service.ts
+++ b/apps/backend/services/asr.service.ts
@@ -386,6 +386,9 @@ export class ASRService implements IASRService {
     const asrClient = this.asrClients.get(deviceId);
     if (asrClient) {
       try {
+        // 移除事件监听器，避免内存泄漏
+        asrClient.removeAllListeners("error");
+        asrClient.removeAllListeners("close");
         await asrClient.close();
       } catch (error) {
         logger.error(`[ASRService] ASR 关闭失败: deviceId=${deviceId}`, error);
@@ -432,6 +435,9 @@ export class ASRService implements IASRService {
   destroy(): void {
     // 清理 ASR 客户端
     for (const asrClient of this.asrClients.values()) {
+      // 移除事件监听器，避免内存泄漏
+      asrClient.removeAllListeners("error");
+      asrClient.removeAllListeners("close");
       asrClient.close();
     }
     this.asrClients.clear();


### PR DESCRIPTION
在 ASRService.destroy() 和 end() 方法中，关闭 ASR 客户端前先移除
"error" 和 "close" 事件监听器，避免长期运行的服务中事件监听器累积
导致内存泄漏。

修复 #3121

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3121