### PR TITLE
fix(frontend): 使用 apiClient 替换 fetch 调用获取工具调用日志

### DIFF
--- a/apps/frontend/src/components/tool-call-logs-dialog.tsx
+++ b/apps/frontend/src/components/tool-call-logs-dialog.tsx
@@ -34,17 +34,14 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { apiClient } from "@/services/api";
 import {
   formatDuration,
   formatJson,
   formatTimestamp,
   generateStableKey,
 } from "@/utils/formatUtils";
-import type {
-  ApiResponse,
-  ToolCallLogsResponse,
-  ToolCallRecord,
-} from "@xiaozhi-client/shared-types";
+import type { ToolCallRecord } from "@xiaozhi-client/shared-types";
 import {
   CheckCircle,
   CheckIcon,
@@ -79,17 +76,11 @@ export function ToolCallLogsDialog() {
       setError(null);
 
       try {
-        const response = await fetch(`/api/tool-calls/logs?limit=${limit}`);
-        const data: ApiResponse<ToolCallLogsResponse> = await response.json();
-
-        if (data.success && data.data) {
-          setLogs(data.data.records);
-          setTotal(data.data.total);
-        } else {
-          setError(data.error?.message || "获取日志失败");
-        }
+        const data = await apiClient.getToolCallLogs(limit);
+        setLogs(data.records);
+        setTotal(data.total);
       } catch (err) {
-        setError("网络请求失败");
+        setError(err instanceof Error ? err.message : "获取日志失败");
         console.error("获取工具调用日志失败:", err);
       } finally {
         if (isRefresh) {

--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -14,6 +14,7 @@ import type {
   MCPServerConfig,
   MCPServerListResponse,
   MCPServerStatus,
+  ToolCallLogsResponse,
   VoicesResponse,
 } from "@xiaozhi-client/shared-types";
 
@@ -1190,6 +1191,26 @@ export class ApiClient {
 
     if (!response.success || !response.data) {
       throw new Error(response.error?.message || "获取 MCP 工具列表失败");
+    }
+
+    return response.data;
+  }
+
+  // ==================== 工具调用日志 API ====================
+
+  /**
+   * 获取工具调用日志
+   * GET /api/tool-calls/logs
+   * @param limit 返回的最大记录数量（默认 50）
+   * @returns 工具调用日志响应
+   */
+  async getToolCallLogs(limit = 50): Promise<ToolCallLogsResponse> {
+    const response: ApiResponse<ToolCallLogsResponse> = await this.request(
+      `/api/tool-calls/logs?limit=${limit}`
+    );
+
+    if (!response.success || !response.data) {
+      throw new Error(response.error?.message || "获取工具调用日志失败");
     }
 
     return response.data;


### PR DESCRIPTION
修复 tool-call-logs-dialog.tsx 直接使用原生 fetch 的架构违规问题。

变更内容：
- 在 api.ts 中添加 getToolCallLogs 方法
- 更新 tool-call-logs-dialog.tsx 使用 apiClient.getToolCallLogs
- 简化错误处理逻辑，利用 apiClient 的统一错误处理

解决的问题：
- 缺少统一错误处理
- 缺少重试机制
- 缺少超时控制
- 架构不一致

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3219