### PR TITLE
fix(backend): 为单文件路径别名导入添加 .js 后缀

### DIFF
--- a/apps/backend/handlers/coze.handler.ts
+++ b/apps/backend/handlers/coze.handler.ts
@@ -4,7 +4,7 @@
  */
 
 import { CozeApiService } from "@/lib/coze";
-import type { CozeWorkflowsParams } from "@/types/coze";
+import type { CozeWorkflowsParams } from "@/types/coze.js";
 import type { AppContext } from "@/types/hono.context.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";

--- a/apps/backend/handlers/mcp-tool.handler.ts
+++ b/apps/backend/handlers/mcp-tool.handler.ts
@@ -20,7 +20,7 @@ import type {
 } from "@/types/toolApi.js";
 import { ToolType } from "@/types/toolApi.js";
 import type { CustomMCPToolWithStats, JSONSchema } from "@/types/toolApi.js";
-import { type ToolSortField, sortTools } from "@/utils/toolSorters";
+import { type ToolSortField, sortTools } from "@/utils/toolSorters.js";
 import { configManager } from "@xiaozhi-client/config";
 import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
 import Ajv from "ajv";

--- a/apps/backend/lib/mcp/cache.ts
+++ b/apps/backend/lib/mcp/cache.ts
@@ -21,7 +21,7 @@ import {
   MCP_CACHE_VERSIONS,
   TOOL_NAME_SEPARATORS,
 } from "@/constants/index.js";
-import type { MCPServiceConfig } from "@/lib/mcp/types";
+import type { MCPServiceConfig } from "@/lib/mcp/types.js";
 import type {
   CacheStatistics,
   EnhancedToolResultCache,

--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -8,7 +8,7 @@ import { EventEmitter } from "node:events";
 import { logger } from "@/Logger.js";
 import { MCPService } from "@/lib/mcp";
 import { MCPCacheManager } from "@/lib/mcp";
-import { ConnectionState } from "@/lib/mcp/types";
+import { ConnectionState } from "@/lib/mcp/types.js";
 import type {
   CustomMCPTool,
   EnhancedToolInfo,
@@ -20,7 +20,7 @@ import type {
   ToolStatusFilter,
   UnifiedServerConfig,
   UnifiedServerStatus,
-} from "@/lib/mcp/types";
+} from "@/lib/mcp/types.js";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { MCPMessage } from "@/types/mcp.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";


### PR DESCRIPTION
修复 apps/backend 中 5 处使用 @/ 路径别名的单文件导入缺少 .js 后缀的问题：
- handlers/mcp-tool.handler.ts:23 - @/utils/toolSorters
- handlers/coze.handler.ts:7 - @/types/coze
- lib/mcp/cache.ts:24 - @/lib/mcp/types
- lib/mcp/manager.ts:11 - @/lib/mcp/types (命名导入)
- lib/mcp/manager.ts:23 - @/lib/mcp/types (类型导入)

符合 ESM 模块规范和项目代码规范一致性要求。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3186