### PR TITLE
refactor(frontend): 将 WebSocketProvider 重命名为 NetworkServiceProvider

### DIFF
--- a/apps/frontend/src/App.tsx
+++ b/apps/frontend/src/App.tsx
@@ -1,12 +1,12 @@
 import { Toaster } from "@/components/ui/sonner";
 import { RestartNotificationProvider } from "@/hooks/useRestartNotifications";
 import DashboardPage from "@/pages/DashboardPage";
-import { WebSocketProvider } from "@/providers/WebSocketProvider";
+import { NetworkServiceProvider } from "@/providers/NetworkServiceProvider";
 import { Navigate, Route, Routes } from "react-router-dom";
 
 function App() {
   return (
-    <WebSocketProvider>
+    <NetworkServiceProvider>
       {/* 重启通知管理器 - 全局监听重启状态变化 */}
       <RestartNotificationProvider />
 
@@ -37,7 +37,7 @@ function App() {
           },
         }}
       />
-    </WebSocketProvider>
+    </NetworkServiceProvider>
   );
 }
 

--- a/apps/frontend/src/components/mcp-server-list.test.tsx
+++ b/apps/frontend/src/components/mcp-server-list.test.tsx
@@ -13,7 +13,7 @@ vi.mock("@/stores/config", () => ({
   useConfigActions: vi.fn(),
 }));
 
