### PR TITLE
fix(asr): 移除重复的 WebSocket close 监听器并显式清理监听器

### DIFF
--- a/packages/asr/src/client/ASR.ts
+++ b/packages/asr/src/client/ASR.ts
@@ -556,6 +556,8 @@ export class ASR extends EventEmitter {
    */
   close(): void {
     if (this.ws) {
+      // 先移除所有事件监听器，避免关闭后触发事件
+      this.ws.removeAllListeners();
       this.ws.close();
       this.ws = null;
       this.connected = false;
@@ -756,12 +758,6 @@ export class ASR extends EventEmitter {
         reject(error);
       });
 
-      this.ws.on("close", () => {
-        this.connected = false;
-        this.emit("close");
-      });
-
-      // Register global message handler for event-driven mode
       // In streaming mode, this enables result/vad_end events via on()
       this.ws.on("message", (data: Buffer) => {
         this.handleMessage(data);


### PR DESCRIPTION
问题：
- _connect() 方法中重复注册了 close 事件监听器（第 749 行和第 759 行）
- close() 方法未显式移除监听器，可能导致资源管理问题

修复：
- 移除重复的 close 监听器注册
- 在 close() 方法中调用 removeAllListeners() 显式移除所有监听器

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3199