### PR TITLE
fix(deps): 统一 ws 包依赖版本声明

### DIFF
--- a/packages/asr/package.json
+++ b/packages/asr/package.json
@@ -50,7 +50,7 @@
     "@discordjs/opus": "^0.10.0",
     "prism-media": "^1.3.5",
     "uuid": "^9.0.1",
-    "ws": "^8.16.0",
+    "ws": "^8.14.2",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/packages/esp32/package.json
+++ b/packages/esp32/package.json
@@ -56,7 +56,7 @@
     "zod": "^4.3.6"
   },
   "peerDependencies": {
-    "ws": "^8.16.0"
+    "ws": "^8.14.2"
   },
   "devDependencies": {
     "@types/node": "^20.10.0",


### PR DESCRIPTION
将 packages/asr 和 packages/esp32 的 ws 依赖版本从 ^8.16.0 统一为 ^8.14.2，
与根 package.json 保持一致，符合 monorepo 最佳实践。

Closes #3259

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3259