### PR TITLE
docs: 修复 config 命令格式与实际 CLI 不一致的问题

### DIFF
--- a/docs/content/reference/command.mdx
+++ b/docs/content/reference/command.mdx
@@ -12,6 +12,8 @@ description: "xiaozhi-client 命令行工具的常用命令参考。"
 | xiaozhi start                                 | 启动服务                    |
 | xiaozhi stop                                  | 停止服务                    |
 | xiaozhi status                                | 查看服务状态                |
-| xiaozhi config mcpEndpoint \<小智接入点地址\> | 设置小智接入点              |
+| xiaozhi config init                           | 初始化配置文件              |
+| xiaozhi config get \<key\>                    | 获取配置值                  |
+| xiaozhi config set \<key\> \<value\>          | 设置配置值                  |
 | xiaozhi mcp list                              | 列出所有 MCP 服务           |
 | xiaozhi mcp list --tools                      | 列出所有正在使用的 MCP 工具 |


### PR DESCRIPTION
- 将错误的 `xiaozhi config mcpEndpoint <地址>` 格式更新为正确的 `xiaozhi config set <key> <value>` 格式
- 补充完整的 config 子命令列表：init、get、set
- 与 quickstart.mdx 和 CLI 实现保持一致

Fixes #3264

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3264