### PR TITLE
fix(cli): 修复 process 信号监听器累积导致的 MaxListeners 超限警告

### DIFF
--- a/apps/backend/WebServerLauncher.ts
+++ b/apps/backend/WebServerLauncher.ts
@@ -5,6 +5,12 @@
  * 用于后台模式启动，替代原有的 adaptiveMCPPipe 启动方式
  */
 
+// 信号处理器注册状态（防止重复注册）
+const signalHandlersRegistered = {
+  SIGINT: false,
+  SIGTERM: false,
+};
+
 // 动态导入避免 CLI 代码执行
 async function importModules() {
   const webServerModule = await import("@/WebServer.js");
@@ -15,6 +21,20 @@ async function importModules() {
     configManager: configModule.configManager,
     logger: loggerModule.logger,
   };
+}
+
+/**
+ * 安全注册信号处理器（防止重复注册）
+ */
+function safeRegisterSignal(
+  signal: "SIGINT" | "SIGTERM",
+  handler: () => void
+): void {
+  if (signalHandlersRegistered[signal]) {
+    return;
+  }
+  signalHandlersRegistered[signal] = true;
+  process.once(signal, handler);
 }
 
 async function main() {
@@ -36,15 +56,15 @@ async function main() {
 
     logger.info("[WEBSERVER_STANDALONE] WebServer 启动成功");
 
-    // 处理退出信号
+    // 处理退出信号（使用安全注册）
     const cleanup = async () => {
       logger.info("[WEBSERVER_STANDALONE] 正在停止 WebServer...");
       await webServer.stop();
       process.exit(0);
     };
 
-    process.once("SIGINT", cleanup);
-    process.once("SIGTERM", cleanup);
+    safeRegisterSignal("SIGINT", cleanup);
+    safeRegisterSignal("SIGTERM", cleanup);
   } catch (error) {
     console.error("WebServer 启动失败:", error);
     process.exit(1);

--- a/packages/cli/src/services/DaemonManager.ts
+++ b/packages/cli/src/services/DaemonManager.ts
@@ -23,6 +23,7 @@ import type {
 } from "../interfaces/Service";
 import { PathUtils } from "../utils/PathUtils";
 import { PlatformUtils } from "../utils/PlatformUtils";
+import { SignalHandlerManager } from "../utils/SignalHandlerManager";
 
 /**
  * 守护进程选项
@@ -161,12 +162,14 @@ export class DaemonManagerImpl implements IDaemonManager {
       const { command, args } = PlatformUtils.getTailCommand(logFilePath);
       const tail = spawn(command, args, { stdio: "inherit" });
 
-      // 处理中断信号
-      process.once("SIGINT", () => {
+      // 使用信号处理器管理器注册清理函数
+      const signalManager = SignalHandlerManager.getInstance();
+      const cleanup = () => {
         console.log("\n断开连接，服务继续在后台运行");
         tail.kill();
-        process.exit(0);
-      });
+      };
+
+      signalManager.registerHandler("SIGINT", "attach-logs", cleanup);
 
       tail.on("exit", () => {
         process.exit(0);

--- a/packages/cli/src/services/ServiceManager.ts
+++ b/packages/cli/src/services/ServiceManager.ts
@@ -22,6 +22,7 @@ import type {
   ServiceStatus,
 } from "../interfaces/Service";
 import { PathUtils } from "../utils/PathUtils";
+import { SignalHandlerManager } from "../utils/SignalHandlerManager";
 import { Validation } from "../utils/Validation";
 
 /**
@@ -280,14 +281,14 @@ export class ServiceManagerImpl implements IServiceManager {
       const { WebServer } = await import("@/WebServer.js");
       const server = new WebServer(port);
 
-      // 处理退出信号
+      // 使用信号处理器管理器注册清理函数
+      const signalManager = SignalHandlerManager.getInstance();
       const cleanup = async () => {
         await server.stop();
-        process.exit(0);
       };
 
-      process.once("SIGINT", cleanup);
-      process.once("SIGTERM", cleanup);
+      signalManager.registerHandler("SIGINT", "mcp-server-mode", cleanup);
+      signalManager.registerHandler("SIGTERM", "mcp-server-mode", cleanup);
 
       await server.start();
     }
@@ -339,15 +340,15 @@ export class ServiceManagerImpl implements IServiceManager {
     const { WebServer } = await import("@/WebServer.js");
     const server = new WebServer();
 
-    // 处理退出信号
+    // 使用信号处理器管理器注册清理函数
+    const signalManager = SignalHandlerManager.getInstance();
     const cleanup = async () => {
       await server.stop();
       this.processManager.cleanupPidFile();
-      process.exit(0);
     };
 
-    process.once("SIGINT", cleanup);
-    process.once("SIGTERM", cleanup);
+    signalManager.registerHandler("SIGINT", "foreground-mode", cleanup);
+    signalManager.registerHandler("SIGTERM", "foreground-mode", cleanup);
 
     // 保存 PID 信息
     this.processManager.savePidInfo(process.pid, "foreground");

--- a/packages/cli/src/utils/SignalHandlerManager.ts
+++ b/packages/cli/src/utils/SignalHandlerManager.ts
@@ -1,0 +1,115 @@
+/**
+ * 信号处理器管理器
+ *
+ * 统一管理 process 信号监听器，避免重复注册导致的 MaxListeners 超限警告。
+ * 采用单例模式确保全局只注册一次信号处理器。
+ *
+ * @module packages/cli/src/utils/SignalHandlerManager
+ */
+
+/**
+ * 清理函数类型
+ */
+type CleanupFunction = () => Promise<void> | void;
+
+/**
+ * 信号处理器管理器
+ *
+ * 使用单例模式确保 process 信号监听器全局只注册一次。
+ * 支持注册多个清理函数，在信号触发时依次执行。
+ */
+export class SignalHandlerManager {
+  private static instance: SignalHandlerManager;
+  private cleanupHandlers: Map<string, CleanupFunction> = new Map();
+  private handlersRegistered = false;
+  private registeredSignals: Set<string> = new Set();
+
+  /**
+   * 获取单例实例
+   */
+  static getInstance(): SignalHandlerManager {
+    if (!SignalHandlerManager.instance) {
+      SignalHandlerManager.instance = new SignalHandlerManager();
+    }
+    return SignalHandlerManager.instance;
+  }
+
+  /**
+   * 注册信号处理器
+   *
+   * @param signal - 信号名称（如 SIGINT, SIGTERM, SIGHUP）
+   * @param handlerId - 处理器唯一标识符
+   * @param cleanup - 清理函数
+   */
+  registerHandler(
+    signal: "SIGINT" | "SIGTERM" | "SIGHUP",
+    handlerId: string,
+    cleanup: CleanupFunction
+  ): void {
+    // 添加或更新清理函数
+    this.cleanupHandlers.set(handlerId, cleanup);
+
+    // 如果该信号尚未注册全局监听器，则注册
+    if (!this.registeredSignals.has(signal)) {
+      this.registerSignalListener(signal);
+      this.registeredSignals.add(signal);
+    }
+  }
+
+  /**
+   * 移除指定处理器
+   *
+   * @param handlerId - 处理器唯一标识符
+   */
+  removeHandler(handlerId: string): void {
+    this.cleanupHandlers.delete(handlerId);
+  }
+
+  /**
+   * 清理所有处理器
+   */
+  clearAllHandlers(): void {
+    this.cleanupHandlers.clear();
+  }
+
+  /**
+   * 重置管理器状态（主要用于测试场景）
+   */
+  reset(): void {
+    this.cleanupHandlers.clear();
+    this.registeredSignals.clear();
+    this.handlersRegistered = false;
+    SignalHandlerManager.instance =
+      undefined as unknown as SignalHandlerManager;
+  }
+
+  /**
+   * 注册信号监听器
+   *
+   * @param signal - 信号名称
+   */
+  private registerSignalListener(signal: string): void {
+    process.once(signal, async () => {
+      await this.executeCleanupHandlers();
+      process.exit(0);
+    });
+  }
+
+  /**
+   * 执行所有清理函数
+   */
+  private async executeCleanupHandlers(): Promise<void> {
+    const handlers = Array.from(this.cleanupHandlers.values());
+
+    for (const handler of handlers) {
+      try {
+        await handler();
+      } catch (error) {
+        // 记录错误但继续执行其他清理函数
+        console.error(
+          `清理函数执行失败: ${error instanceof Error ? error.message : String(error)}`
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
问题：
- ServiceManager 和 DaemonManager 在某些场景下多次注册 SIGINT/SIGTERM/SIGHUP 信号监听器导致监听器累积超过 Node.js 默认限制（11个）
- WebServerLauncher 直接使用 process.once() 注册信号处理器

解决方案：
- 创建 SignalHandlerManager 单例类统一管理信号处理器注册
- 确保每个信号只注册一次全局监听器
- 支持注册多个清理函数，信号触发时依次执行

修改文件：
- packages/cli/src/utils/SignalHandlerManager.ts（新增）
- packages/cli/src/services/ServiceManager.ts
- packages/cli/src/services/DaemonManager.ts
- apps/backend/WebServerLauncher.ts

Related: #3228, #3048

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3228