### PR TITLE
fix(cli): 添加路径别名配置解决 @/ 导入违规问题

### DIFF
--- a/packages/cli/tsconfig.json
+++ b/packages/cli/tsconfig.json
@@ -3,7 +3,11 @@
   "compilerOptions": {
     "composite": true,
     "outDir": "../../dist/cli",
-    "rootDir": "src"
+    "rootDir": "src",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["../../apps/backend/*"]
+    }
   },
   "include": ["src/**/*.ts"],
   "exclude": ["node_modules", "dist", "**/*.test.ts"],


### PR DESCRIPTION
在 packages/cli/tsconfig.json 中添加 baseUrl 和 paths 配置，
使 @/WebServer 导入能够正确解析到 apps/backend 目录。

修复 GitHub Issue #3237 中指出的路径别名违规问题。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3237