### PR TITLE
refactor(frontend): 清理 WebSocket 中 NPM 安装事件的死代码

### DIFF
--- a/apps/frontend/src/services/__tests__/index.test.ts
+++ b/apps/frontend/src/services/__tests__/index.test.ts
@@ -323,33 +323,30 @@ describe("NetworkService", () => {
 
     it("应该支持不同类型的事件", () => {
       const listeners = {
-        npmInstallStarted: vi.fn(),
-        npmInstallLog: vi.fn(),
+        connected: vi.fn(),
+        heartbeat: vi.fn(),
         error: vi.fn(),
       };
 
       mockWebSocketManager.subscribe.mockReturnValue(() => {});
 
       networkService.onWebSocketEvent(
-        "data:npmInstallStarted",
-        listeners.npmInstallStarted
+        "connection:connected",
+        listeners.connected
       );
-      networkService.onWebSocketEvent(
-        "data:npmInstallLog",
-        listeners.npmInstallLog
-      );
+      networkService.onWebSocketEvent("system:heartbeat", listeners.heartbeat);
       networkService.onWebSocketEvent("system:error", listeners.error);
 
       expect(mockWebSocketManager.subscribe).toHaveBeenCalledTimes(3);
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         1,
-        "data:npmInstallStarted",
-        listeners.npmInstallStarted
+        "connection:connected",
+        listeners.connected
       );
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         2,
-        "data:npmInstallLog",
-        listeners.npmInstallLog
+        "system:heartbeat",
+        listeners.heartbeat
       );
       expect(mockWebSocketManager.subscribe).toHaveBeenNthCalledWith(
         3,

--- a/apps/frontend/src/services/__tests__/websocket.test.ts
+++ b/apps/frontend/src/services/__tests__/websocket.test.ts
@@ -285,26 +285,22 @@ describe("WebSocketManager", () => {
     });
 
     it("应该正确处理不同类型的事件", () => {
-      const npmInstallListener = vi.fn();
+      const heartbeatListener = vi.fn();
       const errorListener = vi.fn();
 
-      manager.subscribe("data:npmInstallStarted", npmInstallListener);
+      manager.subscribe("system:heartbeat", heartbeatListener);
       manager.subscribe("system:error", errorListener);
 
-      const testNpmInstallData = {
-        version: "1.0.0",
-        installId: "test-install-id",
-        timestamp: Date.now(),
-      };
+      const testHeartbeatData = { timestamp: Date.now() };
       const testError = {
         error: new Error("test error"),
         message: { type: "error" },
       };
 
-      manager.getEventBus().emit("data:npmInstallStarted", testNpmInstallData);
+      manager.getEventBus().emit("system:heartbeat", testHeartbeatData);
       manager.getEventBus().emit("system:error", testError);
 
-      expect(npmInstallListener).toHaveBeenCalledWith(testNpmInstallData);
+      expect(heartbeatListener).toHaveBeenCalledWith(testHeartbeatData);
       expect(errorListener).toHaveBeenCalledWith(testError);
     });
 
@@ -623,7 +619,7 @@ describe("WebSocketManager", () => {
 
     it("应该能够清理所有监听器", () => {
       manager.subscribe("connection:connected", () => {});
-      manager.subscribe("data:npmInstallStarted", () => {});
+      manager.subscribe("system:heartbeat", () => {});
 
       expect(manager.getEventBus().getListenerCount()).toBe(2);
 

--- a/apps/frontend/src/services/websocket.ts
+++ b/apps/frontend/src/services/websocket.ts
@@ -24,48 +24,6 @@ interface WebSocketMessage {
 }
 
 /**
- * NPM 安装日志事件数据
- */
-export interface NPMInstallLogEvent {
-  version: string;
-  installId: string;
-  type: "stdout" | "stderr";
-  message: string;
-  timestamp: number;
-}
-
-/**
- * NPM 安装开始事件数据
- */
-export interface NPMInstallStartedEvent {
-  version: string;
-  installId: string;
-  timestamp: number;
-}
-
-/**
- * NPM 安装完成事件数据
- */
-export interface NPMInstallCompletedEvent {
-  version: string;
-  installId: string;
-  success: boolean;
-  duration: number;
-  timestamp: number;
-}
-
-/**
- * NPM 安装失败事件数据
- */
-export interface NPMInstallFailedEvent {
-  version: string;
-  installId: string;
-  error: string;
-  duration: number;
-  timestamp: number;
-}
-
-/**
  * 事件总线事件类型
  */
 interface EventBusEvents {
@@ -75,12 +33,6 @@ interface EventBusEvents {
   "connection:disconnected": undefined;
   "connection:reconnecting": { attempt: number; maxAttempts: number };
   "connection:error": { error: Error; context?: string };
-
-  // NPM 安装事件
-  "data:npmInstallStarted": NPMInstallStartedEvent;
-  "data:npmInstallLog": NPMInstallLogEvent;
-  "data:npmInstallCompleted": NPMInstallCompletedEvent;
-  "data:npmInstallFailed": NPMInstallFailedEvent;
 
   // 系统事件
   "system:heartbeat": { timestamp: number };
@@ -469,42 +421,6 @@ export class WebSocketManager {
 
     try {
       switch (message.type) {
-        case "npm:install:started":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:npmInstallStarted",
-              message.data as NPMInstallStartedEvent
-            );
-          }
-          break;
-
-        case "npm:install:log":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:npmInstallLog",
-              message.data as NPMInstallLogEvent
-            );
-          }
-          break;
-
-        case "npm:install:completed":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:npmInstallCompleted",
-              message.data as NPMInstallCompletedEvent
-            );
-          }
-          break;
-
-        case "npm:install:failed":
-          if (message.data) {
-            this.eventBus.emit(
-              "data:npmInstallFailed",
-              message.data as NPMInstallFailedEvent
-            );
-          }
-          break;
-
         case "heartbeatResponse":
           this.lastHeartbeat = Date.now();
           this.eventBus.emit("system:heartbeat", {


### PR DESCRIPTION
## Summary

- 清理 `services/websocket.ts` 中 NPM 安装相关的 4 个事件接口定义、EventBusEvents 类型声明和 handleMessage 中的 4 个 case 分支
- 这些代码是 SSE 迁移 (e74ba3f2) 后遗留的死代码，生产代码中无任何消费者订阅这些事件
- 同步更新测试用例，将引用替换为实际使用的事件类型（`connection:connected`、`system:heartbeat`）
- 文件从 669 行精简至 585 行（-84 行，-106/+15）

## Context

通过分析前端 WebSocket 的所有通信场景发现：
- 配置数据、状态数据、接入点状态等**已全部迁移至 HTTP API/SSE**
- NPM 安装的 4 个 WebSocket 事件 (`data:npmInstallStarted/Log/Completed/Failed`) **无任何生产代码消费者**
- 唯一的订阅者仅存在于测试文件中

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（无修复）
- [x] `pnpm test` 通过（45 文件 / 571 用例 / 0 失败）