### PR TITLE
perf(asr): 使用索引替代 shift() 处理 resultQueue 以优化性能

### DIFF
--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceV2Controller.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceV2Controller.ts
@@ -29,6 +29,7 @@ export class ByteDanceV2Controller extends ByteDanceController {
   ): AsyncGenerator<ListenResult, void, unknown> {
     // 设置结果事件处理 - 在 connect() 之前注册，避免错过初始响应
     const resultQueue: ListenResult[] = [];
+    let processedIndex = 0; // 使用索引追踪已处理位置，替代 shift() 的 O(n) 性能开销
     let resolveNext: (() => void) | null = null;
     let settled = false;
     let endCalled = false; // 标记是否已经调用过 end()
@@ -169,8 +170,14 @@ export class ByteDanceV2Controller extends ByteDanceController {
           });
 
         // 发送帧后立即检查并 yield 可用的结果（不等待帧发送完成）
-        while (resultQueue.length > 0) {
-          yield resultQueue.shift()!;
+        while (processedIndex < resultQueue.length) {
+          yield resultQueue[processedIndex];
+          processedIndex++;
+        }
+        // 定期清理已处理的元素（批量移除），减少内存占用
+        if (processedIndex > 0 && processedIndex >= resultQueue.length) {
+          resultQueue.splice(0, processedIndex);
+          processedIndex = 0;
         }
       }
     } catch (error) {
@@ -207,8 +214,14 @@ export class ByteDanceV2Controller extends ByteDanceController {
     // 注意：并行发送时，发送完成不代表结果处理完成，需要等待连接关闭
     while (true) {
       // 如果队列中有结果，立即 yield
-      while (resultQueue.length > 0) {
-        yield resultQueue.shift()!;
+      while (processedIndex < resultQueue.length) {
+        yield resultQueue[processedIndex];
+        processedIndex++;
+      }
+      // 定期清理已处理的元素（批量移除），减少内存占用
+      if (processedIndex > 0 && processedIndex >= resultQueue.length) {
+        resultQueue.splice(0, processedIndex);
+        processedIndex = 0;
       }
 
       // 如果连接已关闭，退出

--- a/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
+++ b/packages/asr/src/platforms/bytedance/controllers/ByteDanceV3Controller.ts
@@ -33,6 +33,7 @@ export class ByteDanceV3Controller extends ByteDanceController {
 
     // 设置结果事件处理
     const resultQueue: ListenResult[] = [];
+    let processedIndex = 0; // 使用索引追踪已处理位置，替代 shift() 的 O(n) 性能开销
     let resolveNext: (() => void) | null = null;
     let settled = false;
     let endCalled = false;
@@ -170,8 +171,14 @@ export class ByteDanceV3Controller extends ByteDanceController {
           });
 
         // 发送帧后立即检查并 yield 可用的结果（不等待帧发送完成）
-        while (resultQueue.length > 0) {
-          yield resultQueue.shift()!;
+        while (processedIndex < resultQueue.length) {
+          yield resultQueue[processedIndex];
+          processedIndex++;
+        }
+        // 定期清理已处理的元素（批量移除），减少内存占用
+        if (processedIndex > 0 && processedIndex >= resultQueue.length) {
+          resultQueue.splice(0, processedIndex);
+          processedIndex = 0;
         }
       }
     } catch (error) {
@@ -208,8 +215,14 @@ export class ByteDanceV3Controller extends ByteDanceController {
     // 注意：并行发送时，发送完成不代表结果处理完成，需要等待连接关闭
     while (true) {
       // 如果队列中有结果，立即 yield
-      while (resultQueue.length > 0) {
-        yield resultQueue.shift()!;
+      while (processedIndex < resultQueue.length) {
+        yield resultQueue[processedIndex];
+        processedIndex++;
+      }
+      // 定期清理已处理的元素（批量移除），减少内存占用
+      if (processedIndex > 0 && processedIndex >= resultQueue.length) {
+        resultQueue.splice(0, processedIndex);
+        processedIndex = 0;
       }
 
       // 如果连接已关闭，退出


### PR DESCRIPTION
ByteDanceV2Controller 和 ByteDanceV3Controller 的 listenStream() 方法
使用 Array.shift() 处理 resultQueue，在高频 ASR 结果场景下会导致 O(n)
性能开销。

修改内容：
- 添加 processedIndex 变量追踪已处理位置
- 替换两处 Array.shift() 为索引访问方式
- 添加批量清理逻辑减少内存占用

性能提升：
- 单次取值从 O(n) 变为 O(1) 操作
- 批量清理使用 splice 一次性移除多个元素
- 适合流式处理场景，避免累积性能损耗

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3267