### PR TITLE
fix(cli): 修复 ConfigCommandHandler 类型安全问题

### DIFF
--- a/packages/cli/src/commands/ConfigCommandHandler.ts
+++ b/packages/cli/src/commands/ConfigCommandHandler.ts
@@ -4,14 +4,38 @@
 
 import path from "node:path";
 import chalk from "chalk";
-import ora from "ora";
+import ora, { type Ora } from "ora";
+import type {
+  LocalMCPServerConfig,
+  SSEMCPServerConfig,
+} from "@xiaozhi-client/shared-types";
 import type { SubCommand } from "../interfaces/Command";
 import { BaseCommandHandler } from "../interfaces/Command";
 import type {
   CommandArguments,
   CommandOptions,
 } from "../interfaces/CommandTypes";
-import type { IDIContainer } from "../interfaces/Config";
+import type {
+  CLIConfigManager,
+  CLIMCPServerConfig,
+  IDIContainer,
+} from "../interfaces/Config";
+
+/**
+ * 检查是否是 SSE 类型服务器配置（类型守卫）
+ */
+function isSSEConfig(config: CLIMCPServerConfig): config is SSEMCPServerConfig {
+  return "type" in config && config.type === "sse";
+}
+
+/**
+ * 检查配置是否有 command 字段（类型守卫）
+ */
+function hasCommand(
+  config: CLIMCPServerConfig
+): config is LocalMCPServerConfig {
+  return "command" in config;
+}
 
 /**
  * 配置管理命令处理器
@@ -79,7 +103,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         throw new Error("格式必须是 json, json5 或 jsonc");
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<CLIConfigManager>("configManager");
 
       if (configManager.configExists()) {
         spinner.warn("配置文件已存在");
@@ -113,8 +137,8 @@ export class ConfigCommandHandler extends BaseCommandHandler {
   /**
    * 确保配置文件存在，如果不存在则显示提示并返回 false
    */
