### PR TITLE
fix(types): 消除跨包重复类型定义，统一 timeout 类型来源

### DIFF
--- a/apps/backend/types/timeout.ts
+++ b/apps/backend/types/timeout.ts
@@ -1,39 +1,31 @@
 /**
- * 超时错误类型
+ * 超时处理相关类型定义（backend 专用）
+ *
+ * 本模块从 @xiaozhi-client/shared-types 重新导出共享的超时类型，
+ * 并添加 backend 特有的功能函数。
+ *
+ * 共享类型：
+ * - TimeoutError: 超时错误类型
+ * - TimeoutResponse: 超时响应接口
+ * - isTimeoutResponse: 类型守卫函数
+ * - isTimeoutError: 类型守卫函数
+ *
+ * backend 特有：
+ * - createTimeoutResponse: 创建超时响应的工具函数
+ * - getToolSpecificTimeoutMessage: 获取工具特定的超时提示信息
+ * - getDefaultTimeoutMessage: 获取默认超时提示信息
  */
-export class TimeoutError extends Error {
-  public override readonly name = "TimeoutError" as const;
 
-  constructor(message: string) {
-    super(message);
-    this.name = "TimeoutError";
-    Error.captureStackTrace(this, TimeoutError);
-  }
+// 从 shared-types 重新导出共享类型定义
+export {
+  TimeoutError,
+  isTimeoutResponse,
+  isTimeoutError,
+} from "@xiaozhi-client/shared-types";
 
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      stack: this.stack,
-    };
-  }
-}
+export type { TimeoutResponse } from "@xiaozhi-client/shared-types";
 
-/**
- * 超时响应接口
- */
-export interface TimeoutResponse {
-  content: Array<{
-    type: "text";
-    text: string;
-  }>;
-  isError: boolean;
-  taskId: string;
-  status: "timeout";
-  message: string;
-  nextAction: string;
-  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
-}
+import type { TimeoutResponse } from "@xiaozhi-client/shared-types";
 
 /**
  * 创建超时响应的工具函数
@@ -70,7 +62,7 @@ function getToolSpecificTimeoutMessage(
 ): string {
   const toolMessages: Record<string, string> = {
     coze_workflow: `⏱️ 扣子工作流执行超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 工具类型: 扣子工作流
@@ -81,11 +73,9 @@ function getToolSpecificTimeoutMessage(
 1. 使用相同参数重新调用工具
 2. 系统会自动返回已完成的任务结果
 3. 复杂工作流可能需要更长时间处理`,
-
-    default: getDefaultTimeoutMessage(taskId),
   };
 
-  return toolMessages[toolName] || toolMessages.default;
+  return toolMessages[toolName] || getDefaultTimeoutMessage(taskId);
 }
 
 /**
@@ -93,7 +83,7 @@ function getToolSpecificTimeoutMessage(
  */
 function getDefaultTimeoutMessage(taskId: string): string {
   return `⏱️ 工具调用超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 状态: 处理中
@@ -103,29 +93,4 @@ function getDefaultTimeoutMessage(taskId: string): string {
 1. 使用相同的参数重新调用工具
 2. 系统会自动返回已完成的任务结果
 3. 如果长时间未完成，请联系管理员`;
-}
-
-/**
- * 验证是否为超时响应
- */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
-  return !!(
-    response &&
-    response.status === "timeout" &&
-    typeof response.taskId === "string" &&
-    Array.isArray(response.content) &&
-    response.content.length > 0 &&
-    response.content[0].type === "text"
-  );
-}
-
-/**
- * 验证是否为超时错误
- */
-export function isTimeoutError(error: any): error is TimeoutError {
-  return !!(
-    error &&
-    error.name === "TimeoutError" &&
-    error instanceof TimeoutError
-  );
 }

