### PR TITLE
fix(frontend): 修复 Zustand stores 的 WebSocket 监听器泄漏

### DIFF
--- a/apps/frontend/src/stores/config.ts
+++ b/apps/frontend/src/stores/config.ts
@@ -113,6 +113,11 @@ const initialState: ConfigState = {
 };
 
 /**
+ * WebSocket 监听器取消订阅函数
+ */
+let configUpdateUnsubscribe: (() => void) | null = null;
+
+/**
  * 创建配置 Store
  */
 export const useConfigStore = create<ConfigStore>()(
@@ -316,6 +321,13 @@ export const useConfigStore = create<ConfigStore>()(
 
       reset: () => {
         console.log("[ConfigStore] 重置状态");
+
+        // 取消 WebSocket 监听器订阅
+        if (configUpdateUnsubscribe) {
+          configUpdateUnsubscribe();
+          configUpdateUnsubscribe = null;
+        }
+
         set(initialState, false, "reset");
       },
 
@@ -326,11 +338,20 @@ export const useConfigStore = create<ConfigStore>()(
           setLoading({ isLoading: true });
           console.log("[ConfigStore] 初始化配置 Store");
 
-          // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:configUpdate", (config) => {
-            console.log("[ConfigStore] 收到 WebSocket 配置更新");
-            get().setConfig(config, "websocket");
-          });
+          // 取消旧的 WebSocket 监听器订阅（如果存在）
+          if (configUpdateUnsubscribe) {
+            configUpdateUnsubscribe();
+            configUpdateUnsubscribe = null;
+          }
+
+          // 设置 WebSocket 事件监听并保存 unsubscribe 函数
+          configUpdateUnsubscribe = webSocketManager.subscribe(
+            "data:configUpdate",
+            (config) => {
+              console.log("[ConfigStore] 收到 WebSocket 配置更新");
+              get().setConfig(config, "websocket");
+            }
+          );
 
           // 获取初始配置
           await refreshConfig();

--- a/apps/frontend/src/stores/status.ts
+++ b/apps/frontend/src/stores/status.ts
@@ -211,6 +211,12 @@ let pollingTimer: NodeJS.Timeout | null = null;
 let restartPollingTimer: NodeJS.Timeout | null = null;
 
 /**
+ * WebSocket 监听器取消订阅函数
+ */
+let statusUpdateUnsubscribe: (() => void) | null = null;
+let restartStatusUnsubscribe: (() => void) | null = null;
+
+/**
  * 创建状态 Store
  */
 export const useStatusStore = create<StatusStore>()(
@@ -681,6 +687,16 @@ export const useStatusStore = create<StatusStore>()(
         get().stopPolling();
         get().stopRestartPolling();
 
+        // 取消 WebSocket 监听器订阅
+        if (statusUpdateUnsubscribe) {
+          statusUpdateUnsubscribe();
+          statusUpdateUnsubscribe = null;
+        }
+        if (restartStatusUnsubscribe) {
+          restartStatusUnsubscribe();
+          restartStatusUnsubscribe = null;
+        }
+
         // 重置状态
         set(initialState, false, "reset");
       },
@@ -692,16 +708,32 @@ export const useStatusStore = create<StatusStore>()(
           setLoading({ isLoading: true });
           console.log("[StatusStore] 初始化状态 Store");
 
-          // 设置 WebSocket 事件监听
-          webSocketManager.subscribe("data:statusUpdate", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 状态更新");
-            get().setClientStatus(status, "websocket");
-          });
+          // 取消旧的 WebSocket 监听器订阅（如果存在）
+          if (statusUpdateUnsubscribe) {
+            statusUpdateUnsubscribe();
+            statusUpdateUnsubscribe = null;
+          }
+          if (restartStatusUnsubscribe) {
+            restartStatusUnsubscribe();
+            restartStatusUnsubscribe = null;
+          }
 
-          webSocketManager.subscribe("data:restartStatus", (status) => {
-            console.log("[StatusStore] 收到 WebSocket 重启状态更新");
-            get().setRestartStatus(status, "websocket");
-          });
+          // 设置 WebSocket 事件监听并保存 unsubscribe 函数
+          statusUpdateUnsubscribe = webSocketManager.subscribe(
+            "data:statusUpdate",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 状态更新");
+              get().setClientStatus(status, "websocket");
+            }
+          );
+
+          restartStatusUnsubscribe = webSocketManager.subscribe(
+            "data:restartStatus",
+            (status) => {
+              console.log("[StatusStore] 收到 WebSocket 重启状态更新");
+              get().setRestartStatus(status, "websocket");
+            }
+          );
 
           // 获取初始状态
           await refreshStatus();

--- a/apps/frontend/src/stores/websocket.ts
+++ b/apps/frontend/src/stores/websocket.ts
@@ -135,6 +135,25 @@ const initialState: WebSocketState = {
 };
 
 /**
+ * WebSocket 监听器取消订阅函数集合
+ */
+const websocketUnsubscribers: {
+  connecting: (() => void) | null;
+  connected: (() => void) | null;
+  disconnected: (() => void) | null;
+  reconnecting: (() => void) | null;
+  error: (() => void) | null;
+  heartbeat: (() => void) | null;
+} = {
+  connecting: null,
+  connected: null,
+  disconnected: null,
+  reconnecting: null,
+  error: null,
+  heartbeat: null,
+};
+
+/**
  * 创建 WebSocket Store（重构版）
  */
 export const useWebSocketStore = create<WebSocketStore>()(
@@ -258,6 +277,18 @@ export const useWebSocketStore = create<WebSocketStore>()(
 
       reset: () => {
         console.log("[WebSocketStore] 重置状态");
+
+        // 取消所有 WebSocket 监听器订阅
+        for (const key of Object.keys(websocketUnsubscribers) as Array<
+          keyof typeof websocketUnsubscribers
+        >) {
+          const unsubscribe = websocketUnsubscribers[key];
+          if (unsubscribe) {
+            unsubscribe();
+            websocketUnsubscribers[key] = null;
+          }
+        }
+
         set(initialState, false, "reset");
       },
 
@@ -266,33 +297,62 @@ export const useWebSocketStore = create<WebSocketStore>()(
       initialize: () => {
         console.log("[WebSocketStore] 初始化 WebSocket Store");
 
-        // 设置 WebSocket 事件监听
-        webSocketManager.subscribe("connection:connecting", () => {
-          get().setConnectionState(ConnectionState.CONNECTING);
-        });
+        // 取消旧的 WebSocket 监听器订阅（如果存在）
+        for (const key of Object.keys(websocketUnsubscribers) as Array<
+          keyof typeof websocketUnsubscribers
+        >) {
+          const unsubscribe = websocketUnsubscribers[key];
+          if (unsubscribe) {
+            unsubscribe();
+            websocketUnsubscribers[key] = null;
+          }
+        }
 
-        webSocketManager.subscribe("connection:connected", () => {
-          get().setConnectionState(ConnectionState.CONNECTED);
-        });
+        // 设置 WebSocket 事件监听并保存 unsubscribe 函数
+        websocketUnsubscribers.connecting = webSocketManager.subscribe(
+          "connection:connecting",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTING);
+          }
+        );
 
-        webSocketManager.subscribe("connection:disconnected", () => {
-          get().setConnectionState(ConnectionState.DISCONNECTED);
-        });
+        websocketUnsubscribers.connected = webSocketManager.subscribe(
+          "connection:connected",
+          () => {
+            get().setConnectionState(ConnectionState.CONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:reconnecting", () => {
-          get().setConnectionState(ConnectionState.RECONNECTING);
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        websocketUnsubscribers.disconnected = webSocketManager.subscribe(
+          "connection:disconnected",
+          () => {
+            get().setConnectionState(ConnectionState.DISCONNECTED);
+          }
+        );
 
-        webSocketManager.subscribe("connection:error", ({ error }) => {
-          get().setLastError(error);
-        });
+        websocketUnsubscribers.reconnecting = webSocketManager.subscribe(
+          "connection:reconnecting",
+          () => {
+            get().setConnectionState(ConnectionState.RECONNECTING);
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
-        webSocketManager.subscribe("system:heartbeat", () => {
-          const stats = webSocketManager.getConnectionStats();
-          get().setConnectionStats(stats);
-        });
+        websocketUnsubscribers.error = webSocketManager.subscribe(
+          "connection:error",
+          ({ error }) => {
+            get().setLastError(error);
+          }
+        );
+
+        websocketUnsubscribers.heartbeat = webSocketManager.subscribe(
+          "system:heartbeat",
+          () => {
+            const stats = webSocketManager.getConnectionStats();
+            get().setConnectionStats(stats);
+          }
+        );
 
         // 初始化连接状态
         const initialStats = webSocketManager.getConnectionStats();


### PR DESCRIPTION
问题：三个 frontend stores (status/config/websocket) 在 initialize() 中注册
WebSocket 监听器，但 reset() 未取消订阅，导致监听器累积。

修复方案（使用模块级变量）：
- status.ts: 添加 statusUpdateUnsubscribe 和 restartStatusUnsubscribe 变量
- config.ts: 添加 configUpdateUnsubscribe 变量
- websocket.ts: 添加 websocketUnsubscribers 对象管理 6 个监听器

变更：
1. initialize() 先取消旧订阅再注册新订阅（支持重复初始化）
2. reset() 取消所有 WebSocket 监听器订阅并置空变量

Closes #3221

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3221