### PR TITLE
feat(esp32): 添加 VAD 端点检测支持，优化语音识别结束判断

### DIFF
--- a/.cspell/words.txt
+++ b/.cspell/words.txt
@@ -191,6 +191,7 @@ worktrees
 wroom
 WSHANDLER
 wvae
+xfyun
 Xiaoxuan
 xiaoxue
 xiaozhi

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -29,7 +29,7 @@
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",
     "@xiaozhi-client/shared-types": "workspace:*",
-    "univoice": "^0.7.1",
+    "univoice": "^0.10.0",
     "@xiaozhi-client/version": "workspace:*",
     "ajv": "^8.18.0",
     "chalk": "^5.6.0",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@xiaozhi-client/asr": "workspace:*",
     "@xiaozhi-client/esp32": "workspace:*",
     "@xiaozhi-client/shared-types": "workspace:*",
-    "univoice": "^0.7.1",
+    "univoice": "^0.10.0",
     "@xiaozhi-client/config": "workspace:*",
     "@xiaozhi-client/endpoint": "workspace:*",
     "@xiaozhi-client/mcp-core": "workspace:*",

--- a/packages/esp32/package.json
+++ b/packages/esp32/package.json
@@ -1,1 +1,69 @@
-{"name": "@xiaozhi-client/esp32", "version": "1.0.0", "description": "ESP32 硬件设备通信 SDK，提供设备连接管理 + 语音交互全流程（ASR → LLM → TTS）+ 二进制音频协议处理", "type": "module", "main": "./dist/index.js", "types": "./dist/index.d.ts", "exports": {".": {"types": "./dist/index.d.ts", "import": "./dist/index.js"}}, "files": ["dist"], "repository": {"type": "git", "url": "https://github.com/shenjingnan/xiaozhi-client.git", "directory": "packages/esp32"}, "publishConfig": {"access": "public"}, "scripts": {"build": "tsup", "dev": "tsup --watch", "test": "vitest run --coverage.enabled=false", "test:watch": "vitest", "test:coverage": "vitest run --coverage", "check:type": "tsc --noEmit", "lint": "biome check .", "lint:fix": "biome check --write .", "check:spell": "cspell .", "check:cpd": "jscpd . --ignore 'node_modules'", "check:all": "pnpm run lint && pnpm run check:type && pnpm run check:spell && pnpm run check:cpd", "clean:dist": "rimraf dist"}, "keywords": ["esp32", "websocket", "asr", "llm", "tts", "audio-protocol", "iot"], "author": "", "license": "MIT", "dependencies": {"@xiaozhi-client/asr": "workspace:*", "@xiaozhi-client/shared-types": "workspace:*", "openai": "^4.73.0", "prism-media": "^1.3.5", "univoice": "^0.7.1", "zod": "^4.3.6"}, "peerDependencies": {"ws": "^8.16.0"}, "devDependencies": {"@types/node": "^20.10.0", "@types/ws": "^8.5.10", "tsup": "^8.3.5", "typescript": "^5.3.0", "vitest": "^3.2.4"}, "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"}
+{
+  "name": "@xiaozhi-client/esp32",
+  "version": "1.0.0",
+  "description": "ESP32 硬件设备通信 SDK，提供设备连接管理 + 语音交互全流程（ASR → LLM → TTS）+ 二进制音频协议处理",
+  "type": "module",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/shenjingnan/xiaozhi-client.git",
+    "directory": "packages/esp32"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch",
+    "test": "vitest run --coverage.enabled=false",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage",
+    "check:type": "tsc --noEmit",
+    "lint": "biome check .",
+    "lint:fix": "biome check --write .",
+    "check:spell": "cspell .",
+    "check:cpd": "jscpd . --ignore 'node_modules'",
+    "check:all": "pnpm run lint && pnpm run check:type && pnpm run check:spell && pnpm run check:cpd",
+    "clean:dist": "rimraf dist"
+  },
+  "keywords": [
+    "esp32",
+    "websocket",
+    "asr",
+    "llm",
+    "tts",
+    "audio-protocol",
+    "iot"
+  ],
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@xiaozhi-client/asr": "workspace:*",
+    "@xiaozhi-client/shared-types": "workspace:*",
+    "openai": "^4.73.0",
+    "prism-media": "^1.3.5",
+    "univoice": "^0.10.0",
+    "zod": "^4.3.6"
+  },
+  "peerDependencies": {
+    "ws": "^8.16.0"
+  },
+  "devDependencies": {
+    "@types/node": "^20.10.0",
+    "@types/ws": "^8.5.10",
+    "tsup": "^8.3.5",
+    "typescript": "^5.3.0",
+    "vitest": "^3.2.4"
+  },
+  "packageManager": "pnpm@10.23.0+sha512.21c4e5698002ade97e4efe8b8b4a89a8de3c85a37919f957e7a0f30f38fbc5bbdd05980ffe29179b2fb6e6e691242e098d945d1601772cad0fef5fb6411e2a4b"
+}