-vi.mock("@/providers/WebSocketProvider", () => ({
+vi.mock("@/providers/NetworkServiceProvider", () => ({
   useNetworkServiceActions: vi.fn(),
 }));
 
@@ -260,7 +260,7 @@ describe("McpServerList 组件", () => {
     // 使用动态导入设置模拟
     const configModule = await import("@/stores/config");
     const webSocketProviderModule = await import(
-      "@/providers/WebSocketProvider"
+      "@/providers/NetworkServiceProvider"
     );
     const apiModule = await import("@/services/api");
 

--- a/apps/frontend/src/components/mcp-server-list.test.tsx
+++ b/apps/frontend/src/components/mcp-server-list.test.tsx
@@ -259,7 +259,7 @@ describe("McpServerList 组件", () => {
 
     // 使用动态导入设置模拟
     const configModule = await import("@/stores/config");
-    const webSocketProviderModule = await import(
+    const networkServiceProviderModule = await import(
       "@/providers/NetworkServiceProvider"
     );
     const apiModule = await import("@/services/api");
@@ -282,19 +282,19 @@ describe("McpServerList 组件", () => {
       reset: vi.fn(),
       initialize: vi.fn().mockResolvedValue(undefined),
     });
-    vi.mocked(webSocketProviderModule.useNetworkServiceActions).mockReturnValue(
-      {
-        getConfig: vi.fn(),
-        updateConfig: mockUpdateConfig,
-        restartService: vi.fn(),
-        refreshStatus: vi.fn(),
-        getStatus: vi.fn(),
-        restartServiceWithNotification: vi.fn(),
-        changePort: vi.fn(),
-        loadInitialData: vi.fn(),
-        getServerUrl: vi.fn(() => "http://localhost:9999"),
-      }
-    );
+    vi.mocked(
+      networkServiceProviderModule.useNetworkServiceActions
+    ).mockReturnValue({
+      getConfig: vi.fn(),
+      updateConfig: mockUpdateConfig,
+      restartService: vi.fn(),
+      refreshStatus: vi.fn(),
+      getStatus: vi.fn(),
+      restartServiceWithNotification: vi.fn(),
+      changePort: vi.fn(),
+      loadInitialData: vi.fn(),
+      getServerUrl: vi.fn(() => "http://localhost:9999"),
+    });
 
     // 模拟 API 调用
     vi.mocked(apiModule.apiClient.getToolsList).mockImplementation(

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -19,7 +19,7 @@ import {
 } from "@/components/ui/form";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Textarea } from "@/components/ui/textarea";
-import { useNetworkServiceActions } from "@/providers/WebSocketProvider";
+import { useNetworkServiceActions } from "@/providers/NetworkServiceProvider";
 import { mcpFormSchema } from "@/schemas/mcp-form";
 import { useConfig } from "@/stores/config";
 import {

--- a/apps/frontend/src/components/mcp-server/__tests__/mcp-server-table.test.tsx
+++ b/apps/frontend/src/components/mcp-server/__tests__/mcp-server-table.test.tsx
@@ -17,8 +17,8 @@ vi.mock("@/stores/config", () => ({
   })),
 }));
 
-// Mock WebSocketProvider
-vi.mock("@/providers/WebSocketProvider", () => ({
+// Mock NetworkServiceProvider
+vi.mock("@/providers/NetworkServiceProvider", () => ({
   useNetworkServiceActions: () => ({
     updateConfig: vi.fn(),
   }),

--- a/apps/frontend/src/components/system-setting-dialog.tsx
+++ b/apps/frontend/src/components/system-setting-dialog.tsx
@@ -24,7 +24,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useWebSocketActions } from "@/providers/WebSocketProvider";
+import { useNetworkServiceActions } from "@/providers/NetworkServiceProvider";
 import { useConfig } from "@/stores/config";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { AppConfig } from "@xiaozhi-client/shared-types";
@@ -65,7 +65,7 @@ export function SystemSettingDialog() {
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const config = useConfig();
-  const { updateConfig } = useWebSocketActions();
+  const { updateConfig } = useNetworkServiceActions();
 
   const form = useForm<z.infer<typeof formSchema>>({
     resolver: zodResolver(formSchema),

--- a/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
+++ b/apps/frontend/src/components/voice-interaction-setting-dialog.tsx
@@ -36,7 +36,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Separator } from "@/components/ui/separator";
-import { useWebSocketActions } from "@/providers/WebSocketProvider";
+import { useNetworkServiceActions } from "@/providers/NetworkServiceProvider";
 import { type PromptFileInfo, apiClient } from "@/services/api";
 import { useConfig } from "@/stores/config";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -93,7 +93,7 @@ export function VoiceInteractionSettingDialog() {
   const [voices, setVoices] = useState<VoiceInfo[]>([]);
   const [isLoadingVoices, setIsLoadingVoices] = useState(false);
   const config = useConfig();
-  const { updateConfig } = useWebSocketActions();
+  const { updateConfig } = useNetworkServiceActions();
 
   const form = useForm<VoiceInteractionFormValues>({
     resolver: zodResolver(voiceInteractionSchema),

--- a/apps/frontend/src/components/web-url-setting-button.test.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.test.tsx
@@ -65,7 +65,7 @@ vi.mock("react-hook-form", () => ({
 
 // 模拟 hooks
 const mockChangePort = vi.fn();
-vi.mock("@/providers/WebSocketProvider", () => ({
+vi.mock("@/providers/NetworkServiceProvider", () => ({
   useNetworkServiceActions: () => ({
     updateConfig: vi.fn(),
     changePort: mockChangePort,

--- a/apps/frontend/src/components/web-url-setting-button.tsx
+++ b/apps/frontend/src/components/web-url-setting-button.tsx
@@ -17,7 +17,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
-import { useNetworkServiceActions } from "@/providers/WebSocketProvider";
+import { useNetworkServiceActions } from "@/providers/NetworkServiceProvider";
 import { useConfig } from "@/stores/config";
 import { useConnectionStatus } from "@/stores/status";
 import { zodResolver } from "@hookform/resolvers/zod";

--- a/apps/frontend/src/providers/NetworkServiceProvider.tsx
+++ b/apps/frontend/src/providers/NetworkServiceProvider.tsx
@@ -10,7 +10,7 @@
  *
  * @example
  * ```tsx
- * import { NetworkServiceProvider, useNetworkServiceActions } from '@/providers/WebSocketProvider';
+ * import { NetworkServiceProvider, useNetworkServiceActions } from '@/providers/NetworkServiceProvider';
  *
  * function App() {
  *   return (
@@ -128,7 +128,3 @@ export function useNetworkServiceActions() {
   }
   return context;
 }
-
-// 向后兼容的别名
-export const WebSocketProvider = NetworkServiceProvider;
-export const useWebSocketActions = useNetworkServiceActions;

--- a/apps/frontend/src/providers/__tests__/NetworkServiceProvider.test.tsx
+++ b/apps/frontend/src/providers/__tests__/NetworkServiceProvider.test.tsx
@@ -7,7 +7,7 @@ import { describe, expect, it, vi } from "vitest";
 import {
   NetworkServiceProvider,
   useNetworkServiceActions,
-} from "../WebSocketProvider";
+} from "../NetworkServiceProvider";
 
 // Mock useNetworkService hook
 vi.mock("@/hooks/useNetworkService", () => ({

--- a/apps/frontend/src/stores/README.md
+++ b/apps/frontend/src/stores/README.md
@@ -93,7 +93,7 @@ function ConfigPanel() {
 虽然状态可以从 store 获取，但操作方法（如 `updateConfig`, `restartService`）通过 Provider Context 暴露：
 
 ```typescript
-import { useNetworkServiceActions } from '@/providers/WebSocketProvider';
+import { useNetworkServiceActions } from '@/providers/NetworkServiceProvider';
 
 function ConfigEditor() {
   const { updateConfig } = useNetworkServiceActions();


### PR DESCRIPTION
## Summary

- 将 `WebSocketProvider.tsx` 重命名为 `NetworkServiceProvider.tsx`
- 将 `WebSocketProvider.test.tsx` 重命名为 `NetworkServiceProvider.test.tsx`
- 移除 `WebSocketProvider` 和 `useWebSocketActions` 的向后兼容别名导出
- 更新所有 11 处引用（组件导入、测试 mock 路径、文档）

## 背景

项目已完成从 WebSocket 到 HTTP/SSE 的系统性迁移（见 #3257），但 `WebSocketProvider` 文件名和导出名仍保留旧的 WebSocket 命名，与实际功能不符。此次清理使命名与实际实现保持一致。

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（160 文件，0 问题）
- [x] `pnpm test` 通过（43 测试文件 / 530 用例全部通过）