--- a/packages/shared-types/src/index.ts
+++ b/packages/shared-types/src/index.ts
@@ -53,7 +53,9 @@ export type {
 export * from "./frontend";
 
 // 工具类型
-export { TimeoutError } from "./utils";
+export { TimeoutError, isTimeoutResponse, isTimeoutError } from "./utils";
+
+export type { TimeoutResponse } from "./utils";
 
 // TTS 相关类型
 export type { VoiceInfo, VoicesResponse } from "./tts";

--- a/packages/shared-types/src/utils/index.ts
+++ b/packages/shared-types/src/utils/index.ts
@@ -3,14 +3,9 @@
  */
 
 // 超时处理相关类型
-export { TimeoutError } from "./timeout";
+export { TimeoutError, isTimeoutResponse, isTimeoutError } from "./timeout";
 
 export type { TimeoutResponse } from "./timeout";
-
-export {
-  isTimeoutResponse as utilsIsTimeoutResponse,
-  isTimeoutError,
-} from "./timeout";
 
 // 性能监控相关类型
 export type {

--- a/packages/shared-types/src/utils/timeout.ts
+++ b/packages/shared-types/src/utils/timeout.ts
@@ -1,5 +1,13 @@
 /**
- * 超时处理相关类型定义
+ * 超时处理相关共享类型定义
+ *
+ * 本模块提供超时处理的核心类型，供多个包共享使用：
+ * - TimeoutError: 超时错误类型
+ * - TimeoutResponse: 超时响应接口
+ * - isTimeoutResponse: 类型守卫函数
+ * - isTimeoutError: 类型守卫函数
+ *
+ * backend 特有的功能（如 createTimeoutResponse）应在 apps/backend/types/timeout.ts 中定义
  */
 
 /**
@@ -25,6 +33,7 @@ export class TimeoutError extends Error {
 
 /**
  * 超时响应接口
+ * 支持其他未知字段，与 ToolCallResult 保持兼容
  */
 export interface TimeoutResponse {
   content: Array<{
@@ -36,18 +45,24 @@ export interface TimeoutResponse {
   status: "timeout";
   message: string;
   nextAction: string;
+  [key: string]: unknown;
 }
 
 /**
  * 验证是否为超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
+export function isTimeoutResponse(response: unknown): response is TimeoutResponse {
   return !!(
     response &&
+    typeof response === "object" &&
+    "status" in response &&
     response.status === "timeout" &&
+    "taskId" in response &&
     typeof response.taskId === "string" &&
+    "content" in response &&
     Array.isArray(response.content) &&
     response.content.length > 0 &&
+    "type" in response.content[0] &&
     response.content[0].type === "text"
   );
 }
@@ -55,9 +70,11 @@ export function isTimeoutResponse(response: any): response is TimeoutResponse {
 /**
  * 验证是否为超时错误
  */
-export function isTimeoutError(error: any): error is TimeoutError {
+export function isTimeoutError(error: unknown): error is TimeoutError {
   return !!(
     error &&
+    typeof error === "object" &&
+    "name" in error &&
     error.name === "TimeoutError" &&
     error instanceof TimeoutError
   );


### PR DESCRIPTION
修复 apps/backend/types/timeout.ts 与 packages/shared-types/src/utils/timeout.ts
之间约60行重复代码，违反DRY原则的问题。

变更内容：
1. shared-types/timeout.ts: 只保留共享类型定义
   - TimeoutError 类
   - TimeoutResponse 接口
   - isTimeoutResponse 类型守卫
   - isTimeoutError 类型守卫

2. apps/backend/types/timeout.ts: 改为重新导出模式
   - 从 @xiaozhi-client/shared-types 重新导出共享类型
   - 保留 backend 特有的 createTimeoutResponse 等函数

3. 更新 shared-types 导出配置
   - 正确导出所有 timeout 相关类型
   - 使用 export type 导出纯类型

验证结果：
- 类型检查通过（timeout相关错误已解决）
- 重复代码检查通过（timeout.ts不再被报告）
- timeout相关测试全部通过（5个测试）

Fixes #3193

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3193