### PR TITLE
fix(logger): endpoint.route.ts 使用统一 logger 替代 console.error

### DIFF
--- a/apps/backend/routes/domains/endpoint.route.ts
+++ b/apps/backend/routes/domains/endpoint.route.ts
@@ -4,6 +4,7 @@
  * 使用中间件动态注入的 endpointHandler
  */
 
+import { logger } from "@/Logger.js";
 import type { RouteDefinition } from "@/routes/types.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Context } from "hono";
@@ -43,7 +44,7 @@ const withEndpointHandler = async (
     // 使用类型安全的方式调用方法
     return await endpointHandler[handlerName](c);
   } catch (error) {
-    console.error(`端点处理器错误 [${handlerName}]:`, error);
+    logger.error(`端点处理器错误 [${handlerName}]`, error);
     return c.fail(
       "ENDPOINT_HANDLER_ERROR",
       error instanceof Error ? error.message : "端点处理失败",


### PR DESCRIPTION
修复内容：
- 导入 logger：import { logger } from "@/Logger.js"
- 替换 console.error 为 logger.error
- 保持错误日志格式的一致性

相关问题：
- Issue #3125: endpoint.route.ts 使用 console.error 而非 logger
- Issue #3093: packages/mcp-core 使用 console 而非统一日志系统
- Issue #3067: prompt-utils.ts 使用 console 而非 logger
- Issue #3062: lib/npm/manager.ts 在进程启动失败时使用 console.log

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3125