### PR TITLE
perf(notification): 使用索引追踪优化队列溢出性能

### DIFF
--- a/apps/backend/errors/error-helper.ts
+++ b/apps/backend/errors/error-helper.ts
@@ -95,6 +95,9 @@ export interface ErrorStatistics {
 const errorHistory: Map<string, MCPError[]> = new Map();
 const MAX_ERROR_HISTORY = 100;
 
+// 错误历史索引追踪，避免 Array.shift() 的 O(n) 性能开销
+const errorHistoryStartIndex: Map<string, number> = new Map();
+
 function getLogger(): Logger {
   return logger;
 }
@@ -244,18 +247,21 @@ export function formatUserFriendlyMessage(error: MCPError): string {
 
 /**
  * 记录错误历史
+ * 使用索引追踪实现 O(1) 的历史记录限制，避免 Array.shift() 的 O(n) 性能开销
  */
 function recordError(serviceName: string, error: MCPError): void {
   if (!errorHistory.has(serviceName)) {
     errorHistory.set(serviceName, []);
+    errorHistoryStartIndex.set(serviceName, 0);
   }
 
   const errors = errorHistory.get(serviceName)!;
+  const startIndex = errorHistoryStartIndex.get(serviceName)!;
   errors.push(error);
 
-  // 限制历史记录数量
-  if (errors.length > MAX_ERROR_HISTORY) {
-    errors.shift();
+  // 限制历史记录数量 - O(1) 操作：仅增加索引，不实际删除元素
+  if (errors.length - startIndex > MAX_ERROR_HISTORY) {
+    errorHistoryStartIndex.set(serviceName, startIndex + 1);
   }
 
   getLogger().debug(
@@ -268,18 +274,20 @@ function recordError(serviceName: string, error: MCPError): void {
  */
 export function getErrorStatistics(serviceName: string): ErrorStatistics {
   const errors = errorHistory.get(serviceName) || [];
+  const startIndex = errorHistoryStartIndex.get(serviceName) || 0;
+  const validErrors = errors.slice(startIndex);
   const now = Date.now();
   const oneHourAgo = now - 60 * 60 * 1000;
 
   // 计算过去1小时的错误
-  const recentErrors = errors.filter(
+  const recentErrors = validErrors.filter(
     (error) => error.timestamp.getTime() > oneHourAgo
   );
 
   const errorsByCategory = new Map<ErrorCategory, number>();
   const errorsByCode = new Map<string, number>();
 
-  for (const error of errors) {
+  for (const error of validErrors) {
     errorsByCategory.set(
       error.category,
       (errorsByCategory.get(error.category) || 0) + 1
@@ -289,10 +297,11 @@ export function getErrorStatistics(serviceName: string): ErrorStatistics {
 
   return {
     serviceName,
-    totalErrors: errors.length,
+    totalErrors: validErrors.length,
     errorsByCategory,
     errorsByCode,
-    lastError: errors[errors.length - 1],
+    lastError:
+      validErrors.length > 0 ? validErrors[validErrors.length - 1] : undefined,
     errorRate: recentErrors.length, // 过去1小时的错误数量
   };
 }
@@ -316,9 +325,11 @@ export function getAllErrorStatistics(): Map<string, ErrorStatistics> {
 export function clearErrorHistory(serviceName?: string): void {
   if (serviceName) {
     errorHistory.delete(serviceName);
+    errorHistoryStartIndex.delete(serviceName);
     getLogger().info(`[ErrorHandler] 已清理服务 ${serviceName} 的错误历史`);
   } else {
     errorHistory.clear();
+    errorHistoryStartIndex.clear();
     getLogger().info("[ErrorHandler] 已清理所有错误历史");
   }
 }

--- a/apps/backend/services/notification.service.ts
+++ b/apps/backend/services/notification.service.ts
@@ -68,13 +68,22 @@ export interface NotificationMessage {
 }
 
 /**
+ * 消息队列数据结构
+ * 使用 startIndex 实现O(1)的队列溢出处理，避免 Array.shift() 的 O(n) 性能开销
+ */
+interface MessageQueueData {
+  messages: NotificationMessage[];
+  startIndex: number;
+}
+
+/**
  * 通知服务 - 统一的通知管理服务
  */
 export class NotificationService {
   private logger: Logger;
   private eventBus: EventBus;
   private clients: Map<string, WebSocketClient> = new Map();
-  private messageQueue: Map<string, NotificationMessage[]> = new Map();
+  private messageQueue: Map<string, MessageQueueData> = new Map();
   private maxQueueSize = 100;
 
   constructor() {
@@ -266,18 +275,22 @@ export class NotificationService {
 
   /**
    * 将消息加入队列
+   * 使用索引追踪实现 O(1) 的队列溢出处理，避免 Array.shift() 的 O(n) 性能开销
    */
   private queueMessage(clientId: string, message: NotificationMessage): void {
     if (!this.messageQueue.has(clientId)) {
-      this.messageQueue.set(clientId, []);
+      this.messageQueue.set(clientId, {
+        messages: [],
+        startIndex: 0,
+      });
     }
 
-    const queue = this.messageQueue.get(clientId)!;
-    queue.push(message);
+    const queueData = this.messageQueue.get(clientId)!;
+    queueData.messages.push(message);
 
-    // 限制队列大小
-    if (queue.length > this.maxQueueSize) {
-      queue.shift(); // 移除最旧的消息
+    // 限制队列大小 - O(1) 操作：仅增加索引，不实际删除元素
+    if (queueData.messages.length - queueData.startIndex > this.maxQueueSize) {
+      queueData.startIndex++;
       this.logger.warn(`客户端 ${clientId} 消息队列已满，移除最旧消息`);
     }
   }
@@ -286,8 +299,8 @@ export class NotificationService {
    * 发送排队的消息
    */
   private sendQueuedMessages(clientId: string): void {
-    const queue = this.messageQueue.get(clientId);
-    if (!queue || queue.length === 0) {
+    const queueData = this.messageQueue.get(clientId);
+    if (!queueData || queueData.messages.length === queueData.startIndex) {
       return;
     }
 
@@ -296,10 +309,12 @@ export class NotificationService {
       return;
     }
 
-    this.logger.debug(`发送 ${queue.length} 条排队消息给客户端 ${clientId}`);
+    const messageCount = queueData.messages.length - queueData.startIndex;
+    this.logger.debug(`发送 ${messageCount} 条排队消息给客户端 ${clientId}`);
 
-    for (const message of queue) {
-      this.sendMessageToClient(client, message, clientId);
+    // 只发送有效范围内的消息（从 startIndex 开始）
+    for (let i = queueData.startIndex; i < queueData.messages.length; i++) {
+      this.sendMessageToClient(client, queueData.messages[i], clientId);
     }
 
     // 清空队列
@@ -350,7 +365,8 @@ export class NotificationService {
     ).length;
 
     const queuedMessages = Array.from(this.messageQueue.values()).reduce(
-      (total, queue) => total + queue.length,
+      (total, queueData) =>
+        total + (queueData.messages.length - queueData.startIndex),
       0
     );
 


### PR DESCRIPTION
将 NotificationService.queueMessage 和 error-helper.recordError 中的
Array.shift() O(n) 操作替换为索引追踪方案，实现 O(1) 性能：

- notification.service.ts: 使用 startIndex 追踪队列起始位置
- error-helper.ts: 使用 errorHistoryStartIndex Map 追踪错误历史

修复 GitHub Issue #3164 中提出的队列溢出性能问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3164