### PR TITLE
fix(build): 移除已迁移包的 external 配置，修复运行时找不到模块

### DIFF
--- a/apps/backend/tsup.config.ts
+++ b/apps/backend/tsup.config.ts
@@ -238,8 +238,7 @@ export default defineConfig({
     "@modelcontextprotocol/*",
     "prism-media",
     // @xiaozhi-client 内部包（运行时从 dist 读取）
-    "@xiaozhi-client/endpoint",
-    "@xiaozhi-client/mcp-core",
+    // 注意：mcp-core、config、endpoint 已迁移至 src/ 目录，通过 alias 插件内联打包，不再 external
     "@xiaozhi-client/esp32",
     "@xiaozhi-client/esp32.js",
     "univoice",


### PR DESCRIPTION
## Summary

- 修复 `node ./dist/cli/index.js start --debug` 运行时报错 `Cannot find package '@xiaozhi-client/mcp-core'`
- **根因**：`apps/backend/tsup.config.ts` 中 `@xiaozhi-client/mcp-core` 和 `@xiaozhi-client/endpoint` 同时配置为 external 和 alias 插件解析目标，esbuild 对 external 模块跳过插件解析，导致 alias 不生效
- **修复**：从 external 数组中移除这两个已迁移至 `src/` 的包，让 alias 插件在构建时将它们内联打包

## Test plan

- [x] `pnpm build` 构建成功
- [x] 验证 `dist/backend/WebServer.js` 中不再包含 `@xiaozhi-client/mcp-core` / `@xiaozhi-client/endpoint` 的 import
- [ ] `node ./dist/cli/index.js start --debug` 服务正常启动