### PR TITLE
refactor(mcp): 消除跨包重复代码，从 mcp-core 重新导出

### DIFF
--- a/apps/backend/lib/mcp/index.ts
+++ b/apps/backend/lib/mcp/index.ts
@@ -9,8 +9,8 @@
  * - CustomMCPHandler: 自定义 MCP 处理器，处理 Coze 工作流等自定义工具
  * - ToolCallLogger: 工具调用记录器，提供 JSONL 格式的记录功能
  * - ToolCallLogService: 工具调用日志服务，提供查询功能
- * - 类型定义: MCP 相关的所有 TypeScript 类型定义
- * - 工具函数: MCP 工具调用的辅助函数
+ * - 类型定义: MCP 相关的所有 TypeScript 类型定义（从 @xiaozhi-client/mcp-core 重新导出）
+ * - 工具函数: MCP 工具调用的辅助函数（从 @xiaozhi-client/mcp-core 重新导出）
  *
  * @packageDocumentation
  *
@@ -29,11 +29,32 @@
  * const result = await manager.callTool('tool-name', { param: 'value' });
  * ```
  */
+
+// =========================
+// 本地实现模块导出
+// =========================
+
 export * from "@/lib/mcp/manager.js";
 export * from "@/lib/mcp/connection.js";
-export * from "@/lib/mcp/types.js";
-export * from "@/lib/mcp/utils.js";
 export * from "./message.js";
 export * from "@/lib/mcp/cache.js";
 export * from "./custom.js";
 export * from "./log.js";
+
+// =========================
+// 从本地 types.ts 导出
+// =========================
+
+export * from "@/lib/mcp/types.js";
+
+// =========================
+// 从 @xiaozhi-client/mcp-core 重新导出工具函数
+// =========================
+
+export {
+  inferTransportTypeFromUrl,
+  inferTransportTypeFromConfig,
+  validateToolCallParams,
+  TypeFieldNormalizer,
+  normalizeTypeField,
+} from "@xiaozhi-client/mcp-core";

--- a/apps/backend/lib/mcp/types.ts
+++ b/apps/backend/lib/mcp/types.ts
@@ -1,116 +1,107 @@
 /**
  * MCP 核心库类型定义
- * 统一管理所有 MCP 相关的类型定义，避免重复定义和导入路径混乱
- */
-
-import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-
-// =========================
-// 1. 基础传输类型
-// =========================
-
-/**
- * MCP 传输层联合类型定义
- * 支持 STDIO、SSE、StreamableHTTP 三种传输协议
- */
-export type MCPServerTransport =
-  | StdioClientTransport
-  | SSEClientTransport
-  | StreamableHTTPClientTransport;
-
-/**
- * 通信方式枚举
- * 定义 MCP 支持的传输类型
- */
-export enum MCPTransportType {
-  STDIO = "stdio",
-  SSE = "sse",
-  HTTP = "http",
-}
-
-// =========================
-// 2. 配置接口类型
-// =========================
-
-/**
- * ModelScope SSE 自定义选项接口
- * 专门用于 ModelScope 相关的 SSE 配置
- */
-export interface ModelScopeSSEOptions {
-  eventSourceInit?: {
-    fetch?: (
-      url: string | URL | Request,
-      init?: RequestInit
-    ) => Promise<Response>;
-  };
-  requestInit?: RequestInit;
-}
-
-/**
- * MCP 服务配置接口
- * 包含所有 MCP 服务的配置选项
  *
- * 注意：符合 @modelcontextprotocol 官方标准，不包含 name 字段
- * name 应该作为服务标识符独立管理，不是配置的一部分
+ * 从 @xiaozhi-client/mcp-core 重新导出类型定义
+ * 保持向后兼容性，统一导入路径
+ *
+ * 注意：部分类型在 backend 中有自定义定义，这些类型保留在本地
  */
-export interface MCPServiceConfig {
-  type?: MCPTransportType; // 现在是可选的，支持自动推断
-  // stdio 配置
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>; // 环境变量配置
-  // 网络配置
-  url?: string;
-  // 认证配置
-  apiKey?: string;
-  headers?: Record<string, string>;
-  customSSEOptions?: ModelScopeSSEOptions;
-}
-
-/**
- * 内部使用的 MCP 服务配置接口（包含 name 字段）
- * 用于 MCPService 类等内部函数，保持向后兼容
- */
-export interface InternalMCPServiceConfig extends MCPServiceConfig {
-  name: string;
-}
 
 // =========================
-// 3. 状态枚举类型
+// 从 mcp-core 导入类型（用于本地定义和重新导出）
 // =========================
 
-/**
- * 连接状态枚举
- * 合并了 connection.ts 和 TransportAdapter.ts 中的定义
- */
-export enum ConnectionState {
-  DISCONNECTED = "disconnected",
-  CONNECTING = "connecting",
-  CONNECTED = "connected",
-  RECONNECTING = "reconnecting",
-  FAILED = "failed",
-  ERROR = "error", // 从 TransportAdapter.ts 合并的额外状态
-}
+import type {
+  CustomMCPTool,
+  EnhancedToolInfo,
+  HeartbeatConfig,
+  InternalMCPServiceConfig,
+  JSONSchema,
+  LegacyMCPServiceConfig,
+  // 传输相关
+  MCPServerTransport,
+  // 配置相关
+  MCPServiceConfig,
+  MCPServiceConnectionStatus,
+  // 事件相关
+  MCPServiceEventCallbacks,
+  // 状态相关
+  MCPServiceStatus,
+  MCPTransportTypeInput,
+  MCPTransportTypeString,
+  ManagerStatus,
+  ModelScopeSSEOptions,
+  ToolCallParams,
+  ToolCallValidationOptions,
+  // 工具相关
+  ToolInfo,
+  ToolStatusFilter,
+  UnifiedServerConfig,
+  ValidatedToolCallParams,
+} from "@xiaozhi-client/mcp-core";
 
-/**
- * MCP 服务状态接口
- * 描述 MCP 服务的运行时状态信息
- */
-export interface MCPServiceStatus {
-  name: string;
-  connected: boolean;
-  initialized: boolean;
-  transportType: MCPTransportType;
-  toolCount: number;
-  lastError?: string;
-  connectionState: ConnectionState;
-}
+import {
+  ConnectionState,
+  MCPTransportType,
+  ToolCallError,
+  ToolCallErrorCode,
+  ensureToolJSONSchema,
+  isValidToolJSONSchema,
+} from "@xiaozhi-client/mcp-core";
 
 // =========================
-// 4. 工具调用相关类型
+// 类型重新导出
+// =========================
+
+export type {
+  // 配置相关
+  MCPServiceConfig,
+  ModelScopeSSEOptions,
+  UnifiedServerConfig,
+  InternalMCPServiceConfig,
+  LegacyMCPServiceConfig,
+  HeartbeatConfig,
+  MCPTransportTypeInput,
+  MCPTransportTypeString,
+  // 状态相关
+  MCPServiceStatus,
+  MCPServiceConnectionStatus,
+  ManagerStatus,
+  // 工具相关
+  ToolInfo,
+  EnhancedToolInfo,
+  ToolCallParams,
+  ValidatedToolCallParams,
+  ToolCallValidationOptions,
+  CustomMCPTool,
+  JSONSchema,
+  ToolStatusFilter,
+  // 传输相关
+  MCPServerTransport,
+  // 事件相关
+  MCPServiceEventCallbacks,
+};
+
+// =========================
+// 枚举导出
+// =========================
+
+export { MCPTransportType, ConnectionState, ToolCallErrorCode };
+
+// =========================
+// 类导出
+// =========================
+
+export { ToolCallError };
+
+// =========================
+// 类型守卫导出
+// =========================
+
+export { isValidToolJSONSchema, ensureToolJSONSchema };
+
+// =========================
+// Backend 本地定义的类型
 // =========================
 
 /**
@@ -128,159 +119,9 @@ export interface ToolCallResult {
 }
 
 /**
- * JSON Schema 类型定义
- * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
- */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>; // 允许更宽松的格式以保持向后兼容
-
-/**
- * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
- */
-export function isValidToolJSONSchema(obj: unknown): obj is {
-  type: "object";
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "type" in obj &&
-    (obj as { type?: unknown }).type === "object"
-  );
-}
-
-/**
- * 确保对象符合 MCP Tool JSON Schema 格式
- * 如果不符合，会返回一个默认的空对象 schema
- */
-export function ensureToolJSONSchema(schema: JSONSchema): {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  if (isValidToolJSONSchema(schema)) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
-  }
-
-  // 如果不符合标准格式，返回默认的空对象 schema
-  return {
-    type: "object",
-    properties: {} as Record<string, object>,
-    required: [],
-    additionalProperties: true,
-  };
-}
-
-/**
- * CustomMCP 工具类型定义
- * 统一了 manager.ts 和 configManager.ts 中的定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
-  };
-}
-
-/**
- * 工具信息接口
- * 用于缓存工具映射关系，保持向后兼容性
- */
-export interface ToolInfo {
-  serviceName: string;
-  originalName: string;
-  tool: Tool;
-}
-
-// =========================
-// 5. 增强工具信息类型
-// =========================
-
-/**
- * 工具状态过滤选项
- * 用于 getAllTools() 方法过滤不同状态的工具
- */
-export type ToolStatusFilter = "enabled" | "disabled" | "all";
-
-/**
- * 增强的工具信息接口
- * 扩展自 ToolInfo 概念，包含工具的启用状态和使用统计信息
- *
- * @remarks
- * 此接口用于 MCPServiceManager.getAllTools() 方法的返回值，
- * 提供比基础 ToolInfo 更丰富的工具元数据信息。
- *
- * @example
- * ```typescript
- * const tools: EnhancedToolInfo[] = manager.getAllTools('enabled');
- * tools.forEach(tool => {
- *   console.log(`工具: ${tool.name}`);
- *   console.log(`状态: ${tool.enabled ? '已启用' : '已禁用'}`);
- *   console.log(`使用次数: ${tool.usageCount}`);
- * });
- * ```
- */
-export interface EnhancedToolInfo {
-  /** 工具唯一标识符，格式为 "{serviceName}__{originalName}" */
-  name: string;
-
-  /** 工具描述信息 */
-  description: string;
-
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-
-  /** 工具所属的 MCP 服务名称 */
-  serviceName: string;
-
-  /** 工具在 MCP 服务中的原始名称 */
-  originalName: string;
-
-  /** 工具是否启用 (true=已启用，false=已禁用) */
-  enabled: boolean;
-
-  /** 工具使用次数统计 */
-  usageCount: number;
-
-  /** 工具最后使用时间 (ISO 8601 格式字符串) */
-  lastUsedTime: string;
-}
-
-// =========================
-// 6. 服务器配置类型
-// =========================
-
-/**
- * 统一服务器配置接口
- * 从 UnifiedMCPServer 移入，用于统一服务器配置管理
- */
-export interface UnifiedServerConfig {
-  name?: string;
-  enableLogging?: boolean;
-  logLevel?: string;
-  configs?: Record<string, MCPServiceConfig>; // MCPService 配置
-}
-
-/**
  * 统一服务器状态接口
  * 从 UnifiedMCPServer 移入，用于统一服务器状态管理
+ * 注意：此版本不包含 transportCount 属性
  */
 export interface UnifiedServerStatus {
   isRunning: boolean;
@@ -291,98 +132,6 @@ export interface UnifiedServerStatus {
   services?: Record<string, MCPServiceConnectionStatus>;
   totalTools?: number;
   availableTools?: string[];
-}
-
-// =========================
-// 6. 管理器相关类型
-// =========================
-
-/**
- * MCP 服务连接状态接口
- * 重命名原 ServiceStatus 为 MCPServiceConnectionStatus 避免与 CLI 的 ServiceStatus 冲突
- */
-export interface MCPServiceConnectionStatus {
-  connected: boolean;
-  clientName: string;
-}
-
-/**
- * 管理器状态接口
- * 描述 MCP 服务管理器的整体状态
- */
-export interface ManagerStatus {
-  services: Record<string, MCPServiceConnectionStatus>;
-  totalTools: number;
-  availableTools: string[];
-}
-
-// =========================
-// 7. 参数校验相关类型
-// =========================
-
-/**
- * 工具调用参数接口
- * 定义标准工具调用参数结构
- */
-export interface ToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 验证后的工具调用参数
- * 参数校验通过后的标准化参数结构
- */
-export interface ValidatedToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 工具调用验证选项
- * 提供灵活的参数校验配置
- */
-export interface ToolCallValidationOptions {
-  /** 是否验证工具名称，默认为 true */
-  validateName?: boolean;
-  /** 是否验证参数格式，默认为 true */
-  validateArguments?: boolean;
-  /** 是否允许空参数，默认为 true */
-  allowEmptyArguments?: boolean;
-  /** 自定义验证函数 */
-  customValidator?: (params: ToolCallParams) => string | null;
-}
-
-/**
- * 工具调用错误码枚举
- * 统一的工具调用错误码定义
- */
-export enum ToolCallErrorCode {
-  /** 无效参数 */
-  INVALID_PARAMS = -32602,
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = -32601,
-  /** 服务不可用 */
-  SERVICE_UNAVAILABLE = -32001,
-  /** 调用超时 */
-  TIMEOUT = -32002,
-  /** 工具执行错误 */
-  TOOL_EXECUTION_ERROR = -32000,
-}
-
-/**
- * 工具调用错误类
- * 统一的工具调用错误处理
- */
-export class ToolCallError extends Error {
-  constructor(
-    public code: ToolCallErrorCode,
-    message: string,
-    public data?: unknown
-  ) {
-    super(message);
-    this.name = "ToolCallError";
-  }
 }
 
 // =========================

--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -1,191 +1,33 @@
 /**
  * MCP 工具函数模块
  *
- * 提供 MCP 服务配置和工具调用的工具函数：
- * - 传输类型推断（基于 URL 或配置）
- * - 工具调用参数验证
+ * 从 @xiaozhi-client/mcp-core 重新导出工具函数
+ * 保持向后兼容性，统一导入路径
  */
 
-import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
-import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
-import type {
+// =========================
+// 工具函数重新导出
+// =========================
+
+export {
+  inferTransportTypeFromUrl,
+  inferTransportTypeFromConfig,
+  validateToolCallParams,
+} from "@xiaozhi-client/mcp-core";
+
+// =========================
+// 相关类型重新导出
+// =========================
+
+export {
+  MCPTransportType,
+  ToolCallError,
+  ToolCallErrorCode,
+} from "@xiaozhi-client/mcp-core";
+
+export type {
   MCPServiceConfig,
   ToolCallParams,
   ToolCallValidationOptions,
   ValidatedToolCallParams,
-} from "./types.js";
-
-/**
- * 根据 URL 路径推断传输类型
- * 基于路径末尾推断，支持包含多个 / 的复杂路径
- *
- * @param url - 要推断的 URL
- * @param options - 可选配置项
- * @returns 推断出的传输类型
- */
-export function inferTransportTypeFromUrl(
-  url: string,
-  options?: {
-    serviceName?: string;
-  }
-): MCPTransportType {
-  try {
-    const parsedUrl = new URL(url);
-    const pathname = parsedUrl.pathname;
-
-    // 检查路径末尾
-    if (pathname.endsWith("/sse")) {
-      return MCPTransportType.SSE;
-    }
-    if (pathname.endsWith("/mcp")) {
-      return MCPTransportType.HTTP;
-    }
-
-    // 默认类型 - 使用 console 输出
-    if (options?.serviceName) {
-      console.info(
-        `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
-      );
-    }
-    return MCPTransportType.HTTP;
-  } catch (error) {
-    if (options?.serviceName) {
-      console.warn(
-        `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
-        error
-      );
-    }
-    return MCPTransportType.HTTP;
-  }
-}
-
-/**
- * 完整的配置类型推断（包括 command 字段）
- *
- * @param config - MCP 服务配置
- * @param serviceName - 服务名称（用于错误信息）
- * @returns 完整的配置对象，包含推断出的类型
- */
-export function inferTransportTypeFromConfig(
-  config: MCPServiceConfig,
-  serviceName: string
-): MCPServiceConfig {
-  // 如果已显式指定类型，先标准化然后返回
-  if (config.type) {
-    const normalizedConfig = TypeFieldNormalizer.normalizeTypeField(config);
-    return normalizedConfig as MCPServiceConfig;
-  }
-
-  // 基于 command 字段推断
-  if (config.command) {
-    return {
-      ...config,
-      type: MCPTransportType.STDIO,
-    };
-  }
-
-  // 基于 URL 字段推断（排除 null 和 undefined）
-  if (config.url !== undefined && config.url !== null) {
-    const inferredType = inferTransportTypeFromUrl(config.url, {
-      serviceName,
-    });
-    return {
-      ...config,
-      type: inferredType,
-    };
-  }
-
-  throw new Error(
-    `无法为服务 ${serviceName} 推断传输类型。请显式指定 type 字段，或提供 command/url 配置`
-  );
-}
-
-// =========================
-// 参数校验工具函数
-// =========================
-
-/**
- * 验证工具调用参数
- * 对传入的参数进行完整性和格式验证
- *
- * @param params 待验证的参数
- * @param options 验证选项
- * @returns 验证后的参数
- * @throws ToolCallError 验证失败时抛出
- */
-export function validateToolCallParams(
-  params: unknown,
-  options?: ToolCallValidationOptions
-): ValidatedToolCallParams {
-  const opts = {
-    validateName: true,
-    validateArguments: true,
-    allowEmptyArguments: true,
-    ...options,
-  };
-
-  // 1. 验证参数必须是对象
-  if (!params || typeof params !== "object") {
-    throw new ToolCallError(
-      ToolCallErrorCode.INVALID_PARAMS,
-      "请求参数必须是对象"
-    );
-  }
-
-  const paramsObj = params as Record<string, unknown>;
-
-  // 2. 验证工具名称
-  if (opts.validateName) {
-    if (!paramsObj.name || typeof paramsObj.name !== "string") {
-      throw new ToolCallError(
-        ToolCallErrorCode.INVALID_PARAMS,
-        "工具名称必须是非空字符串"
-      );
-    }
-  }
-
-  // 3. 验证工具参数格式
-  if (
-    opts.validateArguments &&
-    paramsObj.arguments !== undefined &&
-    paramsObj.arguments !== null
-  ) {
-    if (
-      typeof paramsObj.arguments !== "object" ||
-      Array.isArray(paramsObj.arguments)
-    ) {
-      throw new ToolCallError(
-        ToolCallErrorCode.INVALID_PARAMS,
-        "工具参数必须是对象"
-      );
-    }
-  }
-
-  // 4. 验证是否允许空参数
-  if (
-    !opts.allowEmptyArguments &&
-    paramsObj.arguments !== undefined &&
-    paramsObj.arguments !== null
-  ) {
-    const argsObj = paramsObj.arguments as Record<string, unknown>;
-    if (Object.keys(argsObj).length === 0) {
-      throw new ToolCallError(
-        ToolCallErrorCode.INVALID_PARAMS,
-        "工具参数不能为空"
-      );
-    }
-  }
-
-  // 5. 执行自定义验证
-  if (opts.customValidator) {
-    const error = opts.customValidator(paramsObj as unknown as ToolCallParams);
-    if (error) {
-      throw new ToolCallError(ToolCallErrorCode.INVALID_PARAMS, error);
-    }
-  }
-
-  return {
-    name: paramsObj.name as string,
-    arguments: paramsObj.arguments as Record<string, unknown>,
-  };
-}
+} from "@xiaozhi-client/mcp-core";

--- a/packages/mcp-core/src/index.ts
+++ b/packages/mcp-core/src/index.ts
@@ -14,6 +14,11 @@ export type {
   MCPServiceConfig,
   ModelScopeSSEOptions,
   UnifiedServerConfig,
+  InternalMCPServiceConfig,
+  LegacyMCPServiceConfig,
+  HeartbeatConfig,
+  MCPTransportTypeInput,
+  MCPTransportTypeString,
   // 状态相关
   MCPServiceStatus,
   MCPServiceConnectionStatus,
@@ -28,6 +33,7 @@ export type {
   ToolCallValidationOptions,
   CustomMCPTool,
   JSONSchema,
+  ToolStatusFilter,
   // 传输相关
   MCPServerTransport,
   // 事件相关


### PR DESCRIPTION
将 apps/backend/lib/mcp/utils.ts 和 types.ts 改为从
@xiaozhi-client/mcp-core 重新导出，消除约 224 行重复代码：

- utils.ts: 移除 inferTransportTypeFromUrl、inferTransportTypeFromConfig、
  validateToolCallParams 的重复实现，改为重新导出

- types.ts: 重新导出大部分类型和枚举，保留 backend 特有类型：
  - ToolCallResult: backend 使用简化接口，与 SDK 版本不同
  - UnifiedServerStatus: backend 版本不包含 transportCount
  - ServiceStatus: 向后兼容别名

- index.ts: 更新导出结构，统一从 mcp-core 导入

- packages/mcp-core/src/index.ts: 新增导出 InternalMCPServiceConfig、
  LegacyMCPServiceConfig、HeartbeatConfig 等类型

修复 GitHub Issue #3149

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3149