### PR TITLE
fix(mcp): handleServiceConnected 方法添加 refreshToolsCache 调用

### DIFF
--- a/apps/backend/lib/mcp/manager.ts
+++ b/apps/backend/lib/mcp/manager.ts
@@ -169,6 +169,9 @@ export class MCPServiceManager extends EventEmitter {
       // 获取最新的工具列表
       const service = this.services.get(data.serviceName);
       if (service) {
+        // 先更新工具缓存
+        await this.refreshToolsCache();
+
         // 重新初始化CustomMCPHandler
         await this.refreshCustomMCPHandlerPublic();
 


### PR DESCRIPTION
在 MCPServiceManager.handleServiceConnected 方法中添加了 refreshToolsCache() 调用，
使其与 handleServiceDisconnected 方法保持一致，确保新连接的 MCP 服务工具正确刷新到缓存中。

修复了 Issue #3243 中描述的问题：日志声称刷新工具缓存但实际未调用 refreshToolsCache()，
导致新连接服务的工具不可用。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3243