### PR TITLE
refactor: 提取 ASR 服务接口到 shared-types，消除跨包重复代码

### DIFF
--- a/apps/backend/services/asr.interface.ts
+++ b/apps/backend/services/asr.interface.ts
@@ -1,98 +1,19 @@
 /**
  * ASR 服务接口
- * 定义语音识别服务的方法和事件
+ * 重新导出共享接口并定义包特定的配置选项
  */
+
+// 从 shared-types 重新导出共享接口
+export type {
+  ASRServiceEvents,
+  IASRService,
+} from "@xiaozhi-client/shared-types/services";
+
+// 从 shared-types 导入基础选项用于扩展
+import type { BaseASRServiceOptions } from "@xiaozhi-client/shared-types/services";
 
 /**
- * ASR 服务事件回调
+ * ASR 服务配置选项（backend 包特定）
+ * 扩展基础选项
  */
-export interface ASRServiceEvents {
-  /**
-   * 识别结果回调
-   * @param deviceId - 设备 ID
-   * @param text - 识别文本
-   * @param isFinal - 是否为最终结果
-   */
-  onResult?: (deviceId: string, text: string, isFinal: boolean) => void;
-
-  /**
-   * 错误回调
-   * @param deviceId - 设备 ID
-   * @param error - 错误对象
-   */
-  onError?: (deviceId: string, error: Error) => void;
-
-  /**
-   * 连接关闭回调
-   * @param deviceId - 设备 ID
-   */
-  onClose?: (deviceId: string) => void;
-}
-
-/**
- * ASR 服务配置选项
- */
-export interface ASRServiceOptions {
-  /**
-   * 事件回调
-   */
-  events?: ASRServiceEvents;
-}
-
-/**
- * ASR 服务接口
- * 定义语音识别所需的方法
- */
-export interface IASRService {
-  /**
-   * 准备 ASR 服务
-   * 只准备配置和缓冲区，不建立连接
-   * 用于在连接建立前缓存音频数据
-   * @param deviceId - 设备 ID
-   */
-  prepare(deviceId: string): Promise<void>;
-
-  /**
-   * 建立 ASR 连接
-   * 建立 WebSocket 连接并开始处理音频流
-   * @param deviceId - 设备 ID
-   */
-  connect(deviceId: string): Promise<void>;
-
-  /**
-   * 初始化 ASR 语音识别服务（已弃用，请使用 prepare + connect）
-   * 如果已存在 ASR 客户端且已连接，则跳过初始化
-   * @param deviceId - 设备 ID
-   * @deprecated 使用 prepare() + connect() 替代
-   */
-  init(deviceId: string): Promise<void>;
-
-  /**
-   * 处理音频数据
-   * 将音频数据推入队列，由 listen() 异步生成器消费
-   * 如果连接未建立，数据会被缓存直到连接建立
-   * @param deviceId - 设备 ID
-   * @param audioData - 裸 Opus 音频数据
-   */
-  handleAudioData(deviceId: string, audioData: Uint8Array): Promise<void>;
-
-  /**
-   * 结束 ASR 语音识别
-   * 标记音频结束，由 listen() 任务自动处理关闭
-   * @param deviceId - 设备 ID
-   */
-  end(deviceId: string): Promise<void>;
-
-  /**
-   * 重置 ASR 服务状态
-   * 清理资源但保留配置，准备下一次语音交互
-   * @param deviceId - 设备 ID
-   */
-  reset(deviceId: string): Promise<void>;
-
-  /**
-   * 销毁服务
-   * 清理所有设备资源
-   */
-  destroy(): void;
-}
+export interface ASRServiceOptions extends BaseASRServiceOptions {}

--- a/packages/esp32/src/services/asr.interface.ts
+++ b/packages/esp32/src/services/asr.interface.ts
@@ -1,108 +1,30 @@
 /**
  * ASR 服务接口
- * 定义语音识别服务的方法和事件
+ * 重新导出共享接口并定义包特定的配置选项
  */
+
+// 从 shared-types 重新导出共享接口
+export type {
+  ASRServiceEvents,
+  IASRService,
+} from "@xiaozhi-client/shared-types/services";
+
+// 从 shared-types 导入基础选项用于扩展
+import type { BaseASRServiceOptions } from "@xiaozhi-client/shared-types/services";
+import type { ILogger, IESP32ConfigProvider } from "../interfaces.js";
 
 /**
- * ASR 服务事件回调
+ * ASR 服务配置选项（ESP32 包特定）
+ * 扩展基础选项，添加日志器和配置提供者
  */
