### PR TITLE
perf(mcp-manage): 优化 listMCPServers 避免 N+1 getConfig() 调用

### DIFF
--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -20,7 +20,11 @@ import type { MCPService } from "@/lib/mcp";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
+import type {
+  AppConfig,
+  ConfigManager,
+  MCPServerConfig,
+} from "@xiaozhi-client/config";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
@@ -404,10 +408,16 @@ export class MCPHandler {
 
   /**
    * 获取服务状态信息
+   * @param serverName 服务名称
+   * @param config 可选的配置对象，避免在循环中重复调用 getConfig()
    */
-  private getServiceStatus(serverName: string): MCPServerStatus {
-    const config = this.configManager.getConfig();
-    const serverConfig = config.mcpServers[serverName];
+  private getServiceStatus(
+    serverName: string,
+    config?: AppConfig
+  ): MCPServerStatus {
+    // 使用传入的 config 或获取新的配置（向后兼容）
+    const actualConfig = config || this.configManager.getConfig();
+    const serverConfig = actualConfig.mcpServers[serverName];
 
     if (!serverConfig) {
       return {
@@ -747,7 +757,7 @@ export class MCPHandler {
       const servers: MCPServerStatus[] = [];
 
       for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
-        const serviceStatus = this.getServiceStatus(serverName);
+        const serviceStatus = this.getServiceStatus(serverName, config);
         servers.push(serviceStatus);
       }
 


### PR DESCRIPTION
修复 Issue #3145: 在 listMCPServers 循环中，每次调用 getServiceStatus
都会重新调用 getConfig()，导致 N+1 次深拷贝性能开销。

修改内容：
- getServiceStatus 方法添加可选 config 参数
- listMCPServers 在循环中传递已获取的 config 对象
- 保持向后兼容，未传 config 时仍调用 getConfig()

性能影响：
- 配置 N 个 MCP 服务时，从 N+1 次 getConfig() 调用减少到 1 次
- 消除不必要的深拷贝操作和内存分配

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3145