### PR TITLE
fix(frontend): 使用 apiClient.updateVersion 替代直接 fetch 调用

### DIFF
--- a/apps/frontend/src/hooks/useNPMInstall.ts
+++ b/apps/frontend/src/hooks/useNPMInstall.ts
@@ -8,6 +8,7 @@
  * - 支持安装操作触发
  */
 
+import { apiClient } from "@/services/api";
 import { webSocketManager } from "@/services/websocket";
 import { useCallback, useEffect, useState } from "react";
 
@@ -141,22 +142,11 @@ export function useNPMInstall() {
     try {
       console.log("[useNPMInstall] 开始安装版本:", version);
 
-      const response = await fetch("/api/update", {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ version }),
-      });
-
-      const result = await response.json();
-
-      if (!result.success) {
-        throw new Error(result.error?.message || "安装请求失败");
-      }
+      // 使用 apiClient 进行版本更新请求
+      const result = await apiClient.updateVersion(version);
 
       console.log("[useNPMInstall] 安装请求已接受:", result);
-      return result;
+      return { success: true, data: result };
     } catch (error) {
       console.error("[useNPMInstall] 安装请求失败:", error);
 


### PR DESCRIPTION
修复前端架构违规问题：
- useNPMInstall.ts 之前直接使用 fetch 调用 /api/update
- 现在统一使用 apiClient.updateVersion 方法
- 错误处理由 apiClient 服务层统一管理

相关 Issue: #3225

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3225