### PR TITLE
fix(localization): 将 message.ts 中的英文注释改为中文

### DIFF
--- a/apps/backend/lib/mcp/message.ts
+++ b/apps/backend/lib/mcp/message.ts
@@ -313,18 +313,18 @@ export class MCPMessageHandler {
    */
   private createErrorResponse(error: Error, id?: string | number): MCPResponse {
     // 根据错误类型确定错误代码
-    let errorCode = -32603; // Internal error
+    let errorCode = -32603; // 内部错误
 
     if (
       error.message.includes("未找到工具") ||
       error.message.includes("未知的方法")
     ) {
-      errorCode = -32601; // Method not found
+      errorCode = -32601; // 方法未找到
     } else if (
       error.message.includes("参数") ||
       error.message.includes("不能为空")
     ) {
-      errorCode = -32602; // Invalid params
+      errorCode = -32602; // 参数无效
     }
 
     return {


### PR DESCRIPTION
修复 apps/backend/lib/mcp/message.ts 文件中 createErrorResponse 方法的三个英文注释：
- "Internal error" → "内部错误"
- "Method not found" → "方法未找到"
- "Invalid params" → "参数无效"

符合 CLAUDE.md 本地化规范要求。

Fixes #3155

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3155