### PR TITLE
fix(frontend): 为 fetch 操作添加网络错误处理

### DIFF
--- a/apps/frontend/src/services/api.ts
+++ b/apps/frontend/src/services/api.ts
@@ -200,22 +200,31 @@ export class ApiClient {
       },
     };
 
-    const response = await fetch(url, { ...defaultOptions, ...options });
+    try {
+      const response = await fetch(url, { ...defaultOptions, ...options });
 
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
 
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+        try {
+          const errorData: ApiErrorResponse = await response.json();
+          errorMessage = errorData.error?.message || errorMessage;
+        } catch {
+          // 如果无法解析错误响应，使用默认错误消息
+        }
+
+        throw new Error(errorMessage);
       }
 
-      throw new Error(errorMessage);
+      return response.json();
+    } catch (error) {
+      // 处理网络错误（DNS 解析失败、CORS 错误、网络断开等）
+      if (error instanceof TypeError) {
+        throw new Error("网络连接失败，无法访问服务器，请检查网络连接");
+      }
+      // 重新抛出其他类型的错误（如已处理的 HTTP 错误）
+      throw error;
     }
-
-    return response.json();
   }
 
   // ==================== 配置管理 API ====================

--- a/apps/frontend/src/services/cozeApi.ts
+++ b/apps/frontend/src/services/cozeApi.ts
@@ -68,22 +68,31 @@ export class CozeApiClient {
       },
     };
 
-    const response = await fetch(url, { ...defaultOptions, ...options });
+    try {
+      const response = await fetch(url, { ...defaultOptions, ...options });
 
-    if (!response.ok) {
-      let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
+      if (!response.ok) {
+        let errorMessage = `HTTP ${response.status}: ${response.statusText}`;
 
-      try {
-        const errorData: ApiErrorResponse = await response.json();
-        errorMessage = errorData.error?.message || errorMessage;
-      } catch {
-        // 如果无法解析错误响应，使用默认错误消息
+        try {
+          const errorData: ApiErrorResponse = await response.json();
+          errorMessage = errorData.error?.message || errorMessage;
+        } catch {
+          // 如果无法解析错误响应，使用默认错误消息
+        }
+
+        throw new Error(errorMessage);
       }
 
-      throw new Error(errorMessage);
+      return response.json();
+    } catch (error) {
+      // 处理网络错误（DNS 解析失败、CORS 错误、网络断开等）
+      if (error instanceof TypeError) {
+        throw new Error("网络连接失败，无法访问服务器，请检查网络连接");
+      }
+      // 重新抛出其他类型的错误（如已处理的 HTTP 错误）
+      throw error;
     }
-
-    return response.json();
   }
 
   /**


### PR DESCRIPTION
- 在 cozeApi.ts 和 api.ts 的 request 方法中添加 try-catch 包裹
- 捕获 TypeError 类型错误（网络连接失败、DNS 解析失败、CORS 错误等）
- 转换为友好的中文错误消息："网络连接失败，无法访问服务器，请检查网络连接"
- 保持原有 HTTP 状态错误处理逻辑不变

Fixes #3308

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3308