### PR TITLE
fix(esp32): 为 waitForBufferDrain 添加超时保护机制防止定时器泄漏

### DIFF
--- a/packages/esp32/src/services/tts.service.ts
+++ b/packages/esp32/src/services/tts.service.ts
@@ -217,8 +217,18 @@ export class TTSService implements ITTSService {
    */
   private waitForBufferDrain(deviceId: string): void {
     const checkInterval = 50; // 每 50ms 检查一次
+    const maxWaitTime = 5000; // 最大等待时间 5 秒
+    const startTime = Date.now();
 
     const check = (): boolean => {
+      // 超时保护
+      if (Date.now() - startTime > maxWaitTime) {
+        this.logger.warn(
+          `[TTSService] 等待缓冲区排空超时: deviceId=${deviceId}`
+        );
+        return true; // 强制结束
+      }
+
       const buffer = this.opusPacketBuffer.get(deviceId);
       const isProcessing = this.isProcessingBuffer.get(deviceId);
 
@@ -239,7 +249,7 @@ export class TTSService implements ITTSService {
       if (check()) return;
     }
 
-    // 循环检查
+    // 循环检查，带超时保护
     const intervalId = setInterval(() => {
       if (check()) {
         clearInterval(intervalId);


### PR DESCRIPTION
waitForBufferDrain 方法使用 setInterval 轮询检查缓冲区状态，
但缺少超时保护机制。如果缓冲区永远不满足条件（例如设备断开连接），
setInterval 会无限运行，导致定时器资源泄漏。

修复方案：
- 添加 maxWaitTime 常量（5000ms）作为最大等待时间
- 记录 startTime 用于计算超时
- 在 check() 函数中检查是否超时
- 超时时记录警告日志并强制结束定时器

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3296