-export interface ASRServiceEvents {
-  /**
-   * 识别结果回调
-   * @param deviceId - 设备 ID
-   * @param text - 识别文本
-   * @param isFinal - 是否为最终结果
-   */
-  onResult?: (deviceId: string, text: string, isFinal: boolean) => void;
-
-  /**
-   * 错误回调
-   * @param deviceId - 设备 ID
-   * @param error - 错误对象
-   */
-  onError?: (deviceId: string, error: Error) => void;
-
-  /**
-   * 连接关闭回调
-   * @param deviceId - 设备 ID
-   */
-  onClose?: (deviceId: string) => void;
-}
-
-/**
- * ASR 服务配置选项
- */
-export interface ASRServiceOptions {
-  /**
-   * 事件回调
-   */
-  events?: ASRServiceEvents;
-
+export interface ASRServiceOptions extends BaseASRServiceOptions {
   /**
    * 日志器（可选）
    */
-  logger?: import("../interfaces.js").ILogger;
+  logger?: ILogger;
 
   /**
    * 配置提供者（可选，用于获取 ASR 配置）
    */
-  configProvider?: import("../interfaces.js").IESP32ConfigProvider;
-}
-
-/**
- * ASR 服务接口
- * 定义语音识别所需的方法
- */
-export interface IASRService {
-  /**
-   * 准备 ASR 服务
-   * 只准备配置和缓冲区，不建立连接
-   * 用于在连接建立前缓存音频数据
-   * @param deviceId - 设备 ID
-   */
-  prepare(deviceId: string): Promise<void>;
-
-  /**
-   * 建立 ASR 连接
-   * 建立 WebSocket 连接并开始处理音频流
-   * @param deviceId - 设备 ID
-   */
-  connect(deviceId: string): Promise<void>;
-
-  /**
-   * 初始化 ASR 语音识别服务（已弃用，请使用 prepare + connect）
-   * 如果已存在 ASR 客户端且已连接，则跳过初始化
-   * @param deviceId - 设备 ID
-   * @deprecated 使用 prepare() + connect() 替代
-   */
-  init(deviceId: string): Promise<void>;
-
-  /**
-   * 处理音频数据
-   * 将音频数据推入队列，由 listen() 异步生成器消费
-   * 如果连接未建立，数据会被缓存直到连接建立
-   * @param deviceId - 设备 ID
-   * @param audioData - 裸 Opus 音频数据
-   */
-  handleAudioData(deviceId: string, audioData: Uint8Array): Promise<void>;
-
-  /**
-   * 结束 ASR 语音识别
-   * 标记音频结束，由 listen() 任务自动处理关闭
-   * @param deviceId - 设备 ID
-   */
-  end(deviceId: string): Promise<void>;
-
-  /**
-   * 重置 ASR 服务状态
-   * 清理资源但保留配置，准备下一次语音交互
-   * @param deviceId - 设备 ID
-   */
-  reset(deviceId: string): Promise<void>;
-
-  /**
-   * 销毁服务
-   * 清理所有设备资源
-   */
-  destroy(): void;
+  configProvider?: IESP32ConfigProvider;
 }

--- a/packages/shared-types/package.json
+++ b/packages/shared-types/package.json
@@ -29,6 +29,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.ts",
       "import": "./dist/utils/index.js"
+    },
+    "./services": {
+      "types": "./dist/services.d.ts",
+      "import": "./dist/services.js"
     }
   },
   "files": [

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -57,3 +57,10 @@ export { TimeoutError } from "./utils";
 
 // TTS 相关类型
 export type { VoiceInfo, VoicesResponse } from "./tts";
+
+// 服务相关类型
+export type {
+  ASRServiceEvents,
+  BaseASRServiceOptions,
+  IASRService,
+} from "./services";

--- a/packages/shared-types/src/services/asr.interface.ts
+++ b/packages/shared-types/src/services/asr.interface.ts
@@ -1,0 +1,99 @@
+/**
+ * ASR 服务接口
+ * 定义语音识别服务的方法和事件
+ */
+
+/**
+ * ASR 服务事件回调
+ */
+export interface ASRServiceEvents {
+  /**
+   * 识别结果回调
+   * @param deviceId - 设备 ID
+   * @param text - 识别文本
+   * @param isFinal - 是否为最终结果
+   */
+  onResult?: (deviceId: string, text: string, isFinal: boolean) => void;
+
+  /**
+   * 错误回调
+   * @param deviceId - 设备 ID
+   * @param error - 错误对象
+   */
+  onError?: (deviceId: string, error: Error) => void;
+
+  /**
+   * 连接关闭回调
+   * @param deviceId - 设备 ID
+   */
+  onClose?: (deviceId: string) => void;
+}
+
+/**
+ * ASR 服务基础配置选项
+ * 各包可扩展此接口添加特定依赖
+ */
+export interface BaseASRServiceOptions {
+  /**
+   * 事件回调
+   */
+  events?: ASRServiceEvents;
+}
+
+/**
+ * ASR 服务接口
+ * 定义语音识别所需的方法
+ */
+export interface IASRService {
+  /**
+   * 准备 ASR 服务
+   * 只准备配置和缓冲区，不建立连接
+   * 用于在连接建立前缓存音频数据
+   * @param deviceId - 设备 ID
+   */
+  prepare(deviceId: string): Promise<void>;
+
+  /**
+   * 建立 ASR 连接
+   * 建立 WebSocket 连接并开始处理音频流
+   * @param deviceId - 设备 ID
+   */
+  connect(deviceId: string): Promise<void>;
+
+  /**
+   * 初始化 ASR 语音识别服务（已弃用，请使用 prepare + connect）
+   * 如果已存在 ASR 客户端且已连接，则跳过初始化
+   * @param deviceId - 设备 ID
+   * @deprecated 使用 prepare() + connect() 替代
+   */
+  init(deviceId: string): Promise<void>;
+
+  /**
+   * 处理音频数据
+   * 将音频数据推入队列，由 listen() 异步生成器消费
+   * 如果连接未建立，数据会被缓存直到连接建立
+   * @param deviceId - 设备 ID
+   * @param audioData - 製 Opus 音频数据
+   */
+  handleAudioData(deviceId: string, audioData: Uint8Array): Promise<void>;
+
+  /**
+   * 结束 ASR 语音识别
+   * 标记音频结束，由 listen() 任务自动处理关闭
+   * @param deviceId - 设备 ID
+   */
+  end(deviceId: string): Promise<void>;
+
+  /**
+   * 重置 ASR 服务状态
+   * 清理资源但保留配置，准备下一次语音交互
+   * @param deviceId - 设备 ID
+   */
+  reset(deviceId: string): Promise<void>;
+
+  /**
+   * 销毁服务
+   * 清理所有设备资源
+   */
+  destroy(): void;
+}

--- a/packages/shared-types/src/services/index.ts
+++ b/packages/shared-types/src/services/index.ts
@@ -1,0 +1,10 @@
+/**
+ * 服务相关类型定义
+ */
+
+// ASR 服务接口
+export type {
+  ASRServiceEvents,
+  BaseASRServiceOptions,
+  IASRService,
+} from "./asr.interface";

--- a/packages/shared-types/tsup.config.ts
+++ b/packages/shared-types/tsup.config.ts
@@ -8,6 +8,7 @@ export default defineConfig({
     api: "src/api/index.ts",
     config: "src/config/index.ts",
     utils: "src/utils/index.ts",
+    services: "src/services/index.ts",
   },
   format: ["esm"],
   target: "node20",


### PR DESCRIPTION
将 ASRServiceEvents 和 IASRService 接口定义移动到 packages/shared-types/src/services/ 目录，
apps/backend 和 packages/esp32 通过 re-export 使用共享接口。

变更内容：
- 新增 packages/shared-types/src/services/asr.interface.ts（共享接口定义）
- 新增 packages/shared-types/src/services/index.ts（导出索引）
- 更新 packages/shared-types/src/index.ts（添加 services 导出）
- 更新 packages/shared-types/package.json（添加 ./services 导出路径）
- 更新 packages/shared-types/tsup.config.ts（添加 services 入口点）
- 更新 apps/backend/services/asr.interface.ts（re-export 共享接口）
- 更新 packages/esp32/src/services/asr.interface.ts（re-export 共享接口）

修复 issue #3178 中检测到的约 98 行重复代码。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3178