### PR TITLE
fix(lib/mcp/utils): 使用 logger 替代 console 输出日志

### DIFF
--- a/apps/backend/lib/mcp/utils.ts
+++ b/apps/backend/lib/mcp/utils.ts
@@ -6,6 +6,7 @@
  * - 工具调用参数验证
  */
 
+import { logger } from "@/Logger.js";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
@@ -41,16 +42,16 @@ export function inferTransportTypeFromUrl(
       return MCPTransportType.HTTP;
     }
 
-    // 默认类型 - 使用 console 输出
+    // 默认类型 - 使用 logger 输出
     if (options?.serviceName) {
-      console.info(
+      logger.info(
         `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
       );
     }
     return MCPTransportType.HTTP;
   } catch (error) {
     if (options?.serviceName) {
-      console.warn(
+      logger.warn(
         `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
         error
       );


### PR DESCRIPTION
将 console.info 和 console.warn 替换为项目统一的 logger 调用，
符合项目日志规范。

修改内容：
- 添加 logger 导入
- console.info → logger.info
- console.warn → logger.warn

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3180