### PR TITLE
docs: 修复 service 命令格式错误

### DIFF
--- a/docs/content/reference/command.mdx
+++ b/docs/content/reference/command.mdx
@@ -9,9 +9,11 @@ description: "xiaozhi-client 命令行工具的常用命令参考。"
 | --------------------------------------------- | --------------------------- |
 | xiaozhi help                                  | 帮助信息                    |
 | xiaozhi create                                | 创建应用                    |
-| xiaozhi start                                 | 启动服务                    |
-| xiaozhi stop                                  | 停止服务                    |
-| xiaozhi status                                | 查看服务状态                |
+| xiaozhi service start                         | 启动服务                    |
+| xiaozhi service stop                          | 停止服务                    |
+| xiaozhi service status                        | 查看服务状态                |
+| xiaozhi service restart                       | 重启服务                    |
+| xiaozhi service attach                        | 连接到后台服务查看日志      |
 | xiaozhi config mcpEndpoint \<小智接入点地址\> | 设置小智接入点              |
 | xiaozhi mcp list                              | 列出所有 MCP 服务           |
 | xiaozhi mcp list --tools                      | 列出所有正在使用的 MCP 工具 |

--- a/packages/cli/src/commands/ServiceCommandHandler.ts
+++ b/packages/cli/src/commands/ServiceCommandHandler.ts
@@ -176,7 +176,7 @@ export class ServiceCommandHandler extends BaseCommandHandler {
     console.log("小智客户端已迁移到纯 HTTP 架构，请使用以下方式：\n");
 
     console.log("1. 启动 Web 服务：");
-    console.log("   xiaozhi start\n");
+    console.log("   xiaozhi service start\n");
 
     console.log("2. 在 Cursor 中配置 HTTP 端点：");
     console.log('   "mcpServers": {');


### PR DESCRIPTION
- 更新 command.mdx 中的服务命令格式
- 将 xiaozhi start/stop/status 改为 xiaozhi service start/stop/status
- 添加 service restart 和 service attach 命令说明
- 修复 ServiceCommandHandler.ts 迁移指南中的命令格式

Closes #3291

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3291