### PR TITLE
fix(ci): 移除 npm-publish 工作流中破坏性的全局 npm 升级

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -88,7 +88,6 @@ jobs:
 
       - name: 安装依赖
         run: |
-          npm install -g npm@latest
           pnpm install --frozen-lockfile
 
       - name: 发布到 npm


### PR DESCRIPTION
## Summary
- 移除 `npm install -g npm@latest` 命令，该命令会全局升级 npm 并破坏其内部模块依赖（`promise-retry`），导致 CI 安装依赖步骤失败（`MODULE_NOT_FOUND`）
- Node.js 版本已通过 `.nvmrc` + `setup-node` 管理，pnpm 版本已通过 `pnpm/action-setup` 固定，无需额外升级 npm

## Test plan
- [ ] 合并后触发 npm-publish workflow 验证发布流程正常完成