### PR TITLE
fix(cli): 使用 TemplateConfig 类型替代 any 类型提升类型安全性

### DIFF
--- a/packages/cli/src/interfaces/Service.ts
+++ b/packages/cli/src/interfaces/Service.ts
@@ -81,6 +81,18 @@ export interface DaemonManager {
 }
 
 /**
+ * 模板配置文件（template.json）结构定义
+ */
+export interface TemplateConfig {
+  /** 模板描述 */
+  description?: string;
+  /** 模板版本 */
+  version?: string;
+  /** 模板作者 */
+  author?: string;
+}
+
+/**
  * 模板信息接口
  */
 export interface TemplateInfo {

--- a/packages/cli/src/services/TemplateManager.ts
+++ b/packages/cli/src/services/TemplateManager.ts
@@ -16,6 +16,7 @@ import path from "node:path";
 import { FileError, ValidationError } from "../errors/index";
 import type {
   TemplateManager as ITemplateManager,
+  TemplateConfig,
   TemplateCreateOptions,
   TemplateInfo,
 } from "../interfaces/Service";
@@ -90,12 +91,12 @@ export class TemplateManagerImpl implements ITemplateManager {
 
       // 读取模板配置文件
       const configPath = path.join(templatePath, "template.json");
-      let config: any = {};
+      let config: TemplateConfig = {};
 
       if (FileUtils.exists(configPath)) {
         try {
           const configContent = FileUtils.readFile(configPath);
-          config = JSON.parse(configContent);
+          config = JSON.parse(configContent) as TemplateConfig;
         } catch (error) {
           console.warn(`模板配置文件解析失败: ${templateName}`);
         }


### PR DESCRIPTION
- 在 interfaces/Service.ts 中定义 TemplateConfig 接口
- 更新 TemplateManager.ts 使用 TemplateConfig 类型解析模板配置
- 移除 getTemplateInfo 方法中的 any 类型使用

修复 Issue #3305

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3305