### PR TITLE
fix: handleServiceConnected 缺少 refreshToolsCache() 调用 (#3243)

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -169,6 +169,9 @@ export class MCPServiceManager extends EventEmitter {
       // 获取最新的工具列表
       const service = this.services.get(data.serviceName);
       if (service) {
+        // 先更新工具缓存
+        await this.refreshToolsCache();
+
         // 重新初始化CustomMCPHandler
         await this.refreshCustomMCPHandlerPublic();
 


### PR DESCRIPTION
## 修复内容

`handleServiceConnected` 方法缺少 `refreshToolsCache()` 调用，导致新连接的 MCP 服务工具不会出现在可用工具列表中。

### 根因分析

对比 `handleServiceDisconnected` 方法（正确实现），`handleServiceConnected` 只调用了 `refreshCustomMCPHandlerPublic()`，没有调用 `refreshToolsCache()`：

**修复前（有问题）：**
```typescript
private async handleServiceConnected(data: {...}): Promise<void> {
  // ...
  if (service) {
    // ❌ 缺少: await this.refreshToolsCache();
    await this.refreshCustomMCPHandlerPublic();  // 只刷新了 CustomMCPHandler
    logger.info(`服务 ${data.serviceName} 工具缓存刷新完成`);  // 日志声称已完成，但实际未刷新
  }
}
```

**修复后：**
```typescript
private async handleServiceConnected(data: {...}): Promise<void> {
  // ...
  if (service) {
    // ✅ 先更新工具缓存
    await this.refreshToolsCache();
    // 再刷新 CustomMCPHandler
    await this.refreshCustomMCPHandlerPublic();
    logger.info(`服务 ${data.serviceName} 工具缓存刷新完成`);
  }
}
```

### 为什么这是个 Bug

1. **代码意图与实际行为不一致**：注释和日志声称刷新工具缓存，但实际行为不符
2. **功能缺失**：新连接的服务工具不会出现在可用工具列表中
3. **与断开连接处理逻辑不一致**：`handleServiceDisconnected` 正确调用了两个刷新方法，而连接成功处理缺少一个

Fixes #3243