-  private async ensureConfigExists(spinner: ora.Ora): Promise<boolean> {
-    const configManager = this.getService<any>("configManager");
+  private async ensureConfigExists(spinner: Ora): Promise<boolean> {
+    const configManager = this.getService<CLIConfigManager>("configManager");
 
     if (!configManager.configExists()) {
       spinner.fail("配置文件不存在");
@@ -138,7 +162,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         return;
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<CLIConfigManager>("configManager");
       const config = configManager.getConfig();
 
       switch (key) {
@@ -163,14 +187,14 @@ export class ConfigCommandHandler extends BaseCommandHandler {
           for (const [name, serverConfig] of Object.entries(
             config.mcpServers
           )) {
-            const server = serverConfig as any;
+            const server = serverConfig as CLIMCPServerConfig;
             // 检查是否是 SSE 类型
-            if ("type" in server && server.type === "sse") {
+            if (isSSEConfig(server)) {
               console.log(chalk.gray(`  ${name}: [SSE] ${server.url}`));
-            } else {
+            } else if (hasCommand(server)) {
               console.log(
                 chalk.gray(
-                  `  ${name}: ${server.command} ${server.args.join(" ")}`
+                  `  ${name}: ${server.command} ${(server.args || []).join(" ")}`
                 )
               );
             }
@@ -242,7 +266,7 @@ export class ConfigCommandHandler extends BaseCommandHandler {
         return;
       }
 
-      const configManager = this.getService<any>("configManager");
+      const configManager = this.getService<CLIConfigManager>("configManager");
 
       switch (key) {
         case "mcpEndpoint":

--- a/packages/cli/src/commands/__tests__/config-command-handler.test.ts
+++ b/packages/cli/src/commands/__tests__/config-command-handler.test.ts
@@ -3,7 +3,10 @@
  */
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import type { IDIContainer } from "../../interfaces/Config";
+import type {
+  CLIConfigManager,
+  IDIContainer,
+} from "../../interfaces/Config";
 import { ConfigCommandHandler } from "../ConfigCommandHandler";
 
 // Mock ora
@@ -33,7 +36,7 @@ vi.mock("chalk", () => ({
 }));
 
 // Mock dependencies
-const mockConfigManager = {
+const mockConfigManager: CLIConfigManager = {
   configExists: vi.fn(),
   initConfig: vi.fn(),
   getConfig: vi.fn(),

--- a/packages/cli/src/interfaces/Config.ts
+++ b/packages/cli/src/interfaces/Config.ts
@@ -2,6 +2,12 @@
  * 配置接口定义
  */
 
+import type {
+  AppConfig,
+  ConnectionConfig,
+  MCPServerConfig,
+} from "@xiaozhi-client/shared-types";
+
 /**
  * 依赖注入容器接口
  */
@@ -23,3 +29,40 @@ export interface ValidationResult {
   /** 错误信息 */
   error?: string;
 }
+
+/**
+ * CLI 命令所需的 ConfigManager 接口
+ * 定义 CLI 配置管理命令处理器所需的最小方法集
+ */
+export interface CLIConfigManager {
+  /** 检查配置文件是否存在 */
+  configExists(): boolean;
+  /** 初始化配置文件 */
+  initConfig(format: "json" | "json5" | "jsonc"): void;
+  /** 获取配置对象 */
+  getConfig(): Readonly<AppConfig>;
+  /** 获取 MCP 端点列表 */
+  getMcpEndpoints(): string[];
+  /** 获取心跳检测间隔（毫秒） */
+  getHeartbeatInterval(): number;
+  /** 获取心跳超时时间（毫秒） */
+  getHeartbeatTimeout(): number;
+  /** 获取重连间隔（毫秒） */
+  getReconnectInterval(): number;
+  /** 获取连接配置 */
+  getConnectionConfig(): Required<ConnectionConfig>;
+  /** 更新 MCP 端点 */
+  updateMcpEndpoint(endpoint: string | string[]): void;
+  /** 更新心跳检测间隔（毫秒） */
+  updateHeartbeatInterval(interval: number): void;
+  /** 更新心跳超时时间（毫秒） */
+  updateHeartbeatTimeout(timeout: number): void;
+  /** 更新重连间隔（毫秒） */
+  updateReconnectInterval(interval: number): void;
+}
+
+/**
+ * CLI 命令中使用的 MCP 服务器配置类型
+ * 用于处理配置显示时的类型安全
+ */
+export type CLIMCPServerConfig = MCPServerConfig;

--- a/packages/config/src/manager.ts
+++ b/packages/config/src/manager.ts
@@ -1175,6 +1175,27 @@ export class ConfigManager {
   }
 
   /**
+   * 更新心跳检测间隔（毫秒）
+   */
+  public updateHeartbeatInterval(interval: number): void {
+    this.updateConnectionConfig({ heartbeatInterval: interval });
+  }
+
+  /**
+   * 更新心跳超时时间（毫秒）
+   */
+  public updateHeartbeatTimeout(timeout: number): void {
+    this.updateConnectionConfig({ heartbeatTimeout: timeout });
+  }
+
+  /**
+   * 更新重连间隔（毫秒）
+   */
+  public updateReconnectInterval(interval: number): void {
+    this.updateConnectionConfig({ reconnectInterval: interval });
+  }
+
+  /**
    * 更新工具使用统计信息（MCP 服务工具）
    * @param serverName 服务名称
    * @param toolName 工具名称


### PR DESCRIPTION
- 定义 CLIConfigManager 接口，提供类型安全的配置管理器方法签名
- 添加 updateHeartbeatInterval/Timeout/ReconnectInterval 便捷方法到 ConfigManager
- 使用类型守卫函数 isSSEConfig 和 hasCommand 替换 any 类型断言
- 替换所有 getService<any> 为 getService<CLIConfigManager>
- 使用 CLIMCPServerConfig 类型替代 serverConfig as any
- 更新测试文件使用 CLIConfigManager 类型声明

解决了 Issue #3197 中报告的 5 处 any 类型使用问题：
- 第 82 行: getService<any> -> getService<CLIConfigManager>
- 第 117 行: getService<any> -> getService<CLIConfigManager>
- 第 141 行: getService<any> -> getService<CLIConfigManager>
- 第 166 行: serverConfig as any -> 类型守卫处理
- 第 245 行: getService<any> -> getService<CLIConfigManager>

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3197