--- a/packages/esp32/src/services/__tests__/asr.service.test.ts
+++ b/packages/esp32/src/services/__tests__/asr.service.test.ts
@@ -3,33 +3,26 @@
  * 测试 ASRService 的语音识别生命周期管理
  */
 
+import { createASR } from "univoice";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ASRService } from "../asr.service.js";
 
-// Mock @xiaozhi-client/asr
-const mockASRClose = vi.fn().mockResolvedValue(undefined);
-const mockASRIsConnected = vi.fn().mockReturnValue(false);
-const mockOn = vi.fn();
+// Mock @xiaozhi-client/asr（仅保留 OpusDecoder 用于 Opus→PCM 解码）
+vi.mock("@xiaozhi-client/asr", () => ({
+  OpusDecoder: {
+    toPcm: vi.fn().mockResolvedValue(Buffer.from([0x01, 0x02, 0x03])),
+  },
+}));
+
+// Mock univoice（ASR 引擎替换为 univoice）
 const mockListenGenerator = (async function* () {
   // 默认不产生任何结果（空生成器）
 })();
 
-vi.mock("@xiaozhi-client/asr", () => ({
-  ASR: vi.fn().mockImplementation(() => ({
-    close: mockASRClose,
-    isConnected: mockASRIsConnected,
-    on: mockOn,
-    bytedance: {
-      v2: {
-        listen: vi.fn().mockReturnValue(mockListenGenerator),
-      },
-    },
+vi.mock("univoice", () => ({
+  createASR: vi.fn().mockImplementation(() => ({
+    listen: vi.fn().mockReturnValue(mockListenGenerator),
   })),
-  AudioFormat: { RAW: "raw" },
-  AuthMethod: { TOKEN: "token" },
-  OpusDecoder: {
-    toPcm: vi.fn().mockResolvedValue(Buffer.from([0x01, 0x02, 0x03])),
-  },
 }));
 
 describe("ASRService", () => {
@@ -56,8 +49,6 @@ describe("ASRService", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    mockASRClose.mockResolvedValue(undefined);
-    mockASRIsConnected.mockReturnValue(false);
     service = new ASRService({
       events: mockEvents,
       configProvider: createValidConfigProvider(),
@@ -80,14 +71,15 @@ describe("ASRService", () => {
 
   describe("connect", () => {
     it("已连接跳过", async () => {
-      mockASRIsConnected.mockReturnValue(true);
-
-      // 先手动创建一个客户端（模拟已连接状态）
-      // 实际上 connect 内部会检查 isConnected，如果返回 true 则跳过
+      // 新实现使用 connected 属性而非 isConnected() 方法
+      // 先 connect 创建客户端（标记 connected=true）
+      await service.prepare("device-1");
       await service.connect("device-1");
 
-      // 由于 mockASRClient 不存在，connect 会尝试创建新的
-      // 但我们验证不会抛错即可
+      // 再次 connect 应该跳过（因为已连接）
+      await service.connect("device-1");
+
+      // 不应抛错，第二次 connect 被跳过
     });
 
     it("正在连接等待完成", async () => {
@@ -202,7 +194,7 @@ describe("ASRService", () => {
   });
 
   describe("destroy", () => {
-    it("清理所有资源并 close 所有客户端", () => {
+    it("清理所有资源并标记客户端断开", () => {
       // 先准备一些设备
       service.prepare("device-1");
       service.prepare("device-2");
@@ -211,6 +203,135 @@ describe("ASRService", () => {
 
       // destroy 后操作不应报错（虽然设备状态已清除）
       expect(() => service.destroy()).not.toThrow(); // 重复销毁安全
+    });
+  });
+
+  describe("VAD 端点检测", () => {
+    it("VAD端点(confidence=1)应触发onResult(isFinal=true)并停止listen", async () => {
+      // 构造模拟生成器：先产生中间结果，再产生VAD端点
+      const mockVadGenerator = (async function* () {
+        yield { text: "你好", isFinal: false, confidence: 0.9 };
+        // VAD 端点：segment.confidence === 1
+        yield {
+          text: "你好世界",
+          isFinal: false,
+          segment: {
+            id: 1,
+            start: 0,
+            end: 1200,
+            text: "你好世界",
+            confidence: 1,
+          },
+        };
+      })();
+
+      vi.mocked(createASR).mockImplementation(
+        () =>
+          ({
+            listen: vi.fn().mockReturnValue(mockVadGenerator),
+          }) as ReturnType<typeof createASR>
+      );
+
+      await service.prepare("device-vad");
+      await service.connect("device-vad");
+
+      // 等待 listen 任务完成
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 验证 onResult 被调用了两次（中间结果 + VAD端点）
+      expect(mockEvents.onResult).toHaveBeenCalledTimes(2);
+
+      // 第一次：中间结果，isFinal=false
+      expect(mockEvents.onResult).toHaveBeenCalledWith(
+        "device-vad",
+        "你好",
+        false
+      );
+
+      // 第二次：VAD端点，应以 isFinal=true 触发
+      expect(mockEvents.onResult).toHaveBeenCalledWith(
+        "device-vad",
+        "你好世界",
+        true
+      );
+    });
+
+    it("非definite segment(confidence<1)不应触发终止", async () => {
+      const mockNonDefiniteGenerator = (async function* () {
+        yield {
+          text: "测试",
+          isFinal: false,
+          segment: {
+            id: 1,
+            start: 0,
+            end: 500,
+            text: "测试",
+            confidence: 0.8,
+          },
+        };
+        // 生成器继续运行（不应break）
+        yield { text: "测试继续", isFinal: false };
+        yield { text: "测试完成", isFinal: true }; // 最终由isFinal终止
+      })();
+
+      vi.mocked(createASR).mockImplementation(
+        () =>
+          ({
+            listen: vi.fn().mockReturnValue(mockNonDefiniteGenerator),
+          }) as ReturnType<typeof createASR>
+      );
+
+      await service.prepare("device-non-definite");
+      await service.connect("device-non-definite");
+
+      // 等待 listen 任务完成
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 应该收到全部3次结果（非definite segment不中断流）
+      expect(mockEvents.onResult).toHaveBeenCalledTimes(3);
+      expect(mockEvents.onResult).toHaveBeenLastCalledWith(
+        "device-non-definite",
+        "测试完成",
+        true
+      );
+    });
+
+    it("无segment信息的chunk正常处理不受影响", async () => {
+      const mockNoSegmentGenerator = (async function* () {
+        yield { text: "第一条", isFinal: false };
+        yield { text: "第二条", isFinal: false };
+        yield { text: "最终", isFinal: true };
+      })();
+
+      vi.mocked(createASR).mockImplementation(
+        () =>
+          ({
+            listen: vi.fn().mockReturnValue(mockNoSegmentGenerator),
+          }) as ReturnType<typeof createASR>
+      );
+
+      await service.prepare("device-no-segment");
+      await service.connect("device-no-segment");
+
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 无 segment 时行为与改造前一致，3次正常回调
+      expect(mockEvents.onResult).toHaveBeenCalledTimes(3);
+      expect(mockEvents.onResult).toHaveBeenCalledWith(
+        "device-no-segment",
+        "第一条",
+        false
+      );
+      expect(mockEvents.onResult).toHaveBeenCalledWith(
+        "device-no-segment",
+        "第二条",
+        false
+      );
+      expect(mockEvents.onResult).toHaveBeenCalledWith(
+        "device-no-segment",
+        "最终",
+        true
+      );
     });
   });
 });

--- a/packages/esp32/src/services/asr.service.ts
+++ b/packages/esp32/src/services/asr.service.ts
@@ -3,7 +3,13 @@
  * 处理语音识别功能
  */
 
-import { ASR, AudioFormat, AuthMethod, OpusDecoder } from "@xiaozhi-client/asr";
+import { OpusDecoder } from "@xiaozhi-client/asr";
+import { createASR } from "univoice";
+import type { BaseASR } from "univoice";
+// 触发 ASR 提供商自动注册（doubao/qwen/glm/xfyun 等）
+import "univoice/asr/providers";
+import { existsSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
 import type { IESP32ConfigProvider, ILogger } from "../interfaces.js";
 import { noopLogger } from "../interfaces.js";
 import type {
@@ -25,6 +31,17 @@ interface DeviceASRState {
 }
 
 /**
+ * ASR 客户端实例包装
+ * 封装 univoice BaseASR 实例，附加连接状态追踪
+ */
+interface ASRClientInstance {
+  /** univoice ASR 实例 */
+  client: BaseASR;
+  /** 是否已连接 */
+  connected: boolean;
+}
+
+/**
  * ASR 服务
  * 处理语音识别功能，通过回调通知识别结果
  */
@@ -42,7 +59,7 @@ export class ASRService implements IASRService {
   private readonly deviceStates = new Map<string, DeviceASRState>();
 
   /** 每个设备的 ASR 客户端（用于语音识别） */
-  private readonly asrClients = new Map<string, ASR>();
+  private readonly asrClients = new Map<string, ASRClientInstance>();
 
   /** 每个设备的音频数据队列（用于 V2 listen API） */
   private readonly audioQueues = new Map<string, Buffer[]>();
@@ -52,6 +69,12 @@ export class ASRService implements IASRService {
 
   /** 每个设备的 V2 listen 任务 */
   private readonly listenTasks = new Map<string, Promise<void>>();
+
+  /** 调试：每个设备的 opus 包计数器 */
+  private readonly debugAudioCounters = new Map<string, number>();
+
+  /** 调试：音频包存储目录 */
+  private static readonly DEBUG_AUDIO_DIR = join(process.cwd(), "tmp", "audio");
 
   /**
    * 构造函数
@@ -98,7 +121,7 @@ export class ASRService implements IASRService {
 
     // 如果已经连接或正在连接，等待连接完成
     const existingClient = this.asrClients.get(deviceId);
-    if (existingClient?.isConnected()) {
+    if (existingClient?.connected) {
       this.logger.debug(
         `[ASRService] ASR 客户端已连接，跳过: deviceId=${deviceId}`
       );
@@ -137,7 +160,9 @@ export class ASRService implements IASRService {
       this.logger.warn(
         `[ASRService] ASR 客户端存在但未连接，关闭旧的: deviceId=${deviceId}`
       );
-      await existingClient.close();
+      // univoice BaseASR 不支持 close()，标记为未连接即可
+      // 底层 WebSocket 会在 listen 结束后自动关闭
+      existingClient.connected = false;
       this.asrClients.delete(deviceId);
     }
 
@@ -152,6 +177,7 @@ export class ASRService implements IASRService {
 
   /**
    * 创建 ASR 客户端
+   * 使用 univoice SDK 创建 Doubao ASR 实例
    * @param deviceId - 设备 ID
    */
   private async createASRClient(deviceId: string): Promise<void> {
@@ -162,54 +188,40 @@ export class ASRService implements IASRService {
       return;
     }
 
-    // 使用 V2 配置格式
-    const asrClient = new ASR({
-      bytedance: {
-        v2: {
-          app: {
-            appid: asrConfig.appid,
-            token: asrConfig.accessToken,
-            cluster: asrConfig.cluster || "volcengine_streaming_common",
-          },
-          user: {
-            uid: `device_${deviceId}`,
-          },
-          audio: {
-            format: AudioFormat.RAW,
-            language: "zh-CN",
-          },
-          request: {
-            reqid: `req_${deviceId}_${Date.now()}`,
-            sequence: 1,
-          },
-        },
-      },
-      authMethod: AuthMethod.TOKEN,
+    // 使用 univoice 创建 Doubao ASR 客户端
+    const asrClient = createASR({
+      provider: "doubao",
+      appKey: asrConfig.appid,
+      accessKey: asrConfig.accessToken,
+      language: "zh-CN",
+      format: "pcm",
+      codec: "raw",
+      audioFormat: { sampleRate: 16000, bits: 16, channel: 1 },
+      mode: "streaming",
+      ...(asrConfig.wsUrl && { baseUrl: asrConfig.wsUrl }),
+      // 启用服务端 VAD 端点检测：当 vadEndWindowSize > 0 时传入 endWindowSize
+      // 服务端将在检测到 vadEndWindowSize(ms) 静音后判定语音结束，
+      // 通过 segment.confidence === 1 标记 definite utterance
+      ...(asrConfig.vadEndWindowSize && asrConfig.vadEndWindowSize > 0
+        ? { endWindowSize: asrConfig.vadEndWindowSize }
+        : {}),
     });
 
-    // 设置事件监听
-    asrClient.on("error", (error: Error) => {
-      this.logger.error(
-        `[ASRService] ASR 错误: deviceId=${deviceId}, error=${error.message}`
-      );
-      this.events.onError?.(deviceId, error);
-    });
-
-    asrClient.on("close", () => {
-      this.logger.info(`[ASRService] ASR 连接关闭: deviceId=${deviceId}`);
-      this.asrClients.delete(deviceId);
-      this.events.onClose?.(deviceId);
-    });
+    // 包装为带连接状态的实例
+    const clientWrapper: ASRClientInstance = {
+      client: asrClient,
+      connected: true,
+    };
 
     // 保存 ASR 客户端
-    this.asrClients.set(deviceId, asrClient);
+    this.asrClients.set(deviceId, clientWrapper);
 
     // 启动 listen 任务处理音频流
     const listenTask = this.startListenTask(deviceId, asrClient);
     this.listenTasks.set(deviceId, listenTask);
 
     this.logger.info(
-      `[ASRService] ASR 客户端已创建（V2）: deviceId=${deviceId}`
+      `[ASRService] ASR 客户端已创建（univoice doubao）: deviceId=${deviceId}`
     );
   }
 
@@ -238,8 +250,11 @@ export class ASRService implements IASRService {
   ): Promise<void> {
     const audioBuffer = Buffer.from(audioData);
     this.logger.debug(
-      `[ASRService] 收到音频数据: deviceId=${deviceId}, size=${audioData.length}`
+      `[ASRService] 收到音频数据: deviceId=${deviceId}, size=${audioBuffer.length}`
     );
+
+    // 调试：异步存储原始 opus 数据包（不阻塞 ASR 流程）
+    this.saveDebugOpusPacket(deviceId, audioBuffer);
 
     const state = this.getOrCreateDeviceState(deviceId);
 
@@ -297,7 +312,43 @@ export class ASRService implements IASRService {
   }
 
   /**
+   * 调试用：异步存储原始 opus 数据包到文件系统
+   * 按设备隔离，按顺序编号命名（00.opus, 01.opus, ...）
+   * 不阻塞 ASR 识别流程，写入失败静默忽略
+   * @param deviceId - 设备 ID
+   * @param opusData - 原始 opus 数据
+   */
+  private saveDebugOpusPacket(deviceId: string, opusData: Buffer): void {
+    // 确保目录存在（仅检查一次）
+    if (!existsSync(ASRService.DEBUG_AUDIO_DIR)) {
+      try {
+        mkdirSync(ASRService.DEBUG_AUDIO_DIR, { recursive: true });
+      } catch {
+        return; // 目录创建失败则跳过
+      }
+    }
+
+    // 获取当前设备的包编号
+    const count = this.debugAudioCounters.get(deviceId) || 0;
+    this.debugAudioCounters.set(deviceId, count + 1);
+
+    // 异步写入，不 await，不阻塞主流程
+    const filename = `${count.toString().padStart(2, "0")}.opus`;
+    const filePath = join(ASRService.DEBUG_AUDIO_DIR, filename);
+
+    import("node:fs/promises")
+      .then((fs) => fs.writeFile(filePath, opusData))
+      .catch(() => {}); // 写入失败静默忽略
+  }
+
+  /** 静音超时时间（毫秒），超过此时间无新音频数据则认为语音结束 */
+  private static readonly SILENCE_TIMEOUT_MS = 1500;
+
+  /**
    * 创建异步生成器，从队列中读取 PCM 数据
+   * 支持静音超时：当超过 SILENCE_TIMEOUT_MS 无新数据时自动结束音频流
+   * 这对 univoice 的 ASR 至关重要，因为它需要在音频流结束后发送结束标记
+   * 服务端收到结束标记后才会发出 isLastPackage=true（isFinal=true）
    * @param deviceId - 设备 ID
    * @returns 异步生成器
    */
@@ -307,18 +358,36 @@ export class ASRService implements IASRService {
     const queue = this.audioQueues.get(deviceId) || [];
 
     while (true) {
-      // 等待队列中有数据
+      // 等待队列中有数据（带超时检测）
+      let lastDataTime = Date.now();
+
       while (queue.length === 0) {
-        // 检查是否已结束
+        // 检查是否已通过 end() 手动标记结束
         if (this.audioEnded.get(deviceId)) {
           this.logger.debug(`[ASRService] 音频流结束: deviceId=${deviceId}`);
           return;
         }
-        // 短暂等待
-        await new Promise((resolve) => setTimeout(resolve, 50));
+
+        // 静音超时检测：超过阈值无新数据则自动结束音频流
+        const elapsed = Date.now() - lastDataTime;
+        if (elapsed >= ASRService.SILENCE_TIMEOUT_MS) {
+          this.logger.info(
+            `[ASRService] 静音超时（${elapsed}ms），自动结束音频流: deviceId=${deviceId}`
+          );
+          return;
+        }
+
+        // 短暂等待后重试
+        await new Promise((resolve) =>
+          setTimeout(
+            resolve,
+            Math.min(50, ASRService.SILENCE_TIMEOUT_MS - elapsed)
+          )
+        );
       }
 
-      // 从队列取出数据
+      // 从队列取出数据，更新最后数据时间
+      lastDataTime = Date.now();
       const pcmData = queue.shift()!;
       yield pcmData;
     }
@@ -326,35 +395,51 @@ export class ASRService implements IASRService {
 
   /**
    * 启动 listen 任务
-   * 使用 V2 API 的 listen() 方法处理音频流
+   * 使用 univoice 的 listen API 进行流式识别
    * @param deviceId - 设备 ID
-   * @param asrClient - ASR 客户端
+   * @param asrClient - univoice ASR 客户端实例
    */
   private async startListenTask(
     deviceId: string,
-    asrClient: ASR
+    asrClient: BaseASR
   ): Promise<void> {
     try {
       // 创建音频流生成器
       const audioStream = this.createAudioStream(deviceId);
 
-      // 使用 V2 listen API 进行流式识别
-      for await (const result of asrClient.bytedance.v2.listen(audioStream)) {
+      // 使用 univoice listen API 进行流式识别
+      // ASRStreamChunk: { text: string; isFinal: boolean; confidence?: number; segment?: ASRSegment }
+      for await (const chunk of asrClient.listen(audioStream, {
+        stream: true,
+      })) {
+        // 检测 VAD 端点：segment.confidence === 1 表示服务端判定用户已说完话（definite utterance）
+        // 这是服务端 VAD 的端点信号，比客户端静音超时更准确、更低延迟
+        const isVadEndpoint = chunk.segment?.confidence === 1;
+
         this.logger.info(
-          `[ASRService] ASR 识别结果: deviceId=${deviceId}, isFinal=${result.isFinal}, text=${result.text}`
+          `[ASRService] ASR 识别结果: deviceId=${deviceId}, ` +
+            `isFinal=${chunk.isFinal}, isVadEndpoint=${isVadEndpoint}, text=${chunk.text}`
         );
 
-        // isFinal 时标记音频结束，停止 listen 循环，避免重复触发 LLM
-        if (result.isFinal) {
+        // 当检测到 VAD 端点或 isFinal 时，标记音频结束并按 isFinal 处理
+        // VAD 端点和 isFinal 在语义上等价：都表示"当前语音片段已结束"
+        const shouldTreatAsFinal = chunk.isFinal || isVadEndpoint;
+
+        if (shouldTreatAsFinal) {
           this.audioEnded.set(deviceId, true);
           this.logger.info(
-            `[ASRService] ASR 识别完成，停止 listen: deviceId=${deviceId}`
+            `[ASRService] ASR 识别完成（${isVadEndpoint ? "VAD端点" : "isFinal"}），停止 listen: deviceId=${deviceId}`
           );
         }
 
         // 触发结果回调，使用异常隔离避免回调抛错导致整条链路终止
+        // VAD 端点时以 isFinal=true 通知调用方，保证下游 LLM/TTS 流程正常触发
         try {
-          this.events.onResult?.(deviceId, result.text || "", result.isFinal);
+          this.events.onResult?.(
+            deviceId,
+            chunk.text || "",
+            shouldTreatAsFinal
+          );
         } catch (callbackError) {
           this.logger.error(
             `[ASRService] onResult 回调执行失败: deviceId=${deviceId}`,
@@ -362,16 +447,23 @@ export class ASRService implements IASRService {
           );
         }
 
-        // isFinal 时 break 停止 listen 循环
-        if (result.isFinal) {
+        // isFinal 或 VAD 端点时 break 停止 listen 循环
+        if (shouldTreatAsFinal) {
           break;
         }
       }
 
       this.logger.info(`[ASRService] listen 任务完成: deviceId=${deviceId}`);
 
+      // 标记连接已关闭并触发 onClose 回调
+      const wrapper = this.asrClients.get(deviceId);
+      if (wrapper) {
+        wrapper.connected = false;
+      }
+      this.events.onClose?.(deviceId);
+      this.asrClients.delete(deviceId);
+
       // 重置音频缓冲区状态，准备下一次识别
-      // 注意：底层 ASR 客户端已关闭连接，下次识别需要重新 connect
       this.audioQueues.set(deviceId, []);
       this.audioEnded.set(deviceId, false);
       this.logger.info(
@@ -382,6 +474,18 @@ export class ASRService implements IASRService {
         `[ASRService] listen 任务出错: deviceId=${deviceId}`,
         error
       );
+
+      // 触发错误回调（替代原来的事件监听模式）
+      if (error instanceof Error) {
+        this.events.onError?.(deviceId, error);
+      }
+
+      // 标记连接已关闭
+      const wrapper = this.asrClients.get(deviceId);
+      if (wrapper) {
+        wrapper.connected = false;
+      }
+      this.asrClients.delete(deviceId);
     }
   }
 
@@ -411,10 +515,11 @@ export class ASRService implements IASRService {
     }
 
     // 关闭 ASR 客户端
-    const asrClient = this.asrClients.get(deviceId);
-    if (asrClient) {
+    const clientWrapper = this.asrClients.get(deviceId);
+    if (clientWrapper) {
       try {
-        await asrClient.close();
+        // 标记连接已关闭，listen 任务会在下一个迭代检测到 audioEnded 后退出
+        clientWrapper.connected = false;
       } catch (error) {
         this.logger.error(
           `[ASRService] ASR 关闭失败: deviceId=${deviceId}`,
@@ -462,8 +567,9 @@ export class ASRService implements IASRService {
    */
   destroy(): void {
     // 清理 ASR 客户端
-    for (const asrClient of this.asrClients.values()) {
-      asrClient.close();
+    for (const wrapper of this.asrClients.values()) {
+      wrapper.connected = false;
+      // listen 任务会因为 audioQueues/audioEnded 清理而自然退出
     }
     this.asrClients.clear();
     // 清理 V2 API 相关状态

--- a/packages/shared-types/src/config/app.ts
+++ b/packages/shared-types/src/config/app.ts
@@ -126,6 +126,10 @@ export interface ASRConfig {
   cluster?: string;
   /** WebSocket 端点 */
   wsUrl?: string;
+  /** VAD 端点检测窗口大小(ms)，启用服务端 VAD 判停
+   *  设为 0 或不传则禁用服务端 VAD，回退到客户端静音超时
+   *  推荐值: 800，最小值: 200 */
+  vadEndWindowSize?: number;
 }
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,8 +117,8 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)
       univoice:
-        specifier: ^0.7.1
-        version: 0.7.1(@discordjs/opus@0.10.0)
+        specifier: ^0.10.0
+        version: 0.10.0(@discordjs/opus@0.10.0)(zod@4.3.6)
       ws:
         specifier: ^8.14.2
         version: 8.19.0
@@ -280,8 +280,8 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)
       univoice:
-        specifier: ^0.7.1
-        version: 0.7.1(@discordjs/opus@0.10.0)
+        specifier: ^0.10.0
+        version: 0.10.0(@discordjs/opus@0.10.0)(zod@4.3.6)
       ws:
         specifier: ^8.14.2
         version: 8.19.0
@@ -709,8 +709,8 @@ importers:
         specifier: ^1.3.5
         version: 1.3.5(@discordjs/opus@0.10.0)
       univoice:
-        specifier: ^0.7.1
-        version: 0.7.1(@discordjs/opus@0.10.0)
+        specifier: ^0.10.0
+        version: 0.10.0(@discordjs/opus@0.10.0)(zod@4.3.6)
       ws:
         specifier: ^8.16.0
         version: 8.19.0
@@ -6042,6 +6042,18 @@ packages:
       zod:
         optional: true
 
+  openai@6.34.0:
+    resolution: {integrity: sha512-yEr2jdGf4tVFYG6ohmr3pF6VJuveP0EA/sS8TBx+4Eq5NT10alu5zg2dmxMXMgqpihRDQlFGpRt2XwsGj+Fyxw==}
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   opus-encdec@0.1.1:
     resolution: {integrity: sha512-TDzyGqYqrwn5UEUNaLsfLGu8Ma+HRNrgLYj7Vx5wfTnafAA21G6Bnm/qTIa3orQi/yZPZYmkdpO/gez4nfA1Rw==}
 
@@ -7218,8 +7230,8 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
-  univoice@0.7.1:
-    resolution: {integrity: sha512-0wEKeHUGtHN5yxVAZXw9pY/veVP8AMD4vjTH0038kFS7hcs9ywYtPOldo9zetxXxrrcQQjiclecDZsljVGeKLA==}
+  univoice@0.10.0:
+    resolution: {integrity: sha512-jWCda3KLKWVPekplxjIpNIoEH9zBFESUKzejbEt7VfFcnoIGL4tf//0uQLVChZH3xFYj1WfBDuBqkgC8PFbdug==}
     engines: {node: '>=20.0.0'}
 
   unpipe@1.0.0:
@@ -10535,14 +10547,6 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
-    dependencies:
-      '@vitest/spy': 3.2.4
-      estree-walker: 3.0.3
-      magic-string: 0.30.21
-    optionalDependencies:
-      vite: 7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2)
-
   '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.10.9)(jiti@1.21.7)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))':
     dependencies:
       '@vitest/spy': 3.2.4
@@ -13459,6 +13463,12 @@ snapshots:
       ws: 8.19.0
       zod: 4.3.6
 
+  openai@6.34.0(ws@8.19.0)(zod@4.3.6):
+    optionalDependencies:
+      ws: 8.19.0
+      zod: 4.3.6
+    optional: true
+
   opus-encdec@0.1.1: {}
 
   ora@5.3.0:
@@ -14870,10 +14880,11 @@ snapshots:
 
   universalify@2.0.1: {}
 
-  univoice@0.7.1(@discordjs/opus@0.10.0):
+  univoice@0.10.0(@discordjs/opus@0.10.0)(zod@4.3.6):
     dependencies:
       ws: 8.19.0
     optionalDependencies:
+      openai: 6.34.0(ws@8.19.0)(zod@4.3.6)
       prism-media: 1.3.5(@discordjs/opus@0.10.0)
     transitivePeerDependencies:
       - '@discordjs/opus'
@@ -14882,6 +14893,7 @@ snapshots:
       - node-opus
       - opusscript
       - utf-8-validate
+      - zod
 
   unpipe@1.0.0: {}
 
@@ -15091,7 +15103,7 @@ snapshots:
     dependencies:
       '@types/chai': 5.2.3
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@20.19.33)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
+      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.10.9)(jiti@2.6.1)(lightningcss@1.30.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.2))
       '@vitest/pretty-format': 3.2.4
       '@vitest/runner': 3.2.4
       '@vitest/snapshot': 3.2.4


### PR DESCRIPTION
## Summary
- 利用 univoice Doubao ASR 内置的服务端 VAD 能力（`endWindowSize`），通过 `segment.confidence === 1` 检测 definite utterance，替代纯客户端 1500ms 静音超时机制
- 预估延迟改善约 700ms+（用户停顿后更快触发 LLM → TTS 流程）
- ASRConfig 新增 `vadEndWindowSize` 可选配置字段（推荐值 800）
- 保留客户端静音超时作为兜底，下游 `esp32-manager.ts` 零改动

## Test plan
- [x] 160/160 单元测试全部通过（含 3 个新增 VAD 测试用例）
- [x] TypeScript 类型检查通过 (`pnpm check:type`)
- [x] Biome lint 检查通过 (`pnpm lint`)
- [ ] 配置 `vadEndWindowSize: 800` 后端到端验证 VAD 触发 LLM/TTS 流程