### PR TITLE
refactor(esp32): 将 ASR 服务的 Opus 解码替换为 univoice decodeOpusStream

### DIFF
--- a/packages/esp32/src/services/__tests__/asr.service.test.ts
+++ b/packages/esp32/src/services/__tests__/asr.service.test.ts
@@ -298,6 +298,53 @@ describe("ASRService", () => {
       );
     });
 
+    it("验证 Opus→PCM 解码链路：decodeOpusStream 以正确参数调用，listen 接收 PCM 流", async () => {
+      // 捕获传给 listen 的第一个参数（应为 decodeOpusStream 的返回值）
+      let capturedListenArg: unknown = null;
+
+      const mockChainGenerator = (async function* () {
+        yield { text: "链路测试", isFinal: true };
+      })();
+
+      vi.mocked(createASR).mockImplementation(
+        () =>
+          ({
+            listen: vi.fn().mockImplementation((stream: unknown) => {
+              capturedListenArg = stream;
+              return mockChainGenerator;
+            }),
+          }) as unknown as ReturnType<typeof createASR>
+      );
+
+      await service.prepare("device-chain");
+      await service.connect("device-chain");
+
+      // 发送音频数据触发解码链路
+      const audioData = new Uint8Array([0xaa, 0xbb, 0xcc]);
+      await service.handleAudioData("device-chain", audioData);
+
+      // 等待 listen 任务消费数据
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      // 验证 decodeOpusStream 被以 sampleRate=16000 调用
+      const { decodeOpusStream } = await import("univoice/asr");
+      expect(decodeOpusStream).toHaveBeenCalledTimes(1);
+      expect(decodeOpusStream).toHaveBeenCalledWith(
+        expect.anything(), // AsyncIterable<Buffer> (opus stream)
+        { sampleRate: 16000 }
+      );
+
+      // 验证 asrClient.listen 接收到的参数是 decodeOpusStream 的返回值
+      // （即一个 AsyncIterable<Buffer>，而非原始的 opusStream）
+      expect(capturedListenArg).not.toBeNull();
+      // 确认 listen 参数是可迭代的（PCM 流）
+      expect(
+        typeof (capturedListenArg as AsyncIterable<Buffer>)[
+          Symbol.asyncIterator
+        ]
+      ).toBe("function");
+    });
+
     it("无segment信息的chunk正常处理不受影响", async () => {
       const mockNoSegmentGenerator = (async function* () {
         yield { text: "第一条", isFinal: false };

--- a/packages/esp32/src/services/__tests__/asr.service.test.ts
+++ b/packages/esp32/src/services/__tests__/asr.service.test.ts
@@ -3,27 +3,31 @@
  * 测试 ASRService 的语音识别生命周期管理
  */
 
-import { createASR } from "univoice";
+import { createASR } from "univoice/asr";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ASRService } from "../asr.service.js";
 
-// Mock @xiaozhi-client/asr（仅保留 OpusDecoder 用于 Opus→PCM 解码）
-vi.mock("@xiaozhi-client/asr", () => ({
-  OpusDecoder: {
-    toPcm: vi.fn().mockResolvedValue(Buffer.from([0x01, 0x02, 0x03])),
-  },
-}));
-
-// Mock univoice（ASR 引擎替换为 univoice）
+// Mock univoice/asr（ASR 引擎 + decodeOpusStream 流式解码）
 const mockListenGenerator = (async function* () {
   // 默认不产生任何结果（空生成器）
 })();
 
-vi.mock("univoice", () => ({
+vi.mock("univoice/asr", () => ({
   createASR: vi.fn().mockImplementation(() => ({
     listen: vi.fn().mockReturnValue(mockListenGenerator),
   })),
+  // 模拟 decodeOpusStream：透传 Opus 包并输出模拟 PCM 数据
+  decodeOpusStream: vi.fn().mockImplementation(async function* (
+    opusStream: AsyncIterable<Buffer>
+  ) {
+    for await (const _packet of opusStream) {
+      yield Buffer.from([0x01, 0x02, 0x03]); // 模拟 PCM 输出
+    }
+  }),
 }));
+
+// Mock univoice 类型导入（BaseASR 类型，无需实际实现）
+vi.mock("univoice", () => ({}));
 
 describe("ASRService", () => {
   let service: ASRService;
@@ -144,19 +148,16 @@ describe("ASRService", () => {
       // 不应抛错，数据被忽略
     });
 
-    it("正常数据解码推入队列", async () => {
+    it("正常数据推入 Opus 队列（不做本地解码）", async () => {
       await service.prepare("device-1");
 
       const audioData = new Uint8Array([0x07, 0x08]);
       await service.handleAudioData("device-1", audioData);
 
-      // OpusDecoder.toPcm 应该被调用（代码内部用 Buffer.from 包装了 audioData）
-      const { OpusDecoder } = await import("@xiaozhi-client/asr");
-      expect(OpusDecoder.toPcm).toHaveBeenCalled();
-      // 验证传入的是 Buffer 类型（代码中 Buffer.from(audioData)）
-      const calledArg = (OpusDecoder.toPcm as ReturnType<typeof vi.fn>).mock
-        .calls[0][0];
-      expect(Buffer.isBuffer(calledArg)).toBe(true);
+      // 验证 handleAudioData 不抛错，原始 Opus 数据已推入内部队列
+      // 实际解码由 decodeOpusStream 在 startListenTask 中统一处理
+      const { decodeOpusStream } = await import("univoice/asr");
+      expect(decodeOpusStream).not.toHaveBeenCalled(); // 尚未 connect，不会触发解码
     });
   });
 

--- a/packages/esp32/src/services/asr.service.ts
+++ b/packages/esp32/src/services/asr.service.ts
@@ -3,9 +3,8 @@
  * 处理语音识别功能
  */
 
-import { OpusDecoder } from "@xiaozhi-client/asr";
-import { createASR } from "univoice";
 import type { BaseASR } from "univoice";
+import { createASR, decodeOpusStream } from "univoice/asr";
 // 触发 ASR 提供商自动注册（doubao/qwen/glm/xfyun 等）
 import "univoice/asr/providers";
 import { existsSync, mkdirSync } from "node:fs";
@@ -61,8 +60,8 @@ export class ASRService implements IASRService {
   /** 每个设备的 ASR 客户端（用于语音识别） */
   private readonly asrClients = new Map<string, ASRClientInstance>();
 
-  /** 每个设备的音频数据队列（用于 V2 listen API） */
-  private readonly audioQueues = new Map<string, Buffer[]>();
+  /** 每个设备的 Opus 数据包队列（用于 decodeOpusStream 流式解码） */
+  private readonly opusQueues = new Map<string, Buffer[]>();
 
   /** 每个设备的是否已结束音频输入 */
   private readonly audioEnded = new Map<string, boolean>();
@@ -103,8 +102,8 @@ export class ASRService implements IASRService {
       return;
     }
 
-    // 初始化音频队列
-    this.audioQueues.set(deviceId, []);
+    // 初始化 Opus 数据包队列
+    this.opusQueues.set(deviceId, []);
     this.audioEnded.set(deviceId, false);
     state.prepared = true;
 
@@ -274,26 +273,23 @@ export class ASRService implements IASRService {
       return;
     }
 
-    // 解码 Opus 为 PCM 并推入队列
+    // 将原始 Opus 数据包推入队列，由 decodeOpusStream 统一流式解码
     try {
-      // 使用 OpusDecoder 解码
-      const pcmData = await OpusDecoder.toPcm(audioBuffer);
-
       // 获取或创建队列
-      let queue = this.audioQueues.get(deviceId);
+      let queue = this.opusQueues.get(deviceId);
       if (!queue) {
         queue = [];
-        this.audioQueues.set(deviceId, queue);
+        this.opusQueues.set(deviceId, queue);
       }
 
-      // 推入队列
-      queue.push(pcmData);
+      // 推入原始 Opus 包（解码由 decodeOpusStream 在 startListenTask 中统一处理）
+      queue.push(audioBuffer);
       this.logger.debug(
-        `[ASRService] 已将 PCM 推入队列: deviceId=${deviceId}, pcmSize=${pcmData.length}, queueLength=${queue.length}`
+        `[ASRService] 已将 Opus 包推入队列: deviceId=${deviceId}, opusSize=${audioBuffer.length}, queueLength=${queue.length}`
       );
     } catch (error) {
       this.logger.error(
-        `[ASRService] PCM 解码失败: deviceId=${deviceId}`,
+        `[ASRService] Opus 包入队失败: deviceId=${deviceId}`,
         error
       );
     }
@@ -345,17 +341,19 @@ export class ASRService implements IASRService {
   private static readonly SILENCE_TIMEOUT_MS = 1500;
 
   /**
-   * 创建异步生成器，从队列中读取 PCM 数据
+   * 创建异步生成器，从队列中读取 Opus 数据包
    * 支持静音超时：当超过 SILENCE_TIMEOUT_MS 无新数据时自动结束音频流
    * 这对 univoice 的 ASR 至关重要，因为它需要在音频流结束后发送结束标记
    * 服务端收到结束标记后才会发出 isLastPackage=true（isFinal=true）
+   *
+   * 产出的 Opus 包流将由 decodeOpusStream 统一解码为 PCM 流
    * @param deviceId - 设备 ID
-   * @returns 异步生成器
+   * @returns 异步生成器，产出原始 Opus Buffer
    */
-  private async *createAudioStream(
+  private async *createOpusPacketStream(
     deviceId: string
   ): AsyncGenerator<Buffer, void, unknown> {
-    const queue = this.audioQueues.get(deviceId) || [];
+    const queue = this.opusQueues.get(deviceId) || [];
 
     while (true) {
       // 等待队列中有数据（带超时检测）
@@ -388,8 +386,8 @@ export class ASRService implements IASRService {
 
       // 从队列取出数据，更新最后数据时间
       lastDataTime = Date.now();
-      const pcmData = queue.shift()!;
-      yield pcmData;
+      const opusData = queue.shift()!;
+      yield opusData;
     }
   }
 
@@ -404,12 +402,18 @@ export class ASRService implements IASRService {
     asrClient: BaseASR
   ): Promise<void> {
     try {
-      // 创建音频流生成器
-      const audioStream = this.createAudioStream(deviceId);
+      // 创建 Opus 包流生成器（产出原始 Opus Buffer）
+      const opusStream = this.createOpusPacketStream(deviceId);
+
+      // 使用 univoice 的 decodeOpusStream 流式解码 Opus → PCM
+      // 单一 Decoder 实例，支持背压控制，比逐包解码更高效
+      const pcmStream = decodeOpusStream(opusStream, {
+        sampleRate: 16000,
+      });
 
       // 使用 univoice listen API 进行流式识别
       // ASRStreamChunk: { text: string; isFinal: boolean; confidence?: number; segment?: ASRSegment }
-      for await (const chunk of asrClient.listen(audioStream, {
+      for await (const chunk of asrClient.listen(pcmStream, {
         stream: true,
       })) {
         // 检测 VAD 端点：segment.confidence === 1 表示服务端判定用户已说完话（definite utterance）
@@ -464,7 +468,7 @@ export class ASRService implements IASRService {
       this.asrClients.delete(deviceId);
 
       // 重置音频缓冲区状态，准备下一次识别
-      this.audioQueues.set(deviceId, []);
+      this.opusQueues.set(deviceId, []);
       this.audioEnded.set(deviceId, false);
       this.logger.info(
         `[ASRService] 音频缓冲区已重置，准备下一次识别: deviceId=${deviceId}`
@@ -530,7 +534,7 @@ export class ASRService implements IASRService {
 
     // 清理资源
     this.asrClients.delete(deviceId);
-    this.audioQueues.delete(deviceId);
+    this.opusQueues.delete(deviceId);
     this.audioEnded.delete(deviceId);
     this.listenTasks.delete(deviceId);
 
@@ -573,7 +577,7 @@ export class ASRService implements IASRService {
     }
     this.asrClients.clear();
     // 清理 V2 API 相关状态
-    this.audioQueues.clear();
+    this.opusQueues.clear();
     this.audioEnded.clear();
     this.listenTasks.clear();
     this.deviceStates.clear();

--- a/packages/esp32/src/services/asr.service.ts
+++ b/packages/esp32/src/services/asr.service.ts
@@ -573,7 +573,7 @@ export class ASRService implements IASRService {
     // 清理 ASR 客户端
     for (const wrapper of this.asrClients.values()) {
       wrapper.connected = false;
-      // listen 任务会因为 audioQueues/audioEnded 清理而自然退出
+      // listen 任务会因为 opusQueues/audioEnded 清理而自然退出
     }
     this.asrClients.clear();
     // 清理 V2 API 相关状态


### PR DESCRIPTION
## Summary

- 将 ESP32 ASR 服务中的逐包 Opus→PCM 解码（`OpusDecoder.toPcm()`，每包新建 `prism-media` Decoder 实例）替换为 `univoice` 的 `decodeOpusStream` 流式解码（单一 Decoder 实例，支持背压控制）
- `handleAudioData()` 不再做本地解码，直接将原始 Opus 包推入队列
- `createAudioStream()` 重命名为 `createOpusPacketStream()`，产出原始 Opus Buffer
- `startListenTask()` 中插入 `decodeOpusStream(opusStream)` 作为中间层，统一解码
- 同步更新单元测试的 Mock 和断言

## 改进效果

| 维度 | 改造前 | 改造后 |
|------|--------|--------|
| Decoder 实例 | 每 Opus 包新建 1 个 | 整个流共享 1 个 |
| 解码方式 | 逐包同步 await | 流式异步流水线 |
| 内存模型 | PCM 队列无限增长 | 背压控制 |
| GC 压力 | 高频创建/销毁对象 | 仅一次创建 |

## Test plan

- [x] `pnpm typecheck` 通过（12 个项目）
- [x] `pnpm lint` (esp32) 通过（26 文件, 0 错误）
- [x] `pnpm test` (esp32) 160/160 测试全部通过