### PR TITLE
refactor(frontend): 清理 WebSocket 中已无消费者的死事件通道

### DIFF
--- a/apps/frontend/src/services/__tests__/index.test.ts
+++ b/apps/frontend/src/services/__tests__/index.test.ts
@@ -323,37 +323,36 @@ describe("NetworkService", () => {
 
     it("应该支持不同类型的事件", () => {
       const listeners = {
-        config: vi.fn(),
-        status: vi.fn(),
-        restart: vi.fn(),
+        npmInstallStarted: vi.fn(),
+        npmInstallLog: vi.fn(),
         error: vi.fn(),
       };
 
       mockWebSocketManager.subscribe.mockReturnValue(() => {});
 
-      networkService.onWebSocketEvent("data:configUpdate", listeners.config);
-      networkService.onWebSocketEvent("data:statusUpdate", listeners.status);
-      networkService.onWebSocketEvent("data:restartStatus", listeners.restart);
+      networkService.onWebSocketEvent(
+        "data:npmInstallStarted",
+        listeners.npmInstallStarted
+      );
+      networkService.onWebSocketEvent(
+        "data:npmInstallLog",
+        listeners.npmInstallLog
+      );
       networkService.onWebSocketEvent("system:error", listeners.error);
 
-      expect(mockWebSocketManager.subscribe).toHaveBeenCalledTimes(4);
+      expect(mockWebSocketManager.subscribe).toHaveBeenCalledTimes(3);
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         1,
-        "data:configUpdate",
-        listeners.config
+        "data:npmInstallStarted",
+        listeners.npmInstallStarted
       );
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         2,
-        "data:statusUpdate",
-        listeners.status
+        "data:npmInstallLog",
+        listeners.npmInstallLog
       );
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         3,
-        "data:restartStatus",
-        listeners.restart
-      );
-      expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
-        4,
         "system:error",
         listeners.error
       );

--- a/apps/frontend/src/services/__tests__/websocket.test.ts
+++ b/apps/frontend/src/services/__tests__/websocket.test.ts
@@ -3,7 +3,6 @@
  * 测试重构后的事件系统和连接管理功能
  */
 
