### PR TITLE
fix(types): 修复 TaskInfo 类型中的 any 类型使用

### DIFF
--- a/packages/shared-types/src/mcp/cache.ts
+++ b/packages/shared-types/src/mcp/cache.ts
@@ -6,6 +6,7 @@ import type { TaskStatus } from "./task";
 
 /**
  * 工具调用结果接口（简化版）
+ * 支持其他未知字段，保持向后兼容性
  */
 export interface ToolCallResult {
   content: Array<{
@@ -13,6 +14,7 @@ export interface ToolCallResult {
     text: string;
   }>;
   isError?: boolean;
+  [key: string]: unknown; // 支持其他未知字段，保持向后兼容
 }
 
 /**

--- a/packages/shared-types/src/mcp/task.ts
+++ b/packages/shared-types/src/mcp/task.ts
@@ -2,6 +2,8 @@
  * MCP 任务相关类型定义
  */
 
+import type { ToolCallResult } from "./cache.js";
+
 /**
  * 任务状态类型
  */
@@ -28,12 +30,12 @@ export interface CacheStateTransition {
 export interface TaskInfo {
   taskId: string;
   toolName: string;
-  arguments: any;
+  arguments: Record<string, unknown>;
   status: TaskStatus;
   startTime: string;
   endTime?: string;
   error?: string;
-  result?: any;
+  result?: ToolCallResult;
 }
 
 /**


### PR DESCRIPTION
修复 packages/shared-types/src/mcp/task.ts 中的 TaskInfo 接口：
- 将 arguments 从 any 改为 Record<string, unknown>
- 将 result 从 any 改为 ToolCallResult

同时为 ToolCallResult 添加索引签名以保持向后兼容性。

相关 Issue: #3163

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3163