### PR TITLE
fix(security): 升级 follow-redirects 至 1.16.0 修复跨域重定向认证头泄露漏洞

### DIFF
--- a/package.json
+++ b/package.json
@@ -170,7 +170,8 @@
       "mathjs@<15.2.0": ">=15.2.0",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
-      "cosmiconfig": ">=7.1.0"
+      "cosmiconfig": ">=7.1.0",
+      "follow-redirects": ">=1.16.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ overrides:
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
   cosmiconfig: '>=7.1.0'
+  follow-redirects: '>=1.16.0'
 
 importers:
 
@@ -5135,8 +5136,8 @@ packages:
   flatted@3.4.2:
     resolution: {integrity: sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==}
 
-  follow-redirects@1.15.11:
-    resolution: {integrity: sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==}
+  follow-redirects@1.16.0:
+    resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
     peerDependencies:
       debug: '*'
@@ -11423,7 +11424,7 @@ snapshots:
 
   axios@1.15.0:
     dependencies:
-      follow-redirects: 1.15.11
+      follow-redirects: 1.16.0
       form-data: 4.0.5
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
@@ -12577,7 +12578,7 @@ snapshots:
 
   flatted@3.4.2: {}
 
-  follow-redirects@1.15.11: {}
+  follow-redirects@1.16.0: {}
 
   form-data-encoder@1.7.2: {}
 


### PR DESCRIPTION
添加 pnpm override 强制升级 follow-redirects 依赖至 >=1.16.0，
修复 CVE 中自定义认证头在跨域重定向时泄露的问题。

依赖路径: xiaozhi-client → nx → axios → follow-redirects

Fixes #3247

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3247