### PR TITLE
refactor(handler): 使用公开的 getService() 方法替代双重断言访问私有属性

### DIFF
--- a/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/apps/backend/handlers/__tests__/mcp-manage.handler.test.ts
@@ -260,9 +260,7 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["new-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 修复 mock 配置 - 确保初始配置不包含新服务，但 updateMcpServer 后包含
     const currentConfig = {
@@ -430,9 +428,7 @@ describe("addMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["disconnected-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.addMCPServer(mockContext as Context);
 
@@ -547,9 +543,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -619,9 +613,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 模拟服务停止失败
     mockMCPServiceManager.stopService = vi
@@ -654,9 +646,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     // 修改配置管理器让它认为这个服务存在
     const originalGetConfig = mockConfigManager.getConfig;
@@ -705,9 +695,7 @@ describe("removeMCPServer", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.removeMCPServer(mockContext as Context);
 
@@ -960,9 +948,7 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -984,9 +970,7 @@ describe("getMCPServerStatus", () => {
       isConnected: vi.fn().mockReturnValue(false),
       getTools: vi.fn().mockReturnValue([]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      [serverName, mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const response = await handler.getMCPServerStatus(mockContext as Context);
 
@@ -1125,10 +1109,13 @@ describe("listMCPServers", () => {
       getTools: vi.fn().mockReturnValue([]),
     };
     // service3 不在 services Map 中（未启动）
-    (mockMCPServiceManager as any).services = new Map([
-      ["service1", mockService1],
-      ["service2", mockService2],
-    ]);
+    mockMCPServiceManager.getService = vi
+      .fn()
+      .mockImplementation((name: string) => {
+        if (name === "service1") return mockService1;
+        if (name === "service2") return mockService2;
+        return undefined; // service3 未启动
+      });
 
     const response = await handler.listMCPServers(mockContext as Context);
 
@@ -1316,9 +1303,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1356,9 +1341,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
@@ -1396,9 +1379,7 @@ describe("addMCPServer with type field normalization", () => {
       isConnected: vi.fn().mockReturnValue(true),
       getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
     };
-    (mockMCPServiceManager as any).services = new Map([
-      ["test-service", mockService],
-    ]);
+    mockMCPServiceManager.getService = vi.fn().mockReturnValue(mockService);
 
     const currentConfig = { mcpServers: {} };
     mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);

--- a/apps/backend/handlers/mcp-manage.handler.ts
+++ b/apps/backend/handlers/mcp-manage.handler.ts
@@ -16,7 +16,6 @@ import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
 import { ErrorCategory, MCPError, MCPErrorCode } from "@/errors/mcp-errors.js";
 import type { MCPServiceManager } from "@/lib/mcp";
-import type { MCPService } from "@/lib/mcp";
 import { getEventBus } from "@/services/event-bus.service.js";
 import type { AppContext } from "@/types/hono.context.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
@@ -24,14 +23,6 @@ import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
 import { normalizeServiceConfig } from "@xiaozhi-client/config";
 import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
-
-/**
- * MCPServiceManager 扩展接口，用于访问私有属性
- * 这个接口定义了我们需要访问但实际上是私有的属性
- */
-interface MCPServiceManagerAccess {
-  services: Map<string, MCPService>;
-}
 
 /**
  * 配置详情接口，包含时间戳
@@ -421,9 +412,7 @@ export class MCPHandler {
 
     // 尝试从 MCPServiceManager 获取实际状态
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.isConnected?.()) {
         const currentTools = service.getTools().map((tool: Tool) => tool.name);
@@ -530,9 +519,7 @@ export class MCPHandler {
    */
   private getServiceTools(serverName: string): Tool[] {
     try {
-      const managerAccess = this
-        .mcpServiceManager as unknown as MCPServiceManagerAccess;
-      const service = managerAccess.services.get(serverName);
+      const service = this.mcpServiceManager.getService(serverName);
 
       if (service?.getTools) {
         return service.getTools();


### PR DESCRIPTION
- 移除 MCPServiceManagerAccess 接口定义
- 将 getServiceStatus 和 getServiceTools 方法中的双重断言替换为公开的 getService() 方法
- 移除未使用的 MCPService 类型导入
- 更新测试 mock 以使用 getService() 方法

修复 Issue #3236

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3236