### PR TITLE
fix(ci): 统一 npm-publish 工作流 YAML 引号风格并固定 Node.js 版本

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -5,14 +5,14 @@ name: NPM Publish
 on:
   push:
     tags:
-      - 'v*.*.*'           # 正式版：v1.0.0, v2.1.3 等
-      - 'v*.*.*-*'         # 预发布版：v1.0.0-beta.0, v1.0.0-rc.1 等
-  workflow_dispatch:       # 手动触发作为备用
+      - "v*.*.*" # 正式版：v1.0.0, v2.1.3 等
+      - "v*.*.*-*" # 预发布版：v1.0.0-beta.0, v1.0.0-rc.1 等
+  workflow_dispatch: # 手动触发作为备用
     inputs:
       dry_run:
-        description: '预演模式（不实际发布）'
+        description: "预演模式（不实际发布）"
         required: false
-        default: 'false'
+        default: "false"
         type: boolean
 
 permissions:
@@ -82,7 +82,7 @@ jobs:
       - name: 设置 Node.js
         uses: actions/setup-node@v4
         with:
-          node-version-file: ".nvmrc"
+          node-version: "22"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- 统一 npm-publish 工作流中所有 YAML 字符串使用双引号，保持风格一致
- 将 `node-version-file: ".nvmrc"` 改为直接指定 `node-version: "22"`
- 与项目"统一 Node.js 版本为 22"（#3283）的决策保持一致

## Test plan
- [ ] 确认 YAML 语法正确无误
- [ ] 通过 tag 触发发布流程验证工作流正常运行