### PR TITLE
fix(nx): 添加 backend type-check 目标缺失的 workspace 依赖

### DIFF
--- a/apps/backend/project.json
+++ b/apps/backend/project.json
@@ -55,7 +55,7 @@
       "options": {
         "command": "pnpm --filter backend run check:type"
       },
-      "dependsOn": ["config:build", "endpoint:build", "version:build"]
+      "dependsOn": ["config:build", "endpoint:build", "version:build", "asr:build", "mcp-core:build", "shared-types:build"]
     },
     "dev": {
       "executor": "nx:run-commands",


### PR DESCRIPTION
apps/backend 的 type-check 目标缺少 asr:build、mcp-core:build 和 shared-types:build 依赖，
导致 TypeScript 编译器无法找到这些包的类型声明文件。

修复：在 dependsOn 中添加所有 workspace 包依赖。

Closes #3133

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3133