### PR TITLE
fix(handler): mcp-tool-log handler 使用构造函数注入依赖

### DIFF
--- a/apps/backend/handlers/mcp-tool-log.handler.ts
+++ b/apps/backend/handlers/mcp-tool-log.handler.ts
@@ -85,9 +85,9 @@ const ToolCallQuerySchema = z
 export class MCPToolLogHandler extends BaseHandler {
   private toolCallLogService: ToolCallLogService;
 
-  constructor() {
+  constructor(toolCallLogService?: ToolCallLogService) {
     super();
-    this.toolCallLogService = new ToolCallLogService();
+    this.toolCallLogService = toolCallLogService ?? new ToolCallLogService();
   }
 
   /**


### PR DESCRIPTION
将 ToolCallLogService 从构造函数内部创建改为可选参数注入：
- 支持测试时注入 mock 实例
- 保持向后兼容（不传入参数时使用默认实例）
- 符合依赖注入原则，提高代码可测试性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3301