### PR TITLE
fix(ci): 统一所有工作流从 .nvmrc 获取 Node.js 版本

### DIFF
--- a/.github/workflows/auto-claude-comment.yml
+++ b/.github/workflows/auto-claude-comment.yml
@@ -49,7 +49,7 @@ jobs:
         if: github.event_name != 'schedule' || steps.check_time.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: 安装依赖

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        node-version: ['22.x']
 
     steps:
     - name: 检出代码
@@ -35,7 +34,7 @@ jobs:
     - name: 设置 Node.js
       uses: actions/setup-node@v4
       with:
-        node-version: ${{ matrix.node-version }}
+        node-version-file: ".nvmrc"
         cache: 'pnpm'
 
     - name: 安装依赖
@@ -84,14 +83,14 @@ jobs:
     # 上传覆盖率（仅 Ubuntu + Node 22.x）
     - name: 上传覆盖率报告
       uses: codecov/codecov-action@v4
-      if: matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
+      if: matrix.os == 'ubuntu-latest'
       with:
         token: ${{ secrets.CODECOV_TOKEN }}
         files: |
           ./coverage/lcov.info
           ./apps/frontend/coverage/lcov.info
         flags: unittests
-        name: codecov-${{ matrix.os }}-node${{ matrix.node-version }}
+        name: codecov-${{ matrix.os }}
         fail_ci_if_error: true
         verbose: true
 
@@ -124,9 +123,9 @@ jobs:
     # 上传构建产物
     - name: 上传覆盖率报告
       uses: actions/upload-artifact@v4
-      if: always() && matrix.os == 'ubuntu-latest' && matrix.node-version == '22.x'
+      if: always() && matrix.os == 'ubuntu-latest'
       with:
-        name: coverage-report-${{ matrix.os }}-node${{ matrix.node-version }}
+        name: coverage-report-${{ matrix.os }}
         path: |
           coverage/
           apps/frontend/coverage/
@@ -136,7 +135,7 @@ jobs:
       uses: actions/upload-artifact@v4
       if: success()
       with:
-        name: build-artifacts-${{ matrix.os }}-node${{ matrix.node-version }}
+        name: build-artifacts-${{ matrix.os }}
         path: |
           dist/
         retention-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         retry_on: error
         command: pnpm run test:coverage
 
-    # 上传覆盖率（仅 Ubuntu + Node 22.x）
+    # 上传覆盖率（仅 Ubuntu，Node 版本由 .nvmrc 决定）
     - name: 上传覆盖率报告
       uses: codecov/codecov-action@v4
       if: matrix.os == 'ubuntu-latest'

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -51,7 +51,7 @@ jobs:
       - name: 设置 Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: 安装依赖

--- a/.github/workflows/create-pr.yml
+++ b/.github/workflows/create-pr.yml
@@ -32,7 +32,7 @@ jobs:
       - name: 设置 Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
 
       - name: 安装依赖

--- a/.github/workflows/issue-hunter.yml
+++ b/.github/workflows/issue-hunter.yml
@@ -60,7 +60,7 @@ jobs:
         if: github.event_name != 'schedule' || steps.check_time.outputs.should_run == 'true'
         uses: actions/setup-node@v4
         with:
-          node-version: '22'
+          node-version-file: ".nvmrc"
           cache: 'pnpm'
 
       - name: 安装依赖

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -82,7 +82,7 @@ jobs:
       - name: 设置 Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
           registry-url: "https://registry.npmjs.org"
 


### PR DESCRIPTION
## Summary
- 将 6 个工作流中硬编码的 `node-version` 统一替换为 `node-version-file: ".nvmrc"`
- 移除 `ci.yml` 中不必要的 `node-version` 矩阵维度，清理相关 artifact 名称引用
- 确保所有工作流的 Node.js 版本管理统一从 `.nvmrc` 单一来源获取

## Test plan
- [ ] 检查 YAML 语法正确性（无缩进错误）
- [ ] 确认无残留硬编码 `node-version`
- [ ] CI 工作流运行验证