-import type { ClientStatus } from "@xiaozhi-client/shared-types";
 import {
   afterEach,
   beforeAll,
@@ -286,39 +285,26 @@ describe("WebSocketManager", () => {
     });
 
     it("应该正确处理不同类型的事件", () => {
-      const configListener = vi.fn();
-      const statusListener = vi.fn();
+      const npmInstallListener = vi.fn();
       const errorListener = vi.fn();
 
-      manager.subscribe("data:configUpdate", configListener);
-      manager.subscribe("data:statusUpdate", statusListener);
+      manager.subscribe("data:npmInstallStarted", npmInstallListener);
       manager.subscribe("system:error", errorListener);
 
-      const testConfig = {
-        mcpEndpoint: "ws://localhost:9999",
-        mcpServers: {
-          "test-server": {
-            command: "node",
-            args: ["server.js"],
-          },
-        },
-      };
-      const testStatus: ClientStatus = {
-        status: "connected",
-        mcpEndpoint: "ws://localhost:9999",
-        activeMCPServers: ["test-server"],
+      const testNpmInstallData = {
+        version: "1.0.0",
+        installId: "test-install-id",
+        timestamp: Date.now(),
       };
       const testError = {
         error: new Error("test error"),
         message: { type: "error" },
       };
 
-      manager.getEventBus().emit("data:configUpdate", testConfig);
-      manager.getEventBus().emit("data:statusUpdate", testStatus);
+      manager.getEventBus().emit("data:npmInstallStarted", testNpmInstallData);
       manager.getEventBus().emit("system:error", testError);
 
-      expect(configListener).toHaveBeenCalledWith(testConfig);
-      expect(statusListener).toHaveBeenCalledWith(testStatus);
+      expect(npmInstallListener).toHaveBeenCalledWith(testNpmInstallData);
       expect(errorListener).toHaveBeenCalledWith(testError);
     });
 
@@ -354,63 +340,6 @@ describe("WebSocketManager", () => {
     beforeEach(() => {
       manager = WebSocketManager.getInstance();
       manager.connect();
-    });
-
-    it("应该处理配置更新消息", () => {
-      const configListener = vi.fn();
-      manager.subscribe("data:configUpdate", configListener);
-
-      const testMessage = {
-        type: "configUpdate",
-        data: {
-          mcpEndpoint: "ws://localhost:8888",
-          mcpServers: {
-            "test-server-2": {
-              command: "node",
-              args: ["server2.js"],
-            },
-          },
-        },
-      };
-
-      (manager as any).ws.mockMessage(testMessage);
-
-      expect(configListener).toHaveBeenCalledWith(testMessage.data);
-    });
-
-    it("应该处理状态更新消息", () => {
-      const statusListener = vi.fn();
-      manager.subscribe("data:statusUpdate", statusListener);
-
-      const testMessage = {
-        type: "statusUpdate",
-        data: {
-          status: "connected",
-          mcpEndpoint: "ws://localhost:9999",
-          activeMCPServers: ["test-server"],
-        },
-      };
-
-      (manager as any).ws.mockMessage(testMessage);
-
-      expect(statusListener).toHaveBeenCalledWith(testMessage.data);
-    });
-
-    it("应该处理重启状态消息", () => {
-      const restartListener = vi.fn();
-      manager.subscribe("data:restartStatus", restartListener);
-
-      const testMessage = {
-        type: "restartStatus",
-        data: { status: "completed", timestamp: Date.now() },
-      };
-
-      (manager as any).ws.mockMessage(testMessage);
-
-      expect(restartListener).toHaveBeenCalledWith({
-        status: "completed",
-        timestamp: expect.any(Number),
-      });
     });
 
     it("应该处理错误消息", () => {
@@ -694,7 +623,7 @@ describe("WebSocketManager", () => {
 
     it("应该能够清理所有监听器", () => {
       manager.subscribe("connection:connected", () => {});
-      manager.subscribe("data:configUpdate", () => {});
+      manager.subscribe("data:npmInstallStarted", () => {});
 
       expect(manager.getEventBus().getListenerCount()).toBe(2);
 

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -8,7 +8,6 @@
  */
 
 import { WEBSOCKET_RECONNECT_DELAY } from "@/constants/timeouts";
-import type { AppConfig, ClientStatus } from "@xiaozhi-client/shared-types";
 
 /**
  * WebSocket 消息类型
@@ -22,27 +21,6 @@ interface WebSocketMessage {
     message: string;
     timestamp?: number;
   };
-}
-
-/**
- * 重启状态接口
- */
-interface RestartStatus {
-  status: "restarting" | "completed" | "failed";
-  error?: string;
-  timestamp: number;
-}
-
-/**
- * 接入点状态变更事件数据
- */
-export interface EndpointStatusChangedEvent {
-  endpoint: string;
-  connected: boolean;
-  operation: "connect" | "disconnect" | "reconnect";
-  success: boolean;
-  message?: string;
-  timestamp: number;
 }
 
 /**
@@ -97,14 +75,6 @@ interface EventBusEvents {
   "connection:disconnected": undefined;
   "connection:reconnecting": { attempt: number; maxAttempts: number };
   "connection:error": { error: Error; context?: string };
-
-  // 数据更新事件
-  "data:configUpdate": AppConfig;
-  "data:statusUpdate": ClientStatus;
-  "data:restartStatus": RestartStatus;
-
-  // 接入点状态事件
-  "data:endpointStatusChanged": EndpointStatusChangedEvent;
 
   // NPM 安装事件
   "data:npmInstallStarted": NPMInstallStartedEvent;
@@ -499,41 +469,6 @@ export class WebSocketManager {
 
     try {
       switch (message.type) {
-        case "configUpdate":
-        case "config":
-          if (message.data) {
-            this.eventBus.emit("data:configUpdate", message.data as AppConfig);
-          }
-          break;
-
-        case "statusUpdate":
-        case "status":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:statusUpdate",
-              message.data as ClientStatus
-            );
-          }
-          break;
-
-        case "restartStatus":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:restartStatus",
-              message.data as RestartStatus
-            );
-          }
-          break;
-
-        case "endpoint_status_changed":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:endpointStatusChanged",
-              message.data as EndpointStatusChangedEvent
-            );
-          }
-          break;
-
         case "npm:install:started":
           if (message.data) {
             this.eventBus.emit(
@@ -727,7 +662,6 @@ export const webSocketManager = WebSocketManager.getInstance();
 export { ConnectionState };
 export type {
   WebSocketMessage,
-  RestartStatus,
   WebSocketManagerConfig,
   EventBusEvents,
   EventListener,


### PR DESCRIPTION
## Summary
- 移除 `configUpdate`、`statusUpdate`、`restartStatus`、`endpoint_status_changed` 四个 WebSocket 推送事件及其相关类型定义和消息处理分支
- 这些事件对应的 `ConfigStore` 和 `StatusStore` 已完全迁移至 HTTP API / HTTP 轮询模式，前端不再有任何消费者订阅这些事件
- 同步更新测试文件，移除对应死代码的测试用例
- 保留心跳机制和 NPM 安装进度推送等仍有活跃消费者的功能

## 背景
通过分析发现，配置、状态、重启三大核心数据的 WebSocket 推送通道虽然代码还在，但实际已经没有任何消费者了。ConfigStore 和 StatusStore 已经完全切换到 HTTP API / HTTP 轮询模式。本次清理移除了这些死代码，减少约 138 行无用代码。

## Test plan
- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过
- [x] `pnpm test` — 44 个测试文件、531 个测试用例全部通过