### PR TITLE
refactor(frontend): 提取 MCP 配置编辑器的共享代码，消除重复

### DIFF
--- a/apps/frontend/src/components/add-mcp-server-button.test.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.test.tsx
@@ -48,7 +48,7 @@ vi.mock("@/stores/config", () => ({
  * 切换到高级模式（JSON 输入）
  */
 async function switchToAdvancedMode() {
-  const advancedTab = screen.getByRole("tab", { name: "高级模式" });
+  const advancedTab = screen.getByRole("tab", { name: /高级模式/ });
   await userEvent.click(advancedTab);
 
   // 等待 JSON textarea 出现

--- a/apps/frontend/src/components/add-mcp-server-button.tsx
+++ b/apps/frontend/src/components/add-mcp-server-button.tsx
@@ -1,51 +1,27 @@
-import { McpServerForm } from "@/components/mcp-server-form";
+import { MCPConfigEditor } from "@/components/mcp-config-editor";
 import { Button } from "@/components/ui/button";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@/components/ui/form";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 import { mcpFormSchema } from "@/schemas/mcp-form";
 import { apiClient } from "@/services/api";
-import {
-  formToApiConfig,
-  formToJson,
-  jsonToFormData,
-} from "@/utils/mcpFormConverter";
+import { formToApiConfig } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { PlusIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
+import type { z } from "zod";
 
 export function AddMcpServerButton() {
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [inputMode, setInputMode] = useState<"form" | "json">("form");
-  const [jsonInput, setJsonInput] = useState<string>("");
 
   // 表单模式的表单实例
   const form = useForm<z.infer<typeof mcpFormSchema>>({
@@ -58,55 +34,13 @@ export function AddMcpServerButton() {
     },
   });
 
-  // 高级模式的表单实例（保持原有验证逻辑）
-  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
-    resolver: zodResolver(jsonFormSchema),
-    defaultValues: {
-      config: "",
-    },
-  });
-
-  // 当弹窗关闭时重置状态
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      if (!newOpen) {
-        // 重置表单和状态
-        form.reset();
-        advancedForm.reset();
-        setJsonInput("");
-        setInputMode("form");
-      }
-      setOpen(newOpen);
-    },
-    [form, advancedForm]
-  );
-
-  // 处理模式切换
-  const handleModeChange = useCallback(
-    (newMode: string) => {
-      if (newMode !== "form" && newMode !== "json") {
-        return; // 忽略无效值
-      }
-
-      if (newMode === "json" && inputMode === "form") {
-        // 表单 → JSON
-        const formValues = form.getValues();
-        try {
-          setJsonInput(formToJson(formValues));
-        } catch {
-          setJsonInput("");
-        }
-      } else if (newMode === "form" && inputMode === "json") {
-        // JSON → 表单
-        const formData = jsonToFormData(jsonInput);
-        if (formData) {
-          form.reset(formData);
-        }
-      }
-      setInputMode(newMode);
-    },
-    [inputMode, form, jsonInput]
-  );
+  // 默认表单值（用于重置）
+  const defaultFormValues: z.infer<typeof mcpFormSchema> = {
+    type: "stdio",
+    name: "",
+    command: "",
+    env: "",
+  };
 
   // 表单模式提交处理
   const handleFormSubmit = useCallback(
@@ -145,61 +79,77 @@ export function AddMcpServerButton() {
   );
 
   // 高级模式提交处理
-  const handleAdvancedSubmit = useCallback(
-    async (values: z.infer<typeof jsonFormSchema>) => {
-      setIsLoading(true);
-      try {
-        // 验证用户输入的配置
-        const validation = validateMCPConfig(values.config);
+  const handleJsonSubmit = useCallback(async (values: { config: string }) => {
+    setIsLoading(true);
+    try {
+      // 验证用户输入的配置
+      const validation = validateMCPConfig(values.config);
 
-        if (!validation.success) {
-          toast.error(validation.error || "配置验证失败");
-          return;
-        }
-
-        const parsedServers = validation.data!;
-
-        // 检查重名
-        const existingServers = await apiClient.listMCPServers();
-        const existingNames = Object.keys(parsedServers).filter((name) =>
-          existingServers.servers.some((server) => server.name === name)
-        );
-        if (existingNames.length > 0) {
-          toast.error(
-            `服务名称冲突: 以下服务已存在: ${existingNames.join(", ")}`
-          );
-          return;
-        }
-
-        // 调用API添加服务器
-        for (const [serverName, serverConfig] of Object.entries(
-          parsedServers
-        )) {
-          const result = await apiClient.addMCPServer(serverName, serverConfig);
-          if (!result) {
-            throw new Error("添加服务器失败");
-          }
-        }
-
-        // 成功反馈
-        const addedCount = Object.keys(parsedServers).length;
-        toast.success(
-          addedCount === 1
-            ? `已添加 MCP 服务 "${Object.keys(parsedServers)[0]}"`
-            : `已添加 ${addedCount} 个 MCP 服务`
-        );
-
-        // 重置表单并关闭对话框
-        advancedForm.reset();
-        setOpen(false);
-      } catch (error) {
-        console.error("更新配置失败:", error);
-        toast.error(error instanceof Error ? error.message : "更新配置失败");
-      } finally {
-        setIsLoading(false);
+      if (!validation.success) {
+        toast.error(validation.error || "配置验证失败");
+        return;
       }
+
+      const parsedServers = validation.data!;
+
+      // 检查重名
+      const existingServers = await apiClient.listMCPServers();
+      const existingNames = Object.keys(parsedServers).filter((name) =>
+        existingServers.servers.some((server) => server.name === name)
+      );
+      if (existingNames.length > 0) {
+        toast.error(
+          `服务名称冲突: 以下服务已存在: ${existingNames.join(", ")}`
+        );
+        return;
+      }
+
+      // 调用API添加服务器
+      for (const [serverName, serverConfig] of Object.entries(parsedServers)) {
+        const result = await apiClient.addMCPServer(serverName, serverConfig);
+        if (!result) {
+          throw new Error("添加服务器失败");
+        }
+      }
+
+      // 成功反馈
+      const addedCount = Object.keys(parsedServers).length;
+      toast.success(
+        addedCount === 1
+          ? `已添加 MCP 服务 "${Object.keys(parsedServers)[0]}"`
+          : `已添加 ${addedCount} 个 MCP 服务`
+      );
+
+      // 重置表单并关闭对话框
+      setOpen(false);
+    } catch (error) {
+      console.error("更新配置失败:", error);
+      toast.error(error instanceof Error ? error.message : "更新配置失败");
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  // 使用 MCPConfigEditor 组件
+  const editor = MCPConfigEditor({
+    form,
+    defaultValues: defaultFormValues,
+    onFormSubmit: handleFormSubmit,
+    onJsonSubmit: handleJsonSubmit,
+    disabled: isLoading,
+    isLoading,
+    submitText: "保存配置",
+  });
+
+  // 当弹窗关闭时重置状态
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        editor.resetState();
+      }
+      setOpen(newOpen);
     },
-    [advancedForm]
+    [editor]
   );
 
   return (
@@ -222,92 +172,7 @@ export function AddMcpServerButton() {
         </DialogHeader>
 
         {/* 模式切换 */}
-        <Tabs value={inputMode} onValueChange={handleModeChange}>
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="form">表单模式</TabsTrigger>
-            <TabsTrigger value="json">高级模式</TabsTrigger>
-          </TabsList>
-
-          {/* 表单模式 */}
-          <TabsContent value="form" className="mt-4">
-            <McpServerForm
-              form={form}
-              onSubmit={handleFormSubmit}
-              disabled={isLoading}
-              submitText={isLoading ? "保存中..." : "保存配置"}
-            />
-          </TabsContent>
-
-          {/* 高级模式 */}
-          <TabsContent value="json" className="mt-4">
-            <Form {...advancedForm}>
-              <form onSubmit={advancedForm.handleSubmit(handleAdvancedSubmit)}>
-                <div className="grid gap-4">
-                  <FormField
-                    control={advancedForm.control}
-                    name="config"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormControl>
-                          <Textarea
-                            className="resize-none h-[300px] font-mono text-sm"
-                            disabled={isLoading}
-                            placeholder={`支持三种通信方式：
-
-1. 本地进程 (stdio):
-{
-  "mcpServers": {
-    "local-server": {
-      "command": "npx",
-      "args": ["-y", "@example/mcp-server"]
-    }
-  }
-}
-
-2. 服务器推送 (SSE):
-{
-  "mcpServers": {
-    "sse-server": {
-      "type": "sse",
-      "url": "https://example.com/sse"
-    }
-  }
-}
-
-3. 流式 HTTP:
-{
-  "mcpServers": {
-    "http-server": {
-      "url": "https://example.com/mcp"
-    }
-  }
-}`}
-                            {...field}
-                            onChange={(event) => {
-                              field.onChange(event);
-                              setJsonInput(event.target.value);
-                            }}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <DialogFooter className="mt-4">
-                  <DialogClose asChild>
-                    <Button variant="outline" disabled={isLoading}>
-                      取消
-                    </Button>
-                  </DialogClose>
-                  <Button type="submit" disabled={isLoading}>
-                    {isLoading ? "保存中..." : "保存"}
-                  </Button>
-                </DialogFooter>
-              </form>
-            </Form>
-          </TabsContent>
-        </Tabs>
+        {editor.renderTabs()}
       </DialogContent>
     </Dialog>
   );

--- a/apps/frontend/src/components/mcp-config-editor.tsx
+++ b/apps/frontend/src/components/mcp-config-editor.tsx
@@ -1,0 +1,181 @@
+/**
+ * MCP 配置编辑器组件
+ * 用于添加和编辑 MCP 服务配置，支持表单模式和高级模式
+ */
+
+import { McpServerForm } from "@/components/mcp-server-form";
+import { Button } from "@/components/ui/button";
+import { DialogClose, DialogFooter } from "@/components/ui/dialog";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormMessage,
+} from "@/components/ui/form";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Textarea } from "@/components/ui/textarea";
+import { MCP_CONFIG_PLACEHOLDER_TEXT } from "@/constants/mcp-config-examples";
+import type { mcpFormSchema } from "@/schemas/mcp-form";
+import { formToJson, jsonToFormData } from "@/utils/mcpFormConverter";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useCallback, useState } from "react";
+import { type UseFormReturn, useForm } from "react-hook-form";
+import { z } from "zod";
+
+// 高级模式的 JSON 表单 schema
+const jsonFormSchema = z.object({
+  config: z.string().min(2, {
+    message: "配置不能为空",
+  }),
+});
+
+interface MCPConfigEditorProps {
+  /** 表单实例（表单模式） */
+  form: UseFormReturn<z.infer<typeof mcpFormSchema>>;
+  /** 表单默认值（用于重置） */
+  defaultValues?: z.infer<typeof mcpFormSchema>;
+  /** 表单模式提交回调 */
+  onFormSubmit: (values: z.infer<typeof mcpFormSchema>) => Promise<void>;
+  /** 高级模式提交回调 */
+  onJsonSubmit: (values: z.infer<typeof jsonFormSchema>) => Promise<void>;
+  /** 是否禁用表单 */
+  disabled?: boolean;
+  /** 是否正在加载 */
+  isLoading?: boolean;
+  /** 提交按钮文本 */
+  submitText?: string;
+  /** 初始 JSON 配置（用于编辑模式） */
+  initialJsonConfig?: string;
+}
+
+export function MCPConfigEditor({
+  form,
+  defaultValues,
+  onFormSubmit,
+  onJsonSubmit,
+  disabled = false,
+  isLoading = false,
+  submitText = "保存",
+  initialJsonConfig = "",
+}: MCPConfigEditorProps) {
+  const [inputMode, setInputMode] = useState<"form" | "json">("form");
+  const [jsonInput, setJsonInput] = useState<string>(initialJsonConfig);
+
+  // 高级模式的表单实例
+  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
+    resolver: zodResolver(jsonFormSchema),
+    defaultValues: {
+      config: initialJsonConfig,
+    },
+  });
+
+  // 处理模式切换
+  const handleModeChange = useCallback(
+    (newMode: string) => {
+      if (newMode !== "form" && newMode !== "json") {
+        return; // 忽略无效值
+      }
+
+      if (newMode === "json" && inputMode === "form") {
+        // 表单 → JSON
+        const formValues = form.getValues();
+        try {
+          const jsonStr = formToJson(formValues);
+          setJsonInput(jsonStr);
+          advancedForm.setValue("config", jsonStr);
+        } catch {
+          setJsonInput("");
+        }
+      } else if (newMode === "form" && inputMode === "json") {
+        // JSON → 表单
+        const formData = jsonToFormData(jsonInput);
+        if (formData) {
+          form.reset(formData);
+        }
+      }
+      setInputMode(newMode);
+    },
+    [inputMode, form, jsonInput, advancedForm]
+  );
+
+  // 重置编辑器状态
+  const resetState = useCallback(() => {
+    form.reset(defaultValues);
+    advancedForm.reset();
+    setJsonInput(initialJsonConfig);
+    setInputMode("form");
+  }, [form, advancedForm, defaultValues, initialJsonConfig]);
+
+  return {
+    // 状态和重置方法
+    inputMode,
+    resetState,
+    // 模式切换处理
+    handleModeChange,
+    // 渲染方法
+    renderTabs: () => (
+      <Tabs value={inputMode} onValueChange={handleModeChange}>
+        <TabsList className="grid w-full grid-cols-2">
+          <TabsTrigger value="form">表单模式</TabsTrigger>
+          <TabsTrigger value="json">高级模式 (JSON)</TabsTrigger>
+        </TabsList>
+
+        {/* 表单模式 */}
+        <TabsContent value="form" className="mt-4">
+          <McpServerForm
+            form={form}
+            defaultValues={defaultValues}
+            onSubmit={onFormSubmit}
+            disabled={disabled}
+            submitText={isLoading ? "保存中..." : submitText}
+          />
+        </TabsContent>
+
+        {/* 高级模式 */}
+        <TabsContent value="json" className="mt-4">
+          <Form {...advancedForm}>
+            <form onSubmit={advancedForm.handleSubmit(onJsonSubmit)}>
+              <div className="grid gap-4">
+                <FormField
+                  control={advancedForm.control}
+                  name="config"
+                  render={({ field }) => (
+                    <FormItem>
+                      <FormControl>
+                        <Textarea
+                          className="resize-none h-[300px] font-mono text-sm"
+                          disabled={isLoading}
+                          placeholder={MCP_CONFIG_PLACEHOLDER_TEXT}
+                          {...field}
+                          onChange={(event) => {
+                            field.onChange(event);
+                            setJsonInput(event.target.value);
+                          }}
+                        />
+                      </FormControl>
+                      <FormMessage />
+                    </FormItem>
+                  )}
+                />
+              </div>
+              <DialogFooter className="mt-4">
+                <DialogClose asChild>
+                  <Button variant="outline" disabled={isLoading}>
+                    取消
+                  </Button>
+                </DialogClose>
+                <Button type="submit" disabled={isLoading}>
+                  {isLoading ? "保存中..." : "保存"}
+                </Button>
+              </DialogFooter>
+            </form>
+          </Form>
+        </TabsContent>
+      </Tabs>
+    ),
+  };
+}
+
+// 导出 jsonFormSchema 供外部使用（如果需要）
+export { jsonFormSchema };

--- a/apps/frontend/src/components/mcp-server-setting-button.tsx
+++ b/apps/frontend/src/components/mcp-server-setting-button.tsx
@@ -1,33 +1,16 @@
-import { McpServerForm } from "@/components/mcp-server-form";
-import { Button } from "@/components/ui/button";
+import { MCPConfigEditor } from "@/components/mcp-config-editor";
 import {
   Dialog,
-  DialogClose,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
   DialogTrigger,
 } from "@/components/ui/dialog";
-import {
-  Form,
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from "@/components/ui/form";
-import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Textarea } from "@/components/ui/textarea";
 import { useNetworkServiceActions } from "@/providers/NetworkServiceProvider";
 import { mcpFormSchema } from "@/schemas/mcp-form";
 import { useConfig } from "@/stores/config";
-import {
-  apiConfigToForm,
-  formToApiConfig,
-  formToJson,
-  jsonToFormData,
-} from "@/utils/mcpFormConverter";
+import { apiConfigToForm, formToApiConfig } from "@/utils/mcpFormConverter";
 import { validateMCPConfig } from "@/utils/mcpValidation";
 import { zodResolver } from "@hookform/resolvers/zod";
 import type { MCPServerConfig } from "@xiaozhi-client/shared-types";
@@ -35,14 +18,7 @@ import { SettingsIcon } from "lucide-react";
 import { useCallback, useState } from "react";
 import { useForm } from "react-hook-form";
 import { toast } from "sonner";
-import z from "zod";
-
-// 高级模式的 JSON 表单 schema
-const jsonFormSchema = z.object({
-  config: z.string().min(2, {
-    message: "配置不能为空",
-  }),
-});
+import type { z } from "zod";
 
 export function McpServerSettingButton({
   mcpServer,
@@ -53,8 +29,6 @@ export function McpServerSettingButton({
 }) {
   const [open, setOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
-  const [inputMode, setInputMode] = useState<"form" | "json">("form");
-  const [jsonInput, setJsonInput] = useState<string>("");
   const config = useConfig();
   const { updateConfig } = useNetworkServiceActions();
 
@@ -67,58 +41,11 @@ export function McpServerSettingButton({
     defaultValues: defaultFormValues,
   });
 
-  // 高级模式的表单实例（保持原有验证逻辑）
-  const advancedForm = useForm<z.infer<typeof jsonFormSchema>>({
-    resolver: zodResolver(jsonFormSchema),
-    defaultValues: {
-      config: JSON.stringify(
-        { mcpServers: { [mcpServerName]: mcpServer } },
-        null,
-        2
-      ),
-    },
-  });
-
-  // 当弹窗关闭时重置状态
-  const handleOpenChange = useCallback(
-    (newOpen: boolean) => {
-      if (!newOpen) {
-        // 重置表单和状态
-        form.reset(defaultFormValues);
-        advancedForm.reset();
-        setJsonInput("");
-        setInputMode("form");
-      }
-      setOpen(newOpen);
-    },
-    [form, advancedForm, defaultFormValues]
-  );
-
-  // 处理模式切换
-  const handleModeChange = useCallback(
-    (newMode: string) => {
-      if (newMode !== "form" && newMode !== "json") {
-        return; // 忽略无效值
-      }
-
-      if (newMode === "json" && inputMode === "form") {
-        // 表单 → JSON
-        const formValues = form.getValues();
-        try {
-          setJsonInput(formToJson(formValues));
-        } catch {
-          setJsonInput("");
-        }
-      } else if (newMode === "form" && inputMode === "json") {
-        // JSON → 表单
-        const formData = jsonToFormData(jsonInput);
-        if (formData) {
-          form.reset(formData);
-        }
-      }
-      setInputMode(newMode);
-    },
-    [inputMode, form, jsonInput]
+  // 初始 JSON 配置字符串
+  const initialJsonConfig = JSON.stringify(
+    { mcpServers: { [mcpServerName]: mcpServer } },
+    null,
+    2
   );
 
   // 表单模式提交处理
@@ -174,8 +101,8 @@ export function McpServerSettingButton({
   );
 
   // 高级模式提交处理
-  const handleAdvancedSubmit = useCallback(
-    async (values: z.infer<typeof jsonFormSchema>) => {
+  const handleJsonSubmit = useCallback(
+    async (values: { config: string }) => {
       if (!config) {
         toast.error("配置数据未加载，请稍后重试");
         return;
@@ -244,6 +171,29 @@ export function McpServerSettingButton({
     [config, mcpServerName, updateConfig]
   );
 
+  // 使用 MCPConfigEditor 组件
+  const editor = MCPConfigEditor({
+    form,
+    defaultValues: defaultFormValues,
+    onFormSubmit: handleFormSubmit,
+    onJsonSubmit: handleJsonSubmit,
+    disabled: isLoading,
+    isLoading,
+    submitText: "保存",
+    initialJsonConfig,
+  });
+
+  // 当弹窗关闭时重置状态
+  const handleOpenChange = useCallback(
+    (newOpen: boolean) => {
+      if (!newOpen) {
+        editor.resetState();
+      }
+      setOpen(newOpen);
+    },
+    [editor]
+  );
+
   return (
     <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogTrigger asChild>
@@ -264,93 +214,7 @@ export function McpServerSettingButton({
         </DialogHeader>
 
         {/* 模式切换 */}
-        <Tabs value={inputMode} onValueChange={handleModeChange}>
-          <TabsList className="grid w-full grid-cols-2">
-            <TabsTrigger value="form">表单模式</TabsTrigger>
-            <TabsTrigger value="json">高级模式 (JSON)</TabsTrigger>
-          </TabsList>
-
-          {/* 表单模式 */}
-          <TabsContent value="form" className="mt-4">
-            <McpServerForm
-              form={form}
-              defaultValues={defaultFormValues}
-              onSubmit={handleFormSubmit}
-              disabled={isLoading}
-              submitText={isLoading ? "保存中..." : "保存"}
-            />
-          </TabsContent>
-
-          {/* 高级模式 */}
-          <TabsContent value="json" className="mt-4">
-            <Form {...advancedForm}>
-              <form onSubmit={advancedForm.handleSubmit(handleAdvancedSubmit)}>
-                <div className="grid gap-4">
-                  <FormField
-                    control={advancedForm.control}
-                    name="config"
-                    render={({ field }) => (
-                      <FormItem>
-                        <FormControl>
-                          <Textarea
-                            className="resize-none h-[300px] font-mono text-sm"
-                            disabled={isLoading}
-                            placeholder={`支持三种通信方式：
-
-1. 本地进程 (stdio):
-{
-  "mcpServers": {
-    "local-server": {
-      "command": "npx",
-      "args": ["-y", "@example/mcp-server"]
-    }
-  }
-}
-
-2. 服务器推送 (SSE):
-{
-  "mcpServers": {
-    "sse-server": {
-      "type": "sse",
-      "url": "https://example.com/sse"
-    }
-  }
-}
-
-3. 流式 HTTP:
-{
-  "mcpServers": {
-    "http-server": {
-      "url": "https://example.com/mcp"
-    }
-  }
-}`}
-                            {...field}
-                            onChange={(event) => {
-                              field.onChange(event);
-                              setJsonInput(event.target.value);
-                            }}
-                          />
-                        </FormControl>
-                        <FormMessage />
-                      </FormItem>
-                    )}
-                  />
-                </div>
-                <DialogFooter className="mt-4">
-                  <DialogClose asChild>
-                    <Button variant="outline" disabled={isLoading}>
-                      取消
-                    </Button>
-                  </DialogClose>
-                  <Button type="submit" disabled={isLoading}>
-                    {isLoading ? "保存中..." : "保存"}
-                  </Button>
-                </DialogFooter>
-              </form>
-            </Form>
-          </TabsContent>
-        </Tabs>
+        {editor.renderTabs()}
       </DialogContent>
     </Dialog>
   );

--- a/apps/frontend/src/constants/mcp-config-examples.ts
+++ b/apps/frontend/src/constants/mcp-config-examples.ts
@@ -1,0 +1,35 @@
+/**
+ * MCP 服务配置示例文本
+ * 用于表单高级模式的 placeholder 提示
+ */
+
+export const MCP_CONFIG_PLACEHOLDER_TEXT = `支持三种通信方式：
+
+1. 本地进程 (stdio):
+{
+  "mcpServers": {
+    "local-server": {
+      "command": "npx",
+      "args": ["-y", "@example/mcp-server"]
+    }
+  }
+}
+
+2. 服务器推送 (SSE):
+{
+  "mcpServers": {
+    "sse-server": {
+      "type": "sse",
+      "url": "https://example.com/sse"
+    }
+  }
+}
+
+3. 流式 HTTP:
+{
+  "mcpServers": {
+    "http-server": {
+      "url": "https://example.com/mcp"
+    }
+  }
+}`;


### PR DESCRIPTION
将 mcp-server-setting-button.tsx 和 add-mcp-server-button.tsx 中的
重复代码提取到共享组件 MCPConfigEditor 和常量文件中：

- 创建 MCP_CONFIG_PLACEHOLDER_TEXT 常量，提取配置示例文本
- 创建 MCPConfigEditor 组件，包含：
  - JSON 表单 schema
  - 模式切换逻辑（表单 ↔ JSON）
  - 高级模式表单结构
- 重构两个按钮组件使用共享编辑器
- 更新测试用例匹配新的 tab 名称

减少约 263 行重复代码，提高代码可维护性。

Fixes #3274

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3274