### PR TITLE
refactor(frontend): 提取 EventBus 类到独立文件

### DIFF
--- a/apps/frontend/src/services/event-bus.ts
+++ b/apps/frontend/src/services/event-bus.ts
@@ -1,0 +1,104 @@
+/**
+ * 前端事件总线服务
+ * 提供统一的事件发布订阅机制，用于解耦模块间的通信
+ *
+ * 特性：
+ * - 类型安全的事件订阅和发布
+ * - 支持多个订阅者
+ * - 返回取消订阅函数，便于管理
+ */
+
+/**
+ * 事件监听器类型
+ */
+export type EventListener<T = unknown> = (data: T) => void;
+
+/**
+ * 事件总线类 - 支持多个订阅者
+ * 使用泛型支持不同的事件类型映射
+ * @template EventMap 事件类型映射，键为事件名称，值为事件数据类型
+ */
+export class EventBus<EventMap = Record<string, unknown>> {
+  private listeners: Map<keyof EventMap, Set<EventListener<unknown>>> =
+    new Map();
+
+  /**
+   * 订阅事件
+   * @param event 事件名称
+   * @param listener 事件监听器
+   * @returns 取消订阅函数
+   */
+  on<K extends keyof EventMap>(
+    event: K,
+    listener: EventListener<EventMap[K]>
+  ): () => void {
+    if (!this.listeners.has(event)) {
+      this.listeners.set(event, new Set());
+    }
+    this.listeners.get(event)!.add(listener as EventListener<unknown>);
+
+    // 返回取消订阅函数
+    return () => {
+      this.off(event, listener);
+    };
+  }
+
+  /**
+   * 取消订阅事件
+   * @param event 事件名称
+   * @param listener 事件监听器
+   */
+  off<K extends keyof EventMap>(
+    event: K,
+    listener: EventListener<EventMap[K]>
+  ): void {
+    const eventListeners = this.listeners.get(event);
+    if (eventListeners) {
+      eventListeners.delete(listener as EventListener<unknown>);
+      if (eventListeners.size === 0) {
+        this.listeners.delete(event);
+      }
+    }
+  }
+
+  /**
+   * 发布事件
+   * @param event 事件名称
+   * @param data 事件数据
+   */
+  emit<K extends keyof EventMap>(event: K, data: EventMap[K]): void {
+    const eventListeners = this.listeners.get(event);
+    if (eventListeners) {
+      for (const listener of eventListeners) {
+        try {
+          listener(data);
+        } catch (error) {
+          // 将事件名称转换为字符串以支持可能的 symbol 类型
+          const eventName = String(event);
+          console.error(`[EventBus] 事件监听器执行失败 (${eventName}):`, error);
+        }
+      }
+    }
+  }
+
+  /**
+   * 清除所有监听器
+   */
+  clear(): void {
+    this.listeners.clear();
+  }
+
+  /**
+   * 获取事件监听器数量
+   * @param event 可选的事件名称，如果不提供则返回所有监听器总数
+   */
+  getListenerCount(event?: keyof EventMap): number {
+    if (event) {
+      return this.listeners.get(event)?.size || 0;
+    }
+    return Array.from(this.listeners.values()).reduce(
+      (total, listeners) => total + listeners.size,
+      0
+    );
+  }
+}

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -8,6 +8,7 @@
  */
 
 import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
+import { EventBus, type EventListener } from "@/services/event-bus.js";
 import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 
 /**
@@ -119,11 +120,6 @@ interface EventBusEvents {
 }
 
 /**
- * 事件监听器类型
- */
-type EventListener<T = unknown> = (data: T) => void;
-
-/**
  * WebSocket 连接状态
  */
 enum ConnectionState {
@@ -145,87 +141,6 @@ interface WebSocketManagerConfig {
 }
 
 /**
- * 事件总线类 - 支持多个订阅者
- */
-class EventBus {
-  private listeners: Map<keyof EventBusEvents, Set<EventListener<unknown>>> =
-    new Map();
-
-  /**
-   * 订阅事件
-   */
-  on<K extends keyof EventBusEvents>(
-    event: K,
-    listener: EventListener<EventBusEvents[K]>
-  ): () => void {
-    if (!this.listeners.has(event)) {
-      this.listeners.set(event, new Set());
-    }
-    this.listeners.get(event)!.add(listener as EventListener<unknown>);
-
-    // 返回取消订阅函数
-    return () => {
-      this.off(event, listener);
-    };
-  }
-
-  /**
-   * 取消订阅事件
-   */
-  off<K extends keyof EventBusEvents>(
-    event: K,
-    listener: EventListener<EventBusEvents[K]>
-  ): void {
-    const eventListeners = this.listeners.get(event);
-    if (eventListeners) {
-      eventListeners.delete(listener as EventListener<unknown>);
-      if (eventListeners.size === 0) {
-        this.listeners.delete(event);
-      }
-    }
-  }
-
-  /**
-   * 发布事件
-   */
-  emit<K extends keyof EventBusEvents>(
-    event: K,
-    data: EventBusEvents[K]
-  ): void {
-    const eventListeners = this.listeners.get(event);
-    if (eventListeners) {
-      for (const listener of eventListeners) {
-        try {
-          listener(data);
-        } catch (error) {
-          console.error(`[EventBus] 事件监听器执行失败 (${event}):`, error);
-        }
-      }
-    }
-  }
-
-  /**
-   * 清除所有监听器
-   */
-  clear(): void {
-    this.listeners.clear();
-  }
-
-  /**
-   * 获取事件监听器数量
-   */
-  getListenerCount(event?: keyof EventBusEvents): number {
-    if (event) {
-      return this.listeners.get(event)?.size || 0;
-    }
-    return Array.from(this.listeners.values()).reduce(
-      (total, listeners) => total + listeners.size,
-      0
-    );
-  }
-}
-
-/**
  * WebSocket 管理器类 - 严格单例模式
  */
 export class WebSocketManager {
@@ -235,7 +150,7 @@ export class WebSocketManager {
   private ws: WebSocket | null = null;
   private url: string;
   private state: ConnectionState = ConnectionState.DISCONNECTED;
-  private eventBus: EventBus = new EventBus();
+  private eventBus: EventBus<EventBusEvents> = new EventBus<EventBusEvents>();
   private reconnectAttempts = 0;
   private maxReconnectAttempts: number;
   private reconnectInterval: number;
@@ -370,7 +285,7 @@ export class WebSocketManager {
   /**
    * 获取事件总线实例（用于高级用法）
    */
-  getEventBus(): EventBus {
+  getEventBus(): EventBus<EventBusEvents> {
     return this.eventBus;
   }
 
@@ -725,10 +640,11 @@ export const webSocketManager = WebSocketManager.getInstance();
 
 // 导出类型和枚举
 export { ConnectionState };
+// 重新导出 EventBus 和 EventListener（从 event-bus.ts）
+export { EventBus, type EventListener } from "@/services/event-bus.js";
 export type {
   WebSocketMessage,
   RestartStatus,
   WebSocketManagerConfig,
   EventBusEvents,
-  EventListener,
 };


### PR DESCRIPTION
将 EventBus 类从 websocket.ts 提取到独立的 event-bus.ts 文件，
遵循单一职责原则，与后端架构保持一致。

变更内容：
- 创建 apps/frontend/src/services/event-bus.ts
- 将 EventBus 类迁移为泛型类，支持不同事件类型映射
- 更新 websocket.ts 导入并使用泛型 EventBus<EventBusEvents>
- 重新导出 EventBus 和 EventListener 类型，保持向后兼容

Closes #3214

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3214