### PR TITLE
fix(handler): 移除 version.handler.ts 中不必要的类型断言

### DIFF
--- a/apps/backend/handlers/version.handler.ts
+++ b/apps/backend/handlers/version.handler.ts
@@ -74,11 +74,11 @@ export class VersionApiHandler extends BaseHandler {
       c.get("logger").debug("处理获取可用版本列表请求");
 
       // 获取查询参数
-      const type = (c.req.query("type") as unknown) || "stable";
+      const type = c.req.query("type") || "stable";
 
       // 验证版本类型参数
       const validTypes = ["stable", "rc", "beta", "all"];
-      if (!validTypes.includes(type as string)) {
+      if (!validTypes.includes(type)) {
         return c.fail(
           "INVALID_VERSION_TYPE",
           `无效的版本类型: ${type}。支持的类型: ${validTypes.join(", ")}`,
@@ -88,7 +88,7 @@ export class VersionApiHandler extends BaseHandler {
       }
 
       const npmManager = new NPMManager();
-      const versions = await npmManager.getAvailableVersions(type as string);
+      const versions = await npmManager.getAvailableVersions(type);
 
       c.get("logger").debug(
         `获取到 ${versions.length} 个可用版本 (类型: ${type})`


### PR DESCRIPTION
移除 getAvailableVersions 方法中使用的 `as unknown` 和 `as string` 类型断言，
提高类型安全性。Hono 的 query() 方法返回 `string | undefined`，使用 `|| "stable"`
后 TypeScript 可正确推断结果类型为 `string`。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3261