### PR TITLE
fix(backend): 修复 event-bus.service.ts 中的 any 类型

### DIFF
--- a/apps/backend/services/event-bus.service.ts
+++ b/apps/backend/services/event-bus.service.ts
@@ -14,8 +14,10 @@
 import { EventEmitter } from "node:events";
 import type { Logger } from "@/Logger.js";
 import { logger } from "@/Logger.js";
+import type { MCPServerAddResult } from "@/handlers/mcp-manage.handler.js";
 import type { ClientInfo } from "@/services/status.service.js";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { MCPServerConfig } from "@xiaozhi-client/config";
 
 /**
  * 事件类型定义
@@ -102,10 +104,14 @@ export interface EventBusEvents {
   // WebSocket 相关事件
   "websocket:client:connected": { clientId: string; timestamp: number };
   "websocket:client:disconnected": { clientId: string; timestamp: number };
-  "websocket:message:received": { type: string; data: any; clientId: string };
+  "websocket:message:received": {
+    type: string;
+    data: unknown;
+    clientId: string;
+  };
 
   // 通知相关事件
-  "notification:broadcast": { type: string; data: any; target?: string };
+  "notification:broadcast": { type: string; data: unknown; target?: string };
   "notification:error": { error: Error; type: string };
 
   // MCP服务相关事件
@@ -126,7 +132,7 @@ export interface EventBusEvents {
   };
   "mcp:server:added": {
     serverName: string;
-    config: any;
+    config: MCPServerConfig;
     tools: string[];
     timestamp: Date;
   };
@@ -160,7 +166,7 @@ export interface EventBusEvents {
     addedCount: number;
     failedCount: number;
     successfullyAddedServers: string[];
-    results: any[];
+    results: MCPServerAddResult[];
     timestamp: Date;
   };
   "mcp:server:rollback": {
@@ -217,7 +223,7 @@ export interface EventBusEvents {
     timestamp: number;
   };
   "large-data-test": {
-    data: any;
+    data: unknown;
     timestamp: number;
   };
   "destroy-test": {
@@ -237,7 +243,7 @@ export interface EventBusEvents {
     timestamp: number;
   };
   "performance-test": {
-    data: any;
+    data: unknown;
     timestamp: number;
   };
   "test:performance": {


### PR DESCRIPTION
修复了 6 处违反类型安全检查目标的 any 类型：

- websocket:message:received.data: any → unknown
- notification:broadcast.data: any → unknown
- mcp:server:added.config: any → MCPServerConfig
- mcp:server:batch_added.results: any[] → MCPServerAddResult[]
- large-data-test.data: any → unknown
- performance-test.data: any → unknown

使用 MCPServerConfig 从 @xiaozhi-client/config 导入，
MCPServerAddResult 从 handler 导入，保持类型一致性。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3273