### PR TITLE
fix(handler): 修复 handleAddMCPTool 方法中的资源泄漏问题

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-tool.core.test.ts
@@ -26,6 +26,10 @@ vi.mock("@xiaozhi-client/config", () => ({
 }));
 
 // 模拟 MCPServiceManager - 在 Context 中提供
+const mockCacheManager = {
+  getAllCachedTools: vi.fn(() => []),
+};
+
 const mockServiceManager = {
   hasTool: vi.fn(() => false),
   hasCustomMCPTool: vi.fn(() => false),
@@ -41,14 +45,8 @@ const mockServiceManager = {
   getConnectedServices: vi.fn(() => []),
   stopService: vi.fn(),
   startService: vi.fn(),
+  getCacheManager: vi.fn(() => mockCacheManager),
 };
-
-// 模拟 MCPCacheManager
-vi.mock("@/lib/mcp", () => ({
-  MCPCacheManager: vi.fn().mockImplementation(() => ({
-    getAllCachedTools: vi.fn().mockResolvedValue([]),
-  })) as any,
-}));
 
 describe("MCPToolHandler - 核心功能测试", () => {
   let handler: MCPToolHandler;
@@ -237,21 +235,14 @@ describe("MCPToolHandler - 核心功能测试", () => {
         () => {}
       );
 
-      // 模拟 MCPCacheManager
-      const { MCPCacheManager } = await import("@/lib/mcp");
-      const mockMCPCacheManager = vi.mocked(MCPCacheManager);
-      mockMCPCacheManager.mockImplementation(
-        () =>
-          ({
-            getAllCachedTools: vi.fn().mockResolvedValue([
-              {
-                name: "test-service__test-tool",
-                description: "测试工具",
-                inputSchema: { type: "object", properties: {} },
-              },
-            ]),
-          }) as any
-      );
+      // 模拟 getCacheManager 返回缓存工具
+      mockCacheManager.getAllCachedTools.mockResolvedValue([
+        {
+          name: "test-service__test-tool",
+          description: "测试工具",
+          inputSchema: { type: "object", properties: {} },
+        },
+      ]);
 
       await handler.addCustomTool(mockContext as Context);
 

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -7,7 +7,6 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import { HTTP_TIMEOUTS } from "@/constants/timeout.constants.js";
 import { MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
-import { MCPCacheManager } from "@/lib/mcp";
 import type { MCPServiceManager } from "@/lib/mcp";
 import type { EnhancedToolInfo } from "@/lib/mcp/types.js";
 import type { CozeWorkflow, WorkflowParameterConfig } from "@/types/coze.js";
@@ -666,8 +665,8 @@ export class MCPToolHandler {
       return c.fail("SERVICE_OR_TOOL_NOT_FOUND", errorMessage, undefined, 404);
     }
 
-    // 从缓存中获取工具信息
-    const cacheManager = new MCPCacheManager();
+    // 从缓存中获取工具信息（使用 MCPServiceManager 的现有缓存管理器实例）
+    const cacheManager = serviceManager.getCacheManager();
     const cachedTools = await cacheManager.getAllCachedTools();
 
     // 查找对应的工具

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -1818,6 +1818,14 @@ export class MCPServiceManager extends EventEmitter {
   async cleanup(): Promise<void> {
     await this.stopAllServices();
 
+    // 清理缓存管理器的定时器，防止资源泄漏
+    try {
+      this.cacheManager.cleanup();
+      logger.info("[MCPManager] 缓存管理器已清理");
+    } catch (error) {
+      logger.error("[MCPManager] 缓存管理器清理失败", { error });
+    }
+
     // 清理事件监听器，防止内存泄漏
     this.eventBus.offEvent(
       "mcp:service:connected",
@@ -1831,5 +1839,13 @@ export class MCPServiceManager extends EventEmitter {
       "mcp:service:connection:failed",
       this.eventListeners.serviceConnectionFailed
     );
+  }
+
+  /**
+   * 获取缓存管理器实例
+   * @returns MCPCacheManager 实例
+   */
+  getCacheManager(): MCPCacheManager {
+    return this.cacheManager;
   }
 }


### PR DESCRIPTION
每次调用 handleAddMCPTool 方法时都创建新的 MCPCacheManager 实例，
但未调用 cleanup() 方法停止定时器，导致 setInterval 定时器泄漏。

修复方案：
- 在 MCPServiceManager 中新增 getCacheManager() 方法
- 在 cleanup() 方法中添加 cacheManager.cleanup() 调用
- handler 使用现有实例而非创建新实例

相关测试已更新以适配新的实现方式。

Fixes #3159

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3159