### PR TITLE
refactor(migrate): 将 apps/backend 迁移至 src/server/ 并废弃原包

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@xiaozhi-client/backend",
   "version": "1.0.0",
+  "deprecated": "DEPRECATED: 已迁移至 src/server/。此包仅保留作为 Nx 项目配置壳。",
   "private": true,
   "type": "module",
   "scripts": {

--- a/biome.json
+++ b/biome.json
@@ -58,7 +58,12 @@
   },
   "overrides": [
     {
-      "include": ["packages/cli/**", "src/cli/**", "src/web/**"],
+      "include": [
+        "packages/cli/**",
+        "src/cli/**",
+        "src/web/**",
+        "src/server/**"
+      ],
       "linter": {
         "rules": {
           "nursery": {

--- a/src/server/Logger.ts
+++ b/src/server/Logger.ts
@@ -1,0 +1,667 @@
+/**
+ * 日志系统模块
+ *
+ * 提供统一的日志记录功能，基于 Pino 日志库实现。
+ *
+ * ## 主要特性
+ *
+ * - **多种日志级别**：支持通过日志级别值进行过滤和阈值设置，包括 trace、debug、info、warn、error、fatal
+ * - **双重输出**：支持控制台和文件双重输出，控制台输出带彩色格式化
+ * - **守护进程模式**：支持守护进程模式（仅文件输出，无控制台输出）
+ * - **结构化日志**：支持结构化日志记录，便于日志分析和查询
+ * - **自动日志轮转**：自动日志文件轮转和管理，防止日志文件过大
+ * - **高性能**：基于 Pino 的高性能异步写入，对应用性能影响极小
+ * - **错误堆栈跟踪**：完整的错误堆栈跟踪，便于问题定位
+ * - **动态日志级别**：支持动态设置日志级别，无需重启应用
+ *
+ * ## 日志级别
+ *
+ * Logger 支持以下日志级别值用于过滤和阈值设置（按严重性递增）：
+ *
+ * - `trace` (10)：最详细的日志级别
+ * - `debug` (20)：调试信息
+ * - `info` (30)：一般信息 - 提供对应的 `logger.info()` 方法
+ * - `warn` (40)：警告信息 - 提供对应的 `logger.warn()` 方法
+ * - `error` (50)：错误信息 - 提供对应的 `logger.error()` 方法
+ * - `fatal` (60)：致命错误
+ *
+ * **注意**：当前提供的记录方法包括 `info()`、`success()`、`warn()`、`error()`、`debug()` 和 `log()`。
+ * 可以通过 `setGlobalLogLevel()` 设置日志级别阈值来控制输出详细程度。
+ *
+ * ## 使用示例
+ *
+ * ### 基本使用
+ *
+ * ```typescript
+ * import { logger } from './Logger.js';
+ *
+ * // 记录信息
+ * logger.info('服务启动成功');
+ * logger.error('发生错误', error);
+ * logger.debug('调试信息', { data: 'value' });
+ * ```
+ *
+ * ### 结构化日志
+ *
+ * ```typescript
+ * // 结构化日志支持
+ * logger.info({ userId: 12345, action: 'login' }, '用户登录');
+ * logger.error({ error: err, requestId: 'abc123' }, '请求处理失败');
+ * ```
+ *
+ * ### 创建自定义 Logger 实例
+ *
+ * ```typescript
+ * import { createLogger } from './Logger.js';
+ *
+ * // 创建指定级别的 Logger
+ * const customLogger = createLogger('debug');
+ * customLogger.debug('这是一条调试日志');
+ * ```
+ *
+ * ### 动态设置日志级别
+ *
+ * ```typescript
+ * import { setGlobalLogLevel } from './Logger.js';
+ *
+ * // 设置全局日志级别
+ * setGlobalLogLevel('debug');
+ * ```
+ *
+ * ### 文件日志配置
+ *
+ * ```typescript
+ * import { logger } from './Logger.js';
+ *
+ * // 初始化日志文件
+ * logger.initLogFile('/path/to/project');
+ *
+ * // 配置日志文件管理参数
+ * logger.setLogFileOptions(10 * 1024 * 1024, 5); // 10MB，最多5个文件
+ * ```
+ *
+ * ## 与 Pino 的集成
+ *
+ * 本模块基于 [Pino](https://getpino.io/) 日志库实现，提供了以下增强：
+ *
+ * - 控制台输出的彩色格式化
+ * - 简化的 API 设计
+ * - 自动日志文件轮转
+ * - 守护进程模式支持
+ * - 结构化日志支持
+ * - 动态日志级别控制
+ *
+ * ## 守护进程模式
+ *
+ * 当环境变量 `XIAOZHI_DAEMON=true` 时，Logger 自动进入守护进程模式：
+ *
+ * - 仅输出到日志文件，不输出到控制台
+ * - 适用于后台服务运行场景
+ *
+ * **重要提示**：守护进程模式下必须先调用 `logger.initLogFile()` 初始化日志文件路径，
+ * 否则日志将被写入 `/dev/null`（等同于被丢弃）。
+ *
+ * @example
+ * ```typescript
+ * // 守护进程模式下的正确使用方式
+ * import { logger } from './Logger.js';
+ *
+ * // 1. 先初始化日志文件
+ * logger.initLogFile('/path/to/project');
+ *
+ * // 2. 再记录日志
+ * logger.info('服务启动成功');
+ * ```
+ *
+ * @module apps/backend/Logger
+ *
+ * @example
+ * ```typescript
+ * import { logger } from './Logger.js';
+ *
+ * logger.info('服务启动成功');
+ * logger.error('发生错误', error);
+ * logger.debug('调试信息', { data: 'value' });
+ * ```
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import chalk from "chalk";
+import pino from "pino";
+import type { Logger as PinoLogger } from "pino";
+import { z } from "zod";
+
+const LogLevelSchema = z.enum([
+  "fatal",
+  "error",
+  "warn",
+  "info",
+  "debug",
+  "trace",
+]);
+type Level = z.infer<typeof LogLevelSchema>;
+
+/**
+ * 格式化日期时间为 YYYY-MM-DD HH:mm:ss 格式
+ * @param date 要格式化的日期对象
+ * @returns 格式化后的日期时间字符串
+ */
+function formatDateTime(date: Date): string {
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, "0");
+  const day = String(date.getDate()).padStart(2, "0");
+  const hours = String(date.getHours()).padStart(2, "0");
+  const minutes = String(date.getMinutes()).padStart(2, "0");
+  const seconds = String(date.getSeconds()).padStart(2, "0");
+
+  return `${year}-${month}-${day} ${hours}:${minutes}:${seconds}`;
+}
+
+/**
+ * 高性能日志记录器，基于 pino 实现
+ *
+ * 特性：
+ * - 支持控制台和文件双重输出
+ * - 支持守护进程模式（仅文件输出）
+ * - 支持结构化日志记录
+ * - 自动日志文件轮转和管理
+ * - 高性能异步写入
+ * - 完整的错误堆栈跟踪
+ */
+export class Logger {
+  private logFilePath: string | null = null;
+  private pinoInstance: PinoLogger;
+  private isDaemonMode: boolean;
+  private logLevel: Level; // 新增：动态日志级别
+  private maxLogFileSize = 10 * 1024 * 1024; // 10MB 默认最大文件大小
+  private maxLogFiles = 5; // 最多保留5个日志文件
+
+  constructor(level: Level = "info") {
+    // 检查是否为守护进程模式
+    this.isDaemonMode = process.env.XIAOZHI_DAEMON === "true";
+
+    // 设置并验证日志级别
+    this.logLevel = this.validateLogLevel(level);
+
+    // 创建 pino 实例
+    this.pinoInstance = this.createPinoInstance();
+  }
+
+  /**
+   * 验证日志级别
+   * @param level 日志级别
+   * @returns 验证后的日志级别
+   */
+  private validateLogLevel(level: string): Level {
+    const normalizedLevel = level.toLowerCase();
+    const result = LogLevelSchema.safeParse(normalizedLevel);
+
+    if (result.success) {
+      return result.data;
+    }
+
+    return "info";
+  }
+
+  private createPinoInstance(): PinoLogger {
+    const streams: pino.StreamEntry[] = [];
+
+    // 控制台流 - 只在非守护进程模式下添加
+    if (!this.isDaemonMode) {
+      // 使用高性能的控制台输出流
+      const consoleStream = this.createOptimizedConsoleStream();
+      streams.push({
+        level: this.logLevel, // 修改：使用动态日志级别
+        stream: consoleStream,
+      });
+    }
+
+    // 文件流 - 如果有日志文件路径，使用高性能异步写入
+    if (this.logFilePath) {
+      streams.push({
+        level: this.logLevel, // 修改：使用动态日志级别
+        stream: pino.destination({
+          dest: this.logFilePath,
+          sync: false, // 异步写入提升性能
+          append: true,
+          mkdir: true,
+        }),
+      });
+    }
+
+    // 如果没有流，创建一个空的流避免错误
+    if (streams.length === 0) {
+      streams.push({
+        level: this.logLevel, // 修改：使用动态日志级别
+        stream: pino.destination({ dest: "/dev/null" }),
+      });
+    }
+
+    return pino(
+      {
+        level: this.logLevel, // 修改：使用动态日志级别
+        // 高性能配置
+        timestamp:
+          pino.stdTimeFunctions?.isoTime || (() => `,"time":${Date.now()}`),
+        formatters: {
+          // 优化级别格式化
+          level: (_label: string, number: number) => ({ level: number }),
+        },
+        // 禁用不必要的功能以提升性能
+        base: null, // 不包含 pid 和 hostname
+        serializers: {
+          // 优化错误序列化，在测试环境中安全处理
+          err: pino.stdSerializers?.err || ((err: any) => err),
+        },
+      },
+      pino.multistream(streams, { dedupe: true })
+    );
+  }
+
+  private createOptimizedConsoleStream() {
+    // 预编译级别映射以提升性能
+    const levelMap = new Map([
+      [20, { name: "DEBUG", color: chalk.gray }],
+      [30, { name: "INFO", color: chalk.blue }],
+      [40, { name: "WARN", color: chalk.yellow }],
+      [50, { name: "ERROR", color: chalk.red }],
+      [60, { name: "FATAL", color: chalk.red }],
+    ]);
+
+    return {
+      write: (chunk: string) => {
+        try {
+          const logObj = JSON.parse(chunk);
+          const message = this.formatConsoleMessageOptimized(logObj, levelMap);
+          // 在测试环境中安全地写入
+          this.safeWrite(`${message}\n`);
+        } catch (error) {
+          // 如果解析失败，直接输出原始内容
+          this.safeWrite(chunk);
+        }
+      },
+    };
+  }
+
+  /**
+   * 安全地写入到 stderr，在测试环境中避免错误
+   */
+  private safeWrite(content: string): void {
+    try {
+      if (process.stderr && typeof process.stderr.write === "function") {
+        process.stderr.write(content);
+      } else if (console && typeof console.error === "function") {
+        // 在测试环境中回退到 console.error
+        console.error(content.trim());
+      }
+    } catch (error) {
+      // 在极端情况下静默失败，避免测试中断
+    }
+  }
+
+  private formatConsoleMessageOptimized(
+    logObj: any,
+    levelMap: Map<number, { name: string; color: (text: string) => string }>
+  ): string {
+    const timestamp = formatDateTime(new Date());
+
+    const levelInfo = levelMap.get(logObj.level) || {
+      name: "UNKNOWN",
+      color: (text: string) => text,
+    };
+    const coloredLevel = levelInfo.color(`[${levelInfo.name}]`);
+
+    // 处理结构化日志中的 args，保持兼容性
+    let message = logObj.msg;
+    if (logObj.args && Array.isArray(logObj.args)) {
+      const argsStr = logObj.args
+        .map((arg: any) =>
+          typeof arg === "object" ? JSON.stringify(arg) : String(arg)
+        )
+        .join(" ");
+      message = `${message} ${argsStr}`;
+    }
+
+    return `[${timestamp}] ${coloredLevel} ${message}`;
+  }
+
+  /**
+   * 初始化日志文件
+   * @param projectDir 项目目录
+   */
+  initLogFile(projectDir: string): void {
+    this.logFilePath = path.join(projectDir, "xiaozhi.log");
+
+    // 检查并轮转日志文件
+    this.rotateLogFileIfNeeded();
+
+    // 确保日志文件存在
+    try {
+      if (!fs.existsSync(this.logFilePath)) {
+        fs.writeFileSync(this.logFilePath, "");
+      }
+    } catch (error) {
+      // 如果创建日志文件失败，记录警告但继续执行
+      // 允许应用在没有文件日志的情况下启动
+      console.warn(
+        `[Logger] 无法创建日志文件 ${this.logFilePath}: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      // 清除日志路径，禁用文件日志
+      this.logFilePath = null;
+    }
+
+    // 重新创建 pino 实例以包含文件流
+    this.pinoInstance = this.createPinoInstance();
+  }
+
+  /**
+   * 设置是否启用文件日志
+   * @param enable 是否启用
+   */
+  enableFileLogging(enable: boolean): void {
+    // 在 pino 实现中，文件日志的启用/禁用通过重新创建实例来实现
+    // 这里保持方法兼容性，但实际上文件日志在 initLogFile 时就已经启用
+    if (enable && this.logFilePath) {
+      // 重新创建 pino 实例以确保文件流正确配置
+      this.pinoInstance = this.createPinoInstance();
+    }
+  }
+
+  /**
+   * 记录信息级别日志
+   * @param message 日志消息
+   * @param args 额外参数
+   * @example
+   * logger.info('用户登录', 'userId', 12345);
+   * logger.info({ userId: 12345, action: 'login' }, '用户登录');
+   */
+  info(message: string, ...args: any[]): void;
+  /**
+   * 记录结构化信息级别日志
+   * @param obj 结构化日志对象
+   * @param message 可选的日志消息
+   */
+  info(obj: object, message?: string): void;
+  info(messageOrObj: string | object, ...args: any[]): void {
+    this.logInfo(messageOrObj, ...args);
+  }
+
+  /**
+   * 内部方法：记录 info 级别的日志
+   * @param messageOrObj 日志消息或对象
+   * @param args 额外参数
+   * @private
+   */
+  private logInfo(messageOrObj: string | object, ...args: any[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        this.pinoInstance.info(messageOrObj);
+      } else {
+        this.pinoInstance.info({ args }, messageOrObj);
+      }
+    } else {
+      this.pinoInstance.info(messageOrObj, args[0] || "");
+    }
+  }
+
+  success(message: string, ...args: any[]): void;
+  success(obj: object, message?: string): void;
+  success(messageOrObj: string | object, ...args: any[]): void {
+    // success 映射为 info 级别，保持 API 兼容性
+    this.logInfo(messageOrObj, ...args);
+  }
+
+  warn(message: string, ...args: any[]): void;
+  warn(obj: object, message?: string): void;
+  warn(messageOrObj: string | object, ...args: any[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        this.pinoInstance.warn(messageOrObj);
+      } else {
+        this.pinoInstance.warn({ args }, messageOrObj);
+      }
+    } else {
+      this.pinoInstance.warn(messageOrObj, args[0] || "");
+    }
+  }
+
+  error(message: string, ...args: any[]): void;
+  error(obj: object, message?: string): void;
+  error(messageOrObj: string | object, ...args: any[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        this.pinoInstance.error(messageOrObj);
+      } else {
+        // 改进错误处理 - 特殊处理 Error 对象
+        const errorArgs = args.map((arg) => {
+          if (arg instanceof Error) {
+            if (this.pinoInstance.level === "debug") return arg.message;
+            return {
+              message: arg.message,
+              stack: arg.stack,
+              name: arg.name,
+              cause: arg.cause,
+            };
+          }
+          return arg;
+        });
+        this.pinoInstance.error({ args: errorArgs }, messageOrObj);
+      }
+    } else {
+      // 结构化错误日志，自动提取错误信息
+      const enhancedObj = this.enhanceErrorObject(messageOrObj);
+      this.pinoInstance.error(enhancedObj, args[0] || "");
+    }
+  }
+
+  debug(message: string, ...args: any[]): void;
+  debug(obj: object, message?: string): void;
+  debug(messageOrObj: string | object, ...args: any[]): void {
+    if (typeof messageOrObj === "string") {
+      if (args.length === 0) {
+        this.pinoInstance.debug(messageOrObj);
+      } else {
+        this.pinoInstance.debug({ args }, messageOrObj);
+      }
+    } else {
+      this.pinoInstance.debug(messageOrObj, args[0] || "");
+    }
+  }
+
+  log(message: string, ...args: any[]): void;
+  log(obj: object, message?: string): void;
+  log(messageOrObj: string | object, ...args: any[]): void {
+    // log 方法使用 info 级别
+    this.logInfo(messageOrObj, ...args);
+  }
+
+  /**
+   * 增强错误对象，提取更多错误信息
+   */
+  private enhanceErrorObject(obj: any): any {
+    const enhanced = { ...obj };
+
+    // 遍历对象属性，查找 Error 实例
+    for (const [key, value] of Object.entries(enhanced)) {
+      if (value instanceof Error) {
+        enhanced[key] = {
+          message: value.message,
+          stack: value.stack,
+          name: value.name,
+          cause: value.cause,
+        };
+      }
+    }
+
+    return enhanced;
+  }
+
+  /**
+   * 检查并轮转日志文件（如果需要）
+   */
+  private rotateLogFileIfNeeded(): void {
+    if (!this.logFilePath || !fs.existsSync(this.logFilePath)) {
+      return;
+    }
+
+    try {
+      const stats = fs.statSync(this.logFilePath);
+      if (stats.size > this.maxLogFileSize) {
+        this.rotateLogFile();
+      }
+    } catch (error) {
+      // 忽略文件状态检查错误
+    }
+  }
+
+  /**
+   * 轮转日志文件
+   */
+  private rotateLogFile(): void {
+    if (!this.logFilePath) return;
+
+    try {
+      const logDir = path.dirname(this.logFilePath);
+      const logName = path.basename(this.logFilePath, ".log");
+
+      // 移动现有的编号日志文件
+      for (let i = this.maxLogFiles - 1; i >= 1; i--) {
+        const oldFile = path.join(logDir, `${logName}.${i}.log`);
+        const newFile = path.join(logDir, `${logName}.${i + 1}.log`);
+
+        if (fs.existsSync(oldFile)) {
+          if (i === this.maxLogFiles - 1) {
+            // 删除最老的文件
+            fs.unlinkSync(oldFile);
+          } else {
+            fs.renameSync(oldFile, newFile);
+          }
+        }
+      }
+
+      // 将当前日志文件重命名为 .1.log
+      const firstRotatedFile = path.join(logDir, `${logName}.1.log`);
+      fs.renameSync(this.logFilePath, firstRotatedFile);
+    } catch (error) {
+      // 轮转失败时忽略错误，继续使用当前文件
+    }
+  }
+
+  /**
+   * 清理旧的日志文件
+   */
+  cleanupOldLogs(): void {
+    if (!this.logFilePath) return;
+
+    try {
+      const logDir = path.dirname(this.logFilePath);
+      const logName = path.basename(this.logFilePath, ".log");
+
+      // 删除超过最大数量的日志文件
+      for (let i = this.maxLogFiles + 1; i <= this.maxLogFiles + 10; i++) {
+        const oldFile = path.join(logDir, `${logName}.${i}.log`);
+        if (fs.existsSync(oldFile)) {
+          fs.unlinkSync(oldFile);
+        }
+      }
+    } catch (error) {
+      // 忽略清理错误
+    }
+  }
+
+  /**
+   * 设置日志文件管理参数
+   */
+  setLogFileOptions(maxSize: number, maxFiles: number): void {
+    this.maxLogFileSize = maxSize;
+    this.maxLogFiles = maxFiles;
+  }
+
+  /**
+   * 关闭日志文件流
+   */
+  close(): void {
+    // pino 实例会自动处理流的关闭
+    // 这里保持方法兼容性
+  }
+
+  /**
+   * 动态设置日志级别
+   * @param level 新的日志级别
+   * @description 动态更新Logger实例的日志级别
+   */
+  setLevel(level: Level): void {
+    this.logLevel = this.validateLogLevel(level);
+
+    // 重新创建pino实例以应用新的日志级别
+    this.pinoInstance = this.createPinoInstance();
+  }
+
+  /**
+   * 获取当前日志级别
+   * @returns 当前日志级别
+   */
+  getLevel(): Level {
+    return this.logLevel;
+  }
+}
+
+// 全局Logger实例管理
+let globalLogger: Logger | null = null;
+let globalLogLevel: Level = "info"; // 全局日志级别
+
+/**
+ * 创建Logger实例
+ * @param level 日志级别，默认为全局级别
+ * @returns Logger实例
+ */
+export function createLogger(level?: Level): Logger {
+  return new Logger(level || globalLogLevel);
+}
+
+/**
+ * 获取全局Logger实例
+ * @returns 全局Logger实例
+ */
+export function getLogger(): Logger {
+  if (!globalLogger) {
+    globalLogger = new Logger(globalLogLevel); // 使用全局级别
+  }
+  return globalLogger;
+}
+
+/**
+ * 设置全局Logger实例
+ * @param logger 新的Logger实例
+ */
+export function setGlobalLogger(logger: Logger): void {
+  globalLogger = logger;
+}
+
+/**
+ * 设置全局日志级别
+ * @param level 新的日志级别
+ * @description 更新全局日志级别，并影响现有和未来的Logger实例
+ */
+export function setGlobalLogLevel(level: Level): void {
+  globalLogLevel = level;
+
+  // 如果已存在全局Logger实例，更新其级别
+  if (globalLogger) {
+    globalLogger.setLevel(level);
+  }
+}
+
+/**
+ * 获取当前全局日志级别
+ * @returns 当前日志级别
+ */
+export function getGlobalLogLevel(): Level {
+  return globalLogLevel;
+}
+
+// 导出默认实例（向后兼容）
+export const logger = getLogger();

--- a/src/server/WebServer.ts
+++ b/src/server/WebServer.ts
@@ -1,0 +1,975 @@
+/**
+ * Web 服务器
+ *
+ * 负责：
+ * - 启动和管理 HTTP/HTTPS 服务器
+ * - 注册和管理路由
+ * - 集成中间件（CORS、日志、错误处理等）
+ * - 管理 ESP32 设备 WebSocket 连接
+ * - 集成 MCP 服务和端点管理器
+ * - 生命周期管理（启动、停止、清理）
+ *
+ * @example
+ * ```typescript
+ * import { WebServer } from './WebServer';
+ *
+ * const server = new WebServer();
+ * await server.start();
+ * ```
+ */
+
+import { createServer } from "node:http";
+import type { IncomingMessage, Server, ServerResponse } from "node:http";
+import type { ServerType } from "@hono/node-server";
+import { serve } from "@hono/node-server";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Hono } from "hono";
+import { WebSocketServer } from "ws";
+import type WebSocket from "ws";
+import { normalizeServiceConfig } from "../config/index.js";
+import { configManager } from "../config/index.js";
+import type { MCPServerConfig } from "../config/index.js";
+import { EndpointManager } from "../endpoint/index.js";
+import type { SimpleConnectionStatus } from "../endpoint/index.js";
+import {
+  ESP32DeviceManager,
+  type IESP32ConfigProvider,
+} from "../esp32/index.js";
+import type { Logger } from "./Logger.js";
+import { logger } from "./Logger.js";
+import {
+  ConfigApiHandler,
+  CozeHandler,
+  ESP32Handler,
+  MCPHandler,
+  MCPRouteHandler,
+  MCPToolHandler,
+  MCPToolLogHandler,
+  ServiceApiHandler,
+  StaticFileHandler,
+  StatusApiHandler,
+  TTSApiHandler,
+  UpdateApiHandler,
+  VersionApiHandler,
+} from "./handlers/index.js";
+import { MCPServiceManager } from "./lib/mcp";
+import type { EnhancedToolInfo } from "./lib/mcp/types.js";
+import { ensureToolJSONSchema } from "./lib/mcp/types.js";
+import {
+  corsMiddleware,
+  endpointManagerMiddleware,
+  endpointsMiddleware,
+  errorHandlerMiddleware,
+  loggerMiddleware,
+  mcpServiceManagerMiddleware,
+  notFoundHandlerMiddleware,
+  responseEnhancerMiddleware,
+} from "./middlewares/index.js";
+import type { EventBus, EventBusEvents } from "./services/index.js";
+import {
+  StatusService,
+  destroyEventBus,
+  getEventBus,
+} from "./services/index.js";
+import type { AppContext } from "./types/index.js";
+import { createApp } from "./types/index.js";
+
+import { HTTP_SERVER_CONFIG } from "./constants/index.js";
+import { MCPServiceManagerNotInitializedError } from "./errors/mcp-errors.middleware.js";
+// 路由系统导入
+import {
+  type HandlerDependencies,
+  RouteManager,
+  // 导入所有路由配置
+  configRoutes,
+  cozeRoutes,
+  endpointRoutes,
+  esp32Routes,
+  mcpRoutes,
+  mcpserverRoutes,
+  miscRoutes,
+  servicesRoutes,
+  staticRoutes,
+  statusRoutes,
+  toolLogsRoutes,
+  toolsRoutes,
+  ttsRoutes,
+  updateRoutes,
+  versionRoutes,
+} from "./routes/index.js";
+
+// 统一成功响应格式
+interface ApiSuccessResponse<T = unknown> {
+  success: boolean;
+  data?: T;
+  message?: string;
+}
+
+// 小智连接状态响应格式
+interface XiaozhiConnectionStatusResponse {
+  type: "multi-endpoint" | "single-endpoint" | "none";
+  connected?: boolean;
+  endpoint?: string;
+  manager?: {
+    connectedConnections: number;
+    totalConnections: number;
+    healthCheckStats: Record<string, unknown>;
+  };
+  connections?: SimpleConnectionStatus[];
+}
+
+/**
+ * WebServer - 主控制器，协调各个服务和处理器
+ */
+export class WebServer {
+  private app: Hono<AppContext>;
+  private httpServer: ServerType | null = null;
+  private wss: WebSocketServer | null = null;
+  private logger: Logger;
+  private port: number;
+
+  // 事件总线
+  private eventBus: EventBus;
+
+  // 服务层
+  private statusService: StatusService;
+  private esp32Manager: ESP32DeviceManager;
+
+  // HTTP API 处理器
+  private configApiHandler: ConfigApiHandler;
+  private statusApiHandler: StatusApiHandler;
+  private serviceApiHandler: ServiceApiHandler;
+  private mcpToolHandler: MCPToolHandler;
+  private mcpToolLogHandler: MCPToolLogHandler;
+  private versionApiHandler: VersionApiHandler;
+  private staticFileHandler: StaticFileHandler;
+  private mcpRouteHandler: MCPRouteHandler;
+  private mcpHandler?: MCPHandler;
+  private updateApiHandler: UpdateApiHandler;
+  private cozeHandler: CozeHandler;
+  private ttsApiHandler: TTSApiHandler;
+  private esp32Handler: ESP32Handler;
+
+  // 路由系统
+  private routeManager?: RouteManager;
+
+  // 连接管理相关属性
+  private endpointManager: EndpointManager | null = null;
+  private mcpServiceManager: MCPServiceManager | null = null; // WebServer 直接管理的实例
+
+  // 事件监听器清理函数数组
+  private eventListenerUnsubscribers: Array<() => void> = [];
+
+  constructor(port?: number) {
+    // 端口配置
+    try {
+      this.port =
+        port ?? configManager.getWebUIPort() ?? HTTP_SERVER_CONFIG.DEFAULT_PORT;
+    } catch (error) {
+      // 配置读取失败时使用默认端口
+      this.port = port ?? HTTP_SERVER_CONFIG.DEFAULT_PORT;
+    }
+    this.logger = logger;
+
+    // 初始化事件总线
+    this.eventBus = getEventBus();
+
+    // 初始化服务层
+    this.statusService = new StatusService();
+
+    // 创建基于 configManager 的配置提供者
+    const esp32ConfigProvider: IESP32ConfigProvider = {
+      getASRConfig: () => configManager.getASRConfig(),
+      getTTSConfig: () => configManager.getTTSConfig(),
+      getLLMConfig: () => configManager.getLLMConfig(),
+      isLLMConfigValid: () => configManager.isLLMConfigValid(),
+    };
+
+    // 创建 ESP32 设备管理器（使用新包）
+    this.esp32Manager = new ESP32DeviceManager({
+      logger,
+      configProvider: esp32ConfigProvider,
+    });
+
+    // 初始化 HTTP API 处理器
+    this.configApiHandler = new ConfigApiHandler();
+    this.statusApiHandler = new StatusApiHandler(this.statusService);
+    this.serviceApiHandler = new ServiceApiHandler(this.statusService);
+    this.mcpToolHandler = new MCPToolHandler();
+    this.mcpToolLogHandler = new MCPToolLogHandler();
+    this.versionApiHandler = new VersionApiHandler();
+    this.staticFileHandler = new StaticFileHandler();
+    this.mcpRouteHandler = new MCPRouteHandler();
+    this.updateApiHandler = new UpdateApiHandler();
+    this.cozeHandler = new CozeHandler();
+    this.ttsApiHandler = new TTSApiHandler();
+    this.esp32Handler = new ESP32Handler(this.esp32Manager);
+
+    // MCPServerApiHandler 将在 start() 方法中初始化，因为它需要 mcpServiceManager
+
+    // 初始化 Hono 应用
+    this.app = createApp();
+    this.setupMiddleware();
+
+    // 在所有路由设置完成后，设置 404 处理
+    this.app.notFound(notFoundHandlerMiddleware);
+
+    // 监听 MCP 服务添加事件
+    this.setupMCPServerAddedListener();
+  }
+
+  /**
+   * 初始化所有连接（配置驱动）
+   */
+  private async initializeConnections(): Promise<void> {
+    try {
+      this.logger.debug("开始初始化连接...");
+
+      // 2. 初始化 MCP 服务管理器（WebServer 直接管理）
+      if (!this.mcpServiceManager) {
+        this.logger.debug("创建新的 MCPServiceManager 实例");
+        this.mcpServiceManager = new MCPServiceManager();
+        // 启动服务管理器，确保它可以正常工作
+        await this.mcpServiceManager.start();
+      } else {
+        this.logger.debug("使用现有的 MCPServiceManager 实例，跳过创建");
+      }
+
+      // 1. 读取配置
+      const config = await this.loadConfiguration();
+
+      // 2.1. 初始化 MCP 服务器 API 处理器
+      this.mcpHandler = new MCPHandler(this.mcpServiceManager, configManager);
+
+      // 3. 从配置加载 MCP 服务
+      await this.loadMCPServicesFromConfig(config.mcpServers);
+
+      // 4. 获取工具列表
+      const rawTools: EnhancedToolInfo[] = this.mcpServiceManager.getAllTools();
+      this.logger.debug(`已加载 ${rawTools.length} 个工具`);
+
+      // 5. 转换工具格式以符合 MCP SDK 要求
+      const tools: Tool[] = rawTools.map((tool) => ({
+        name: tool.name,
+        description: tool.description || "",
+        inputSchema: ensureToolJSONSchema(tool.inputSchema),
+      }));
+
+      // 6. 初始化小智接入点连接
+      await this.initializeXiaozhiConnection(config.mcpEndpoint);
+
+      this.logger.debug("所有连接初始化完成");
+    } catch (error) {
+      this.logger.error("连接初始化失败:", error);
+      // 降级模式：即使配置加载失败，也确保 MCPServiceManager 可用
+      if (!this.mcpServiceManager) {
+        this.logger.warn(
+          "配置加载失败，正在进入降级模式。在降级模式下：\n" +
+            "1. 将创建一个空配置的 MCPServiceManager 实例\n" +
+            "2. 不会加载任何 MCP 服务器或端点\n" +
+            "3. WebServer 仍然可以启动并提供基础 API 服务\n" +
+            "4. 用户需要通过 API 重新配置端点或服务器\n" +
+            "5. 建议尽快运行 'xiaozhi init' 初始化配置文件"
+        );
+        this.mcpServiceManager = new MCPServiceManager();
+        await this.mcpServiceManager.start();
+        this.logger.info("降级模式已激活，MCPServiceManager 使用空配置启动");
+      }
+    }
+  }
+
+  /**
+   * 加载配置文件
+   */
+  private async loadConfiguration(): Promise<{
+    mcpEndpoint: string | string[];
+    mcpServers: Record<string, MCPServerConfig>;
+    webUIPort: number;
+  }> {
+    if (!configManager.configExists()) {
+      throw new Error("配置文件不存在，请先运行 'xiaozhi init' 初始化配置");
+    }
+
+    // 在加载配置前，先清理无效的服务器工具配置
+    // 确保 mcpServerConfig 与 mcpServers 保持同步
+    configManager.cleanupInvalidServerToolsConfig();
+
+    const config = configManager.getConfig();
+
+    return {
+      mcpEndpoint: config.mcpEndpoint,
+      mcpServers: config.mcpServers,
+      webUIPort: config.webUI?.port ?? HTTP_SERVER_CONFIG.DEFAULT_PORT,
+    };
+  }
+
+  /**
+   * 从配置加载 MCP 服务
+   */
+  private async loadMCPServicesFromConfig(
+    mcpServers: Record<string, MCPServerConfig>
+  ): Promise<void> {
+    if (!this.mcpServiceManager) {
+      throw new Error("MCPServiceManager 未初始化");
+    }
+
+    for (const [name, config] of Object.entries(mcpServers)) {
+      this.logger.debug(`添加 MCP 服务配置: ${name}`);
+      // 使用配置适配器转换配置格式
+      const serviceConfig = normalizeServiceConfig(config);
+      this.mcpServiceManager.addServiceConfig(name, serviceConfig);
+    }
+
+    await this.mcpServiceManager.startAllServices();
+  }
+
+  /**
+   * 初始化小智接入点连接（使用新 API）
+   */
+  private async initializeXiaozhiConnection(
+    mcpEndpoint: string | string[]
+  ): Promise<void> {
+    // 处理多端点配置
+    const endpoints = Array.isArray(mcpEndpoint) ? mcpEndpoint : [mcpEndpoint];
+    const validEndpoints = endpoints.filter(
+      (ep) => ep && !ep.includes("<请填写")
+    );
+
+    // 1. 初始化连接管理器（无论是否有有效端点）
+    this.logger.debug(
+      `初始化小智接入点连接管理器，端点数量: ${validEndpoints.length}`
+    );
+
+    try {
+      // 创建连接管理器实例（总是创建）
+      if (!this.endpointManager) {
+        this.endpointManager = new EndpointManager({
+          defaultReconnectDelay: 2000,
+        });
+        // ✅ 传入 mcpServiceManager 实例
+        this.endpointManager.setMcpManager(this.mcpServiceManager!);
+        this.logger.debug("✅ 新建连接管理器实例");
+      }
+
+      this.logger.debug("✅ 连接管理器设置完成");
+
+      // 2. 只有在有有效端点时才创建并添加端点
+      if (validEndpoints.length > 0) {
+        this.logger.debug("有效端点列表:", validEndpoints);
+
+        // 直接使用 URL 字符串添加端点（新 API）
+        for (const endpointUrl of validEndpoints) {
+          this.endpointManager.addEndpoint(endpointUrl);
+          this.logger.debug(`✅ 已添加端点: ${endpointUrl}`);
+        }
+
+        // 连接所有端点
+        await this.endpointManager.connect();
+
+        // 设置端点添加事件监听器
+        this.endpointManager.on(
+          "endpointAdded",
+          (event: { endpoint: string }) => {
+            this.logger.debug(`端点已添加: ${event.endpoint}`);
+          }
+        );
+
+        // 设置端点移除事件监听器
+        this.endpointManager.on(
+          "endpointRemoved",
+          (event: { endpoint: string }) => {
+            this.logger.debug(`端点已移除: ${event.endpoint}`);
+          }
+        );
+
+        this.logger.debug(
+          `小智接入点连接管理器初始化完成，管理 ${validEndpoints.length} 个端点`
+        );
+      } else {
+        this.logger.debug("小智接入点连接管理器初始化完成（无端点）");
+      }
+    } catch (error) {
+      this.logger.error("小智接入点连接管理器初始化失败:", error);
+      // 抛出错误，让调用者知道初始化失败
+      throw error;
+    }
+  }
+
+  /**
+   * 设置连接管理器实例（主要用于测试依赖注入）
+   */
+  public setXiaozhiConnectionManager(manager: EndpointManager): void {
+    this.endpointManager = manager;
+  }
+
+  /**
+   * 获取小智连接管理器实例
+   * 提供给中间件使用
+   * WebServer 启动后始终返回有效的连接管理器实例
+   * @throws {Error} 如果连接管理器未初始化
+   */
+  public getEndpointManager(): EndpointManager {
+    if (!this.endpointManager) {
+      throw new Error(
+        "小智连接管理器未初始化，请确保 WebServer 已调用 start() 方法完成初始化"
+      );
+    }
+    return this.endpointManager;
+  }
+
+  /**
+   * 设置 MCP 服务管理器实例（主要用于测试依赖注入）
+   * 警告：如果要替换现有实例，调用者需要负责清理原有实例的资源
+   */
+  public setMCPServiceManager(manager: MCPServiceManager): void {
+    // 如果已有实例且它正在运行，先清理它
+    if (this.mcpServiceManager && this.mcpServiceManager !== manager) {
+      this.logger.warn(
+        "替换现有的 MCPServiceManager 实例，注意清理原有实例的资源"
+      );
+      // 注意：这里不直接调用 stopAllServices，因为调用者可能还在使用它
+      // 调用者应该负责清理原有实例
+    }
+
+    this.mcpServiceManager = manager;
+    this.logger.debug("MCPServiceManager 实例已更新");
+  }
+
+  /**
+   * 获取 MCP 服务管理器实例
+   * 提供给中间件使用
+   * WebServer 启动后始终返回有效的服务管理器实例
+   * @throws {MCPServiceManagerNotInitializedError} 如果服务管理器未初始化
+   */
+  public getMCPServiceManager(): MCPServiceManager {
+    if (!this.mcpServiceManager) {
+      throw new MCPServiceManagerNotInitializedError(
+        "MCPServiceManager 未初始化，请确保 WebServer 已调用 start() 方法完成初始化"
+      );
+    }
+    return this.mcpServiceManager;
+  }
+
+  /**
+   * 获取小智连接状态信息
+   */
+  getEndpointConnectionStatus(): XiaozhiConnectionStatusResponse {
+    if (this.endpointManager) {
+      const connectionStatuses = this.endpointManager.getConnectionStatus();
+      return {
+        type: "multi-endpoint",
+        manager: {
+          connectedConnections: connectionStatuses.filter(
+            (status: SimpleConnectionStatus) => status.connected
+          ).length,
+          totalConnections: connectionStatuses.length,
+          healthCheckStats: {}, // 简化后不再提供复杂的健康检查统计
+        },
+        connections: connectionStatuses,
+      };
+    }
+
+    return {
+      type: "none",
+      connected: false,
+    };
+  }
+
+  /**
+   * 带重试的连接方法
+   */
+  private async connectWithRetry<T>(
+    connectionFn: () => Promise<T>,
+    context: string,
+    maxAttempts = 5,
+    initialDelay = 1000,
+    maxDelay = 30000,
+    backoffMultiplier = 2
+  ): Promise<T> {
+    let lastError: Error | null = null;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      try {
+        this.logger.info(`${context} - 尝试连接 (${attempt}/${maxAttempts})`);
+        return await connectionFn();
+      } catch (error) {
+        lastError = error as Error;
+        this.logger.warn(`${context} - 连接失败:`, error);
+
+        if (attempt < maxAttempts) {
+          const delay = Math.min(
+            initialDelay * backoffMultiplier ** (attempt - 1),
+            maxDelay
+          );
+          this.logger.info(`${context} - ${delay}ms 后重试...`);
+          await this.sleep(delay);
+        }
+      }
+    }
+
+    throw new Error(
+      `${context} - 连接失败，已达到最大重试次数: ${lastError?.message}`
+    );
+  }
+
+  /**
+   * 延迟工具方法
+   */
+  private sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, ms));
+  }
+
+  private setupMiddleware() {
+    // Logger 中间件 - 必须在最前面
+    this.app?.use("*", loggerMiddleware);
+
+    // 响应增强中间件 - 在 logger 之后，其他中间件之前
+    // 这样所有路由都可以使用 c.success、c.fail、c.paginate 方法
+    this.app?.use("*", responseEnhancerMiddleware);
+
+    // 注入 WebServer 实例到上下文
+    // 使用类型断言避免循环引用问题
+    this.app?.use("*", async (c, next) => {
+      c.set(
+        "webServer",
+        this as unknown as import("./types/hono.context.js").IWebServer
+      );
+      await next();
+    });
+
+    // MCP Service Manager 中间件 - 必须在 WebServer 注入之后
+    this.app?.use("*", mcpServiceManagerMiddleware);
+
+    // 小智连接管理器中间件
+    this.app?.use("*", endpointManagerMiddleware());
+
+    // 小智接入点处理器中间件（在连接管理器中间件之后）
+    this.app?.use("*", endpointsMiddleware());
+
+    // CORS 中间件
+    this.app?.use("*", corsMiddleware);
+
+    // 错误处理中间件
+    this.app?.onError(errorHandlerMiddleware);
+
+    // 注入路由系统依赖
+    // 注意：这个中间件必须在路由注册之前设置
+    this.app?.use("*", async (c, next) => {
+      const dependencies = this.createHandlerDependencies();
+      c.set("dependencies", dependencies);
+      await next();
+    });
+  }
+
+  /**
+   * 创建处理器依赖对象
+   * 统一管理依赖对象的创建，避免代码重复
+   */
+  private createHandlerDependencies(): HandlerDependencies {
+    return {
+      configApiHandler: this.configApiHandler,
+      statusApiHandler: this.statusApiHandler,
+      serviceApiHandler: this.serviceApiHandler,
+      mcpToolHandler: this.mcpToolHandler,
+      mcpToolLogHandler: this.mcpToolLogHandler,
+      versionApiHandler: this.versionApiHandler,
+      staticFileHandler: this.staticFileHandler,
+      mcpRouteHandler: this.mcpRouteHandler,
+      mcpHandler: this.mcpHandler,
+      updateApiHandler: this.updateApiHandler,
+      cozeHandler: this.cozeHandler,
+      ttsApiHandler: this.ttsApiHandler,
+      esp32Handler: this.esp32Handler,
+      // endpointHandler 通过中间件动态注入，不在此初始化
+    };
+  }
+
+  /**
+   * 设置路由系统
+   */
+  private setupRouteSystem(): void {
+    // 初始化路由管理器，注入 Logger 实例
+    this.routeManager = new RouteManager(this.logger);
+  }
+
+  /**
+   * 从路由配置设置路由
+   */
+  private setupRoutesFromRegistry(): void {
+    if (!this.routeManager || !this.app) {
+      throw new Error("路由系统未初始化");
+    }
+
+    try {
+      // 注册所有路由配置 - static 放在最后，作为回退
+      this.routeManager.registerRoutes({
+        config: configRoutes,
+        status: statusRoutes,
+        tools: toolsRoutes,
+        mcp: mcpRoutes,
+        version: versionRoutes,
+        services: servicesRoutes,
+        update: updateRoutes,
+        coze: cozeRoutes,
+        "tool-logs": toolLogsRoutes,
+        mcpserver: mcpserverRoutes,
+        endpoint: endpointRoutes,
+        misc: miscRoutes,
+        tts: ttsRoutes,
+        esp32: esp32Routes,
+        static: staticRoutes, // 放在最后作为回退
+      });
+
+      // 应用路由到 Hono 应用
+      this.routeManager.applyToApp(this.app);
+
+      this.logger.info("路由系统注册完成");
+    } catch (error) {
+      this.logger.error("路由系统注册失败:", error);
+    }
+  }
+
+  private setupWebSocket() {
+    if (!this.wss) return;
+
+    this.wss.on("connection", (ws, req) => {
+      // 检查是否是ESP32设备连接
+      const url = req.url
+        ? new URL(req.url, `http://${req.headers.host}`)
+        : null;
+      const isESP32Device = url?.pathname === "/ws";
+
+      if (isESP32Device) {
+        // 处理ESP32设备连接
+        this.handleESP32DeviceConnection(ws, req);
+        return;
+      }
+
+      // Web 客户端 WebSocket 已移除，关闭非 ESP32 连接
+      this.logger.warn("Web 客户端 WebSocket 连接已被弃用，拒绝连接");
+      ws.close(
+        1000,
+        "Web client WebSocket is deprecated. Use HTTP API instead."
+      );
+    });
+  }
+
+  /**
+   * 处理ESP32设备WebSocket连接
+   */
+  private handleESP32DeviceConnection(
+    ws: WebSocket,
+    req: IncomingMessage
+  ): void {
+    const deviceId = req.headers["device-id"] as string;
+    const clientId = req.headers["client-id"] as string;
+    const token = req.headers.authorization as string | undefined;
+
+    // 提取Bearer token
+    const authToken = token?.replace("Bearer ", "");
+
+    this.logger.info(
+      `[WS-ESP32] 收到ESP32设备连接请求: deviceId=${deviceId}, clientId=${clientId}, url=${req.url}`
+    );
+
+    if (!deviceId || !clientId) {
+      this.logger.warn(
+        `[WS-ESP32] 连接缺少必要的请求头: device-id="${deviceId}", client-id="${clientId}"`
+      );
+      ws.close(1008, "Missing required headers");
+      return;
+    }
+
+    this.logger.info(
+      `[WS-ESP32] ESP32设备WebSocket连接: deviceId=${deviceId}, clientId=${clientId}`
+    );
+
+    // 委托给 ESP32DeviceManager 处理
+    this.esp32Manager
+      .handleWebSocketConnection(ws, deviceId, clientId, authToken)
+      .then(() => {
+        this.logger.info(
+          `[WS-ESP32] ESP32设备连接处理成功: deviceId=${deviceId}`
+        );
+      })
+      .catch((error) => {
+        this.logger.error(
+          `[WS-ESP32] ESP32设备连接处理失败: deviceId=${deviceId}`,
+          error
+        );
+        // 只有在 WebSocket 处于可关闭状态时才关闭
+        // ws.OPEN = 1, ws.CONNECTING = 0
+        if (ws.readyState === 1 || ws.readyState === 0) {
+          ws.close(1011, "Connection handling failed");
+        }
+      });
+  }
+
+  /**
+   * 设置 MCP 服务添加事件监听
+   * 当添加新的 MCP 服务后，自动重连接入点以同步服务列表
+   */
+  private setupMCPServerAddedListener(): void {
+    // 监听单个服务添加事件
+    const singleServerListener = async (
+      eventData: EventBusEvents["mcp:server:added"]
+    ) => {
+      this.logger.info(
+        `检测到 MCP 服务添加: ${eventData.serverName}，工具数量: ${eventData.tools.length}`
+      );
+
+      if (!this.endpointManager) {
+        this.logger.warn("EndpointManager 未初始化，跳过重连");
+        return;
+      }
+
+      try {
+        // 获取当前连接的端点数量
+        const connectionStatuses = this.endpointManager.getConnectionStatus();
+        const connectedEndpointCount = connectionStatuses.filter(
+          (status) => status.connected
+        ).length;
+
+        if (connectedEndpointCount === 0) {
+          this.logger.debug("当前没有已连接的端点，跳过重连");
+          return;
+        }
+
+        this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
+
+        // 重连所有端点
+        await this.endpointManager.reconnect();
+
+        this.logger.info("接入点重连成功，新服务工具已同步");
+
+        // 发送重连完成事件
+        this.eventBus.emitEvent("endpoint:reconnect:completed", {
+          trigger: "mcp_server_added",
+          serverName: eventData.serverName,
+          endpointCount: connectedEndpointCount,
+          timestamp: Date.now(),
+        });
+      } catch (error) {
+        this.logger.error("接入点重连失败:", error);
+
+        // 发送重连失败事件
+        this.eventBus.emitEvent("endpoint:reconnect:failed", {
+          trigger: "mcp_server_added",
+          serverName: eventData.serverName,
+          error: error instanceof Error ? error.message : String(error),
+          timestamp: Date.now(),
+        });
+      }
+    };
+
+    this.eventBus.onEvent("mcp:server:added", singleServerListener);
+
+    // 存储清理函数
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("mcp:server:added", singleServerListener);
+    });
+
+    // 监听批量服务添加事件
+    const batchServerListener = async (
+      eventData: EventBusEvents["mcp:server:batch_added"]
+    ) => {
+      this.logger.info(
+        `检测到批量 MCP 服务添加: ${eventData.addedCount} 个成功，${eventData.failedCount} 个失败`
+      );
+
+      if (!this.endpointManager || eventData.addedCount === 0) {
+        return;
+      }
+
+      try {
+        // 获取当前连接的端点数量
+        const connectionStatuses = this.endpointManager.getConnectionStatus();
+        const connectedEndpointCount = connectionStatuses.filter(
+          (status) => status.connected
+        ).length;
+
+        if (connectedEndpointCount === 0) {
+          this.logger.debug("当前没有已连接的端点，跳过重连");
+          return;
+        }
+
+        this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
+
+        // 重连所有端点
+        await this.endpointManager.reconnect();
+
+        this.logger.info("接入点重连成功，批量服务工具已同步");
+
+        // 发送重连完成事件
+        this.eventBus.emitEvent("endpoint:reconnect:completed", {
+          trigger: "mcp_server_batch_added",
+          serverName: undefined,
+          endpointCount: connectedEndpointCount,
+          timestamp: Date.now(),
+        });
+      } catch (error) {
+        this.logger.error("接入点重连失败:", error);
+
+        // 发送重连失败事件
+        this.eventBus.emitEvent("endpoint:reconnect:failed", {
+          trigger: "mcp_server_batch_added",
+          serverName: undefined,
+          error: error instanceof Error ? error.message : String(error),
+          timestamp: Date.now(),
+        });
+      }
+    };
+
+    this.eventBus.onEvent("mcp:server:batch_added", batchServerListener);
+
+    // 存储清理函数
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("mcp:server:batch_added", batchServerListener);
+    });
+  }
+
+  public async start(): Promise<void> {
+    // 检查服务器是否已经启动
+    if (this.httpServer) {
+      this.logger.warn("Web server is already running");
+      return;
+    }
+
+    // 1. 初始化所有连接（配置驱动）
+    // 这必须在启动服务器之前完成，确保 MCPServiceManager 可用
+    await this.initializeConnections();
+
+    // 2. 设置路由系统（在连接初始化之后）
+    this.setupRouteSystem();
+    this.setupRoutesFromRegistry();
+
+    // 3. 启动 HTTP 服务器
+    const server = serve({
+      fetch: this.app.fetch,
+      port: this.port,
+      hostname: HTTP_SERVER_CONFIG.DEFAULT_BIND_ADDRESS, // 绑定到所有网络接口，支持 Docker 部署
+      createServer,
+    });
+
+    // 保存服务器实例
+    this.httpServer = server;
+
+    // 设置 WebSocket 服务器
+    if (!this.httpServer) {
+      throw new Error("HTTP server 未初始化");
+    }
+    this.wss = new WebSocketServer({
+      server: this.httpServer as Server<
+        typeof IncomingMessage,
+        typeof ServerResponse
+      >,
+    });
+    this.setupWebSocket();
+
+    this.logger.info(
+      `Web server listening on http://${HTTP_SERVER_CONFIG.DEFAULT_BIND_ADDRESS}:${this.port}`
+    );
+    this.logger.info(`Local access: http://localhost:${this.port}`);
+  }
+
+  public stop(): Promise<void> {
+    return new Promise((resolve) => {
+      let resolved = false;
+
+      const doResolve = () => {
+        if (!resolved) {
+          resolved = true;
+          resolve();
+        }
+      };
+
+      // 清理连接管理器和 MCPServiceManager
+      (async () => {
+        try {
+          if (this.endpointManager) {
+            await this.endpointManager.cleanup();
+            this.logger.debug("连接管理器已清理");
+          }
+        } catch (error) {
+          this.logger.error("连接管理器清理失败:", error);
+        }
+
+        try {
+          if (this.mcpServiceManager) {
+            await this.mcpServiceManager.stopAllServices();
+            this.mcpServiceManager = null;
+            this.logger.debug("MCPServiceManager 已清理");
+          }
+        } catch (error) {
+          this.logger.error("MCPServiceManager 清理失败:", error);
+        }
+
+        // 强制断开所有 WebSocket 客户端连接
+        if (this.wss) {
+          for (const client of this.wss.clients) {
+            client.terminate();
+          }
+
+          // 关闭 WebSocket 服务器
+          this.wss.close(() => {
+            let forceCloseTimer: NodeJS.Timeout | undefined;
+
+            const cleanupAndResolve = () => {
+              if (forceCloseTimer) {
+                clearTimeout(forceCloseTimer);
+                forceCloseTimer = undefined;
+              }
+              doResolve();
+            };
+
+            // 强制关闭 HTTP 服务器，不等待现有连接
+            if (this.httpServer) {
+              this.httpServer.close(() => {
+                this.logger.info("Web 服务器已停止");
+                cleanupAndResolve();
+              });
+
+              // 设置超时，如果 2 秒内没有关闭则强制退出
+              forceCloseTimer = setTimeout(() => {
+                // 超时触发后标记定时器已失效，保持与 cleanupAndResolve 中的语义一致
+                forceCloseTimer = undefined;
+                this.logger.info("Web 服务器已强制停止");
+                doResolve();
+              }, 2000);
+            } else {
+              this.logger.info("Web 服务器已停止");
+              cleanupAndResolve();
+            }
+          });
+        } else {
+          this.logger.info("Web 服务器已停止");
+          doResolve();
+        }
+      })();
+    });
+  }
+
+  /**
+   * 销毁 WebServer 实例，清理所有资源
+   */
+  public destroy(): void {
+    this.logger.debug("销毁 WebServer 实例");
+
+    // 移除所有事件监听器，防止内存泄漏
+    for (const unsubscribe of this.eventListenerUnsubscribers) {
+      unsubscribe();
+    }
+    this.eventListenerUnsubscribers = [];
+    this.logger.debug("已移除所有事件总线监听器");
+
+    // 销毁服务层
+    this.statusService.destroy();
+    // 异步销毁 ESP32 设备管理器（fire and forget）
+    this.esp32Manager.destroy();
+
+    // 销毁事件总线
+    destroyEventBus();
+
+    this.logger.debug("WebServer 实例已销毁");
+  }
+}

--- a/src/server/WebServerLauncher.ts
+++ b/src/server/WebServerLauncher.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+
+/**
+ * WebServer 独立启动脚本
+ * 用于后台模式启动，替代原有的 adaptiveMCPPipe 启动方式
+ */
+
+// 动态导入避免 CLI 代码执行
+async function importModules() {
+  const webServerModule = await import("./WebServer.js");
+  const configModule = await import("../config/index.js");
+  const loggerModule = await import("./Logger.js");
+  return {
+    WebServer: webServerModule.WebServer,
+    configManager: configModule.configManager,
+    logger: loggerModule.logger,
+  };
+}
+
+async function main() {
+  const args = process.argv.slice(2);
+
+  try {
+    // 动态导入模块
+    const { WebServer, configManager, logger } = await importModules();
+
+    // 初始化日志
+    if (process.env.XIAOZHI_CONFIG_DIR) {
+      logger.initLogFile(process.env.XIAOZHI_CONFIG_DIR);
+      logger.enableFileLogging(true);
+    }
+
+    // 启动 WebServer
+    const webServer = new WebServer();
+    await webServer.start();
+
+    logger.info("[WEBSERVER_STANDALONE] WebServer 启动成功");
+
+    // 处理退出信号
+    const cleanup = async () => {
+      logger.info("[WEBSERVER_STANDALONE] 正在停止 WebServer...");
+      await webServer.stop();
+      process.exit(0);
+    };
+
+    process.once("SIGINT", cleanup);
+    process.once("SIGTERM", cleanup);
+  } catch (error) {
+    console.error("WebServer 启动失败:", error);
+    process.exit(1);
+  }
+}
+
+// 检查是否为直接执行
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}

--- a/src/server/__tests__/config-sync-integration.test.ts
+++ b/src/server/__tests__/config-sync-integration.test.ts
@@ -1,0 +1,282 @@
+/**
+ * 配置同步集成测试
+ * 验证 mcpServerConfig 与 mcpServers 的同步机制
+ */
+
+import { existsSync, readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../config/index.js";
+import { ConfigManager } from "../../config/index.js";
+
+// 模拟 fs 模块
+vi.mock("node:fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs")>();
+  return {
+    ...actual,
+    existsSync: vi.fn(),
+    readFileSync: vi.fn(),
+    writeFileSync: vi.fn(),
+    copyFileSync: vi.fn(),
+  };
+});
+
+// 模拟 path 模块
+vi.mock("node:path", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:path")>();
+  return {
+    ...actual,
+    resolve: vi.fn(),
+    dirname: vi.fn(),
+  };
+});
+
+// 模拟 url 模块
+vi.mock("node:url", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:url")>();
+  return {
+    ...actual,
+    fileURLToPath: vi.fn(),
+  };
+});
+
+// 模拟 logger
+vi.mock("../Logger", () => ({
+  logger: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  },
+}));
+
+describe("配置同步集成测试", () => {
+  let configManager: ConfigManager;
+  const mockExistsSync = vi.mocked(existsSync);
+  const mockReadFileSync = vi.mocked(readFileSync);
+  const mockWriteFileSync = vi.mocked(writeFileSync);
+  const mockResolve = vi.mocked(resolve);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 重置单例实例
+    // @ts-ignore - accessing private static property for testing
+    ConfigManager.instance = undefined;
+
+    configManager = ConfigManager.getInstance();
+
+    // 设置默认模拟
+    mockResolve.mockImplementation(
+      (dir: string, file: string) => `${dir}/${file}`
+    );
+
+    // Mock process.cwd and process.env
+    vi.stubGlobal("process", {
+      ...process,
+      cwd: vi.fn().mockReturnValue("/test/cwd"),
+      env: { ...process.env },
+    });
+
+    mockExistsSync.mockImplementation((path) => {
+      if (path.toString().includes("xiaozhi.config.json5")) return false;
+      if (path.toString().includes("xiaozhi.config.jsonc")) return false;
+      if (path.toString().includes("xiaozhi.config.json")) return true;
+      return false;
+    });
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it("应该在启动时清理无效的服务器工具配置", () => {
+    // 模拟配置文件内容：mcpServers 中只有 calculator，但 mcpServerConfig 中有多个服务
+    const configWithInvalidServers: AppConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        calculator: {
+          command: "node",
+          args: ["./mcpServers/calculator.js"],
+        },
+        // 注意：datetime 服务已被用户删除
+      },
+      mcpServerConfig: {
+        calculator: {
+          tools: {
+            add: {
+              description: "Add two numbers",
+              enable: true,
+            },
+            subtract: {
+              description: "Subtract two numbers",
+              enable: true,
+            },
+          },
+        },
+        datetime: {
+          // 这个配置应该被清理，因为 datetime 服务不在 mcpServers 中
+          tools: {
+            getCurrentTime: {
+              description: "Get current time",
+              enable: true,
+            },
+            formatDate: {
+              description: "Format date",
+              enable: false,
+            },
+          },
+        },
+        "removed-service": {
+          // 这个配置也应该被清理
+          tools: {
+            someOldTool: {
+              description: "Some old tool",
+              enable: true,
+            },
+          },
+        },
+      },
+    };
+
+    mockReadFileSync.mockReturnValue(JSON.stringify(configWithInvalidServers));
+
+    // 调用清理方法
+    configManager.cleanupInvalidServerToolsConfig();
+
+    // 验证 writeFileSync 被调用
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    // 验证保存的配置只包含有效的服务器配置
+    const savedConfig = JSON.parse(
+      mockWriteFileSync.mock.calls[0][1] as string
+    );
+
+    expect(savedConfig.mcpServerConfig).toEqual({
+      calculator: {
+        tools: {
+          add: {
+            description: "Add two numbers",
+            enable: true,
+          },
+          subtract: {
+            description: "Subtract two numbers",
+            enable: true,
+          },
+        },
+      },
+    });
+
+    // 验证无效的服务器配置被删除
+    expect(savedConfig.mcpServerConfig).not.toHaveProperty("datetime");
+    expect(savedConfig.mcpServerConfig).not.toHaveProperty("removed-service");
+  });
+
+  it("应该在没有无效配置时不修改文件", () => {
+    // 模拟配置文件内容：mcpServerConfig 与 mcpServers 完全匹配
+    const validConfig: AppConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        calculator: {
+          command: "node",
+          args: ["./mcpServers/calculator.js"],
+        },
+        datetime: {
+          command: "node",
+          args: ["./mcpServers/datetime.js"],
+        },
+      },
+      mcpServerConfig: {
+        calculator: {
+          tools: {
+            add: {
+              description: "Add two numbers",
+              enable: true,
+            },
+          },
+        },
+        datetime: {
+          tools: {
+            getCurrentTime: {
+              description: "Get current time",
+              enable: true,
+            },
+          },
+        },
+      },
+    };
+
+    mockReadFileSync.mockReturnValue(JSON.stringify(validConfig));
+
+    // 调用清理方法
+    configManager.cleanupInvalidServerToolsConfig();
+
+    // 验证 writeFileSync 没有被调用，因为没有需要清理的配置
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+
+  it("应该处理完全清空的情况", () => {
+    // 模拟配置文件内容：mcpServers 为空，但 mcpServerConfig 中有配置
+    const configWithEmptyServers: AppConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {}, // 用户删除了所有服务
+      mcpServerConfig: {
+        calculator: {
+          tools: {
+            add: {
+              description: "Add two numbers",
+              enable: true,
+            },
+          },
+        },
+        datetime: {
+          tools: {
+            getCurrentTime: {
+              description: "Get current time",
+              enable: true,
+            },
+          },
+        },
+      },
+    };
+
+    mockReadFileSync.mockReturnValue(JSON.stringify(configWithEmptyServers));
+
+    // 调用清理方法
+    configManager.cleanupInvalidServerToolsConfig();
+
+    // 验证 writeFileSync 被调用
+    expect(mockWriteFileSync).toHaveBeenCalledTimes(1);
+
+    // 验证保存的配置中 mcpServerConfig 为空
+    const savedConfig = JSON.parse(
+      mockWriteFileSync.mock.calls[0][1] as string
+    );
+
+    expect(savedConfig.mcpServerConfig).toEqual({});
+  });
+
+  it("应该在 mcpServerConfig 不存在时不执行任何操作", () => {
+    // 模拟配置文件内容：没有 mcpServerConfig 字段
+    const configWithoutServerConfig: AppConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        calculator: {
+          command: "node",
+          args: ["./mcpServers/calculator.js"],
+        },
+      },
+      // 没有 mcpServerConfig 字段
+    };
+
+    mockReadFileSync.mockReturnValue(JSON.stringify(configWithoutServerConfig));
+
+    // 调用清理方法
+    configManager.cleanupInvalidServerToolsConfig();
+
+    // 验证 writeFileSync 没有被调用
+    expect(mockWriteFileSync).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/index.ts
+++ b/src/server/__tests__/index.ts
@@ -1,0 +1,14 @@
+/**
+ * 测试工具模块的统一导出
+ */
+
+export {
+  DEFAULT_TEST_CONFIG,
+  createMockConfigManager,
+  createMockLogger,
+  mockConfigManager,
+  mockLogger,
+  setupConfigManagerMock,
+  setupLoggerMock,
+  setupCommonMocks,
+} from "./utils/index.js";

--- a/src/server/__tests__/logger.test.ts
+++ b/src/server/__tests__/logger.test.ts
@@ -1,0 +1,407 @@
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Logger, logger } from "../Logger.js";
+
+// 模拟依赖
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  statSync: vi.fn(),
+  renameSync: vi.fn(),
+  unlinkSync: vi.fn(),
+}));
+
+vi.mock("node:path", () => ({
+  join: vi.fn(),
+  dirname: vi.fn(),
+  basename: vi.fn(),
+}));
+
+vi.mock("chalk", () => ({
+  default: {
+    blue: vi.fn((text) => `blue(${text})`),
+    green: vi.fn((text) => `green(${text})`),
+    yellow: vi.fn((text) => `yellow(${text})`),
+    red: vi.fn((text) => `red(${text})`),
+    gray: vi.fn((text) => `gray(${text})`),
+  },
+}));
+
+// 使用正确结构模拟 pino
+vi.mock("pino", () => {
+  const mockDestination = vi.fn(() => ({
+    write: vi.fn(),
+    end: vi.fn(),
+  }));
+
+  const mockPinoInstance = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    fatal: vi.fn(),
+  };
+
+  const mockMultistream = vi.fn(() => mockPinoInstance);
+
+  const mockPino = Object.assign(
+    vi.fn(() => mockPinoInstance),
+    {
+      multistream: mockMultistream,
+      destination: mockDestination,
+      stdSerializers: {
+        err: vi.fn((err) => ({ message: err.message, stack: err.stack })),
+      },
+      stdTimeFunctions: {
+        isoTime: vi.fn(() => `,"time":"${new Date().toISOString()}"`),
+      },
+    }
+  );
+
+  return {
+    default: mockPino,
+  };
+});
+
+// 模拟 console.error 以避免测试期间的实际输出
+const originalConsoleError = console.error;
+const mockConsoleError = vi.fn();
+
+describe("Logger", async () => {
+  const mockFs = vi.mocked(fs);
+  const mockPath = vi.mocked(path);
+  const pinoModule = await import("pino");
+  const mockPino = vi.mocked(pinoModule.default);
+
+  let mockDestination: any;
+  let mockPinoInstance: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 模拟 pino destination
+    mockDestination = {
+      write: vi.fn(),
+      end: vi.fn(),
+    };
+
+    // 模拟 pino 实例
+    mockPinoInstance = {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      fatal: vi.fn(),
+    };
+
+    // 设置 pino 模拟
+    mockPino.mockReturnValue(mockPinoInstance);
+    (mockPino as any).multistream = vi.fn().mockReturnValue(mockPinoInstance);
+    (mockPino as any).destination = vi.fn().mockReturnValue(mockDestination);
+
+    // 设置 fs 模拟
+    mockPath.join.mockImplementation((...args) => args.join("/"));
+    mockPath.dirname.mockImplementation((p) =>
+      p.split("/").slice(0, -1).join("/")
+    );
+    mockPath.basename.mockImplementation((p, ext) => {
+      const name = p.split("/").pop() || "";
+      return ext ? name.replace(ext, "") : name;
+    });
+
+    // 模拟 console.error
+    console.error = mockConsoleError;
+
+    // 重置环境
+    process.env.XIAOZHI_DAEMON = undefined;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    console.error = originalConsoleError;
+  });
+
+  describe("constructor", () => {
+    it("应该创建 logger 实例（默认设置）", () => {
+      const testLogger = new Logger();
+
+      expect(mockPino).toHaveBeenCalled();
+      expect(testLogger).toBeInstanceOf(Logger);
+    });
+
+    it("应该从环境变量检测守护进程模式", () => {
+      process.env.XIAOZHI_DAEMON = "true";
+      const testLogger = new Logger();
+
+      expect(mockPino).toHaveBeenCalled();
+      expect(testLogger).toBeInstanceOf(Logger);
+    });
+
+    it("应该检测非守护进程模式", () => {
+      process.env.XIAOZHI_DAEMON = "false";
+      const testLogger = new Logger();
+
+      expect(mockPino).toHaveBeenCalled();
+      expect(testLogger).toBeInstanceOf(Logger);
+    });
+  });
+
+  describe("initLogFile", () => {
+    it("应该在日志文件不存在时初始化", () => {
+      const testLogger = new Logger();
+      mockFs.existsSync.mockReturnValue(false);
+
+      testLogger.initLogFile("/test/project");
+
+      expect(mockPath.join).toHaveBeenCalledWith(
+        "/test/project",
+        "xiaozhi.log"
+      );
+      expect(mockFs.writeFileSync).toHaveBeenCalledWith(
+        "/test/project/xiaozhi.log",
+        ""
+      );
+      // 验证 pino 实例被重新创建
+      expect(mockPino).toHaveBeenCalledTimes(2); // 一次构造函数，一次 initLogFile
+    });
+
+    it("应该在日志文件已存在时初始化", () => {
+      const testLogger = new Logger();
+      mockFs.existsSync.mockReturnValue(true);
+
+      testLogger.initLogFile("/test/project");
+
+      expect(mockFs.writeFileSync).not.toHaveBeenCalled();
+      // 验证 pino 实例被重新创建
+      expect(mockPino).toHaveBeenCalledTimes(2); // 一次构造函数，一次 initLogFile
+    });
+  });
+
+  describe("文件日志记录", () => {
+    it("应该在初始化日志文件时自动启用文件日志记录", () => {
+      const testLogger = new Logger();
+
+      testLogger.initLogFile("/test/project");
+
+      // 验证 pino.destination 被调用来创建文件流
+      expect(mockPino.destination).toHaveBeenCalledWith({
+        dest: "/test/project/xiaozhi.log",
+        sync: false,
+        append: true,
+        mkdir: true,
+      });
+    });
+
+    it("应该在没有设置日志文件路径时不创建文件流", () => {
+      const testLogger = new Logger();
+
+      // 只应该创建控制台流，不创建文件流
+      expect(mockPino.destination).not.toHaveBeenCalled();
+    });
+
+    it("应该在守护进程模式下处理文件日志记录", () => {
+      process.env.XIAOZHI_DAEMON = "true";
+      const testLogger = new Logger();
+      testLogger.initLogFile("/test/project");
+
+      // 在守护进程模式下，应该只有文件流，没有控制台流
+      expect(mockPino.multistream).toHaveBeenCalled();
+      expect(mockPino.destination).toHaveBeenCalled();
+    });
+
+    it("应该处理 close 方法", () => {
+      const testLogger = new Logger();
+
+      // close 方法应该存在且不抛出错误
+      expect(() => testLogger.close()).not.toThrow();
+    });
+  });
+
+  describe("日志记录方法", () => {
+    let testLogger: Logger;
+
+    beforeEach(() => {
+      testLogger = new Logger();
+      testLogger.initLogFile("/test/project");
+    });
+
+    it("应该记录 info 消息", () => {
+      testLogger.info("Test info message", "arg1", "arg2");
+
+      expect(mockPinoInstance.info).toHaveBeenCalledWith(
+        { args: ["arg1", "arg2"] },
+        "Test info message"
+      );
+    });
+
+    it("应该记录带结构化数据的 info 消息", () => {
+      testLogger.info({ userId: 123, action: "test" }, "User action");
+
+      expect(mockPinoInstance.info).toHaveBeenCalledWith(
+        { userId: 123, action: "test" },
+        "User action"
+      );
+    });
+
+    it("应该记录不带参数的 info 消息", () => {
+      testLogger.info("Simple message");
+
+      expect(mockPinoInstance.info).toHaveBeenCalledWith("Simple message");
+    });
+
+    it("应该记录 success 消息（映射到 info）", () => {
+      testLogger.success("Test success message");
+
+      expect(mockPinoInstance.info).toHaveBeenCalledWith(
+        "Test success message"
+      );
+    });
+
+    it("应该记录 warning 消息", () => {
+      testLogger.warn("Test warning message");
+
+      expect(mockPinoInstance.warn).toHaveBeenCalledWith(
+        "Test warning message"
+      );
+    });
+
+    it("应该记录 error 消息", () => {
+      testLogger.error("Test error message");
+
+      expect(mockPinoInstance.error).toHaveBeenCalledWith("Test error message");
+    });
+
+    it("应该记录带 Error 对象的 error 消息", () => {
+      const error = new Error("Test error");
+      testLogger.error("Operation failed", error);
+
+      expect(mockPinoInstance.error).toHaveBeenCalledWith(
+        {
+          args: [
+            {
+              message: "Test error",
+              stack: error.stack,
+              name: "Error",
+              cause: undefined,
+            },
+          ],
+        },
+        "Operation failed"
+      );
+    });
+
+    it("应该记录 debug 消息", () => {
+      testLogger.debug("Test debug message");
+
+      expect(mockPinoInstance.debug).toHaveBeenCalledWith("Test debug message");
+    });
+
+    it("应该记录常规消息（映射到 info）", () => {
+      testLogger.log("Test log message");
+
+      expect(mockPinoInstance.info).toHaveBeenCalledWith("Test log message");
+    });
+  });
+
+  describe("close", () => {
+    it("应该优雅地处理 close", () => {
+      const testLogger = new Logger();
+      testLogger.initLogFile("/test/project");
+
+      // 不应该抛出错误
+      expect(() => testLogger.close()).not.toThrow();
+    });
+
+    it("应该在日志文件不存在时处理 close", () => {
+      const testLogger = new Logger();
+
+      // 不应该抛出错误
+      expect(() => testLogger.close()).not.toThrow();
+    });
+  });
+
+  describe("单例实例", () => {
+    it("应该导出单例 logger 实例", () => {
+      expect(logger).toBeInstanceOf(Logger);
+    });
+  });
+
+  describe("文件管理", () => {
+    let testLogger: Logger;
+
+    beforeEach(() => {
+      testLogger = new Logger();
+    });
+
+    it("应该设置日志文件选项", () => {
+      testLogger.setLogFileOptions(5 * 1024 * 1024, 10);
+
+      // 不应该抛出错误
+      expect(() => testLogger.setLogFileOptions(1024, 3)).not.toThrow();
+    });
+
+    it("应该清理旧日志", () => {
+      testLogger.initLogFile("/test/project");
+
+      // 不应该抛出错误
+      expect(() => testLogger.cleanupOldLogs()).not.toThrow();
+    });
+
+    it("应该处理日志轮转", () => {
+      mockFs.existsSync.mockReturnValue(true);
+      mockFs.statSync.mockReturnValue({
+        size: BigInt(20 * 1024 * 1024),
+        isFile: () => true,
+        isDirectory: () => false,
+        isBlockDevice: () => false,
+        isCharacterDevice: () => false,
+        isSymbolicLink: () => false,
+        isFIFO: () => false,
+        isSocket: () => false,
+        dev: BigInt(0),
+        ino: BigInt(0),
+        mode: BigInt(0),
+        nlink: BigInt(0),
+        uid: BigInt(0),
+        gid: BigInt(0),
+        rdev: BigInt(0),
+        blksize: BigInt(0),
+        blocks: BigInt(0),
+        atimeNs: BigInt(0),
+        mtimeNs: BigInt(0),
+        ctimeNs: BigInt(0),
+        birthtimeNs: BigInt(0),
+        atime: new Date(),
+        mtime: new Date(),
+        ctime: new Date(),
+        birthtime: new Date(),
+      } as any); // 20MB 文件
+
+      testLogger.initLogFile("/test/project");
+
+      // 轮转期间不应该抛出错误
+      expect(() => testLogger.initLogFile("/test/project")).not.toThrow();
+    });
+  });
+
+  describe("工具函数", () => {
+    it("应该处理安全的写入操作", () => {
+      const testLogger = new Logger();
+
+      // 测试日志记录即使在边缘情况下也能工作
+      expect(() => testLogger.info("Test message")).not.toThrow();
+      expect(() => testLogger.error("Test error")).not.toThrow();
+    });
+
+    it("应该增强错误对象", () => {
+      const testLogger = new Logger();
+      const error = new Error("Test error");
+      error.cause = new Error("Root cause");
+
+      testLogger.error({ operation: "test", error }, "Operation failed");
+
+      expect(mockPinoInstance.error).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/__tests__/utils/index.ts
+++ b/src/server/__tests__/utils/index.ts
@@ -1,0 +1,14 @@
+/**
+ * 测试工具模块的统一导出
+ */
+
+export {
+  DEFAULT_TEST_CONFIG,
+  createMockConfigManager,
+  createMockLogger,
+  mockConfigManager,
+  mockLogger,
+  setupConfigManagerMock,
+  setupLoggerMock,
+  setupCommonMocks,
+} from "./testMocks.js";

--- a/src/server/__tests__/utils/testMocks.ts
+++ b/src/server/__tests__/utils/testMocks.ts
@@ -1,0 +1,130 @@
+/**
+ * 统一的测试配置Mock工具
+ * 用于避免在各个测试文件中重复定义configManager和logger的mock配置
+ */
+
+import { vi } from "vitest";
+
+/**
+ * 默认的测试配置
+ */
+export const DEFAULT_TEST_CONFIG = {
+  mcpEndpoint: "ws://localhost:8080",
+  mcpServers: {
+    "test-service": {
+      command: "node",
+      args: ["test-server.js"],
+      env: {},
+    },
+  },
+  modelscope: {
+    apiKey: "test-api-key",
+    baseUrl: "https://test.modelscope.com",
+  },
+  connection: {
+    heartbeat: {
+      enabled: true,
+      interval: 1000,
+      timeout: 5000,
+    },
+    retry: {
+      maxAttempts: 3,
+      delay: 1000,
+    },
+  },
+  webUI: {
+    enabled: true,
+    port: 3000,
+  },
+};
+
+/**
+ * 创建configManager的mock对象
+ */
+export const createMockConfigManager = (overrides = {}) => {
+  return {
+    configExists: vi.fn().mockReturnValue(true),
+    getConfig: vi.fn().mockReturnValue(DEFAULT_TEST_CONFIG),
+    setConfig: vi.fn().mockResolvedValue(undefined),
+    validateConfig: vi.fn().mockReturnValue({ valid: true }),
+    getMcpEndpoints: vi.fn().mockReturnValue(["ws://localhost:8080"]),
+    getServiceConfig: vi
+      .fn()
+      .mockReturnValue(DEFAULT_TEST_CONFIG.mcpServers["test-service"]),
+    watchConfig: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+    getLLMConfig: vi.fn().mockReturnValue(null),
+    isLLMConfigValid: vi.fn().mockReturnValue(false),
+    getTTSConfig: vi.fn().mockReturnValue({}),
+    getASRConfig: vi.fn().mockReturnValue({}),
+    ...overrides,
+  };
+};
+
+/**
+ * 创建logger的mock对象
+ */
+export const createMockLogger = (overrides = {}) => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    success: vi.fn(),
+    withTag: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      success: vi.fn(),
+    }),
+    ...overrides,
+  };
+  return mockLogger;
+};
+
+/**
+ * 统一的configManager mock导出
+ */
+export const mockConfigManager = {
+  configManager: createMockConfigManager(),
+};
+
+/**
+ * 统一的logger mock导出
+ */
+export const mockLogger = {
+  logger: createMockLogger(),
+};
+
+/**
+ * 为测试文件设置configManager mock
+ * 注意：由于 Vitest 的限制，需要在测试文件中手动设置
+ */
+export const setupConfigManagerMock = (overrides = {}) => {
+  // 需要在测试文件中手动设置：
+  // vi.mock("../../../config/index.js", () => ({ configManager: createMockConfigManager(overrides) }));
+};
+
+/**
+ * 为测试文件设置logger mock
+ * 注意：由于 Vitest 的限制，需要在测试文件中手动设置
+ */
+export const setupLoggerMock = (overrides = {}) => {
+  // 需要在测试文件中手动设置：
+  // vi.mock("../../Logger.js", () => ({ logger: createMockLogger(overrides) }));
+};
+
+/**
+ * 为测试文件同时设置configManager和logger mock
+ * 注意：由于 Vitest 的限制，需要在测试文件顶部直接使用 vi.mock
+ */
+export const setupCommonMocks = (
+  configOverrides = {},
+  loggerOverrides = {}
+) => {
+  // 这些 mock 需要在测试文件中手动设置，因为 Vitest 的限制
+  // 使用示例：
+  // import { setupCommonMocks, createMockConfigManager, createMockLogger } from "./utils/index.js";
+  // vi.mock("../../Logger.js", () => ({ logger: createMockLogger(loggerOverrides) }));
+  // vi.mock("../../../config/index.js", () => ({ configManager: createMockConfigManager(configOverrides) }));
+};

--- a/src/server/__tests__/webserver/webserver.cleanup.test.ts
+++ b/src/server/__tests__/webserver/webserver.cleanup.test.ts
@@ -1,0 +1,415 @@
+import { createServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configManager } from "../../../config/index.js";
+import { WebServer } from "../../WebServer";
+
+// Mock configManager
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    configExists: vi.fn(),
+    getConfig: vi.fn(),
+    getMcpEndpoint: vi.fn(),
+    getMcpServers: vi.fn(),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    getWebUIPort: vi.fn(),
+    setToolEnabled: vi.fn(),
+    removeServerToolsConfig: vi.fn(),
+    cleanupInvalidServerToolsConfig: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({}),
+    getConfigDir: vi.fn().mockReturnValue("/tmp"),
+    getCustomMCPTools: vi.fn().mockReturnValue([]),
+    clearAllStatsUpdateLocks: vi.fn(),
+    validateConfig: vi.fn(),
+    updateConfig: vi.fn(),
+    getLLMConfig: vi.fn(() => null),
+    isLLMConfigValid: vi.fn(() => false),
+    getTTSConfig: vi.fn(() => ({})),
+    getASRConfig: vi.fn(() => ({})),
+  },
+}));
+
+// Mock Logger 模块
+vi.mock("../../Logger", () => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn(() => mockLogger),
+  };
+  return {
+    logger: mockLogger,
+    Logger: vi.fn(() => mockLogger),
+  };
+});
+
+// Mock EventBus 服务
+vi.mock("../../services/EventBus", () => {
+  const mockEventBus = {
+    onEvent: vi.fn(),
+    emitEvent: vi.fn(),
+    emit: vi.fn(),
+    removeAllListeners: vi.fn(),
+    destroy: vi.fn(),
+  };
+  return {
+    getEventBus: vi.fn(() => mockEventBus),
+    destroyEventBus: vi.fn(),
+    EventBus: vi.fn(() => mockEventBus),
+  };
+});
+
+// Mock 各种服务
+const mockConfigServiceInstance = {
+  getConfig: vi.fn(),
+  updateConfig: vi.fn(),
+  getMcpEndpoint: vi.fn(),
+  updateMcpEndpoint: vi.fn(),
+};
+
+vi.mock("../../services/ConfigService", () => {
+  return {
+    ConfigService: vi.fn(() => mockConfigServiceInstance),
+  };
+});
+
+vi.mock("../../services/StatusService", () => {
+  const mockStatusService = {
+    getStatus: vi.fn(),
+    updateClientInfo: vi.fn(),
+    getClientInfo: vi.fn(),
+  };
+  return {
+    StatusService: vi.fn(() => mockStatusService),
+  };
+});
+
+// Mock CLI
+vi.mock("@cli", () => ({
+  getServiceStatus: vi.fn(),
+}));
+
+// Mock child_process
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+  })),
+}));
+
+// Mock EndpointManager
+vi.mock("../../lib/endpoint/index", () => ({
+  EndpointManager: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    setServiceManager: vi.fn(),
+    getConnectionStatus: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+  })),
+}));
+
+// Mock normalizeServiceConfig
+vi.mock("../../adapters/ConfigAdapter", () => ({
+  normalizeServiceConfig: vi.fn((name, config) => config),
+}));
+
+// 动态端口管理
+function getAvailablePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    server.listen(0, () => {
+      const port = (server.address() as any)?.port;
+      server.close(() => {
+        if (port) {
+          resolve(port);
+        } else {
+          reject(new Error("无法获取可用端口"));
+        }
+      });
+    });
+  });
+}
+
+describe("WebServer 配置清理功能", () => {
+  let mockConfigManager: any;
+  let webServer: WebServer;
+  let currentPort: number;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 获取可用端口
+    currentPort = await getAvailablePort();
+
+    mockConfigManager = vi.mocked(configManager);
+
+    // 设置默认的 mock 返回值
+    mockConfigManager.configExists.mockReturnValue(true);
+    mockConfigManager.getConfig.mockReturnValue({
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        test: { command: "node", args: ["test.js"] },
+      },
+    });
+    mockConfigManager.getMcpEndpoint.mockReturnValue("wss://test.endpoint");
+    mockConfigManager.getMcpServers.mockReturnValue({
+      test: { command: "node", args: ["test.js"] },
+    });
+    mockConfigManager.getWebUIPort.mockReturnValue(currentPort);
+  });
+
+  afterEach(async () => {
+    if (webServer) {
+      try {
+        await webServer.stop();
+      } catch (error) {
+        // 忽略停止时的错误
+      }
+    }
+    vi.clearAllMocks();
+  });
+
+  it("应该在删除服务时同时清理工具配置", async () => {
+    const newConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {}, // 删除了所有服务
+    };
+
+    // 创建 WebServer 实例并启动
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    try {
+      // 通过 HTTP API 更新配置
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(newConfig),
+        }
+      );
+
+      expect(response.status).toBe(200);
+
+      // 验证响应内容
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.message).toBe("配置更新成功");
+    } finally {
+      await webServer.stop();
+    }
+  });
+
+  it("应该只清理被删除的服务配置", async () => {
+    // 模拟当前有两个服务
+    mockConfigManager.getMcpServers.mockReturnValue({
+      calculator: { command: "node", args: ["calculator.js"] },
+      datetime: { command: "node", args: ["datetime.js"] },
+    });
+
+    const newConfig = {
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        // 只保留 datetime 服务，删除 calculator 服务
+        datetime: { command: "node", args: ["datetime.js"] },
+      },
+    };
+
+    // 创建 WebServer 实例并启动
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    try {
+      // 通过 HTTP API 更新配置
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify(newConfig),
+        }
+      );
+
+      expect(response.status).toBe(200);
+
+      // 验证响应内容
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.message).toBe("配置更新成功");
+    } finally {
+      await webServer.stop();
+    }
+  });
+
+  describe("启动时配置清理", () => {
+    beforeEach(() => {
+      // Mock Hono and WebSocket
+      vi.doMock("hono", () => ({
+        Hono: vi.fn(() => ({
+          use: vi.fn(),
+          get: vi.fn(),
+          put: vi.fn(),
+          onError: vi.fn(),
+          fetch: vi.fn(),
+        })),
+      }));
+
+      vi.doMock("hono/cors", () => ({
+        cors: vi.fn(),
+      }));
+
+      vi.doMock("@hono/node-server", () => ({
+        serve: vi.fn(() => ({
+          close: vi.fn(),
+        })),
+        createServer: vi.fn(),
+      }));
+
+      vi.doMock("ws", () => ({
+        WebSocketServer: vi.fn(() => ({
+          clients: new Set(),
+          close: vi.fn(),
+        })),
+      }));
+    });
+
+    it("应该在启动时调用配置清理方法", async () => {
+      webServer = new WebServer(currentPort);
+
+      // 模拟启动过程中的配置加载
+      try {
+        // @ts-ignore - 调用私有方法用于测试
+        await (webServer as any).loadConfiguration();
+      } catch (error) {
+        // 忽略其他初始化错误，我们只关心配置清理是否被调用
+      }
+
+      // 验证配置清理方法被调用
+      expect(
+        mockConfigManager.cleanupInvalidServerToolsConfig
+      ).toHaveBeenCalledTimes(1);
+    });
+
+    it("应该在配置文件不存在时抛出错误而不调用清理方法", async () => {
+      mockConfigManager.configExists.mockReturnValue(false);
+
+      webServer = new WebServer(currentPort);
+
+      // 应该抛出错误
+      await expect(async () => {
+        // @ts-ignore - 调用私有方法用于测试
+        await (webServer as any).loadConfiguration();
+      }).rejects.toThrow("配置文件不存在");
+
+      // 验证配置清理方法没有被调用
+      expect(
+        mockConfigManager.cleanupInvalidServerToolsConfig
+      ).not.toHaveBeenCalled();
+    });
+
+    it("应该在清理配置后正常返回配置信息", async () => {
+      const expectedConfig = {
+        mcpEndpoint: "wss://test.endpoint",
+        mcpServers: {
+          test: { command: "node", args: ["test.js"] },
+        },
+        webUI: { port: currentPort },
+      };
+
+      mockConfigManager.getConfig.mockReturnValue(expectedConfig);
+
+      webServer = new WebServer(currentPort);
+
+      // @ts-ignore - 调用私有方法用于测试
+      const config = await (webServer as any).loadConfiguration();
+
+      // 验证配置清理方法被调用
+      expect(
+        mockConfigManager.cleanupInvalidServerToolsConfig
+      ).toHaveBeenCalledTimes(1);
+
+      // 验证返回的配置正确
+      expect(config).toEqual({
+        mcpEndpoint: expectedConfig.mcpEndpoint,
+        mcpServers: expectedConfig.mcpServers,
+        webUIPort: currentPort,
+      });
+    });
+
+    it("webUI.port 缺失时应使用默认端口", async () => {
+      const expectedConfig = {
+        mcpEndpoint: "wss://test.endpoint",
+        mcpServers: {},
+        // 不包含 webUI.port
+      };
+
+      mockConfigManager.getConfig.mockReturnValue(expectedConfig);
+      webServer = new WebServer(currentPort);
+
+      const config = await (webServer as any).loadConfiguration();
+
+      // 应使用 DEFAULT_PORT（从 HTTP_SERVER_CONFIG 获取）
+      expect(config.webUIPort).toBeGreaterThan(0);
+    });
+
+    it("mcpEndpoint 为数组时应正确返回", async () => {
+      const expectedConfig = {
+        mcpEndpoint: ["wss://ep1.example.com", "wss://ep2.example.com"],
+        mcpServers: {},
+      };
+
+      mockConfigManager.getConfig.mockReturnValue(expectedConfig);
+      webServer = new WebServer(currentPort);
+
+      const config = await (webServer as any).loadConfiguration();
+
+      expect(config.mcpEndpoint).toEqual([
+        "wss://ep1.example.com",
+        "wss://ep2.example.com",
+      ]);
+    });
+
+    it("mcpServers 为空对象时应正确返回", async () => {
+      const expectedConfig = {
+        mcpEndpoint: [],
+        mcpServers: {},
+      };
+
+      mockConfigManager.getConfig.mockReturnValue(expectedConfig);
+      webServer = new WebServer(currentPort);
+
+      const config = await (webServer as any).loadConfiguration();
+
+      expect(config.mcpServers).toEqual({});
+    });
+
+    it("cleanupInvalidServerToolsConfig 应在 getConfig 之前被调用", async () => {
+      const callOrder: string[] = [];
+      mockConfigManager.cleanupInvalidServerToolsConfig.mockImplementation(
+        () => {
+          callOrder.push("cleanup");
+        }
+      );
+      mockConfigManager.getConfig.mockImplementation(() => {
+        callOrder.push("getConfig");
+        return { mcpEndpoint: [], mcpServers: {} };
+      });
+
+      webServer = new WebServer(currentPort);
+      await (webServer as any).loadConfiguration();
+
+      expect(callOrder).toEqual(["cleanup", "getConfig"]);
+    });
+  });
+});

--- a/src/server/__tests__/webserver/webserver.integration.test.ts
+++ b/src/server/__tests__/webserver/webserver.integration.test.ts
@@ -1,0 +1,1730 @@
+import { createServer } from "node:http";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import WebSocket from "ws";
+import { EndpointManager } from "../../../endpoint/index.js";
+import { WebServer } from "../../WebServer";
+
+vi.mock("../../../config/index.js", () => {
+  const mockConfigManager = {
+    getConfig: vi.fn(),
+    getMcpEndpoint: vi.fn(),
+    getMcpServers: vi.fn(),
+    getMcpServerConfig: vi.fn(),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    getWebUIPort: vi.fn(),
+    setToolEnabled: vi.fn(),
+    removeServerToolsConfig: vi.fn(),
+    configExists: vi.fn(),
+    cleanupInvalidServerToolsConfig: vi.fn(),
+    addMcpEndpoint: vi.fn(),
+    removeMcpEndpoint: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({}),
+    getConfigDir: vi.fn().mockReturnValue("/tmp"),
+    getCustomMCPTools: vi.fn(() => []),
+    getCustomMCPConfig: vi.fn(() => null),
+    hasValidCustomMCPTools: vi.fn(() => false),
+    clearAllStatsUpdateLocks: vi.fn(),
+    // ESP32 配置提供者所需方法
+    getASRConfig: vi.fn().mockReturnValue(null),
+    getTTSConfig: vi.fn().mockReturnValue(null),
+    getLLMConfig: vi.fn().mockReturnValue(null),
+    isLLMConfigValid: vi.fn().mockReturnValue(false),
+  };
+  return {
+    configManager: mockConfigManager,
+    ConfigManager: vi.fn(() => mockConfigManager),
+  };
+});
+// Mock Logger 模块 - 注意路径和大小写
+vi.mock("../../Logger", () => {
+  const mockLogger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn(() => mockLogger),
+  };
+  return {
+    logger: mockLogger,
+    Logger: vi.fn(() => mockLogger),
+  };
+});
+
+// Mock @services/index.js
+// 注意：WebServer.ts 从 @services/index.js 导入多个模块，必须全部 Mock
+vi.mock("../../services/index.js", () => {
+  const mockEventBus = {
+    onEvent: vi.fn().mockReturnThis(),
+    offEvent: vi.fn().mockReturnThis(),
+    emit: vi.fn(),
+    emitEvent: vi.fn(),
+    removeAllListeners: vi.fn(),
+    destroy: vi.fn(),
+  };
+
+  // 从其他 mock 获取实例
+  const mockStatusServiceInstance = {
+    getStatus: vi.fn(() => ({
+      client: {
+        status: "connected",
+        mcpEndpoint: "wss://test.endpoint",
+        activeMCPServers: ["test"],
+      },
+    })),
+    updateClientInfo: vi.fn(),
+    getClientInfo: vi.fn(() => ({
+      status: "connected",
+      mcpEndpoint: "wss://test.endpoint",
+      activeMCPServers: ["test"],
+    })),
+    destroy: vi.fn(),
+  };
+
+  // Mock DeviceRegistryService
+  const mockDeviceRegistryServiceInstance = {
+    getDevice: vi.fn(),
+    getAllDevices: vi.fn(() => []),
+    createDevice: vi.fn(),
+    updateDeviceStatus: vi.fn(),
+    updateLastSeen: vi.fn(),
+    deleteDevice: vi.fn(),
+    destroy: vi.fn(),
+  };
+
+  // Mock ESP32Service
+  const mockESP32ServiceInstance = {
+    handleOTARequest: vi.fn(),
+    handleWebSocketConnection: vi.fn(),
+    listDevices: vi.fn(() => ({ devices: [], total: 0 })),
+    getDevice: vi.fn(),
+    deleteDevice: vi.fn(),
+    disconnectDevice: vi.fn(),
+    destroy: vi.fn(),
+    getConnection: vi.fn(),
+    setupTTSGetConnection: vi.fn(),
+  };
+
+  return {
+    // EventBus 相关
+    getEventBus: vi.fn(() => mockEventBus),
+    destroyEventBus: vi.fn(),
+    EventBus: vi.fn(() => mockEventBus),
+    // StatusService 相关
+    StatusService: vi.fn(() => mockStatusServiceInstance),
+    // DeviceRegistryService 相关
+    DeviceRegistryService: vi.fn(() => mockDeviceRegistryServiceInstance),
+    // ESP32Service 相关
+    ESP32Service: vi.fn(() => mockESP32ServiceInstance),
+  };
+});
+
+// Mock 各种服务
+const mockConfigServiceInstance = {
+  getConfig: vi.fn(() => ({
+    mcpEndpoint: "wss://test.endpoint",
+    mcpServers: {
+      test: { command: "node", args: ["test.js"] },
+    },
+  })),
+  updateConfig: vi.fn().mockResolvedValue(undefined),
+  getMcpEndpoint: vi.fn(() => "wss://test.endpoint"),
+  updateMcpEndpoint: vi.fn().mockResolvedValue(undefined),
+};
+
+vi.mock("../../services/ConfigService", () => {
+  return {
+    ConfigService: vi.fn(() => mockConfigServiceInstance),
+  };
+});
+
+// StatusService 和 NotificationService 已在 @services/index.js mock 中定义
+
+// Mock API 处理器
+vi.mock("../../handlers/config.handler", () => {
+  const mockConfigApiHandler = {
+    getConfig: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          mcpEndpoint: "wss://test.endpoint",
+          mcpServers: { test: { command: "node", args: ["test.js"] } },
+        },
+      })
+    ),
+    updateConfig: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "配置更新成功",
+      })
+    ),
+    getMcpEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { endpoint: "wss://test.endpoint" },
+      })
+    ),
+    getMcpEndpoints: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { endpoints: ["wss://test.endpoint"] },
+      })
+    ),
+    getMcpServers: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { test: { command: "node", args: ["test.js"] } },
+      })
+    ),
+    getConnectionConfig: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { timeout: 5000 },
+      })
+    ),
+    reloadConfig: vi.fn((c) =>
+      c.json({
+        success: true,
+        message: "配置重新加载成功",
+      })
+    ),
+    getConfigPath: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { path: "/test/config.json" },
+      })
+    ),
+    checkConfigExists: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { exists: true },
+      })
+    ),
+    updateMcpEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "MCP 端点更新成功",
+      })
+    ),
+  };
+  return {
+    ConfigApiHandler: vi.fn(() => mockConfigApiHandler),
+  };
+});
+
+vi.mock("../../handlers/status.handler", () => {
+  const mockStatusApiHandler = {
+    getStatus: vi.fn((c) =>
+      c.json({
+        status: "connected",
+        mcpEndpoint: "wss://test.endpoint",
+        activeMCPServers: ["test"],
+      })
+    ),
+    getClientStatus: vi.fn((c) => c.json({ status: "connected" })),
+    getRestartStatus: vi.fn((c) => c.json({ status: "idle" })),
+    checkClientConnected: vi.fn((c) => c.json({ connected: true })),
+    getLastHeartbeat: vi.fn((c) => c.json({ lastHeartbeat: Date.now() })),
+    getActiveMCPServers: vi.fn((c) => c.json({ servers: ["test"] })),
+    updateClientStatus: vi.fn((c) => c.json({ success: true })),
+    setActiveMCPServers: vi.fn((c) => c.json({ success: true })),
+    resetStatus: vi.fn((c) => c.json({ success: true })),
+  };
+  return {
+    StatusApiHandler: vi.fn(() => mockStatusApiHandler),
+  };
+});
+
+vi.mock("../../handlers/service.handler", () => {
+  const mockServiceApiHandler = {
+    restartService: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "重启请求已接收",
+      })
+    ),
+    stopService: vi.fn((c) =>
+      c.json({
+        success: true,
+        message: "服务停止请求已接收",
+      })
+    ),
+    startService: vi.fn((c) =>
+      c.json({
+        success: true,
+        message: "服务启动请求已接收",
+      })
+    ),
+    getServiceStatus: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { status: "running", pid: 12345 },
+      })
+    ),
+    getServiceHealth: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { healthy: true, uptime: 3600 },
+      })
+    ),
+  };
+  return {
+    ServiceApiHandler: vi.fn(() => mockServiceApiHandler),
+  };
+});
+vi.mock("@cli/Container", () => ({
+  createContainer: vi.fn(() => ({
+    get: vi.fn((serviceName) => {
+      if (serviceName === "serviceManager") {
+        return {
+          getStatus: vi.fn(),
+        };
+      }
+      return {};
+    }),
+  })),
+}));
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(() => ({
+    unref: vi.fn(),
+  })),
+}));
+
+// Mock 静态文件处理器
+vi.mock("../../handlers/static-file.handler", () => {
+  const mockStaticFileHandler = {
+    handleStaticFile: vi.fn((c) =>
+      c.text("<!DOCTYPE html><html><body>Test</body></html>", 200, {
+        "Content-Type": "text/html",
+      })
+    ),
+  };
+  return {
+    StaticFileHandler: vi.fn(() => mockStaticFileHandler),
+  };
+});
+
+vi.mock("../../../endpoint/index.js", () => ({
+  EndpointManager: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    setServiceManager: vi.fn(),
+    getConnectionStatus: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+  })),
+  EndpointConnection: vi.fn().mockImplementation(() => ({
+    setServiceManager: vi.fn(),
+    connect: vi.fn(),
+    disconnect: vi.fn(),
+  })),
+}));
+
+vi.mock("../../lib/config/adapter.js", () => ({
+  normalizeServiceConfig: vi.fn((_name, config) => config),
+  isModelScopeURL: vi.fn((url) => url.includes("modelscope")),
+}));
+
+vi.mock("../../handlers/version.handler", () => {
+  const mockVersionApiHandler = {
+    getVersion: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { version: "1.0.0", commit: "abc123" },
+      })
+    ),
+    getVersionSimple: vi.fn((c) => c.text("1.0.0")),
+    clearVersionCache: vi.fn((c) =>
+      c.json({
+        success: true,
+        message: "版本缓存已清空",
+      })
+    ),
+  };
+  return {
+    VersionApiHandler: vi.fn(() => mockVersionApiHandler),
+  };
+});
+
+vi.mock("../../handlers/mcp-tool.handler", () => {
+  const mockMCPToolHandler = {
+    callTool: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { result: "tool call result" },
+      })
+    ),
+    listTools: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { tools: ["tool1", "tool2"] },
+      })
+    ),
+    getCustomTools: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { tools: ["custom1", "custom2"] },
+      })
+    ),
+    addCustomTool: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "自定义工具添加成功",
+      })
+    ),
+    updateCustomTool: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "自定义工具更新成功",
+      })
+    ),
+    removeCustomTool: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: null,
+        message: "自定义工具删除成功",
+      })
+    ),
+  };
+  return {
+    MCPToolHandler: vi.fn(() => mockMCPToolHandler),
+  };
+});
+
+vi.mock("../../handlers/coze.handler", () => {
+  const mockCozeHandler = {
+    getWorkspaces: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { workspaces: ["workspace1", "workspace2"] },
+      })
+    ),
+    getWorkflows: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { workflows: ["workflow1", "workflow2"] },
+      })
+    ),
+    clearCache: vi.fn((c) =>
+      c.json({
+        success: true,
+        message: "缓存已清空",
+      })
+    ),
+    getCacheStats: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: { cacheSize: 100, hitRate: 0.8 },
+      })
+    ),
+  };
+  return {
+    CozeHandler: vi.fn(() => mockCozeHandler),
+  };
+});
+
+vi.mock("../../handlers/mcp.handler", () => {
+  const mockMCPRouteHandler = {
+    handlePost: vi.fn((c) =>
+      c.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { success: true },
+      })
+    ),
+    handleGet: vi.fn((c) =>
+      c.json({
+        jsonrpc: "2.0",
+        id: 1,
+        result: { status: "ok" },
+      })
+    ),
+  };
+  return {
+    MCPRouteHandler: vi.fn(() => mockMCPRouteHandler),
+  };
+});
+
+vi.mock("../../handlers/endpoint.handler", () => {
+  const mockEndpointHandler = {
+    getEndpointStatus: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          endpoint: "ws://localhost:9999",
+          connected: true,
+          initialized: true,
+        },
+      })
+    ),
+    connectEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          endpoint: "ws://localhost:9999",
+          connected: true,
+          operation: "connect",
+        },
+      })
+    ),
+    disconnectEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          endpoint: "ws://localhost:9999",
+          connected: false,
+          operation: "disconnect",
+        },
+      })
+    ),
+    addEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          endpoint: "ws://new.endpoint",
+          connected: false,
+          operation: "add",
+        },
+      })
+    ),
+    removeEndpoint: vi.fn((c) =>
+      c.json({
+        success: true,
+        data: {
+          endpoint: "ws://old.endpoint",
+          operation: "remove",
+          success: true,
+        },
+      })
+    ),
+  };
+  return {
+    EndpointHandler: vi.fn(() => mockEndpointHandler),
+  };
+});
+
+// 端口管理工具函数
+const getAvailablePort = async (): Promise<number> => {
+  return new Promise((resolve, reject) => {
+    const server = createServer();
+    let resolved = false;
+
+    const onError = (err: any) => {
+      if (!resolved) {
+        resolved = true;
+        server.close();
+        reject(err);
+      }
+    };
+
+    server.on("error", onError);
+
+    server.listen(0, "127.0.0.1", () => {
+      if (resolved) return;
+
+      const port = (server.address() as any)?.port;
+      if (!port) {
+        resolved = true;
+        server.close();
+        reject(new Error("Failed to get available port"));
+        return;
+      }
+
+      // 确保端口完全释放后再解析
+      server.close(() => {
+        if (!resolved) {
+          resolved = true;
+          // 额外等待一小段时间确保端口释放
+          setTimeout(() => resolve(port), 50);
+        }
+      });
+    });
+  });
+};
+
+describe("WebServer 集成测试", () => {
+  let webServer: WebServer;
+  let mockConfigManager: any;
+  let currentPort: number;
+
+  beforeEach(async () => {
+    const { configManager } = await import("../../../config/index.js");
+    mockConfigManager = configManager;
+
+    // 获取唯一的可用端口
+    currentPort = await getAvailablePort();
+    // 设置默认的 mock 返回值
+    mockConfigManager.getConfig.mockReturnValue({
+      mcpEndpoint: "wss://test.endpoint",
+      mcpServers: {
+        test: { command: "node", args: ["test.js"] },
+      },
+    });
+    mockConfigManager.getMcpEndpoint.mockReturnValue("wss://test.endpoint");
+    mockConfigManager.getMcpServers.mockReturnValue({
+      test: { command: "node", args: ["test.js"] },
+    });
+    mockConfigManager.getWebUIPort.mockReturnValue(currentPort);
+    mockConfigManager.configExists.mockReturnValue(true);
+    mockConfigManager.updateMcpEndpoint.mockResolvedValue(undefined);
+    mockConfigManager.updateWebUIConfig.mockResolvedValue(undefined);
+    mockConfigManager.removeMcpServer.mockResolvedValue(undefined);
+    mockConfigManager.removeServerToolsConfig.mockResolvedValue(undefined);
+  });
+
+  afterEach(async () => {
+    if (webServer) {
+      try {
+        await webServer.stop();
+      } catch (error) {
+        console.warn("Failed to stop webServer in afterEach:", error);
+      }
+      webServer = null as any;
+    }
+    vi.clearAllMocks();
+  });
+
+  it("应该在指定端口上启动服务器", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const response = await fetch(`http://localhost:${currentPort}/api/status`);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data).toHaveProperty("status");
+    expect(data).toHaveProperty("mcpEndpoint");
+    expect(data).toHaveProperty("activeMCPServers");
+  });
+
+  it("应该通过 HTTP API 返回配置", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const response = await fetch(`http://localhost:${currentPort}/api/config`);
+    expect(response.status).toBe(200);
+
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(data.data.mcpEndpoint).toBe("wss://test.endpoint");
+    expect(data.data.mcpServers).toHaveProperty("test");
+  });
+
+  it("应该通过 HTTP API 更新配置", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const newConfig = {
+      mcpEndpoint: "wss://new.endpoint",
+      mcpServers: {},
+    };
+
+    const response = await fetch(`http://localhost:${currentPort}/api/config`, {
+      method: "PUT",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(newConfig),
+    });
+
+    expect(response.status).toBe(200);
+
+    // 验证响应内容
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.message).toBe("配置更新成功");
+  });
+
+  it("应该拒绝 Web 客户端 WebSocket 连接", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const ws = new WebSocket(`ws://localhost:${currentPort}`);
+
+    await new Promise<void>((resolve, reject) => {
+      const timeout = setTimeout(() => {
+        ws.close();
+        reject(new Error("WebSocket test timeout"));
+      }, 4000);
+
+      ws.on("close", (code: number, reason: Buffer) => {
+        // Web 客户端连接应被服务端关闭（非 /ws 路径被拒绝）
+        clearTimeout(timeout);
+        expect(code).toBe(1000);
+        resolve();
+      });
+
+      ws.on("error", (err: Error) => {
+        // 连接错误也是可接受的行为
+        clearTimeout(timeout);
+        resolve();
+      });
+    });
+  });
+
+  it("应该通过 HTTP API 更新客户端状态", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const statusUpdate = {
+      activeMCPServers: ["test-server"],
+    };
+
+    const response = await fetch(
+      `http://localhost:${currentPort}/api/status/mcp-servers`,
+      {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify(statusUpdate),
+      }
+    );
+
+    expect(response.status).toBe(200);
+  });
+
+  it("应该处理 404 未找到路由", async () => {
+    webServer = new WebServer(currentPort);
+    await webServer.start();
+
+    const response = await fetch(`http://localhost:${currentPort}/api/unknown`);
+    expect(response.status).toBe(404);
+  });
+
+  describe("端口配置", () => {
+    beforeEach(() => {
+      mockConfigManager.getWebUIPort.mockReturnValue(8080);
+    });
+
+    it("应该使用指定的端口号", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/status`
+      );
+      expect(response.status).toBe(200);
+    });
+
+    it("应该在没有指定端口时从配置文件获取端口", async () => {
+      // 使用动态端口而不是固定的8080，避免端口冲突
+      const configPort = currentPort;
+      mockConfigManager.getWebUIPort.mockReturnValue(configPort);
+      webServer = new WebServer();
+      await webServer.start();
+
+      const response = await fetch(`http://localhost:${configPort}/api/status`);
+      expect(response.status).toBe(200);
+      expect(mockConfigManager.getWebUIPort).toHaveBeenCalled();
+    });
+
+    it("应该在配置读取失败时使用默认端口", async () => {
+      mockConfigManager.getWebUIPort.mockImplementation(() => {
+        throw new Error("配置文件不存在");
+      });
+
+      // 这个测试验证配置读取失败时服务器能正常启动
+      // 由于我们不能假设默认端口9999在CI环境中可用
+      // 我们主要验证WebServer构造函数不会抛出异常，并且服务器能启动
+      webServer = new WebServer();
+
+      // 验证WebServer实例创建成功（没有抛出异常）
+      expect(webServer).toBeDefined();
+
+      // 验证服务器能够启动（这会使用默认端口9999或其他可用端口）
+      await expect(webServer.start()).resolves.not.toThrow();
+    }, 10000); // 增加超时时间到10秒
+
+    it("应该处理 webUI 配置更新", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const newConfig = {
+        mcpEndpoint: "wss://test.endpoint",
+        mcpServers: {},
+        webUI: { port: 8080 },
+      };
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newConfig),
+        }
+      );
+
+      expect(response.status).toBe(200);
+
+      // 验证响应内容
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.message).toBe("配置更新成功");
+    });
+  });
+
+  describe("自动重启功能", () => {
+    let mockSpawn: any;
+
+    beforeEach(async () => {
+      const { spawn } = await import("node:child_process");
+      mockSpawn = vi.mocked(spawn);
+    });
+
+    it("应该在配置更新时不会触发自动重启", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // 确保服务器已启动并监听
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      const newConfig = {
+        mcpEndpoint: "wss://test.endpoint",
+        mcpServers: {},
+        webUI: { autoRestart: true },
+      };
+
+      // 使用重试机制处理可能的连接问题
+      let response: Response | undefined;
+      let retries = 3;
+
+      while (retries > 0) {
+        try {
+          response = await fetch(`http://localhost:${currentPort}/api/config`, {
+            method: "PUT",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify(newConfig),
+          });
+          break;
+        } catch (error) {
+          retries--;
+          if (retries === 0) throw error;
+          await new Promise((resolve) => setTimeout(resolve, 200));
+        }
+      }
+
+      if (!response) {
+        throw new Error("Failed to connect to server after retries");
+      }
+
+      const result = await response.json();
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+
+      // Wait to ensure no restart is triggered
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      // 验证没有触发重启
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it("应该在自动重启设置下保存配置而不重启", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const newConfig = {
+        mcpEndpoint: "wss://test.endpoint",
+        mcpServers: {},
+        webUI: { autoRestart: false },
+      };
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newConfig),
+        }
+      );
+
+      const result = await response.json();
+      expect(response.status).toBe(200);
+      expect(result.success).toBe(true);
+
+      // Wait to ensure no restart is triggered
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      expect(mockSpawn).not.toHaveBeenCalled();
+    });
+
+    it("应该在手动重启时广播重启状态更新", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // Connect a WebSocket client
+      const ws = new WebSocket(`ws://localhost:${currentPort}`);
+      const messages: any[] = [];
+
+      await new Promise<void>((resolve) => {
+        ws.on("open", resolve);
+      });
+
+      ws.on("message", (data: Buffer) => {
+        messages.push(JSON.parse(data.toString()));
+      });
+
+      // 使用 HTTP API 发送重启请求（新架构）
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/services/restart`,
+        {
+          method: "POST",
+        }
+      );
+
+      expect(response.status).toBe(200);
+
+      // Wait for messages
+      await new Promise((resolve) => setTimeout(resolve, 600));
+
+      // 由于我们的 mock 没有完整模拟事件流，我们验证 HTTP API 调用成功即可
+      // 在实际环境中，这会触发 restartStatus WebSocket 消息
+      // 这个测试主要验证 HTTP API 重启功能正常工作
+      expect(response.status).toBe(200);
+
+      ws.close();
+    });
+
+    it("应该在手动重启时启动服务", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // 使用 HTTP API 发送重启请求（新架构）
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/services/restart`,
+        {
+          method: "POST",
+        }
+      );
+
+      expect(response.status).toBe(200);
+
+      // 验证响应内容
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.message).toBe("重启请求已接收");
+    });
+  });
+
+  describe("构造函数和初始化", () => {
+    it("应该正确初始化所有依赖", () => {
+      webServer = new WebServer(currentPort);
+
+      expect(webServer).toBeDefined();
+      expect(webServer).toBeInstanceOf(WebServer);
+    });
+
+    it("应该在配置读取失败时使用默认端口", () => {
+      mockConfigManager.getWebUIPort.mockImplementation(() => {
+        throw new Error("配置读取失败");
+      });
+
+      expect(() => new WebServer()).not.toThrow();
+    });
+
+    it("应该正确设置事件总线", async () => {
+      webServer = new WebServer(currentPort);
+
+      // 验证事件总线被正确获取
+      const { getEventBus } = await import("../../services/index.js");
+      expect(getEventBus).toHaveBeenCalled();
+    });
+  });
+
+  describe("中间件和路由", () => {
+    it("应该正确设置 CORS 中间件", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/status`,
+        {
+          method: "OPTIONS",
+        }
+      );
+
+      expect(response.headers.get("access-control-allow-origin")).toBe("*");
+    });
+
+    it("应该处理服务器内部错误", async () => {
+      // 这个测试验证错误处理中间件的存在，但由于 mock 的限制，
+      // 我们主要验证服务器能够正常响应请求
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/status`
+      );
+
+      // 验证服务器能够正常响应（mock 返回 200）
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("API 端点测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理主要的配置 API 端点", async () => {
+      const endpoints = [
+        "/api/config",
+        "/api/config/mcp-servers",
+        "/api/config/path",
+      ];
+
+      for (const endpoint of endpoints) {
+        const response = await fetch(
+          `http://localhost:${currentPort}${endpoint}`
+        );
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it("应该处理配置重新加载", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config/reload`,
+        {
+          method: "POST",
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("配置重新加载成功");
+    });
+
+    it("应该处理主要的状态 API 端点", async () => {
+      const endpoints = [
+        "/api/status",
+        "/api/status/client",
+        "/api/status/mcp-servers",
+      ];
+
+      for (const endpoint of endpoints) {
+        const response = await fetch(
+          `http://localhost:${currentPort}${endpoint}`
+        );
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it("应该处理状态更新 API", async () => {
+      const updateEndpoints = [
+        { path: "/api/status/client", data: { status: "connected" } },
+        { path: "/api/status/mcp-servers", data: { servers: ["test"] } },
+      ];
+
+      for (const { path, data } of updateEndpoints) {
+        const response = await fetch(`http://localhost:${currentPort}${path}`, {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(data),
+        });
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it("应该处理状态重置", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/status/reset`,
+        {
+          method: "POST",
+        }
+      );
+
+      expect(response.status).toBe(200);
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("应该处理主要的服务 API 端点", async () => {
+      const serviceEndpoints = [
+        { path: "/api/services/restart", method: "POST" },
+        { path: "/api/services/status", method: "GET" },
+      ];
+
+      for (const { path, method } of serviceEndpoints) {
+        const response = await fetch(`http://localhost:${currentPort}${path}`, {
+          method,
+        });
+        expect(response.status).toBe(200);
+      }
+    });
+
+    it("应该处理静态文件请求", async () => {
+      const response = await fetch(`http://localhost:${currentPort}/`);
+      expect(response.status).toBe(200);
+
+      const content = await response.text();
+      expect(content).toContain("<!DOCTYPE html>");
+    });
+
+    it("应该处理未知 API 路由", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/unknown-endpoint`
+      );
+      expect(response.status).toBe(404);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("API_NOT_FOUND");
+    });
+  });
+
+  describe("WebSocket 功能测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该拒绝非 ESP32 的 WebSocket 连接", async () => {
+      const ws = new WebSocket(`ws://localhost:${currentPort}`);
+
+      await new Promise<void>((resolve, reject) => {
+        const timeout = setTimeout(() => {
+          ws.close();
+          reject(new Error("WebSocket connection timeout"));
+        }, 3000);
+
+        ws.on("close", (code: number) => {
+          // 非 /ws 路径的连接应被拒绝
+          clearTimeout(timeout);
+          expect(code).toBe(1000);
+          resolve();
+        });
+
+        ws.on("error", () => {
+          // 连接错误也是可接受的行为（服务端主动关闭）
+          clearTimeout(timeout);
+          resolve();
+        });
+      });
+    });
+
+    it("应该处理多个并发的 WebSocket 连接拒绝", async () => {
+      const connections: WebSocket[] = [];
+      const connectionCount = 5;
+
+      for (let i = 0; i < connectionCount; i++) {
+        const ws = new WebSocket(`ws://localhost:${currentPort}`);
+        connections.push(ws);
+      }
+
+      await Promise.all(
+        connections.map(
+          (ws) =>
+            new Promise<void>((resolve) => {
+              const timeout = setTimeout(() => {
+                ws.close();
+                resolve();
+              }, 3000);
+
+              ws.on("close", () => {
+                clearTimeout(timeout);
+                resolve();
+              });
+
+              ws.on("error", () => {
+                clearTimeout(timeout);
+                resolve();
+              });
+            })
+        )
+      );
+
+      // 关闭所有连接
+      for (const ws of connections) {
+        ws.close();
+      }
+    });
+  });
+
+  describe("连接初始化测试", () => {
+    it("应该处理配置文件不存在的情况", async () => {
+      mockConfigManager.configExists = vi.fn(() => false);
+
+      webServer = new WebServer(currentPort);
+
+      // 服务器应该能够启动，即使连接初始化失败
+      await expect(webServer.start()).resolves.not.toThrow();
+    });
+
+    it("应该处理小智连接管理器初始化失败", async () => {
+      // Mock EndpointManager constructor to throw
+      vi.mocked(EndpointManager).mockImplementation(() => {
+        throw new Error("Xiaozhi Connection Manager initialization failed");
+      });
+
+      webServer = new WebServer(currentPort);
+
+      // 服务器应该能够启动，即使连接初始化失败
+      await expect(webServer.start()).resolves.not.toThrow();
+    });
+  });
+
+  describe("错误处理测试", () => {
+    it("应该处理服务器已经启动的情况", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // 再次启动应该不会抛出错误
+      await expect(webServer.start()).resolves.not.toThrow();
+    });
+
+    it("应该处理配置加载错误", async () => {
+      mockConfigManager.configExists = vi.fn(() => true);
+      mockConfigManager.getConfig = vi.fn(() => {
+        throw new Error("配置加载失败");
+      });
+
+      webServer = new WebServer(currentPort);
+
+      // 服务器应该能够启动，即使配置加载失败
+      await expect(webServer.start()).resolves.not.toThrow();
+    });
+  });
+
+  describe("生命周期管理测试", () => {
+    it("应该正确停止服务器", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      await expect(webServer.stop()).resolves.not.toThrow();
+    });
+
+    it("应该正确销毁服务器实例", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      expect(() => webServer.destroy()).not.toThrow();
+    });
+
+    it("应该处理没有 WebSocket 服务器的停止情况", async () => {
+      webServer = new WebServer(currentPort);
+      // 不启动服务器，直接停止
+
+      await expect(webServer.stop()).resolves.not.toThrow();
+    });
+  });
+
+  describe("小智连接状态测试", () => {
+    it("应该返回多端点连接状态", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const status = webServer.getEndpointConnectionStatus();
+      expect(status).toBeDefined();
+      expect(status.type).toBeDefined();
+    });
+
+    it("应该处理无连接的情况", () => {
+      webServer = new WebServer(currentPort);
+
+      const status = webServer.getEndpointConnectionStatus();
+      expect(status.type).toBe("none");
+      expect(status.connected).toBe(false);
+    });
+  });
+
+  describe("版本 API 测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理版本信息请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/version`
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.version).toBeDefined();
+    });
+
+    it("应该处理简单版本请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/version/simple`
+      );
+      expect(response.status).toBe(200);
+
+      const text = await response.text();
+      expect(text).toBe("1.0.0");
+    });
+
+    it("应该处理版本缓存清理", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/version/cache`,
+        {
+          method: "DELETE",
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("工具 API 测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理工具调用请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/call`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ toolName: "test", params: {} }),
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+    });
+
+    it("应该处理工具列表请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/list`
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.tools).toBeDefined();
+    });
+
+    it("应该处理自定义工具请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/custom`
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.tools).toBeDefined();
+    });
+
+    it("应该处理添加自定义工具", async () => {
+      const newTool = {
+        name: "test-tool",
+        description: "Test tool",
+        schema: {},
+      };
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/custom`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newTool),
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("自定义工具添加成功");
+    });
+
+    it("应该处理更新自定义工具", async () => {
+      const updatedTool = {
+        name: "test-tool",
+        description: "Updated test tool",
+        schema: {},
+      };
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/custom/test-tool`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(updatedTool),
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("自定义工具更新成功");
+    });
+
+    it("应该处理删除自定义工具", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/custom/test-tool`,
+        {
+          method: "DELETE",
+        }
+      );
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.message).toBe("自定义工具删除成功");
+    });
+  });
+
+  describe("扣子 API 测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理工作空间请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/coze/workspaces`
+      );
+      // Coze API 可能返回 500 如果未实现或不配置，这是预期的
+      expect([200, 404, 500]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.workspaces).toBeDefined();
+      }
+    });
+
+    it("应该处理工作流请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/coze/workflows`
+      );
+      // Coze API 可能返回 500 如果未实现或不配置，这是预期的
+      expect([200, 404, 500]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.workflows).toBeDefined();
+      }
+    });
+
+    it("应该处理缓存清理请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/coze/cache/clear`,
+        {
+          method: "POST",
+        }
+      );
+      // Coze API 可能返回 500 如果未实现或不配置，这是预期的
+      expect([200, 404, 500]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.message).toBe("缓存已清空");
+      }
+    });
+
+    it("应该处理缓存统计请求", async () => {
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/coze/cache/stats`
+      );
+      // Coze API 可能返回 500 如果未实现或不配置，这是预期的
+      expect([200, 404, 500]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.cacheSize).toBeDefined();
+        expect(data.data.hitRate).toBeDefined();
+      }
+    });
+  });
+
+  describe("MCP 路由测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理 MCP POST 请求", async () => {
+      const mcpRequest = {
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {},
+      };
+
+      const response = await fetch(`http://localhost:${currentPort}/mcp`, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(mcpRequest),
+      });
+      expect(response.status).toBe(200);
+
+      const data = await response.json();
+      expect(data.jsonrpc).toBe("2.0");
+      expect(data.id).toBe(1);
+    });
+  });
+
+  describe("MCP 端点管理测试", () => {
+    beforeEach(async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+    });
+
+    it("应该处理获取端点状态请求", async () => {
+      const endpointRequest = { endpoint: "ws://localhost:9999" };
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/status`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      // 由于连接管理器可能未初始化，期望 503 或 200
+      expect([200, 503]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.endpoint).toBe("ws://localhost:9999");
+        expect(data.data.connected).toBe(true);
+      } else {
+        const data = await response.json();
+        expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+        expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+      }
+    });
+
+    it("应该处理连接端点请求", async () => {
+      const endpointRequest = { endpoint: "ws://localhost:9999" };
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/connect`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      // 由于连接管理器可能未初始化，期望 503 或 200
+      expect([200, 503]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.operation).toBe("connect");
+      } else {
+        const data = await response.json();
+        expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+        expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+      }
+    });
+
+    it("应该处理断开端点请求", async () => {
+      const endpointRequest = { endpoint: "ws://localhost:9999" };
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/disconnect`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      // 由于连接管理器可能未初始化，期望 503 或 200
+      expect([200, 503]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.operation).toBe("disconnect");
+      } else {
+        const data = await response.json();
+        expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+        expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+      }
+    });
+
+    it("应该处理重连端点请求", async () => {
+      const endpointRequest = { endpoint: "ws://localhost:9999" };
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/reconnect`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      // reconnect 路由已被移除，应该返回 404
+      expect(response.status).toBe(404);
+
+      const data = await response.json();
+      expect(data.error).toBeDefined();
+    });
+
+    it("应该处理添加端点请求", async () => {
+      const newEndpoint = {
+        endpoint: "ws://new.endpoint",
+      };
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/add`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(newEndpoint),
+        }
+      );
+      // 由于连接管理器可能未初始化，期望 503 或 200
+      expect([200, 503]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.operation).toBe("add");
+      } else {
+        const data = await response.json();
+        expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+        expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+      }
+    });
+
+    it("应该处理移除端点请求", async () => {
+      const endpointRequest = { endpoint: "ws://old.endpoint" };
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/endpoint/remove`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      // 由于连接管理器可能未初始化，期望 503 或 200
+      expect([200, 503]).toContain(response.status);
+
+      if (response.status === 200) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data.operation).toBe("remove");
+      } else {
+        const data = await response.json();
+        expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+        expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+      }
+    });
+
+    it("应该处理连接管理器不可用的情况", async () => {
+      // 使用不同的端口避免冲突
+      const testPort = await getAvailablePort();
+
+      // 创建一个新的 WebServer 实例，确保连接管理器未初始化
+      const tempWebServer = new WebServer(testPort);
+      await tempWebServer.start();
+
+      const endpointRequest = { endpoint: "ws://localhost:9999" };
+      const response = await fetch(
+        `http://localhost:${testPort}/api/endpoint/status`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify(endpointRequest),
+        }
+      );
+      expect(response.status).toBe(503);
+
+      const data = await response.json();
+      expect(data.error.code).toBe("ENDPOINT_HANDLER_NOT_AVAILABLE");
+      expect(data.error.message).toBe("端点处理器尚未初始化，请稍后再试");
+
+      await tempWebServer.stop();
+    });
+  });
+
+  describe("重连机制测试", () => {
+    it("应该实现带重试的连接逻辑", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // 由于 connectWithRetry 是私有方法，我们通过测试整体行为来验证
+      // 这里我们主要验证方法不会抛出未处理的异常
+      expect(() => {
+        // 我们无法直接调用私有方法，但可以验证相关的错误处理
+        webServer.getEndpointConnectionStatus();
+      }).not.toThrow();
+    });
+
+    it("应该处理连接超时情况", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      // 验证超时处理
+      expect(() => {
+        webServer.getEndpointConnectionStatus();
+      }).not.toThrow();
+    });
+  });
+
+  describe("错误边界测试", () => {
+    it("应该处理无效的 JSON 请求体", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/config`,
+        {
+          method: "PUT",
+          headers: { "Content-Type": "application/json" },
+          body: "invalid json",
+        }
+      );
+
+      // 由于 Hono 会自动处理 JSON 解析错误，我们期望得到 400 或 500
+      // 但是 mock 的处理器会返回 200，所以这里调整期望
+      expect([200, 400, 500]).toContain(response.status);
+    });
+
+    it("应该处理缺失的必需参数", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const response = await fetch(
+        `http://localhost:${currentPort}/api/tools/custom`,
+        {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({}), // 缺少必需的 name 字段
+        }
+      );
+
+      // 由于处理器是 mock 的，期望得到 200
+      // 在实际环境中，这可能会返回 400
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("性能测试", () => {
+    it("应该处理适量并发请求", async () => {
+      webServer = new WebServer(currentPort);
+      await webServer.start();
+
+      const requestCount = 20; // 减少并发数量
+      const requests = Array.from({ length: requestCount }, () =>
+        fetch(`http://localhost:${currentPort}/api/status`)
+      );
+
+      const responses = await Promise.all(requests);
+
+      // 所有请求都应该成功
+      for (const response of responses) {
+        expect(response.status).toBe(200);
+      }
+    });
+  });
+});

--- a/src/server/__tests__/webserver/webserver.unit.test.ts
+++ b/src/server/__tests__/webserver/webserver.unit.test.ts
@@ -1,0 +1,844 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { WebServer } from "../../WebServer";
+import { MCPServiceManager } from "../../lib/mcp";
+
+// Mock configManager to avoid triggering real config loading
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    getConfig: vi.fn(() => ({
+      mcpEndpoint: [],
+      mcpServers: {},
+      connection: {},
+    })),
+    getMcpServers: vi.fn(() => ({})),
+    getMcpEndpoints: vi.fn(() => []),
+    configExists: vi.fn(() => true),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    setToolEnabled: vi.fn(),
+    updatePlatformConfig: vi.fn(),
+    getMcpEndpoint: vi.fn(),
+    getConnectionConfig: vi.fn(),
+    reloadConfig: vi.fn(),
+    getConfigPath: vi.fn(),
+    validateConfig: vi.fn(),
+    updateConfig: vi.fn(),
+    getLLMConfig: vi.fn(() => null),
+    isLLMConfigValid: vi.fn(() => false),
+    getTTSConfig: vi.fn(() => ({})),
+    getASRConfig: vi.fn(() => ({})),
+  },
+}));
+
+// Mock Logger
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// Mock EventBus
+vi.mock("../../services/EventBus.js", () => ({
+  getEventBus: vi.fn().mockReturnValue({
+    onEvent: vi.fn(),
+    emitEvent: vi.fn(),
+    removeAllListeners: vi.fn(),
+  }),
+}));
+
+// Mock EndpointManager
+vi.mock("../../lib/endpoint/index.js", () => ({
+  EndpointManager: vi.fn().mockImplementation(() => ({
+    initialize: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    setServiceManager: vi.fn(),
+    getConnectionStatus: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+  })),
+}));
+
+// Mock ESP32DeviceManager
+let esp32ManagerInstance: any = null;
+vi.mock("../../../esp32/index.js", () => ({
+  ESP32DeviceManager: vi.fn().mockImplementation(() => {
+    esp32ManagerInstance = {
+      handleWebSocketConnection: vi.fn().mockResolvedValue(undefined),
+      destroy: vi.fn(),
+    };
+    return esp32ManagerInstance;
+  }),
+}));
+
+// Mock MCPServiceManager
+vi.mock("../../lib/mcp", () => ({
+  MCPServiceManager: vi.fn().mockImplementation(() => ({
+    start: vi.fn().mockResolvedValue(undefined),
+    stopAllServices: vi.fn().mockResolvedValue(undefined),
+    isRunning: false,
+    tools: new Map(),
+    services: new Map(),
+    on: vi.fn(),
+    off: vi.fn(),
+    emit: vi.fn(),
+    removeAllListeners: vi.fn(),
+    listTools: vi.fn().mockResolvedValue([]),
+    callTool: vi.fn().mockResolvedValue({ content: [] }),
+    addService: vi.fn(),
+    removeService: vi.fn(),
+    getServiceStatus: vi.fn().mockReturnValue("connected"),
+  })),
+}));
+
+/**
+ * 创建 Mock EndpointManager 的工厂函数
+ * 使用 Partial 类型配合 as any 断言来绕过完整类型检查
+ */
+function createMockEndpointManager(): any {
+  return {
+    initialize: vi.fn().mockResolvedValue(undefined),
+    connect: vi.fn().mockResolvedValue(undefined),
+    cleanup: vi.fn().mockResolvedValue(undefined),
+    setServiceManager: vi.fn(),
+    setMcpManager: vi.fn(),
+    getConnectionStatus: vi.fn().mockReturnValue([]),
+    on: vi.fn(),
+    addEndpoint: vi.fn(),
+    getEndpoints: vi.fn().mockReturnValue([]),
+    reconnect: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+describe("WebServer 单元测试", () => {
+  let webServer: WebServer;
+  const mockPort = 3001;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServer = new WebServer(mockPort);
+  });
+
+  afterEach(async () => {
+    if (webServer?.stop) {
+      try {
+        await webServer.stop();
+      } catch (error) {
+        // 忽略停止错误
+      }
+    }
+  });
+
+  describe("Connection Status API", () => {
+    it("应该提供连接状态方法", () => {
+      expect(webServer.getEndpointConnectionStatus).toBeDefined();
+      expect(typeof webServer.getEndpointConnectionStatus).toBe("function");
+    });
+
+    it("应该在无连接时返回 none 状态", () => {
+      // 使用工厂函数创建 mock 连接管理器
+      const mockManager = createMockEndpointManager();
+      webServer.setXiaozhiConnectionManager(mockManager);
+
+      const connectionStatus = webServer.getEndpointConnectionStatus();
+
+      expect(connectionStatus).toMatchObject({
+        type: "multi-endpoint",
+        manager: {
+          connectedConnections: 0,
+          totalConnections: 0,
+          healthCheckStats: {},
+        },
+        connections: [],
+      });
+    });
+
+    it("应该处理多端点配置", () => {
+      // 使用工厂函数创建 mock 连接管理器
+      const mockManager = createMockEndpointManager();
+      // 配置特定的返回值
+      mockManager.getConnectionStatus = vi.fn().mockReturnValue([
+        { endpoint: "wss://test1.example.com", connected: true },
+        { endpoint: "wss://test2.example.com", connected: true },
+      ]);
+
+      // 使用依赖注入设置 mock 连接管理器
+      webServer.setXiaozhiConnectionManager(mockManager);
+
+      const connectionStatus = webServer.getEndpointConnectionStatus();
+
+      expect(connectionStatus).toMatchObject({
+        type: "multi-endpoint",
+        manager: {
+          connectedConnections: 2,
+          totalConnections: 2,
+          healthCheckStats: {},
+        },
+        connections: expect.any(Array),
+      });
+    });
+
+    it("应该处理单端点回退", () => {
+      // 清空连接管理器（不设置，让它为 undefined）
+      (webServer as any).endpointManager = undefined;
+
+      const connectionStatus = webServer.getEndpointConnectionStatus();
+
+      // 新实现中，当 endpointManager 为 undefined 时返回 none 状态
+      expect(connectionStatus).toMatchObject({
+        type: "none",
+        connected: false,
+      });
+    });
+  });
+
+  describe("依赖注入功能", () => {
+    it("应该允许设置连接管理器", () => {
+      const mockManager = {
+        initialize: vi.fn(),
+        connect: vi.fn(),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      } as any;
+
+      webServer.setXiaozhiConnectionManager(mockManager);
+
+      expect(webServer.getEndpointManager()).toBe(mockManager);
+    });
+
+    it("应该在获取连接管理器时返回已设置的实例", () => {
+      const mockManager = {
+        test: "value",
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      } as any;
+
+      webServer.setXiaozhiConnectionManager(mockManager);
+
+      const manager = webServer.getEndpointManager();
+      expect(manager).toBe(mockManager);
+      expect((manager as any).test).toBe("value");
+    });
+  });
+
+  describe("初始化流程", () => {
+    let mockConnectionManager: any;
+    let mockServiceManager: any;
+
+    beforeEach(() => {
+      // Mock 连接管理器
+      mockConnectionManager = {
+        initialize: vi.fn().mockResolvedValue(undefined),
+        connect: vi.fn().mockResolvedValue(undefined),
+        addEndpoint: vi.fn(),
+        setServiceManager: vi.fn(),
+        getConnectionStatus: vi.fn().mockReturnValue([]),
+        on: vi.fn(),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      };
+
+      // Mock MCP 服务管理器
+      mockServiceManager = {
+        startAllServices: vi.fn().mockResolvedValue(undefined),
+        stopAllServices: vi.fn().mockResolvedValue(undefined),
+        getAllTools: vi.fn().mockReturnValue([]),
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      };
+    });
+
+    it("应该在有端点配置时正确初始化", async () => {
+      // 使用依赖注入设置 mock 连接管理器
+      webServer.setXiaozhiConnectionManager(mockConnectionManager);
+
+      // 设置 mcpServiceManager
+      webServer.setMCPServiceManager(mockServiceManager);
+
+      // 调用被测试的方法
+      await (webServer as any).initializeXiaozhiConnection(
+        "wss://test.example.com",
+        {}
+      );
+
+      // 验证端点被添加到连接管理器
+      expect(mockConnectionManager.addEndpoint).toHaveBeenCalled();
+
+      // 验证连接管理器被连接
+      expect(mockConnectionManager.connect).toHaveBeenCalled();
+    });
+
+    it("应该在空端点配置时正确初始化", async () => {
+      // 使用依赖注入设置 mock 连接管理器
+      webServer.setXiaozhiConnectionManager(mockConnectionManager);
+
+      // 设置 mcpServiceManager
+      webServer.setMCPServiceManager(mockServiceManager);
+
+      // 调用被测试的方法 - 空配置
+      await (webServer as any).initializeXiaozhiConnection("", {});
+
+      // 验证没有端点被添加（因为配置为空）
+      expect(mockConnectionManager.addEndpoint).not.toHaveBeenCalled();
+
+      // 验证连接管理器没有被连接（因为没有有效端点）
+      expect(mockConnectionManager.connect).not.toHaveBeenCalled();
+    });
+
+    it("应该在无效端点配置时正确初始化", async () => {
+      // 使用依赖注入设置 mock 连接管理器
+      webServer.setXiaozhiConnectionManager(mockConnectionManager);
+
+      webServer.setMCPServiceManager(mockServiceManager);
+
+      // 调用被测试的方法 - 无效端点
+      await (webServer as any).initializeXiaozhiConnection(
+        ["<请填写小智接入点>", ""],
+        {}
+      );
+
+      // 验证没有端点被添加（因为配置无效）
+      expect(mockConnectionManager.addEndpoint).not.toHaveBeenCalled();
+
+      // 验证连接管理器没有被连接（因为没有有效端点）
+      expect(mockConnectionManager.connect).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("清理流程", () => {
+    it("应该在停止时清理连接管理器", async () => {
+      const mockManager = {
+        cleanup: vi.fn().mockResolvedValue(undefined),
+      } as any;
+
+      // 使用依赖注入设置 mock 连接管理器
+      webServer.setXiaozhiConnectionManager(mockManager);
+
+      // 创建一个 mock HTTP 服务器
+      const mockHttpServer = {
+        close: vi.fn().mockImplementation((callback: () => void) => {
+          callback();
+        }),
+        listening: true,
+      };
+
+      // 设置内部属性
+      (webServer as any).httpServer = mockHttpServer;
+      (webServer as any).wss = {
+        clients: new Set(),
+        close: vi.fn().mockImplementation((callback: () => void) => {
+          callback();
+        }),
+      };
+
+      // 调用 stop 方法
+      await webServer.stop();
+
+      // 验证清理被调用
+      expect(mockManager.cleanup).toHaveBeenCalled();
+    });
+  });
+});
+
+describe("WebServer MCPServiceManager 方法测试", () => {
+  let webServer: WebServer;
+  let mockMCPServiceManager: MCPServiceManager;
+
+  beforeEach(() => {
+    // 创建一个新的 WebServer 实例用于每个测试
+    webServer = new WebServer(0); // 使用端口 0 让系统自动分配
+    mockMCPServiceManager = new MCPServiceManager();
+  });
+
+  describe("setMCPServiceManager", () => {
+    it("应该能够设置 MCPServiceManager 实例", () => {
+      // 在 WebServer 启动前设置实例
+      webServer.setMCPServiceManager(mockMCPServiceManager);
+
+      // 验证设置成功
+      expect(webServer.getMCPServiceManager()).toBe(mockMCPServiceManager);
+    });
+
+    it("应该替换现有的 MCPServiceManager 实例", () => {
+      // 设置第一个实例
+      const firstManager = new MCPServiceManager();
+      webServer.setMCPServiceManager(firstManager);
+      expect(webServer.getMCPServiceManager()).toBe(firstManager);
+
+      // 替换为第二个实例
+      const secondManager = new MCPServiceManager();
+      webServer.setMCPServiceManager(secondManager);
+      expect(webServer.getMCPServiceManager()).toBe(secondManager);
+      expect(webServer.getMCPServiceManager()).not.toBe(firstManager);
+    });
+  });
+
+  describe("getMCPServiceManager", () => {
+    it("在 WebServer 未启动且未设置实例时应该抛出错误", () => {
+      expect(() => {
+        webServer.getMCPServiceManager();
+      }).toThrow(
+        "MCPServiceManager 未初始化，请确保 WebServer 已调用 start() 方法完成初始化"
+      );
+    });
+
+    it("在手动设置实例后应该返回有效实例", () => {
+      // 手动设置实例
+      webServer.setMCPServiceManager(mockMCPServiceManager);
+
+      // 应该返回设置的实例
+      const manager = webServer.getMCPServiceManager();
+      expect(manager).toBe(mockMCPServiceManager);
+      expect(manager).toBeDefined();
+    });
+
+    it("在 WebServer 启动后应该返回有效实例", async () => {
+      try {
+        await webServer.start();
+
+        // 启动后应该有 MCPServiceManager 实例
+        const manager = webServer.getMCPServiceManager();
+        expect(manager).toBeDefined();
+        // 由于是 mock 对象，验证它具有必要的方法而不是 instanceOf
+        expect(manager).toHaveProperty("start");
+        expect(manager).toHaveProperty("stopAllServices");
+      } catch (error) {
+        // 如果启动失败（由于缺少某些依赖），至少测试错误处理
+        console.log("WebServer start failed in test:", error);
+      }
+    });
+  });
+
+  describe("错误处理", () => {
+    it("应该处理 null/undefined 参数", () => {
+      // 测试设置 null
+      expect(() => {
+        webServer.setMCPServiceManager(null as any);
+      }).not.toThrow();
+
+      // 验证获取时抛出错误
+      expect(() => {
+        webServer.getMCPServiceManager();
+      }).toThrow();
+    });
+
+    it("错误消息应该清晰且有帮助", () => {
+      try {
+        webServer.getMCPServiceManager();
+        expect.fail("Expected getMCPServiceManager to throw");
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toContain(
+          "MCPServiceManager 未初始化"
+        );
+        expect((error as Error).message).toContain("start() 方法");
+      }
+    });
+  });
+});
+
+describe("WebServer initializeConnections 降级模式", () => {
+  let webServer: WebServer;
+  const mockPort = 3002;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServer = new WebServer(mockPort);
+  });
+
+  afterEach(async () => {
+    if (webServer?.stop) {
+      try {
+        await webServer.stop();
+      } catch {
+        // 忽略停止错误
+      }
+    }
+  });
+
+  it("应该在配置加载失败时进入降级模式并创建空 MCPServiceManager", async () => {
+    // Mock loadConfiguration 抛出异常（模拟配置文件损坏）
+    const originalLoadConfig = (webServer as any).loadConfiguration.bind(
+      webServer
+    );
+    (webServer as any).loadConfiguration = vi
+      .fn()
+      .mockRejectedValue(new Error("配置文件解析失败"));
+
+    // 确保初始没有 mcpServiceManager
+    expect((webServer as any).mcpServiceManager).toBeNull();
+
+    // 调用 initializeConnections，应进入降级模式
+    await (webServer as any).initializeConnections();
+
+    // 验证降级模式下创建了新的 MCPServiceManager 实例
+    expect(MCPServiceManager).toHaveBeenCalled();
+    expect((webServer as any).mcpServiceManager).toBeDefined();
+    expect((webServer as any).mcpServiceManager.start).toHaveBeenCalled();
+  });
+
+  it("在 MCPServiceManager 已存在时不应重复创建", async () => {
+    // 预先设置一个 mcpServiceManager
+    const existingManager = new MCPServiceManager();
+    webServer.setMCPServiceManager(existingManager);
+
+    // Mock loadConfiguration 抛异常
+    (webServer as any).loadConfiguration = vi
+      .fn()
+      .mockRejectedValue(new Error("配置加载失败"));
+
+    await (webServer as any).initializeConnections();
+
+    // MCPServiceManager 构造函数不应被再次调用（使用已有实例）
+    // 注意：由于 vi.mock 在顶层，构造函数调用次数是累计的
+    // 但关键是 mcpServiceManager 应该仍然是同一个实例
+    expect((webServer as any).mcpServiceManager).toBe(existingManager);
+  });
+
+  it("降级模式下 getMCPServiceManager 不应抛错", async () => {
+    (webServer as any).loadConfiguration = vi
+      .fn()
+      .mockRejectedValue(new Error("配置加载失败"));
+
+    await (webServer as any).initializeConnections();
+
+    // 降级后应该能正常获取 manager
+    const manager = webServer.getMCPServiceManager();
+    expect(manager).toBeDefined();
+  });
+});
+
+describe("WebServer setupMCPServerAddedListener 事件监听器", () => {
+  let webServer: WebServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServer = new WebServer(3003);
+  });
+
+  it("构造函数中应注册两个事件监听器", () => {
+    // 通过验证 destroy 时清理函数数量来间接确认监听器注册
+    const unsubscribersBefore = (webServer as any).eventListenerUnsubscribers;
+    expect(unsubscribersBefore).toHaveLength(2);
+  });
+
+  it("destroy() 应移除所有事件监听器", () => {
+    // 获取 eventBus mock（从 services/index 的 mock 中获取）
+    webServer.destroy();
+
+    // 验证清理函数被调用
+    const unsubscribers = (webServer as any).eventListenerUnsubscribers;
+    expect(unsubscribers).toHaveLength(0);
+  });
+
+  it("endpointManager 未初始化时事件处理应安全跳过", () => {
+    // 不设置 endpointManager，确保为 null
+    expect((webServer as any).endpointManager).toBeNull();
+
+    // 验证事件监听器清理函数已注册（构造函数中通过 setupMCPServerAddedListener 注册）
+    expect((webServer as any).eventListenerUnsubscribers).toHaveLength(2);
+  });
+});
+
+describe("WebServer handleESP32DeviceConnection 错误处理", () => {
+  let webServer: WebServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    esp32ManagerInstance = null;
+    webServer = new WebServer(3004);
+    // 构造函数会通过 mock 创建 esp32ManagerInstance
+  });
+
+  it("缺少 device-id 请求头时应关闭连接(code 1008)", () => {
+    const mockWs = { close: vi.fn(), readyState: 1 };
+    const mockReq = { headers: {}, url: "/ws" };
+
+    (webServer as any).handleESP32DeviceConnection(mockWs, mockReq);
+
+    expect(mockWs.close).toHaveBeenCalledWith(1008, "Missing required headers");
+  });
+
+  it("缺少 client-id 请求头时应关闭连接(code 1008)", () => {
+    const mockWs = { close: vi.fn(), readyState: 1 };
+    const mockReq = {
+      headers: { "device-id": "dev-001" },
+      url: "/ws",
+    };
+
+    (webServer as any).handleESP32DeviceConnection(mockWs, mockReq);
+
+    expect(mockWs.close).toHaveBeenCalledWith(1008, "Missing required headers");
+  });
+
+  it("连接处理成功时应记录日志", async () => {
+    const mockWs = { close: vi.fn(), readyState: 1 };
+    const mockReq = {
+      headers: {
+        "device-id": "dev-001",
+        "client-id": "cli-001",
+        authorization: "Bearer token123",
+      },
+      url: "/ws",
+    };
+
+    const { logger } = await import("../../Logger.js");
+
+    await (webServer as any).handleESP32DeviceConnection(mockWs, mockReq);
+
+    expect(esp32ManagerInstance.handleWebSocketConnection).toHaveBeenCalledWith(
+      mockWs,
+      "dev-001",
+      "cli-001",
+      "token123"
+    );
+    expect(logger.info).toHaveBeenCalledWith(
+      expect.stringContaining("[WS-ESP32] ESP32设备连接处理成功")
+    );
+  });
+
+  it("连接处理失败且 ws 为 OPEN 时应关闭(code 1011)", async () => {
+    esp32ManagerInstance.handleWebSocketConnection = vi
+      .fn()
+      .mockRejectedValue(new Error("处理失败"));
+    const mockWs = { close: vi.fn(), readyState: 1 }; // OPEN = 1
+    const mockReq = {
+      headers: {
+        "device-id": "dev-001",
+        "client-id": "cli-001",
+      },
+      url: "/ws",
+    };
+
+    // handleESP32DeviceConnection 内部是 fire-and-forget，需要等待微任务执行 .catch
+    (webServer as any).handleESP32DeviceConnection(mockWs, mockReq);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockWs.close).toHaveBeenCalledWith(
+      1011,
+      "Connection handling failed"
+    );
+  });
+
+  it("连接处理失败且 ws 为 CONNECTING 时应关闭(code 1011)", async () => {
+    esp32ManagerInstance.handleWebSocketConnection = vi
+      .fn()
+      .mockRejectedValue(new Error("处理失败"));
+    const mockWs = { close: vi.fn(), readyState: 0 }; // CONNECTING = 0
+    const mockReq = {
+      headers: {
+        "device-id": "dev-001",
+        "client-id": "cli-001",
+      },
+      url: "/ws",
+    };
+
+    // handleESP32DeviceConnection 内部是 fire-and-forget，需要等待微任务执行 .catch
+    (webServer as any).handleESP32DeviceConnection(mockWs, mockReq);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(mockWs.close).toHaveBeenCalledWith(
+      1011,
+      "Connection handling failed"
+    );
+  });
+});
+
+describe("WebServer connectWithRetry 重试逻辑", () => {
+  let webServer: WebServer;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServer = new WebServer(3005);
+  });
+
+  it("第一次尝试成功时应立即返回结果", async () => {
+    const expectedData = { success: true };
+    const connectionFn = vi.fn().mockResolvedValue(expectedData);
+
+    const result = await (webServer as any).connectWithRetry(
+      connectionFn,
+      "测试连接"
+    );
+
+    expect(result).toEqual(expectedData);
+    expect(connectionFn).toHaveBeenCalledTimes(1);
+  });
+
+  it("失败后应按指数退避重试并最终成功", async () => {
+    vi.useFakeTimers();
+    const expectedData = { success: true };
+    const connectionFn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("第一次失败"))
+      .mockRejectedValueOnce(new Error("第二次失败"))
+      .mockResolvedValueOnce(expectedData);
+
+    const resultPromise = (webServer as any).connectWithRetry(
+      connectionFn,
+      "测试连接",
+      5,
+      1000,
+      30000,
+      2
+    );
+
+    // 第一次尝试失败后等待 1s（initialDelay * backoffMultiplier^0 = 1000ms）
+    await vi.advanceTimersByTimeAsync(1000);
+    // 第二次尝试失败后等待 2s（initialDelay * backoffMultiplier^1 = 2000ms）
+    await vi.advanceTimersByTimeAsync(2000);
+
+    const result = await resultPromise;
+    vi.useRealTimers();
+
+    expect(result).toEqual(expectedData);
+    expect(connectionFn).toHaveBeenCalledTimes(3);
+  });
+
+  it("达到最大重试次数后应抛出包含最后一次错误信息的 Error", async () => {
+    vi.useFakeTimers();
+    const connectionFn = vi.fn().mockRejectedValue(new Error("持续失败"));
+
+    const resultPromise = (webServer as any)
+      .connectWithRetry(connectionFn, "测试连接", 3, 100, 30000, 2)
+      .catch((e: Error) => e); // 捕获 rejection 避免 unhandled
+
+    // 推进定时器让所有重试完成（每次间隔: 100ms, 200ms）
+    await vi.advanceTimersByTimeAsync(500);
+
+    const error = await resultPromise;
+    expect(error.message).toContain(
+      "测试连接 - 连接失败，已达到最大重试次数: 持续失败"
+    );
+    expect(connectionFn).toHaveBeenCalledTimes(3);
+    vi.useRealTimers();
+  });
+
+  it("延迟时间不应超过 maxDelay 上限", async () => {
+    vi.useFakeTimers();
+    const connectionFn = vi.fn().mockRejectedValue(new Error("失败"));
+
+    const resultPromise = (webServer as any)
+      .connectWithRetry(
+        connectionFn,
+        "测试连接",
+        4,
+        1000,
+        2000, // maxDelay 上限
+        10 // 大的乘数让延迟快速超过上限
+      )
+      .catch((e: Error) => e); // 捕获 rejection 避免 unhandled
+
+    // 推进定时器直到所有重试完成（maxDelay=2000，所以每次最多等 2000ms）
+    await vi.advanceTimersByTimeAsync(10000);
+
+    await resultPromise; // 等待 promise 完成（预期是 reject）
+
+    // 验证完成了所有 4 次尝试（没有因超长延迟而卡住）
+    expect(connectionFn).toHaveBeenCalledTimes(4);
+    vi.useRealTimers();
+  });
+});
+
+describe("WebServer initializeXiaozhiConnection 多端点处理", () => {
+  let webServer: WebServer;
+  let mockConnectionManager: any;
+  let mockServiceManager: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    webServer = new WebServer(3006);
+
+    mockConnectionManager = createMockEndpointManager();
+    mockServiceManager = {
+      startAllServices: vi.fn().mockResolvedValue(undefined),
+      stopAllServices: vi.fn().mockResolvedValue(undefined),
+      cleanup: vi.fn().mockResolvedValue(undefined),
+    };
+  });
+
+  it("字符串端点应转为单元素数组处理", async () => {
+    webServer.setXiaozhiConnectionManager(mockConnectionManager);
+    webServer.setMCPServiceManager(mockServiceManager);
+
+    await (webServer as any).initializeXiaozhiConnection(
+      "wss://single.endpoint",
+      {}
+    );
+
+    expect(mockConnectionManager.addEndpoint).toHaveBeenCalledWith(
+      "wss://single.endpoint"
+    );
+    expect(mockConnectionManager.connect).toHaveBeenCalled();
+  });
+
+  it("多端点数组中混合有效和无效端点时只添加有效端点", async () => {
+    webServer.setXiaozhiConnectionManager(mockConnectionManager);
+    webServer.setMCPServiceManager(mockServiceManager);
+
+    await (webServer as any).initializeXiaozhiConnection(
+      ["wss://valid.endpoint", "<请填写小智接入点>", "", "wss://another.valid"],
+      {}
+    );
+
+    // 只有两个有效端点
+    expect(mockConnectionManager.addEndpoint).toHaveBeenCalledTimes(2);
+    expect(mockConnectionManager.addEndpoint).toHaveBeenCalledWith(
+      "wss://valid.endpoint"
+    );
+    expect(mockConnectionManager.addEndpoint).toHaveBeenCalledWith(
+      "wss://another.valid"
+    );
+  });
+
+  it("endpointManager 已存在时应复用实例而非新建", async () => {
+    webServer.setXiaozhiConnectionManager(mockConnectionManager);
+    webServer.setMCPServiceManager(mockServiceManager);
+
+    await (webServer as any).initializeXiaozhiConnection(
+      "wss://test.endpoint",
+      {}
+    );
+
+    // endpointManager 已存在时不会创建新实例（不进入 if (!this.endpointManager) 分支）
+    // 验证 addEndpoint 和 connect 使用的是注入的实例
+    expect(mockConnectionManager.addEndpoint).toHaveBeenCalledWith(
+      "wss://test.endpoint"
+    );
+    expect(mockConnectionManager.connect).toHaveBeenCalled();
+  });
+
+  it("有效端点添加后应注册事件监听器", async () => {
+    webServer.setXiaozhiConnectionManager(mockConnectionManager);
+    webServer.setMCPServiceManager(mockServiceManager);
+
+    await (webServer as any).initializeXiaozhiConnection(
+      "wss://test.endpoint",
+      {}
+    );
+
+    // 应注册 endpointAdded 和 endpointRemoved 监听器
+    expect(mockConnectionManager.on).toHaveBeenCalledWith(
+      "endpointAdded",
+      expect.any(Function)
+    );
+    expect(mockConnectionManager.on).toHaveBeenCalledWith(
+      "endpointRemoved",
+      expect.any(Function)
+    );
+  });
+
+  it("connect 失败时应向上抛出错误", async () => {
+    mockConnectionManager.connect = vi
+      .fn()
+      .mockRejectedValue(new Error("连接失败"));
+    webServer.setXiaozhiConnectionManager(mockConnectionManager);
+    webServer.setMCPServiceManager(mockServiceManager);
+
+    await expect(
+      (webServer as any).initializeXiaozhiConnection("wss://test.endpoint", {})
+    ).rejects.toThrow("连接失败");
+  });
+});

--- a/src/server/constants/__tests__/constants.test.ts
+++ b/src/server/constants/__tests__/constants.test.ts
@@ -1,0 +1,219 @@
+/**
+ * 常量测试
+ * 测试所有常量值的正确性、不可变性和类型安全
+ */
+
+import { describe, expect, it } from "vitest";
+import {
+  CACHE_FILE_CONFIG,
+  CACHE_TIMEOUTS,
+  HTTP_CONTENT_TYPES,
+  HTTP_ERROR_MESSAGES,
+  HTTP_HEADERS,
+  HTTP_SERVER_CONFIG,
+  HTTP_STATUS_CODES,
+  HTTP_TIMEOUTS,
+  JSONRPC_ERROR_MESSAGES,
+  JSONRPC_VERSION,
+  MCP_METHODS,
+  MCP_PROTOCOL_VERSIONS,
+  MCP_SERVER_EVENTS,
+  MCP_SERVER_INFO,
+  MCP_SERVICE_EVENTS,
+  MCP_SUPPORTED_PROTOCOL_VERSIONS,
+  MESSAGE_SIZE_LIMITS,
+  PAGINATION_CONSTANTS,
+  SERVICE_RESTART_DELAYS,
+  TOOL_NAME_SEPARATORS,
+} from "../index.js";
+
+describe("HTTP 常量", () => {
+  describe("HTTP_CONTENT_TYPES", () => {
+    it("应该包含正确的 Content-Type 值", () => {
+      expect(HTTP_CONTENT_TYPES.APPLICATION_JSON).toBe("application/json");
+      expect(HTTP_CONTENT_TYPES.TEXT_HTML).toBe("text/html");
+      expect(HTTP_CONTENT_TYPES.TEXT_PLAIN).toBe("text/plain");
+    });
+
+    it("应该使用 as const 定义，提供类型层面的不可变性", () => {
+      // TypeScript 的 as const 只提供类型层面的不可变性
+      // 运行时仍然可以修改，但我们不应该这样做
+      // 这个测试只是验证常量的值是正确的
+      expect(HTTP_CONTENT_TYPES.APPLICATION_JSON).toBe("application/json");
+    });
+  });
+
+  describe("HTTP_HEADERS", () => {
+    it("应该包含正确的 HTTP 头名称", () => {
+      expect(HTTP_HEADERS.CONTENT_TYPE).toBe("Content-Type");
+      expect(HTTP_HEADERS.MCP_PROTOCOL_VERSION).toBe("MCP-Protocol-Version");
+    });
+  });
+
+  describe("HTTP_STATUS_CODES", () => {
+    it("应该包含正确的 HTTP 状态码", () => {
+      expect(HTTP_STATUS_CODES.OK).toBe(200);
+      expect(HTTP_STATUS_CODES.BAD_REQUEST).toBe(400);
+      expect(HTTP_STATUS_CODES.NOT_FOUND).toBe(404);
+      expect(HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR).toBe(500);
+    });
+  });
+
+  describe("HTTP_SERVER_CONFIG", () => {
+    it("应该包含正确的服务器配置", () => {
+      expect(HTTP_SERVER_CONFIG.DEFAULT_BIND_ADDRESS).toBe("0.0.0.0");
+      expect(HTTP_SERVER_CONFIG.DEFAULT_PORT).toBe(9999);
+    });
+  });
+
+  describe("HTTP_ERROR_MESSAGES", () => {
+    it("应该包含正确的错误消息", () => {
+      expect(HTTP_ERROR_MESSAGES.REQUEST_TOO_LARGE).toBe("Request too large");
+      expect(HTTP_ERROR_MESSAGES.INVALID_CONTENT_TYPE).toBe(
+        "Content-Type must be application/json"
+      );
+    });
+  });
+});
+
+describe("MCP 常量", () => {
+  describe("JSONRPC_VERSION", () => {
+    it("应该是 2.0", () => {
+      expect(JSONRPC_VERSION).toBe("2.0");
+    });
+  });
+
+  describe("MCP_PROTOCOL_VERSIONS", () => {
+    it("应该包含支持的协议版本", () => {
+      expect(MCP_PROTOCOL_VERSIONS.V2024_11_05).toBe("2024-11-05");
+      expect(MCP_PROTOCOL_VERSIONS.V2025_06_18).toBe("2025-06-18");
+      expect(MCP_PROTOCOL_VERSIONS.DEFAULT).toBe("2024-11-05");
+    });
+  });
+
+  describe("MCP_SUPPORTED_PROTOCOL_VERSIONS", () => {
+    it("应该包含所有支持的协议版本", () => {
+      expect(MCP_SUPPORTED_PROTOCOL_VERSIONS).toContain("2024-11-05");
+      expect(MCP_SUPPORTED_PROTOCOL_VERSIONS).toContain("2025-06-18");
+      expect(MCP_SUPPORTED_PROTOCOL_VERSIONS).toHaveLength(2);
+    });
+  });
+
+  describe("MCP_SERVER_INFO", () => {
+    it("应该包含正确的服务器信息", () => {
+      expect(MCP_SERVER_INFO.NAME).toBe("xiaozhi-mcp-server");
+      expect(MCP_SERVER_INFO.VERSION).toBe("1.0.0");
+    });
+  });
+
+  describe("MCP_METHODS", () => {
+    it("应该包含所有 MCP 方法名称", () => {
+      expect(MCP_METHODS.INITIALIZE).toBe("initialize");
+      expect(MCP_METHODS.TOOLS_LIST).toBe("tools/list");
+      expect(MCP_METHODS.TOOLS_CALL).toBe("tools/call");
+      expect(MCP_METHODS.RESOURCES_LIST).toBe("resources/list");
+      expect(MCP_METHODS.PROMPTS_LIST).toBe("prompts/list");
+      expect(MCP_METHODS.PING).toBe("ping");
+    });
+  });
+
+  describe("JSONRPC_ERROR_MESSAGES", () => {
+    it("应该包含正确的错误消息", () => {
+      expect(JSONRPC_ERROR_MESSAGES.PARSE_ERROR).toBe(
+        "Parse error: Invalid JSON"
+      );
+      expect(JSONRPC_ERROR_MESSAGES.METHOD_NOT_FOUND).toBe("Method not found");
+      expect(JSONRPC_ERROR_MESSAGES.TOOL_NOT_FOUND).toBe("未找到工具");
+    });
+  });
+});
+
+describe("事件常量", () => {
+  describe("MCP_SERVICE_EVENTS", () => {
+    it("应该包含正确的 MCP 服务事件名称", () => {
+      expect(MCP_SERVICE_EVENTS.CONNECTED).toBe("mcp:service:connected");
+      expect(MCP_SERVICE_EVENTS.DISCONNECTED).toBe("mcp:service:disconnected");
+      expect(MCP_SERVICE_EVENTS.CONNECTION_FAILED).toBe(
+        "mcp:service:connection:failed"
+      );
+    });
+  });
+
+  describe("MCP_SERVER_EVENTS", () => {
+    it("应该包含正确的 MCP 服务器事件名称", () => {
+      expect(MCP_SERVER_EVENTS.ADDED).toBe("mcp:server:added");
+      expect(MCP_SERVER_EVENTS.BATCH_ADDED).toBe("mcp:server:batch_added");
+      expect(MCP_SERVER_EVENTS.REMOVED).toBe("mcp:server:removed");
+    });
+  });
+});
+
+describe("超时和延迟常量", () => {
+  describe("CACHE_TIMEOUTS", () => {
+    it("应该包含正确的缓存超时值", () => {
+      expect(CACHE_TIMEOUTS.TTL).toBe(300000);
+      expect(CACHE_TIMEOUTS.CLEANUP_INTERVAL).toBe(60000);
+    });
+
+    it("TTL 应该大于清理间隔", () => {
+      expect(CACHE_TIMEOUTS.TTL).toBeGreaterThan(
+        CACHE_TIMEOUTS.CLEANUP_INTERVAL
+      );
+    });
+  });
+
+  describe("HTTP_TIMEOUTS", () => {
+    it("应该包含正确的 HTTP 超时值", () => {
+      expect(HTTP_TIMEOUTS.DEFAULT).toBe(30000);
+      expect(HTTP_TIMEOUTS.LONG_RUNNING).toBe(60000);
+    });
+  });
+
+  describe("SERVICE_RESTART_DELAYS", () => {
+    it("应该包含正确的服务重启延迟值", () => {
+      expect(SERVICE_RESTART_DELAYS.EXECUTION_DELAY).toBe(500);
+      expect(SERVICE_RESTART_DELAYS.SUCCESS_NOTIFICATION_DELAY).toBe(5000);
+    });
+  });
+});
+
+describe("缓存相关常量", () => {
+  describe("MESSAGE_SIZE_LIMITS", () => {
+    it("应该包含正确的消息大小限制", () => {
+      expect(MESSAGE_SIZE_LIMITS.DEFAULT).toBe(1024 * 1024);
+      expect(MESSAGE_SIZE_LIMITS.MAX).toBe(10 * 1024 * 1024);
+    });
+
+    it("最大限制应该大于默认限制", () => {
+      expect(MESSAGE_SIZE_LIMITS.MAX).toBeGreaterThan(
+        MESSAGE_SIZE_LIMITS.DEFAULT
+      );
+    });
+  });
+
+  describe("PAGINATION_CONSTANTS", () => {
+    it("应该包含正确的分页限制", () => {
+      expect(PAGINATION_CONSTANTS.DEFAULT_LIMIT).toBe(50);
+      expect(PAGINATION_CONSTANTS.MAX_LIMIT).toBe(200);
+    });
+
+    it("最大限制应该大于默认限制", () => {
+      expect(PAGINATION_CONSTANTS.MAX_LIMIT).toBeGreaterThan(
+        PAGINATION_CONSTANTS.DEFAULT_LIMIT
+      );
+    });
+  });
+
+  describe("CACHE_FILE_CONFIG", () => {
+    it("应该包含正确的缓存文件配置", () => {
+      expect(CACHE_FILE_CONFIG.FILENAME).toBe("xiaozhi.cache.json");
+      expect(CACHE_FILE_CONFIG.TEMP_SUFFIX).toBe(".tmp");
+    });
+  });
+
+  describe("TOOL_NAME_SEPARATORS", () => {
+    it("应该包含正确的分隔符", () => {
+      expect(TOOL_NAME_SEPARATORS.SERVICE_TOOL_SEPARATOR).toBe("__");
+    });
+  });
+});

--- a/src/server/constants/api.constants.ts
+++ b/src/server/constants/api.constants.ts
@@ -1,0 +1,13 @@
+/**
+ * API 相关常量定义
+ */
+
+/**
+ * 分页相关常量
+ */
+export const PAGINATION_CONSTANTS = {
+  /** 默认每页记录数 */
+  DEFAULT_LIMIT: 50,
+  /** 最大每页记录数 */
+  MAX_LIMIT: 200,
+} as const;

--- a/src/server/constants/cache.constants.ts
+++ b/src/server/constants/cache.constants.ts
@@ -1,0 +1,31 @@
+/**
+ * 缓存相关常量定义
+ */
+
+/**
+ * 消息大小限制常量
+ */
+export const MESSAGE_SIZE_LIMITS = {
+  /** 默认消息大小限制（1MB） */
+  DEFAULT: 1024 * 1024,
+  /** 最大消息大小限制（10MB） */
+  MAX: 10 * 1024 * 1024,
+} as const;
+
+/**
+ * 缓存文件相关常量
+ */
+export const CACHE_FILE_CONFIG = {
+  /** 缓存文件名 */
+  FILENAME: "xiaozhi.cache.json",
+  /** 临时文件后缀 */
+  TEMP_SUFFIX: ".tmp",
+} as const;
+
+/**
+ * 工具名称分隔符常量
+ */
+export const TOOL_NAME_SEPARATORS = {
+  /** 服务名与工具名之间的分隔符 */
+  SERVICE_TOOL_SEPARATOR: "__",
+} as const;

--- a/src/server/constants/event.constants.ts
+++ b/src/server/constants/event.constants.ts
@@ -1,0 +1,31 @@
+/**
+ * 事件名称常量定义
+ */
+
+/**
+ * MCP 服务相关事件
+ */
+export const MCP_SERVICE_EVENTS = {
+  /** 服务已连接 */
+  CONNECTED: "mcp:service:connected",
+  /** 服务已断开连接 */
+  DISCONNECTED: "mcp:service:disconnected",
+  /** 服务连接失败 */
+  CONNECTION_FAILED: "mcp:service:connection:failed",
+} as const;
+
+/**
+ * MCP 服务器相关事件
+ */
+export const MCP_SERVER_EVENTS = {
+  /** 服务器已添加 */
+  ADDED: "mcp:server:added",
+  /** 批量添加服务器 */
+  BATCH_ADDED: "mcp:server:batch_added",
+  /** 服务器已移除 */
+  REMOVED: "mcp:server:removed",
+  /** 服务器已启动 */
+  STARTED: "mcp:server:started",
+  /** 服务器已停止 */
+  STOPPED: "mcp:server:stopped",
+} as const;

--- a/src/server/constants/http.constants.ts
+++ b/src/server/constants/http.constants.ts
@@ -1,0 +1,97 @@
+/**
+ * HTTP 协议相关常量定义
+ */
+
+/**
+ * HTTP Content-Type 常量
+ */
+export const HTTP_CONTENT_TYPES = {
+  /** JSON 格式 */
+  APPLICATION_JSON: "application/json",
+  /** HTML 格式 */
+  TEXT_HTML: "text/html",
+  /** 纯文本格式 */
+  TEXT_PLAIN: "text/plain",
+  /** CSS 样式表 */
+  TEXT_CSS: "text/css",
+  /** JavaScript 代码 */
+  APPLICATION_JAVASCRIPT: "application/javascript",
+  /** XML 格式 */
+  APPLICATION_XML: "application/xml",
+  /** PDF 文档 */
+  APPLICATION_PDF: "application/pdf",
+  /** ZIP 压缩包 */
+  APPLICATION_ZIP: "application/zip",
+  /** 八位字节流 */
+  APPLICATION_OCTET_STREAM: "application/octet-stream",
+} as const;
+
+/**
+ * HTTP 请求头常量
+ */
+export const HTTP_HEADERS = {
+  /** Content-Type 头 */
+  CONTENT_TYPE: "Content-Type",
+  /** Content-Length 头 */
+  CONTENT_LENGTH: "content-length",
+  /** MCP 协议版本头 */
+  MCP_PROTOCOL_VERSION: "MCP-Protocol-Version",
+  /** 响应时间头 */
+  X_RESPONSE_TIME: "X-Response-Time",
+} as const;
+
+/**
+ * HTTP 状态码常量
+ */
+export const HTTP_STATUS_CODES = {
+  /** 成功 */
+  OK: 200,
+  /** 已创建 */
+  CREATED: 201,
+  /** 无内容 */
+  NO_CONTENT: 204,
+  /** 错误的请求 */
+  BAD_REQUEST: 400,
+  /** 未授权 */
+  UNAUTHORIZED: 401,
+  /** 禁止访问 */
+  FORBIDDEN: 403,
+  /** 未找到 */
+  NOT_FOUND: 404,
+  /** 请求超时 */
+  REQUEST_TIMEOUT: 408,
+  /** 内部服务器错误 */
+  INTERNAL_SERVER_ERROR: 500,
+  /** 服务不可用 */
+  SERVICE_UNAVAILABLE: 503,
+} as const;
+
+/**
+ * HTTP 服务器配置常量
+ */
+export const HTTP_SERVER_CONFIG = {
+  /** 默认绑定地址 */
+  DEFAULT_BIND_ADDRESS: "0.0.0.0",
+  /** 默认端口 */
+  DEFAULT_PORT: 9999,
+} as const;
+
+/**
+ * HTTP 错误消息常量
+ */
+export const HTTP_ERROR_MESSAGES = {
+  /** 请求过大错误消息 */
+  REQUEST_TOO_LARGE: "Request too large",
+  /** 消息过大错误消息 */
+  MESSAGE_TOO_LARGE: "Message too large",
+  /** 无效请求错误消息 */
+  INVALID_REQUEST: "Invalid Request",
+  /** Content-Type 必须是 application/json */
+  INVALID_CONTENT_TYPE: "Content-Type must be application/json",
+  /** 解析错误 */
+  PARSE_ERROR: "Parse error",
+  /** 无效的 JSON */
+  INVALID_JSON: "Invalid JSON",
+  /** 内部错误 */
+  INTERNAL_ERROR: "Internal error",
+} as const;

--- a/src/server/constants/index.ts
+++ b/src/server/constants/index.ts
@@ -1,0 +1,35 @@
+/**
+ * 常量统一导出入口
+ *
+ * 本文件统一导出所有常量模块，提供单一的导入入口点
+ *
+ * @example
+ * ```typescript
+ * // 导入所有常量
+ * import * as Constants from "@constants/index.js";
+ *
+ * // 或使用命名导入
+ * import { HTTP_CONTENT_TYPES, MCP_METHODS } from "@constants/index.js";
+ * ```
+ */
+
+// API 相关常量
+export * from "./api.constants.js";
+
+// HTTP 协议常量
+export * from "./http.constants.js";
+
+// MCP 协议常量
+export * from "./mcp.constants.js";
+
+// 事件名称常量
+export * from "./event.constants.js";
+
+// 超时和延迟常量
+export * from "./timeout.constants.js";
+
+// 缓存相关常量
+export * from "./cache.constants.js";
+
+// TTS 音色常量
+export * from "./voices.js";

--- a/src/server/constants/mcp.constants.ts
+++ b/src/server/constants/mcp.constants.ts
@@ -1,0 +1,88 @@
+/**
+ * MCP 协议相关常量定义
+ */
+
+/**
+ * JSON-RPC 版本常量
+ */
+export const JSONRPC_VERSION = "2.0" as const;
+
+/**
+ * MCP 协议版本常量
+ */
+export const MCP_PROTOCOL_VERSIONS = {
+  /** 2024-11-05 版本 */
+  V2024_11_05: "2024-11-05",
+  /** 2025-06-18 版本 */
+  V2025_06_18: "2025-06-18",
+  /** 默认版本 */
+  DEFAULT: "2024-11-05",
+} as const;
+
+/**
+ * MCP 支持的协议版本数组
+ */
+export const MCP_SUPPORTED_PROTOCOL_VERSIONS = [
+  MCP_PROTOCOL_VERSIONS.V2024_11_05,
+  MCP_PROTOCOL_VERSIONS.V2025_06_18,
+] as const;
+
+/**
+ * MCP 服务器信息常量
+ */
+export const MCP_SERVER_INFO = {
+  /** 服务器名称 */
+  NAME: "xiaozhi-mcp-server",
+  /** 服务器版本 */
+  VERSION: "1.0.0",
+} as const;
+
+/**
+ * MCP 方法名称常量
+ */
+export const MCP_METHODS = {
+  /** 初始化 */
+  INITIALIZE: "initialize",
+  /** 已初始化通知 */
+  INITIALIZED: "notifications/initialized",
+  /** 工具列表 */
+  TOOLS_LIST: "tools/list",
+  /** 调用工具 */
+  TOOLS_CALL: "tools/call",
+  /** 资源列表 */
+  RESOURCES_LIST: "resources/list",
+  /** 提示列表 */
+  PROMPTS_LIST: "prompts/list",
+  /** Ping */
+  PING: "ping",
+} as const;
+
+/**
+ * JSON-RPC 错误消息常量
+ */
+export const JSONRPC_ERROR_MESSAGES = {
+  /** 解析错误消息 */
+  PARSE_ERROR: "Parse error: Invalid JSON",
+  /** 无效请求消息 */
+  INVALID_REQUEST: "Invalid Request: Message does not conform to JSON-RPC 2.0",
+  /** 方法未找到消息 */
+  METHOD_NOT_FOUND: "Method not found",
+  /** 无效参数消息 */
+  INVALID_PARAMS: "Invalid params",
+  /** 内部错误消息 */
+  INTERNAL_ERROR: "Internal error",
+  /** 未找到工具消息 */
+  TOOL_NOT_FOUND: "未找到工具",
+  /** 未知方法消息 */
+  UNKNOWN_METHOD: "未知的方法",
+} as const;
+
+/**
+ * MCP 缓存版本常量
+ */
+export const MCP_CACHE_VERSIONS = {
+  /** 缓存文件格式版本 */
+  CACHE_VERSION: "1.0.0",
+  /** 缓存条目版本 */
+  CACHE_ENTRY_VERSION: "1.0.0",
+} as const;

--- a/src/server/constants/timeout.constants.ts
+++ b/src/server/constants/timeout.constants.ts
@@ -1,0 +1,34 @@
+/**
+ * 超时和延迟常量定义
+ * 所有时间单位均为毫秒（ms）
+ */
+
+/**
+ * 缓存相关超时常量
+ */
+export const CACHE_TIMEOUTS = {
+  /** 缓存 TTL（生存时间） */
+  TTL: 300000,
+  /** 清理间隔 */
+  CLEANUP_INTERVAL: 60000,
+} as const;
+
+/**
+ * HTTP 相关超时常量
+ */
+export const HTTP_TIMEOUTS = {
+  /** 默认超时 */
+  DEFAULT: 30000,
+  /** 长运行任务超时 */
+  LONG_RUNNING: 60000,
+} as const;
+
+/**
+ * 服务重启相关延迟常量
+ */
+export const SERVICE_RESTART_DELAYS = {
+  /** 重启执行延迟 */
+  EXECUTION_DELAY: 500,
+  /** 成功状态通知延迟 */
+  SUCCESS_NOTIFICATION_DELAY: 5000,
+} as const;

--- a/src/server/constants/voices.ts
+++ b/src/server/constants/voices.ts
@@ -1,0 +1,298 @@
+/**
+ * TTS 音色数据常量
+ * 来源于火山引擎豆包语音合成模型 2.0
+ */
+
+import type { VoiceInfo } from "../types/index.js";
+
+/**
+ * TTS 音色列表
+ * 仅包含 2.0 版本的音色（推荐，支持情感变化）
+ */
+export const TTS_VOICES: VoiceInfo[] = [
+  // === 通用场景 ===
+  {
+    name: "Vivi 2.0",
+    voiceType: "zh_female_vv_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文、日文、印尼、墨西哥西班牙语",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "小何 2.0",
+    voiceType: "zh_female_xiaohe_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "云舟 2.0",
+    voiceType: "zh_male_m191_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "小天 2.0",
+    voiceType: "zh_male_taocheng_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "刘飞 2.0",
+    voiceType: "zh_male_liufei_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "魅力苏菲 2.0",
+    voiceType: "zh_male_sophie_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "清新女声 2.0",
+    voiceType: "zh_female_qingxinnvsheng_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "甜美小源 2.0",
+    voiceType: "zh_female_tianmeixiaoyuan_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "甜美桃子 2.0",
+    voiceType: "zh_female_tianmeitaozi_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "爽快思思 2.0",
+    voiceType: "zh_female_shuangkuaisisi_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "邻家女孩 2.0",
+    voiceType: "zh_female_linjianvhai_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "少年梓辛/Brayan 2.0",
+    voiceType: "zh_male_shaonianzixin_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "魅力女友 2.0",
+    voiceType: "zh_female_meilinvyou_uranus_bigtts",
+    scene: "通用场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+
+  // === 角色扮演 ===
+  {
+    name: "知性灿灿 2.0",
+    voiceType: "zh_female_cancan_uranus_bigtts",
+    scene: "角色扮演",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "撒娇学妹 2.0",
+    voiceType: "zh_female_sajiaoxuemei_uranus_bigtts",
+    scene: "角色扮演",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+
+  // === 视频配音 ===
+  {
+    name: "佩奇猪 2.0",
+    voiceType: "zh_female_peiqi_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "猴哥 2.0",
+    voiceType: "zh_male_sunwukong_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "大壹 2.0",
+    voiceType: "zh_male_dayi_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "黑猫侦探社咪仔 2.0",
+    voiceType: "zh_female_mizai_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "鸡汤女 2.0",
+    voiceType: "zh_female_jitangnv_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "流畅女声 2.0",
+    voiceType: "zh_female_liuchangnv_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "儒雅逸辰 2.0",
+    voiceType: "zh_male_ruyayichen_uranus_bigtts",
+    scene: "视频配音",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+
+  // === 教育场景 ===
+  {
+    name: "Tina老师 2.0",
+    voiceType: "zh_female_yingyujiaoxue_uranus_bigtts",
+    scene: "教育场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+
+  // === 客服场景 ===
+  {
+    name: "暖阳女声 2.0",
+    voiceType: "zh_female_kefunvsheng_uranus_bigtts",
+    scene: "客服场景",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "轻盈朵朵 2.0",
+    voiceType: "saturn_zh_female_qingyingduoduo_cs_tob",
+    scene: "客服场景",
+    language: "中文",
+    capabilities: ["指令遵循"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "温婉珊珊 2.0",
+    voiceType: "saturn_zh_female_wenwanshanshan_cs_tob",
+    scene: "客服场景",
+    language: "中文",
+    capabilities: ["指令遵循"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "热情艾娜 2.0",
+    voiceType: "saturn_zh_female_reqingaina_cs_tob",
+    scene: "客服场景",
+    language: "中文",
+    capabilities: ["指令遵循"],
+    modelVersion: "2.0",
+  },
+
+  // === 有声阅读 ===
+  {
+    name: "儿童绘本 2.0",
+    voiceType: "zh_female_xiaoxue_uranus_bigtts",
+    scene: "有声阅读",
+    language: "中文",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+
+  // === 多语种 ===
+  {
+    name: "Tim",
+    voiceType: "en_male_tim_uranus_bigtts",
+    scene: "多语种",
+    language: "美式英语",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "Dacey",
+    voiceType: "en_female_dacey_uranus_bigtts",
+    scene: "多语种",
+    language: "美式英语",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+  {
+    name: "Stokie",
+    voiceType: "en_female_stokie_uranus_bigtts",
+    scene: "多语种",
+    language: "美式英语",
+    capabilities: ["情感变化", "指令遵循", "ASMR"],
+    modelVersion: "2.0",
+  },
+];
+
+/**
+ * 获取所有场景列表
+ */
+export function getVoiceScenes(): string[] {
+  const scenes = new Set<string>();
+  for (const voice of TTS_VOICES) {
+    scenes.add(voice.scene);
+  }
+  return Array.from(scenes);
+}
+
+/**
+ * 按场景分组获取音色
+ */
+export function getVoicesByScene(): Map<string, VoiceInfo[]> {
+  const result = new Map<string, VoiceInfo[]>();
+  for (const voice of TTS_VOICES) {
+    const voices = result.get(voice.scene) || [];
+    voices.push(voice);
+    result.set(voice.scene, voices);
+  }
+  return result;
+}

--- a/src/server/errors/__tests__/error-helper.integration.test.ts
+++ b/src/server/errors/__tests__/error-helper.integration.test.ts
@@ -1,0 +1,107 @@
+import { existsSync, unlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Logger } from "../../Logger.js";
+import type { InternalMCPServiceConfig } from "../../lib/mcp";
+import { MCPTransportType } from "../../lib/mcp";
+import type { MCPError } from "../error-helper.js";
+import {
+  ErrorCategory,
+  categorizeError,
+  clearErrorHistory,
+  getErrorStatistics,
+  shouldAlert,
+} from "../error-helper.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js");
+
+describe("高级功能集成测试", () => {
+  let mockLogger: any;
+  let testConfigPath: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 模拟 Logger
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      withTag: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(Logger).mockImplementation(() => mockLogger);
+
+    // 创建测试配置
+    const testConfigs: InternalMCPServiceConfig[] = [
+      {
+        name: "test-service",
+        type: MCPTransportType.STDIO,
+        command: "test-command",
+        args: ["--test"],
+      },
+    ];
+
+    testConfigPath = join(
+      tmpdir(),
+      `integration-test-config-${Date.now()}.json`
+    );
+    writeFileSync(
+      testConfigPath,
+      JSON.stringify({ mcpServices: testConfigs }, null, 2)
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearErrorHistory();
+
+    // 清理测试文件
+    if (existsSync(testConfigPath)) {
+      unlinkSync(testConfigPath);
+    }
+  });
+
+  describe("错误处理集成", () => {
+    it("应该正确分类错误", () => {
+      const serviceName = "test-service";
+
+      // 模拟不同类型的错误
+      const toolError = new Error("Tool call failed");
+      const connectionError = new Error("Connection failed");
+      const configError = new Error("Invalid configuration");
+
+      const mcpToolError = categorizeError(toolError, serviceName);
+      const mcpConnectionError = categorizeError(connectionError, serviceName);
+      const mcpConfigError = categorizeError(configError, serviceName);
+
+      // 验证错误分类
+      expect(mcpToolError.category).toBe(ErrorCategory.TOOL_CALL);
+      expect(mcpConnectionError.category).toBe(ErrorCategory.CONNECTION);
+      expect(mcpConfigError.category).toBe(ErrorCategory.CONFIGURATION);
+    });
+
+    it("应该为高错误率触发警报", () => {
+      const serviceName = "test-service-2";
+
+      // 生成多个错误以触发警报
+      const errors: MCPError[] = [];
+      for (let i = 0; i < 12; i++) {
+        const error = new Error(`Error ${i}`);
+        const mcpError = categorizeError(error, serviceName);
+        errors.push(mcpError);
+
+        if (i === 11) {
+          // 最后一个错误应该触发警报
+          expect(shouldAlert(mcpError)).toBe(true);
+        }
+      }
+
+      // 验证错误统计
+      const errorStats = getErrorStatistics(serviceName);
+      expect(errorStats.totalErrors).toBe(12);
+    });
+  });
+});

--- a/src/server/errors/__tests__/error-helper.test.ts
+++ b/src/server/errors/__tests__/error-helper.test.ts
@@ -1,0 +1,291 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { Logger } from "../../Logger.js";
+import type { MCPError } from "../error-helper.js";
+import {
+  ErrorCategory,
+  RecoveryStrategy,
+  categorizeError,
+  clearErrorHistory,
+  formatUserFriendlyMessage,
+  getErrorStatistics,
+  shouldAlert,
+} from "../error-helper.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js");
+
+describe("ErrorHandler", () => {
+  let mockLogger: any;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 模拟 Logger
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+      withTag: vi.fn().mockReturnThis(),
+    };
+    vi.mocked(Logger).mockImplementation(() => mockLogger);
+
+    // 清除错误历史
+    clearErrorHistory();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    clearErrorHistory();
+  });
+
+  describe("categorizeError", () => {
+    it("should categorize connection errors", () => {
+      const error = new Error("Connection refused");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.CONNECTION);
+      expect(mcpError.code).toBe("CONNECTION_FAILED");
+      expect(mcpError.recoverable).toBe(true);
+      expect(mcpError.recoveryStrategy).toBe(RecoveryStrategy.RECONNECT);
+      expect(mcpError.serviceName).toBe("test-service");
+    });
+
+    it("should categorize transport errors", () => {
+      const error = new Error("Transport initialization failed");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.TRANSPORT);
+      expect(mcpError.code).toBe("TRANSPORT_ERROR");
+      expect(mcpError.recoverable).toBe(true);
+      expect(mcpError.recoveryStrategy).toBe(RecoveryStrategy.RESTART_SERVICE);
+    });
+
+    it("should categorize tool call errors", () => {
+      const error = new Error("Tool method not found");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.TOOL_CALL);
+      expect(mcpError.code).toBe("TOOL_CALL_ERROR");
+      expect(mcpError.recoverable).toBe(true);
+      expect(mcpError.recoveryStrategy).toBe(RecoveryStrategy.RETRY);
+    });
+
+    it("should categorize configuration errors", () => {
+      const error = new Error("Invalid config provided");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.CONFIGURATION);
+      expect(mcpError.code).toBe("CONFIG_ERROR");
+      expect(mcpError.recoverable).toBe(false);
+      expect(mcpError.recoveryStrategy).toBe(
+        RecoveryStrategy.MANUAL_INTERVENTION
+      );
+    });
+
+    it("should categorize timeout errors", () => {
+      const error = new Error("Request timed out");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.TIMEOUT);
+      expect(mcpError.code).toBe("TIMEOUT_ERROR");
+      expect(mcpError.recoverable).toBe(true);
+      expect(mcpError.recoveryStrategy).toBe(RecoveryStrategy.RETRY);
+    });
+
+    it("should categorize authentication errors", () => {
+      const error = new Error("Unauthorized access");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.AUTHENTICATION);
+      expect(mcpError.code).toBe("AUTH_ERROR");
+      expect(mcpError.recoverable).toBe(false);
+      expect(mcpError.recoveryStrategy).toBe(
+        RecoveryStrategy.MANUAL_INTERVENTION
+      );
+    });
+
+    it("should categorize network errors", () => {
+      const error = new Error("Network request failed");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.NETWORK);
+      expect(mcpError.code).toBe("NETWORK_ERROR");
+      expect(mcpError.recoverable).toBe(true);
+      expect(mcpError.recoveryStrategy).toBe(RecoveryStrategy.RETRY);
+    });
+
+    it("should handle unknown errors", () => {
+      const error = new Error("Some unknown error");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(mcpError.category).toBe(ErrorCategory.UNKNOWN);
+      expect(mcpError.code).toBe("UNKNOWN_ERROR");
+      expect(mcpError.recoverable).toBe(false);
+      expect(mcpError.recoveryStrategy).toBe(
+        RecoveryStrategy.MANUAL_INTERVENTION
+      );
+    });
+
+    it("should include context information", () => {
+      const error = new Error("Test error");
+      const context = { operation: "tool_call", toolName: "test_tool" };
+      const mcpError = categorizeError(error, "test-service", context);
+
+      expect(mcpError.context).toEqual(context);
+      expect(mcpError.originalError).toBe(error);
+    });
+  });
+
+  describe("formatUserFriendlyMessage", () => {
+    it("should format connection error messages", () => {
+      const error: MCPError = {
+        category: ErrorCategory.CONNECTION,
+        code: "CONNECTION_FAILED",
+        message: "Connection refused",
+        serviceName: "test-service",
+        timestamp: new Date(),
+        recoverable: true,
+        recoveryStrategy: RecoveryStrategy.RECONNECT,
+      };
+
+      const message = formatUserFriendlyMessage(error);
+      expect(message).toBe(
+        "服务 test-service 发生错误：连接失败，正在尝试重新连接..."
+      );
+    });
+
+    it("should format tool call error messages", () => {
+      const error: MCPError = {
+        category: ErrorCategory.TOOL_CALL,
+        code: "TOOL_CALL_ERROR",
+        message: "Invalid params",
+        serviceName: "test-service",
+        timestamp: new Date(),
+        recoverable: true,
+        recoveryStrategy: RecoveryStrategy.RETRY,
+      };
+
+      const message = formatUserFriendlyMessage(error);
+      expect(message).toBe(
+        "服务 test-service 发生错误：工具调用失败，请检查参数后重试"
+      );
+    });
+
+    it("should format configuration error messages", () => {
+      const error: MCPError = {
+        category: ErrorCategory.CONFIGURATION,
+        code: "CONFIG_ERROR",
+        message: "Invalid config",
+        serviceName: "test-service",
+        timestamp: new Date(),
+        recoverable: false,
+        recoveryStrategy: RecoveryStrategy.MANUAL_INTERVENTION,
+      };
+
+      const message = formatUserFriendlyMessage(error);
+      expect(message).toBe(
+        "服务 test-service 发生错误：配置错误，请检查服务配置"
+      );
+    });
+  });
+
+  describe("error statistics", () => {
+    it("should track error statistics", () => {
+      const error1 = new Error("Connection failed");
+      const error2 = new Error("Tool call failed");
+      const error3 = new Error("Connection failed");
+
+      categorizeError(error1, "test-service");
+      categorizeError(error2, "test-service");
+      categorizeError(error3, "test-service");
+
+      const stats = getErrorStatistics("test-service");
+
+      expect(stats.totalErrors).toBe(3);
+      expect(stats.errorsByCategory.get(ErrorCategory.CONNECTION)).toBe(2);
+      expect(stats.errorsByCategory.get(ErrorCategory.TOOL_CALL)).toBe(1);
+    });
+
+    it("should calculate error rate", () => {
+      const error = new Error("Test error");
+      categorizeError(error, "test-service");
+
+      const stats = getErrorStatistics("test-service");
+      expect(stats.errorRate).toBe(1); // 1 error in the past hour
+    });
+
+    it("should return empty statistics for unknown service", () => {
+      const stats = getErrorStatistics("unknown-service");
+
+      expect(stats.totalErrors).toBe(0);
+      expect(stats.errorsByCategory.size).toBe(0);
+      expect(stats.errorsByCode.size).toBe(0);
+      expect(stats.lastError).toBeUndefined();
+      expect(stats.errorRate).toBe(0);
+    });
+  });
+
+  describe("shouldAlert", () => {
+    it("should alert for high error rate", () => {
+      // Generate 11 errors to exceed threshold
+      for (let i = 0; i < 11; i++) {
+        const error = new Error(`Error ${i}`);
+        categorizeError(error, "test-service");
+      }
+
+      const lastError = getErrorStatistics("test-service").lastError!;
+      expect(shouldAlert(lastError)).toBe(true);
+    });
+
+    it("should alert for non-recoverable errors", () => {
+      const error = new Error("Invalid config");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(shouldAlert(mcpError)).toBe(true);
+    });
+
+    it("should alert for authentication errors", () => {
+      const error = new Error("Unauthorized");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(shouldAlert(mcpError)).toBe(true);
+    });
+
+    it("should not alert for recoverable errors with low rate", () => {
+      const error = new Error("Connection failed");
+      const mcpError = categorizeError(error, "test-service");
+
+      expect(shouldAlert(mcpError)).toBe(false);
+    });
+  });
+
+  describe("clearErrorHistory", () => {
+    it("should clear specific service error history", () => {
+      const error = new Error("Test error");
+      categorizeError(error, "test-service");
+
+      let stats = getErrorStatistics("test-service");
+      expect(stats.totalErrors).toBe(1);
+
+      clearErrorHistory("test-service");
+
+      stats = getErrorStatistics("test-service");
+      expect(stats.totalErrors).toBe(0);
+    });
+
+    it("should clear all error history", () => {
+      const error1 = new Error("Test error 1");
+      const error2 = new Error("Test error 2");
+      categorizeError(error1, "service1");
+      categorizeError(error2, "service2");
+
+      clearErrorHistory();
+
+      const stats1 = getErrorStatistics("service1");
+      const stats2 = getErrorStatistics("service2");
+      expect(stats1.totalErrors).toBe(0);
+      expect(stats2.totalErrors).toBe(0);
+    });
+  });
+});

--- a/src/server/errors/error-helper.ts
+++ b/src/server/errors/error-helper.ts
@@ -1,0 +1,358 @@
+/**
+ * MCP 错误处理辅助工具模块
+ *
+ * 本模块提供 MCP 服务错误处理的核心类型定义和工具函数，包括：
+ *
+ * - **错误分类**：通过 ErrorCategory 枚举对错误进行分类
+ * - **恢复策略**：定义错误的恢复策略（重试、重连等）
+ * - **错误创建**：统一的错误创建工厂函数
+ * - **错误判断**：判断错误是否可恢复的工具函数
+ * - **错误格式化**：将错误格式化为用户友好的消息
+ * - **错误统计**：跟踪和统计错误历史记录
+ *
+ * @example
+ * ```typescript
+ * // 推荐：通过错误模块入口以命名空间方式导入，避免与 mcp-errors 命名冲突
+ * import * as ErrorHelper from "../errors/index.js";
+ *
+ * const error = ErrorHelper.categorizeError(
+ *   new Error("Connection failed"),
+ *   "my-service"
+ * );
+ * // error.category === ErrorHelper.ErrorCategory.CONNECTION
+ * // error.recoverable === true
+ * // error.recoveryStrategy === ErrorHelper.RecoveryStrategy.RECONNECT
+ * ```
+ */
+
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+
+/**
+ * 错误分类枚举
+ */
+export enum ErrorCategory {
+  CONNECTION = "connection",
+  TRANSPORT = "transport",
+  TOOL_CALL = "tool_call",
+  CONFIGURATION = "configuration",
+  TIMEOUT = "timeout",
+  AUTHENTICATION = "authentication",
+  NETWORK = "network",
+  UNKNOWN = "unknown",
+  // 以下值用于向后兼容 mcp-errors.ts 中的原有枚举值
+  VALIDATION = "validation",
+  OPERATION = "operation",
+  SYSTEM = "system",
+  EXTERNAL = "external",
+}
+
+/**
+ * 恢复策略枚举
+ */
+export enum RecoveryStrategy {
+  RETRY = "retry",
+  RECONNECT = "reconnect",
+  RESTART_SERVICE = "restart_service",
+  IGNORE = "ignore",
+  MANUAL_INTERVENTION = "manual_intervention",
+}
+
+/**
+ * 错误上下文基础类型
+ * 所有错误上下文都应使用此类型，而非 any
+ */
+export type ErrorContext = Record<string, unknown>;
+
+/**
+ * MCP 错误接口
+ */
+export interface MCPError {
+  category: ErrorCategory;
+  code: string;
+  message: string;
+  serviceName: string;
+  timestamp: Date;
+  recoverable: boolean;
+  recoveryStrategy: RecoveryStrategy;
+  originalError?: Error;
+  context?: ErrorContext;
+}
+
+/**
+ * 错误统计接口
+ */
+export interface ErrorStatistics {
+  serviceName: string;
+  totalErrors: number;
+  errorsByCategory: Map<ErrorCategory, number>;
+  errorsByCode: Map<string, number>;
+  lastError?: MCPError;
+  errorRate: number; // 错误率（过去1小时）
+}
+
+// 错误历史存储
+const errorHistory: Map<string, MCPError[]> = new Map();
+const MAX_ERROR_HISTORY = 100;
+
+function getLogger(): Logger {
+  return logger;
+}
+
+/**
+ * 分类错误
+ */
+export function categorizeError(
+  error: Error,
+  serviceName: string,
+  context?: ErrorContext
+): MCPError {
+  const timestamp = new Date();
+  const message = error.message.toLowerCase();
+
+  let category = ErrorCategory.UNKNOWN;
+  let code = "UNKNOWN_ERROR";
+  let recoverable = false;
+  let recoveryStrategy = RecoveryStrategy.MANUAL_INTERVENTION;
+
+  // 连接相关错误
+  if (
+    message.includes("connection") ||
+    message.includes("connect") ||
+    message.includes("econnrefused") ||
+    message.includes("enotfound")
+  ) {
+    category = ErrorCategory.CONNECTION;
+    code = "CONNECTION_FAILED";
+    recoverable = true;
+    recoveryStrategy = RecoveryStrategy.RECONNECT;
+  }
+  // 传输层错误
+  else if (
+    message.includes("transport") ||
+    message.includes("stdio") ||
+    message.includes("sse") ||
+    message.includes("http")
+  ) {
+    category = ErrorCategory.TRANSPORT;
+    code = "TRANSPORT_ERROR";
+    recoverable = true;
+    recoveryStrategy = RecoveryStrategy.RESTART_SERVICE;
+  }
+  // 工具调用错误
+  else if (
+    message.includes("tool") ||
+    message.includes("method not found") ||
+    message.includes("invalid params")
+  ) {
+    category = ErrorCategory.TOOL_CALL;
+    code = "TOOL_CALL_ERROR";
+    recoverable = true;
+    recoveryStrategy = RecoveryStrategy.RETRY;
+  }
+  // 配置错误
+  else if (
+    message.includes("config") ||
+    message.includes("invalid") ||
+    message.includes("missing")
+  ) {
+    category = ErrorCategory.CONFIGURATION;
+    code = "CONFIG_ERROR";
+    recoverable = false;
+    recoveryStrategy = RecoveryStrategy.MANUAL_INTERVENTION;
+  }
+  // 超时错误
+  else if (message.includes("timeout") || message.includes("timed out")) {
+    category = ErrorCategory.TIMEOUT;
+    code = "TIMEOUT_ERROR";
+    recoverable = true;
+    recoveryStrategy = RecoveryStrategy.RETRY;
+  }
+  // 认证错误
+  else if (
+    message.includes("auth") ||
+    message.includes("unauthorized") ||
+    message.includes("forbidden")
+  ) {
+    category = ErrorCategory.AUTHENTICATION;
+    code = "AUTH_ERROR";
+    recoverable = false;
+    recoveryStrategy = RecoveryStrategy.MANUAL_INTERVENTION;
+  }
+  // 网络错误
+  else if (
+    message.includes("network") ||
+    message.includes("fetch") ||
+    message.includes("request failed")
+  ) {
+    category = ErrorCategory.NETWORK;
+    code = "NETWORK_ERROR";
+    recoverable = true;
+    recoveryStrategy = RecoveryStrategy.RETRY;
+  }
+
+  const mcpError: MCPError = {
+    category,
+    code,
+    message: error.message,
+    serviceName,
+    timestamp,
+    recoverable,
+    recoveryStrategy,
+    originalError: error,
+    context,
+  };
+
+  // 记录错误历史
+  recordError(serviceName, mcpError);
+
+  return mcpError;
+}
+
+/**
+ * 获取恢复策略
+ */
+export function getRecoveryStrategy(error: MCPError): RecoveryStrategy {
+  return error.recoveryStrategy;
+}
+
+/**
+ * 格式化用户友好的错误消息
+ */
+export function formatUserFriendlyMessage(error: MCPError): string {
+  const baseMessage = `服务 ${error.serviceName} 发生错误`;
+
+  switch (error.category) {
+    case ErrorCategory.CONNECTION:
+      return `${baseMessage}：连接失败，正在尝试重新连接...`;
+    case ErrorCategory.TRANSPORT:
+      return `${baseMessage}：通信异常，正在重启服务...`;
+    case ErrorCategory.TOOL_CALL:
+      return `${baseMessage}：工具调用失败，请检查参数后重试`;
+    case ErrorCategory.CONFIGURATION:
+      return `${baseMessage}：配置错误，请检查服务配置`;
+    case ErrorCategory.TIMEOUT:
+      return `${baseMessage}：请求超时，正在重试...`;
+    case ErrorCategory.AUTHENTICATION:
+      return `${baseMessage}：认证失败，请检查 API 密钥`;
+    case ErrorCategory.NETWORK:
+      return `${baseMessage}：网络异常，正在重试...`;
+    default:
+      return `${baseMessage}：${error.message}`;
+  }
+}
+
+/**
+ * 记录错误历史
+ */
+function recordError(serviceName: string, error: MCPError): void {
+  if (!errorHistory.has(serviceName)) {
+    errorHistory.set(serviceName, []);
+  }
+
+  const errors = errorHistory.get(serviceName)!;
+  errors.push(error);
+
+  // 限制历史记录数量
+  if (errors.length > MAX_ERROR_HISTORY) {
+    errors.shift();
+  }
+
+  getLogger().debug(
+    `[ErrorHandler] 记录错误历史: ${serviceName} - ${error.code}`
+  );
+}
+
+/**
+ * 获取错误统计
+ */
+export function getErrorStatistics(serviceName: string): ErrorStatistics {
+  const errors = errorHistory.get(serviceName) || [];
+  const now = Date.now();
+  const oneHourAgo = now - 60 * 60 * 1000;
+
+  // 计算过去1小时的错误
+  const recentErrors = errors.filter(
+    (error) => error.timestamp.getTime() > oneHourAgo
+  );
+
+  const errorsByCategory = new Map<ErrorCategory, number>();
+  const errorsByCode = new Map<string, number>();
+
+  for (const error of errors) {
+    errorsByCategory.set(
+      error.category,
+      (errorsByCategory.get(error.category) || 0) + 1
+    );
+    errorsByCode.set(error.code, (errorsByCode.get(error.code) || 0) + 1);
+  }
+
+  return {
+    serviceName,
+    totalErrors: errors.length,
+    errorsByCategory,
+    errorsByCode,
+    lastError: errors[errors.length - 1],
+    errorRate: recentErrors.length, // 过去1小时的错误数量
+  };
+}
+
+/**
+ * 获取所有服务的错误统计
+ */
+export function getAllErrorStatistics(): Map<string, ErrorStatistics> {
+  const statistics = new Map<string, ErrorStatistics>();
+
+  for (const serviceName of errorHistory.keys()) {
+    statistics.set(serviceName, getErrorStatistics(serviceName));
+  }
+
+  return statistics;
+}
+
+/**
+ * 清理错误历史
+ */
+export function clearErrorHistory(serviceName?: string): void {
+  if (serviceName) {
+    errorHistory.delete(serviceName);
+    getLogger().info(`[ErrorHandler] 已清理服务 ${serviceName} 的错误历史`);
+  } else {
+    errorHistory.clear();
+    getLogger().info("[ErrorHandler] 已清理所有错误历史");
+  }
+}
+
+/**
+ * 判断错误是否可恢复
+ */
+export function isRecoverable(error: MCPError): boolean {
+  return error.recoverable;
+}
+
+/**
+ * 判断错误是否应该触发告警
+ */
+export function shouldAlert(error: MCPError): boolean {
+  const statistics = getErrorStatistics(error.serviceName);
+
+  // 如果错误率过高，触发告警
+  if (statistics.errorRate > 10) {
+    return true;
+  }
+
+  // 如果是不可恢复的错误，触发告警
+  if (!error.recoverable) {
+    return true;
+  }
+
+  // 如果是认证或配置错误，触发告警
+  if (
+    error.category === ErrorCategory.AUTHENTICATION ||
+    error.category === ErrorCategory.CONFIGURATION
+  ) {
+    return true;
+  }
+
+  return false;
+}

--- a/src/server/errors/index.ts
+++ b/src/server/errors/index.ts
@@ -1,0 +1,27 @@
+/**
+ * 错误处理模块
+ *
+ * 统一导出所有错误处理相关的类型和工具：
+ *
+ * - **直接导出**：从 `mcp-errors.ts` 导出错误类型定义
+ * - **命名空间导出**：从 `error-helper.ts` 导出错误辅助工具
+ *
+ * @packageDocumentation
+ *
+ * @example
+ * ```typescript
+ * // 导入错误类型
+ * import { MCPErrorCode, MCPError } from '../errors/index.js';
+ *
+ * // 导入错误辅助工具（推荐使用命名空间导入）
+ * import * as ErrorHelper from '../errors/index.js';
+ *
+ * // 使用错误辅助工具
+ * const categorizedError = ErrorHelper.categorizeError(error, 'service-name');
+ * ```
+ */
+
+export * from "./mcp-errors.js";
+
+// ErrorHelper 使用命名空间导出以避免与 mcp-errors 中的类型冲突
+export * as ErrorHelper from "./error-helper.js";

--- a/src/server/errors/mcp-errors.middleware.ts
+++ b/src/server/errors/mcp-errors.middleware.ts
@@ -1,0 +1,23 @@
+/**
+ * MCP 中间件相关的错误定义
+ */
+
+/**
+ * MCPServiceManager 未初始化错误
+ */
+export class MCPServiceManagerNotInitializedError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "MCPServiceManagerNotInitializedError";
+  }
+}
+
+/**
+ * WebServer 不可用错误
+ */
+export class WebServerNotAvailableError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "WebServerNotAvailableError";
+  }
+}

--- a/src/server/errors/mcp-errors.ts
+++ b/src/server/errors/mcp-errors.ts
@@ -1,0 +1,371 @@
+/**
+ * MCP服务错误类型定义
+ *
+ * 本模块提供了统一的错误处理框架，包括：
+ * - 标准化的错误代码和分类
+ * - 结构化的错误信息
+ * - 可扩展的错误处理器
+ * - 错误转换和格式化工具
+ *
+ * @module mcp-errors
+ */
+
+import { ErrorCategory } from "./error-helper.js";
+
+// 重新导出 ErrorCategory 以保持向后兼容性
+export { ErrorCategory };
+
+/**
+ * MCP错误代码枚举
+ *
+ * 定义了所有MCP服务相关的错误代码，用于错误分类和处理。
+ * 错误代码按功能区域分组：配置、连接、操作、系统等。
+ */
+export enum MCPErrorCode {
+  // 配置错误 - 服务配置相关的问题
+  /** 服务已存在，尝试添加重复服务时使用 */
+  SERVER_ALREADY_EXISTS = "SERVER_ALREADY_EXISTS",
+  /** 服务未找到，操作不存在的服务时使用 */
+  SERVER_NOT_FOUND = "SERVER_NOT_FOUND",
+  /** 配置格式无效或内容不正确 */
+  INVALID_CONFIG = "INVALID_CONFIG",
+  /** 服务名称不符合规范 */
+  INVALID_SERVICE_NAME = "INVALID_SERVICE_NAME",
+
+  // 连接错误 - 网络连接和服务通信问题
+  /** 无法建立到服务的连接 */
+  CONNECTION_FAILED = "CONNECTION_FAILED",
+  /** 连接超时 */
+  CONNECTION_TIMEOUT = "CONNECTION_TIMEOUT",
+  /** 服务暂时不可用 */
+  SERVICE_UNAVAILABLE = "SERVICE_UNAVAILABLE",
+
+  // 操作错误 - 服务操作过程中的问题
+  /** 一般操作失败 */
+  OPERATION_FAILED = "OPERATION_FAILED",
+  /** 服务添加操作失败 */
+  ADD_FAILED = "ADD_FAILED",
+  /** 服务移除操作失败 */
+  REMOVE_FAILED = "REMOVE_FAILED",
+  /** 工具同步操作失败 */
+  SYNC_FAILED = "SYNC_FAILED",
+
+  // 系统错误 - 内部系统问题
+  /** 内部系统错误 */
+  INTERNAL_ERROR = "INTERNAL_ERROR",
+  /** 配置更新操作失败 */
+  CONFIG_UPDATE_FAILED = "CONFIG_UPDATE_FAILED",
+
+  // 工具同步错误 - 工具管理相关错误
+  /** 工具同步失败 */
+  TOOL_SYNC_FAILED = "TOOL_SYNC_FAILED",
+  /** 工具验证失败 */
+  TOOL_VALIDATION_FAILED = "TOOL_VALIDATION_FAILED",
+  /** 工具未找到 */
+  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
+}
+
+/**
+ * MCP错误严重级别
+ */
+export enum ErrorSeverity {
+  LOW = "low", // 轻微错误，不影响主要功能
+  MEDIUM = "medium", // 中等错误，影响部分功能
+  HIGH = "high", // 严重错误，影响核心功能
+  CRITICAL = "critical", // 致命错误，系统无法继续运行
+}
+
+/**
+ * 错误详情接口
+ */
+export interface ErrorDetails {
+  serverName?: string;
+  config?: unknown;
+  tools?: string[];
+  timestamp: string;
+  severity: ErrorSeverity;
+  category: ErrorCategory;
+  stack?: string;
+  context?: Record<string, unknown>;
+  operation?: string;
+  errors?: string[];
+}
+
+/**
+ * 标准化的MCP错误类
+ */
+export class MCPError extends Error {
+  public readonly code: MCPErrorCode;
+  public readonly severity: ErrorSeverity;
+  public readonly category: ErrorCategory;
+  public readonly details: ErrorDetails;
+  public readonly timestamp: string;
+
+  constructor(
+    code: MCPErrorCode,
+    message: string,
+    severity: ErrorSeverity = ErrorSeverity.MEDIUM,
+    category: ErrorCategory = ErrorCategory.SYSTEM,
+    details: Partial<ErrorDetails> = {}
+  ) {
+    super(message);
+    this.name = "MCPError";
+    this.code = code;
+    this.severity = severity;
+    this.category = category;
+    this.timestamp = new Date().toISOString();
+
+    // 合并详情信息
+    this.details = {
+      ...details,
+      timestamp: this.timestamp,
+      severity: this.severity,
+      category: this.category,
+      stack: this.stack,
+    };
+
+    // 保持堆栈跟踪
+    if (Error.captureStackTrace) {
+      Error.captureStackTrace(this, MCPError);
+    }
+  }
+
+  /**
+   * 转换为JSON格式
+   */
+  toJSON() {
+    return {
+      name: this.name,
+      code: this.code,
+      message: this.message,
+      severity: this.severity,
+      category: this.category,
+      details: this.details,
+      timestamp: this.timestamp,
+    };
+  }
+
+  /**
+   * 创建配置错误
+   */
+  static configError(
+    code: MCPErrorCode,
+    message: string,
+    details: Partial<ErrorDetails> = {}
+  ): MCPError {
+    return new MCPError(
+      code,
+      message,
+      ErrorSeverity.MEDIUM,
+      ErrorCategory.CONFIGURATION,
+      details
+    );
+  }
+
+  /**
+   * 创建连接错误
+   */
+  static connectionError(
+    code: MCPErrorCode,
+    message: string,
+    details: Partial<ErrorDetails> = {}
+  ): MCPError {
+    return new MCPError(
+      code,
+      message,
+      ErrorSeverity.HIGH,
+      ErrorCategory.CONNECTION,
+      details
+    );
+  }
+
+  /**
+   * 创建操作错误
+   */
+  static operationError(
+    code: MCPErrorCode,
+    message: string,
+    details: Partial<ErrorDetails> = {}
+  ): MCPError {
+    return new MCPError(
+      code,
+      message,
+      ErrorSeverity.MEDIUM,
+      ErrorCategory.OPERATION,
+      details
+    );
+  }
+
+  /**
+   * 创建系统错误
+   */
+  static systemError(
+    code: MCPErrorCode,
+    message: string,
+    details: Partial<ErrorDetails> = {}
+  ): MCPError {
+    return new MCPError(
+      code,
+      message,
+      ErrorSeverity.HIGH,
+      ErrorCategory.SYSTEM,
+      details
+    );
+  }
+
+  /**
+   * 创建验证错误
+   */
+  static validationError(
+    code: MCPErrorCode,
+    message: string,
+    details: Partial<ErrorDetails> = {}
+  ): MCPError {
+    return new MCPError(
+      code,
+      message,
+      ErrorSeverity.LOW,
+      ErrorCategory.VALIDATION,
+      details
+    );
+  }
+
+  /**
+   * 从普通错误创建MCPError
+   */
+  static fromError(
+    error: Error,
+    defaultCode: MCPErrorCode = MCPErrorCode.INTERNAL_ERROR,
+    category: ErrorCategory = ErrorCategory.SYSTEM
+  ): MCPError {
+    return new MCPError(
+      defaultCode,
+      error.message,
+      ErrorSeverity.MEDIUM,
+      category,
+      {
+        stack: error.stack,
+        context: { originalError: error.name },
+      }
+    );
+  }
+}
+
+/**
+ * 错误处理器接口
+ */
+export interface ErrorHandler {
+  canHandle(error: Error): boolean;
+  handle(error: Error, context?: Record<string, unknown>): MCPError | null;
+}
+
+/**
+ * 默认错误处理器
+ */
+export class DefaultErrorHandler implements ErrorHandler {
+  canHandle(error: Error): boolean {
+    return !(error instanceof MCPError);
+  }
+
+  handle(error: Error, context?: Record<string, unknown>): MCPError {
+    return MCPError.fromError(
+      error,
+      MCPErrorCode.INTERNAL_ERROR,
+      ErrorCategory.SYSTEM
+    );
+  }
+}
+
+/**
+ * 配置错误处理器
+ */
+export class ConfigErrorHandler implements ErrorHandler {
+  canHandle(error: Error): boolean {
+    return (
+      error.message.includes("配置") ||
+      error.message.includes("config") ||
+      error.message.includes("JSON") ||
+      error.message.includes("解析")
+    );
+  }
+
+  handle(error: Error, context?: Record<string, unknown>): MCPError {
+    return MCPError.configError(
+      MCPErrorCode.INVALID_CONFIG,
+      `配置错误: ${error.message}`,
+      { context }
+    );
+  }
+}
+
+/**
+ * 连接错误处理器
+ */
+export class ConnectionErrorHandler implements ErrorHandler {
+  canHandle(error: Error): boolean {
+    return (
+      error.message.includes("连接") ||
+      error.message.includes("connection") ||
+      error.message.includes("timeout") ||
+      error.message.includes("ECONNREFUSED") ||
+      error.message.includes("ENOTFOUND")
+    );
+  }
+
+  handle(error: Error, context?: Record<string, unknown>): MCPError {
+    return MCPError.connectionError(
+      MCPErrorCode.CONNECTION_FAILED,
+      `连接失败: ${error.message}`,
+      { context }
+    );
+  }
+}
+
+/**
+ * 错误处理器注册表
+ */
+export class ErrorHandlerRegistry {
+  private handlers: ErrorHandler[] = [];
+
+  constructor() {
+    // 注册默认处理器
+    this.registerHandler(new ConfigErrorHandler());
+    this.registerHandler(new ConnectionErrorHandler());
+    this.registerHandler(new DefaultErrorHandler());
+  }
+
+  /**
+   * 注册错误处理器
+   */
+  registerHandler(handler: ErrorHandler): void {
+    this.handlers.unshift(handler); // 添加到前面，优先处理
+  }
+
+  /**
+   * 处理错误
+   */
+  handleError(error: Error, context?: Record<string, unknown>): MCPError {
+    // 如果已经是MCPError，直接返回
+    if (error instanceof MCPError) {
+      return error;
+    }
+
+    // 查找合适的处理器
+    for (const handler of this.handlers) {
+      if (handler.canHandle(error)) {
+        const result = handler.handle(error, context);
+        if (result) {
+          return result;
+        }
+      }
+    }
+
+    // 如果没有处理器能处理，使用默认处理器
+    return new DefaultErrorHandler().handle(error, context);
+  }
+}
+
+/**
+ * 全局错误处理器实例
+ */
+export const globalErrorHandler = new ErrorHandlerRegistry();

--- a/src/server/handlers/__tests__/basic.test.ts
+++ b/src/server/handlers/__tests__/basic.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it, vi } from "vitest";
+
+// 模拟依赖以避免触发真实的配置加载
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    getConfig: vi.fn(() => ({
+      mcpEndpoint: [],
+      mcpServers: {},
+      connection: {},
+    })),
+    getMcpServers: vi.fn(() => ({})),
+    getMcpEndpoints: vi.fn(() => []),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    setToolEnabled: vi.fn(),
+    updatePlatformConfig: vi.fn(),
+    getMcpEndpoint: vi.fn(),
+    getConnectionConfig: vi.fn(),
+    reloadConfig: vi.fn(),
+    getConfigPath: vi.fn(),
+    configExists: vi.fn(() => true),
+    validateConfig: vi.fn(),
+    updateConfig: vi.fn(),
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  exec: vi.fn(),
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../services/EventBus.js", () => ({
+  getEventBus: vi.fn().mockReturnValue({
+    emitEvent: vi.fn(),
+  }),
+}));
+
+vi.mock("../../services/StatusService.js", () => ({
+  StatusService: vi.fn().mockImplementation(() => ({
+    updateRestartStatus: vi.fn(),
+  })),
+}));
+
+describe("处理器基础测试", () => {
+  it("应该能够导入处理器模块", async () => {
+    // 测试所有处理器模块都可以无错误导入
+    const modules = [
+      () => import("../config.handler.js"),
+      () => import("../service.handler.js"),
+      () => import("../static-file.handler.js"),
+      () => import("../status.handler.js"),
+    ];
+
+    for (const importModule of modules) {
+      await expect(importModule()).resolves.toBeDefined();
+    }
+  });
+
+  it("应该具有正确的类构造函数", async () => {
+    const { ConfigApiHandler } = await import("../config.handler.js");
+    const { StaticFileHandler } = await import("../static-file.handler.js");
+    const { ServiceApiHandler } = await import("../service.handler.js");
+    const { StatusApiHandler } = await import("../status.handler.js");
+    const { StatusService } = await import("../../services/status.service.js");
+
+    const mockStatusService = new StatusService();
+
+    expect(() => new ConfigApiHandler()).not.toThrow();
+    expect(() => new StaticFileHandler()).not.toThrow();
+    expect(() => new ServiceApiHandler(mockStatusService)).not.toThrow();
+    expect(() => new StatusApiHandler(mockStatusService)).not.toThrow();
+  });
+});

--- a/src/server/handlers/__tests__/config.handler.test.ts
+++ b/src/server/handlers/__tests__/config.handler.test.ts
@@ -1,0 +1,561 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { AppConfig } from "../../../config/index.js";
+import { ConfigApiHandler } from "../config.handler.js";
+
+// 模拟依赖项
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    getConfig: vi.fn(),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    setToolEnabled: vi.fn(),
+    updatePlatformConfig: vi.fn(),
+    getMcpEndpoint: vi.fn(),
+    getMcpEndpoints: vi.fn(),
+    getMcpServers: vi.fn(),
+    getConnectionConfig: vi.fn(),
+    reloadConfig: vi.fn(),
+    getConfigPath: vi.fn(),
+    configExists: vi.fn(),
+    validateConfig: vi.fn(),
+    updateConfig: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({
+      maxRecords: 100,
+      logFilePath: undefined,
+    }),
+    getConfigDir: vi.fn().mockReturnValue(process.cwd()),
+  },
+}));
+
+describe("ConfigApiHandler", () => {
+  let configApiHandler: ConfigApiHandler;
+  let mockConfigManager: any;
+  let mockLogger: any;
+  let mockContext: any;
+
+  const mockConfig: AppConfig = {
+    mcpEndpoint: "ws://localhost:3000",
+    mcpServers: {
+      calculator: {
+        command: "node",
+        args: ["calculator.js"],
+      },
+      datetime: {
+        command: "python",
+        args: ["datetime.py"],
+      },
+    },
+    connection: {
+      heartbeatInterval: 30000,
+      heartbeatTimeout: 35000,
+      reconnectInterval: 5000,
+    },
+    webUI: {
+      port: 3001,
+    },
+  };
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 模拟 Logger
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { logger } = await import("../../Logger.js");
+    Object.assign(logger, mockLogger);
+
+    // 模拟 ConfigManager
+    mockConfigManager = {
+      getConfig: vi.fn(),
+      updateMcpEndpoint: vi.fn(),
+      updateMcpServer: vi.fn(),
+      removeMcpServer: vi.fn(),
+      updateConnectionConfig: vi.fn(),
+      updateModelScopeConfig: vi.fn(),
+      updateWebUIConfig: vi.fn(),
+      setToolEnabled: vi.fn(),
+      updatePlatformConfig: vi.fn(),
+      getMcpEndpoint: vi.fn(),
+      getMcpEndpoints: vi.fn(),
+      getMcpServers: vi.fn(),
+      getConnectionConfig: vi.fn(),
+      reloadConfig: vi.fn(),
+      getConfigPath: vi.fn(),
+      configExists: vi.fn(),
+      validateConfig: vi.fn(),
+      updateConfig: vi.fn(),
+      getToolCallLogConfig: vi.fn().mockReturnValue({
+        maxRecords: 100,
+        logFilePath: undefined,
+      }),
+      getConfigDir: vi.fn().mockReturnValue(process.cwd()),
+    };
+    const { configManager } = await import("../../../config/index.js");
+    Object.assign(configManager, mockConfigManager);
+
+    // 模拟 Hono 上下文
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") return mockLogger;
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      json: vi.fn().mockReturnValue(new Response()),
+      req: {
+        json: vi.fn(),
+      },
+      logger: mockLogger, // 向后兼容
+    };
+
+    configApiHandler = new ConfigApiHandler();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("应该使用正确的依赖项初始化", () => {
+      expect(configApiHandler).toBeInstanceOf(ConfigApiHandler);
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("getConfig", () => {
+    it("应该成功返回配置", async () => {
+      mockConfigManager.getConfig.mockReturnValue(mockConfig);
+
+      await configApiHandler.getConfig(mockContext);
+
+      expect(mockConfigManager.getConfig).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取配置请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取配置成功");
+      expect(mockContext.success).toHaveBeenCalledWith(mockConfig);
+    });
+
+    it("应该处理配置服务错误", async () => {
+      const error = new Error("Config read failed");
+      mockConfigManager.getConfig.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getConfig(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("获取配置失败:", error);
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_READ_ERROR",
+        "Config read failed",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理非 Error 异常", async () => {
+      mockConfigManager.getConfig.mockImplementation(() => {
+        throw "String error";
+      });
+
+      await configApiHandler.getConfig(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_READ_ERROR",
+        "获取配置失败",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("updateConfig", () => {
+    it("应该成功更新配置", async () => {
+      mockContext.req.json.mockResolvedValue(mockConfig);
+
+      await configApiHandler.updateConfig(mockContext);
+
+      // 验证 validateConfig 被调用
+      expect(mockConfigManager.validateConfig).toHaveBeenCalledWith(mockConfig);
+      // 验证 updateConfig 被调用
+      expect(mockConfigManager.updateConfig).toHaveBeenCalledWith(mockConfig);
+      expect(mockContext.req.json).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理更新配置请求");
+      expect(mockLogger.info).toHaveBeenCalledWith("配置更新成功");
+      expect(mockContext.success).toHaveBeenCalledWith(
+        undefined,
+        "配置更新成功"
+      );
+    });
+
+    it("应该处理无效请求体 - null", async () => {
+      mockContext.req.json.mockResolvedValue(null);
+      mockConfigManager.validateConfig.mockImplementation(() => {
+        throw new Error("配置必须是有效的对象");
+      });
+
+      await configApiHandler.updateConfig(mockContext);
+
+      expect(mockConfigManager.updateConfig).not.toHaveBeenCalled();
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_UPDATE_ERROR",
+        "配置必须是有效的对象"
+      );
+    });
+
+    it("应该处理无效请求体 - string", async () => {
+      mockContext.req.json.mockResolvedValue("invalid config");
+      mockConfigManager.validateConfig.mockImplementation(() => {
+        throw new Error("配置必须是有效的对象");
+      });
+
+      await configApiHandler.updateConfig(mockContext);
+
+      expect(mockConfigManager.updateConfig).not.toHaveBeenCalled();
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_UPDATE_ERROR",
+        "配置必须是有效的对象"
+      );
+    });
+
+    it("应该处理配置更新错误", async () => {
+      const error = new Error("Config update failed");
+      mockContext.req.json.mockResolvedValue(mockConfig);
+      mockConfigManager.validateConfig.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.updateConfig(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("配置更新失败:", error);
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_UPDATE_ERROR",
+        "Config update failed"
+      );
+    });
+
+    it("应该处理 JSON 解析错误", async () => {
+      const jsonError = new Error("Invalid JSON");
+      mockContext.req.json.mockRejectedValue(jsonError);
+
+      await configApiHandler.updateConfig(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("配置更新失败:", jsonError);
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_UPDATE_ERROR",
+        "Invalid JSON"
+      );
+    });
+  });
+
+  describe("getMcpEndpoint", () => {
+    it("应该成功返回 MCP 端点", async () => {
+      const endpoint = "ws://localhost:3000";
+      mockConfigManager.getMcpEndpoint.mockReturnValue(endpoint);
+
+      await configApiHandler.getMcpEndpoint(mockContext);
+
+      expect(mockConfigManager.getMcpEndpoint).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取 MCP 端点请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取 MCP 端点成功");
+      expect(mockContext.success).toHaveBeenCalledWith({ endpoint });
+    });
+
+    it("应该处理 MCP 端点错误", async () => {
+      const error = new Error("MCP endpoint read failed");
+      mockConfigManager.getMcpEndpoint.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getMcpEndpoint(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "获取 MCP 端点失败:",
+        error
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "MCP_ENDPOINT_READ_ERROR",
+        "MCP endpoint read failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("getMcpEndpoints", () => {
+    it("应该成功返回 MCP 端点列表", async () => {
+      const endpoints = ["ws://localhost:3000", "ws://localhost:3001"];
+      mockConfigManager.getMcpEndpoints.mockReturnValue(endpoints);
+
+      await configApiHandler.getMcpEndpoints(mockContext);
+
+      expect(mockConfigManager.getMcpEndpoints).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "处理获取 MCP 端点列表请求"
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取 MCP 端点列表成功");
+      expect(mockContext.success).toHaveBeenCalledWith({ endpoints });
+    });
+
+    it("should handle MCP endpoints error", async () => {
+      const error = new Error("MCP endpoints read failed");
+      mockConfigManager.getMcpEndpoints.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getMcpEndpoints(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "获取 MCP 端点列表失败:",
+        error
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "MCP_ENDPOINTS_READ_ERROR",
+        "MCP endpoints read failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("getMcpServers", () => {
+    it("should return MCP servers configuration successfully", async () => {
+      const servers = {
+        calculator: { command: "node", args: ["calculator.js"] },
+        datetime: { command: "python", args: ["datetime.py"] },
+      };
+      mockConfigManager.getMcpServers.mockReturnValue(servers);
+
+      await configApiHandler.getMcpServers(mockContext);
+
+      expect(mockConfigManager.getMcpServers).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "处理获取 MCP 服务配置请求"
+      );
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取 MCP 服务配置成功");
+      expect(mockContext.success).toHaveBeenCalledWith({ servers });
+    });
+
+    it("should handle MCP servers error", async () => {
+      const error = new Error("MCP servers read failed");
+      mockConfigManager.getMcpServers.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getMcpServers(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "获取 MCP 服务配置失败:",
+        error
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "MCP_SERVERS_READ_ERROR",
+        "MCP servers read failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("getConnectionConfig", () => {
+    it("should return connection configuration successfully", async () => {
+      const connection = {
+        heartbeatInterval: 30000,
+        heartbeatTimeout: 35000,
+        reconnectInterval: 5000,
+      };
+      mockConfigManager.getConnectionConfig.mockReturnValue(connection);
+
+      await configApiHandler.getConnectionConfig(mockContext);
+
+      expect(mockConfigManager.getConnectionConfig).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取连接配置请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取连接配置成功");
+      expect(mockContext.success).toHaveBeenCalledWith({ connection });
+    });
+
+    it("should handle connection config error", async () => {
+      const error = new Error("Connection config read failed");
+      mockConfigManager.getConnectionConfig.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getConnectionConfig(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("获取连接配置失败:", error);
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONNECTION_CONFIG_READ_ERROR",
+        "Connection config read failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("reloadConfig", () => {
+    it("should reload configuration successfully", async () => {
+      mockConfigManager.getConfig.mockReturnValue(mockConfig);
+
+      await configApiHandler.reloadConfig(mockContext);
+
+      expect(mockConfigManager.reloadConfig).toHaveBeenCalledTimes(1);
+      expect(mockConfigManager.getConfig).toHaveBeenCalledTimes(1);
+      expect(mockLogger.info).toHaveBeenCalledWith("处理重新加载配置请求");
+      expect(mockLogger.info).toHaveBeenCalledWith("重新加载配置成功");
+      expect(mockContext.success).toHaveBeenCalledWith(
+        mockConfig,
+        "配置重新加载成功"
+      );
+    });
+
+    it("should handle reload config error", async () => {
+      const error = new Error("Config reload failed");
+      mockConfigManager.getConfig.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.reloadConfig(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("重新加载配置失败:", error);
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_RELOAD_ERROR",
+        "Config reload failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("getConfigPath", () => {
+    it("should return config file path successfully", async () => {
+      const path = "/path/to/config.json";
+      mockConfigManager.getConfigPath.mockReturnValue(path);
+
+      await configApiHandler.getConfigPath(mockContext);
+
+      expect(mockConfigManager.getConfigPath).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取配置文件路径请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取配置文件路径成功");
+      expect(mockContext.success).toHaveBeenCalledWith({ path });
+    });
+
+    it("should handle config path error", async () => {
+      const error = new Error("Config path read failed");
+      mockConfigManager.getConfigPath.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.getConfigPath(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "获取配置文件路径失败:",
+        error
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_PATH_READ_ERROR",
+        "Config path read failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("checkConfigExists", () => {
+    it("should return true when config exists", async () => {
+      mockConfigManager.configExists.mockReturnValue(true);
+
+      await configApiHandler.checkConfigExists(mockContext);
+
+      expect(mockConfigManager.configExists).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理检查配置是否存在请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("配置存在检查结果: true");
+      expect(mockContext.success).toHaveBeenCalledWith({ exists: true });
+    });
+
+    it("should return false when config does not exist", async () => {
+      mockConfigManager.configExists.mockReturnValue(false);
+
+      await configApiHandler.checkConfigExists(mockContext);
+
+      expect(mockConfigManager.configExists).toHaveBeenCalledTimes(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理检查配置是否存在请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("配置存在检查结果: false");
+      expect(mockContext.success).toHaveBeenCalledWith({ exists: false });
+    });
+
+    it("should handle config exists check error", async () => {
+      const error = new Error("Config exists check failed");
+      mockConfigManager.configExists.mockImplementation(() => {
+        throw error;
+      });
+
+      await configApiHandler.checkConfigExists(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "检查配置是否存在失败:",
+        error
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_EXISTS_CHECK_ERROR",
+        "Config exists check failed",
+        undefined,
+        500
+      );
+    });
+  });
+});

--- a/src/server/handlers/__tests__/endpoint.handler.test.ts
+++ b/src/server/handlers/__tests__/endpoint.handler.test.ts
@@ -1,0 +1,989 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConnectionStatus } from "../../../endpoint/index.js";
+import { EndpointHandler } from "../endpoint.handler.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+// 创建全局的 mockEventBus 实例，以便在测试中使用
+const mockEventBusInstance = {
+  emitEvent: vi.fn(),
+};
+
+// Mock EventBus 模块
+vi.mock("../../services/EventBus.js", () => ({
+  getEventBus: vi.fn(() => mockEventBusInstance),
+}));
+
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    getMcpEndpoints: vi.fn(),
+    addMcpEndpoint: vi.fn(),
+    removeMcpEndpoint: vi.fn(),
+    getConfig: vi.fn(),
+    // 新增的事件回调支持
+    eventCallbacks: new Map(),
+    on: vi.fn(),
+    emitEvent: vi.fn(),
+  },
+}));
+
+// Mock EndpointManager
+const mockConnectionManager = {
+  getConnectionStatus: vi.fn(),
+  getEndpoint: vi.fn(),
+  connectExistingEndpoint: vi.fn(),
+  disconnectEndpoint: vi.fn(),
+  triggerReconnect: vi.fn(),
+  addEndpoint: vi.fn(),
+  removeEndpoint: vi.fn(),
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+};
+
+// Mock endpoint instance
+const createMockEndpointInstance = (connected = false) => ({
+  isConnected: vi.fn().mockReturnValue(connected),
+  connect: vi.fn().mockResolvedValue(undefined),
+  disconnect: vi.fn().mockResolvedValue(undefined),
+});
+
+describe("EndpointHandler", () => {
+  let handler: EndpointHandler;
+  let mockContext: any;
+  let mockEmitEvent: ReturnType<typeof vi.fn>;
+
+  const mockEndpointStatus: ConnectionStatus = {
+    endpoint: "ws://localhost:3000",
+    connected: false,
+    initialized: true,
+    lastError: undefined,
+    lastConnected: undefined,
+  };
+
+  beforeEach(async () => {
+    // 清除所有 mock 的调用记录，同时恢复 mock 实现到定义时的默认值
+    vi.clearAllMocks();
+
+    // 确保 connect 和 disconnect 的默认行为正确设置
+    // 这样可以防止测试用例之间的 mock 污染
+    mockConnectionManager.connect.mockResolvedValue(undefined);
+    mockConnectionManager.disconnect.mockResolvedValue(undefined);
+
+    // 创建本地 mock 对象，使用 any 类型避免类型检查
+    const mockConfigManager: any = {
+      getMcpEndpoints: vi.fn(),
+      addMcpEndpoint: vi.fn(),
+      removeMcpEndpoint: vi.fn(),
+      getConfig: vi.fn(),
+      eventCallbacks: new Map(),
+      on: vi.fn(),
+      emitEvent: vi.fn(),
+    };
+
+    // 将 mock 注入到导入的 configManager
+    const { configManager } = await import("../../../config/index.js");
+    Object.assign(configManager, mockConfigManager);
+
+    // 获取 mockEventBus 的 emitEvent 方法
+    mockEmitEvent = mockEventBusInstance.emitEvent;
+
+    // 创建处理器实例 - getEventBus 已经在模块级别被 mock
+    handler = new EndpointHandler(mockConnectionManager as any, configManager);
+
+    // 手动替换 handler 的 eventBus，确保使用 mock 实例
+    // biome-ignore lint/complexity/useLiteralKeys: Need to access private property for testing
+    // biome-ignore lint/suspicious/noExplicitAny: Need to assign mock instance
+    handler["eventBus"] = mockEventBusInstance as any;
+
+    // Create mock context - 修复 mock 配置，返回真实的 Response 对象
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      json: vi.fn().mockImplementation((data, status) => {
+        return new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      success: vi.fn().mockImplementation((data, message, status = 200) => {
+        const response: {
+          success: true;
+          data?: unknown;
+          message?: string;
+        } = { success: true };
+        if (data !== undefined) {
+          response.data = data;
+        }
+        if (message) {
+          response.message = message;
+        }
+        return new Response(JSON.stringify(response), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: unknown, status = 400) => {
+            const response = {
+              success: false,
+              error: { code, message },
+            };
+            if (details !== undefined) {
+              (
+                response.error as {
+                  code: string;
+                  message: string;
+                  details: unknown;
+                }
+              ).details = details;
+            }
+            return new Response(JSON.stringify(response), {
+              status,
+              headers: { "Content-Type": "application/json" },
+            });
+          }
+        ),
+      req: {
+        param: vi.fn(),
+        json: vi.fn(),
+      },
+    };
+  });
+
+  describe("getEndpointStatus", () => {
+    it("应该成功获取接入点状态", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response).toBeDefined();
+      expect(mockConnectionManager.getConnectionStatus).toHaveBeenCalled();
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toEqual(mockEndpointStatus);
+    });
+
+    it("应该返回404当接入点不存在时", async () => {
+      // Arrange
+      const endpoint = "ws://nonexistent:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_NOT_FOUND");
+    });
+
+    it("应该返回400当端点参数无效时", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: "" });
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回400当端点参数为null时", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: null });
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回400当端点参数为undefined时", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: undefined });
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该正确处理URL编码的端点地址", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000/api";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        { ...mockEndpointStatus, endpoint },
+      ]);
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+    });
+
+    it("应该返回500当获取连接状态失败时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockImplementation(() => {
+        throw new Error("获取状态失败");
+      });
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_STATUS_READ_ERROR");
+    });
+  });
+
+  describe("connectEndpoint", () => {
+    it("应该成功连接已存在的接入点", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+
+      // 模拟未连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // 设置连接后的状态（已连接）
+      const connectedStatus = { ...mockEndpointStatus, connected: true };
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toEqual(connectedStatus);
+      expect(mockConnectionManager.getEndpoint).toHaveBeenCalledWith(endpoint);
+      expect(mockConnectionManager.connect).toHaveBeenCalledWith(endpoint);
+      expect(mockEmitEvent).toHaveBeenCalledWith(
+        "endpoint:status:changed",
+        expect.objectContaining({
+          endpoint,
+          connected: true,
+          operation: "connect",
+          success: true,
+          message: "接入点连接成功",
+          timestamp: expect.any(Number),
+          source: "http-api",
+        })
+      );
+    });
+
+    it("应该返回404当接入点不存在时", async () => {
+      // Arrange
+      const endpoint = "ws://nonexistent:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(null);
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_NOT_FOUND");
+      expect(responseData.error.message).toBe("端点不存在，请先添加接入点");
+    });
+
+    it("应该正常处理已连接的接入点（幂等操作）", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const connectedStatus = { ...mockEndpointStatus, connected: true };
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // 模拟已连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert - EndpointManager.connect() 会优雅地处理已连接的情况
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.connect).toHaveBeenCalledWith(endpoint);
+    });
+
+    it("应该返回400当端点参数无效时", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: "" });
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回500当连接操作失败时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟连接失败
+      mockConnectionManager.connect.mockRejectedValue(new Error("连接失败"));
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_CONNECT_ERROR");
+      expect(responseData.error.message).toBe("连接失败");
+    });
+
+    it("应该返回500当连接后无法获取状态时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+
+      // 模拟未连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // 设置连接后状态为空（导致 find 返回 undefined）
+      mockConnectionManager.getConnectionStatus.mockReturnValue([]);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert - connect 调用后找不到状态时会返回 500
+      expect(response.status).toBe(500);
+      expect(mockConnectionManager.connect).toHaveBeenCalledWith(endpoint);
+      const responseData = await response.json();
+      // 源代码在连接成功但找不到状态时返回 ENDPOINT_STATUS_NOT_FOUND
+      expect(responseData.error.code).toBe("ENDPOINT_STATUS_NOT_FOUND");
+    });
+
+    it("应该正确处理URL编码的端点地址", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000/api";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+
+      // 模拟未连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // 设置连接后的状态 - 使用展开运算符确保覆盖 endpoint 字段
+      const connectedStatus = {
+        ...mockEndpointStatus,
+        endpoint: "ws://localhost:3000/api",
+        connected: true,
+      };
+      // 确保 mock 返回正确配置的状态数组
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.connect).toHaveBeenCalledWith(endpoint);
+      expect(mockConnectionManager.getEndpoint).toHaveBeenCalledWith(endpoint);
+    });
+
+    it("应该正确处理非Error类型的异常", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟连接时抛出字符串错误
+      mockConnectionManager.connect.mockRejectedValue("字符串错误");
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_CONNECT_ERROR");
+      expect(responseData.error.message).toBe("接入点连接失败");
+    });
+  });
+
+  describe("disconnectEndpoint", () => {
+    it("应该成功断开已连接的接入点", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const connectedStatus = { ...mockEndpointStatus, connected: true };
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // 模拟已连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(mockConnectionManager.getEndpoint).toHaveBeenCalledWith(endpoint);
+      expect(mockConnectionManager.disconnect).toHaveBeenCalledWith(endpoint);
+      expect(mockEmitEvent).toHaveBeenCalledWith(
+        "endpoint:status:changed",
+        expect.objectContaining({
+          endpoint,
+          connected: false,
+          operation: "disconnect",
+          success: true,
+          message: "接入点断开成功",
+          timestamp: expect.any(Number),
+          source: "http-api",
+        })
+      );
+    });
+
+    it("应该返回404当接入点不存在时", async () => {
+      // Arrange
+      const endpoint = "ws://nonexistent:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(null);
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_NOT_FOUND");
+    });
+
+    it("应该正常处理未连接的接入点（幂等操作）", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟未连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert - EndpointManager.disconnect() 会优雅地处理未连接的情况
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.disconnect).toHaveBeenCalledWith(endpoint);
+    });
+
+    it("应该返回400当端点参数无效时", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: "" });
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回500当断开操作失败时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const connectedStatus = { ...mockEndpointStatus, connected: true };
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // 模拟断开失败
+      mockConnectionManager.disconnect.mockRejectedValue(new Error("断开失败"));
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_DISCONNECT_ERROR");
+      expect(responseData.error.message).toBe("断开失败");
+    });
+
+    it("应该返回200当断开后无法获取状态时（使用fallback状态）", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const connectedStatus = { ...mockEndpointStatus, connected: true };
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([]);
+
+      // 模拟已连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert - disconnect 调用后找不到状态时，源代码会返回 fallbackStatus
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.disconnect).toHaveBeenCalledWith(endpoint);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      // 源代码会返回一个 fallbackStatus，而不是错误
+      expect(responseData.data).toEqual({
+        endpoint,
+        connected: false,
+        initialized: true,
+      });
+    });
+
+    it("应该正确处理URL编码的端点地址", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000/api";
+      const connectedStatus = {
+        ...mockEndpointStatus,
+        endpoint: "ws://localhost:3000/api", // 使用完整的端点地址
+        connected: true,
+      };
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        connectedStatus,
+      ]);
+
+      // 模拟已连接的端点实例
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.disconnectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.disconnect).toHaveBeenCalledWith(endpoint);
+      expect(mockConnectionManager.getEndpoint).toHaveBeenCalledWith(endpoint);
+    });
+  });
+
+  describe("addEndpoint", () => {
+    it("应该成功添加新端点", async () => {
+      // Arrange
+      const endpoint = "wss://new-endpoint.example.com/mcp";
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      // 第一次调用返回 undefined（端点不存在），之后返回实例
+      mockConnectionManager.getEndpoint
+        .mockReturnValueOnce(undefined)
+        .mockReturnValue(mockEndpointInstance);
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        {
+          endpoint,
+          connected: true,
+          initialized: true,
+        },
+      ]);
+      const { configManager } = await import("../../../config/index.js");
+      const cm = configManager as any;
+      cm.getConfig.mockReturnValue({
+        mcpServers: {},
+        connection: { reconnectInterval: 2000 },
+      });
+      cm.addMcpEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.endpoint).toBe(endpoint);
+      expect(mockConnectionManager.addEndpoint).toHaveBeenCalled();
+      expect(cm.addMcpEndpoint).toHaveBeenCalledWith(endpoint);
+    });
+
+    it("应该返回409当端点已存在时", async () => {
+      // Arrange
+      const endpoint = "wss://existing-endpoint.example.com/mcp";
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance); // 端点已存在
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_ALREADY_EXISTS");
+      expect(responseData.error.message).toContain("端点已存在");
+    });
+
+    it("应该返回400当端点参数无效时（参数验证在parseEndpointFromBody中提前处理）", async () => {
+      // Arrange
+      const requestBody = { endpoint: null };
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      // 参数验证在 parseEndpointFromBody 中提前处理，返回 400
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回400当端点参数为空字符串时（参数验证在parseEndpointFromBody中提前处理）", async () => {
+      // Arrange
+      const requestBody = { endpoint: "" };
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      // 参数验证在 parseEndpointFromBody 中提前处理，返回 400
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回500当JSON解析失败时（JSON解析错误在parseEndpointFromBody中处理）", async () => {
+      // Arrange
+      mockContext.req.json.mockRejectedValue(new Error("JSON解析失败"));
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      // JSON 解析错误在 parseEndpointFromBody 中处理，返回 500
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_ADD_ERROR");
+    });
+  });
+
+  describe("removeEndpoint", () => {
+    it("应该成功移除已连接的端点", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+      const { configManager } = await import("../../../config/index.js");
+      const cm = configManager as any;
+      cm.removeMcpEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.endpoint).toBe(endpoint);
+      expect(responseData.data.operation).toBe("removed");
+      expect(responseData.data.wasConnected).toBe(true);
+      // 注意：新的实现先更新配置文件，然后由 EndpointManager.removeEndpoint 内部调用 disconnect
+      // 所以这里不期望 mockEndpointInstance.disconnect 被直接调用
+      expect(mockConnectionManager.removeEndpoint).toHaveBeenCalledWith(
+        mockEndpointInstance
+      );
+      expect(cm.removeMcpEndpoint).toHaveBeenCalledWith(endpoint);
+      expect(mockEmitEvent).toHaveBeenCalledWith(
+        "endpoint:status:changed",
+        expect.objectContaining({
+          endpoint,
+          connected: false,
+          operation: "remove",
+          success: true,
+        })
+      );
+    });
+
+    it("应该成功移除未连接的端点", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+      const { configManager } = await import("../../../config/index.js");
+      const cm = configManager as any;
+      cm.removeMcpEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      const responseData = await response.json();
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.wasConnected).toBe(false);
+      expect(mockEndpointInstance.disconnect).not.toHaveBeenCalled();
+      expect(mockConnectionManager.removeEndpoint).toHaveBeenCalledWith(
+        mockEndpointInstance
+      );
+    });
+
+    it("应该返回404当端点不存在时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_NOT_FOUND");
+      expect(responseData.error.message).toContain("端点不存在");
+    });
+
+    it("应该在断开连接失败时继续移除操作", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const mockEndpointInstance = createMockEndpointInstance(true);
+      mockEndpointInstance.disconnect.mockRejectedValue(
+        new Error("断开连接失败")
+      );
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+      const { configManager } = await import("../../../config/index.js");
+      const cm = configManager as any;
+      cm.removeMcpEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(200);
+      expect(mockConnectionManager.removeEndpoint).toHaveBeenCalledWith(
+        mockEndpointInstance
+      );
+    });
+
+    it("应该返回400当端点参数无效时（参数验证在parseEndpointFromBody中提前处理）", async () => {
+      // Arrange
+      mockContext.req.json.mockResolvedValue({ endpoint: "" });
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT");
+    });
+
+    it("应该返回500当JSON解析失败时（JSON解析错误在parseEndpointFromBody中处理）", async () => {
+      // Arrange
+      mockContext.req.json.mockRejectedValue(new Error("JSON解析失败"));
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_REMOVE_ERROR");
+    });
+
+    it("应该返回500当配置更新失败时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+      const { configManager } = await import("../../../config/index.js");
+      const cm = configManager as any;
+      cm.removeMcpEndpoint.mockImplementation(() => {
+        throw new Error("配置更新失败");
+      });
+
+      // Act
+      const response = await handler.removeEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_REMOVE_ERROR");
+    });
+  });
+
+  describe("边界场景和错误处理", () => {
+    it("应该正确处理并返回500错误当连接操作失败时", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟连接失败的端点实例
+      mockConnectionManager.connect.mockRejectedValue(new Error("连接失败"));
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_CONNECT_ERROR");
+    });
+
+    it("应该返回400当端点URL格式无效时", async () => {
+      // Arrange
+      const endpoint = "not-a-valid-url";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getEndpoint.mockReturnValue(undefined);
+
+      // Act
+      const response = await handler.addEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("INVALID_ENDPOINT_FORMAT");
+    });
+
+    it("应该正确处理非Error类型的异常", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟连接时抛出字符串错误
+      mockConnectionManager.connect.mockRejectedValue("字符串错误");
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_CONNECT_ERROR");
+      expect(responseData.error.message).toBe("接入点连接失败");
+    });
+
+    it("应该正确处理空数组返回的状态", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([]);
+
+      // Act
+      const response = await handler.getEndpointStatus(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_NOT_FOUND");
+    });
+
+    it("应该正确处理连接操作失败的情况", async () => {
+      // Arrange
+      const endpoint = "ws://localhost:3000";
+      mockContext.req.json.mockResolvedValue({ endpoint });
+      mockConnectionManager.getConnectionStatus.mockReturnValue([
+        mockEndpointStatus,
+      ]);
+
+      // 模拟连接失败的端点实例
+      mockConnectionManager.connect.mockRejectedValue(new Error("连接超时"));
+      const mockEndpointInstance = createMockEndpointInstance(false);
+      mockConnectionManager.getEndpoint.mockReturnValue(mockEndpointInstance);
+
+      // Act
+      const response = await handler.connectEndpoint(mockContext);
+
+      // Assert
+      expect(response.status).toBe(500);
+      const responseData = await response.json();
+      expect(responseData.error.code).toBe("ENDPOINT_CONNECT_ERROR");
+      expect(responseData.error.message).toBe("连接超时");
+    });
+  });
+});

--- a/src/server/handlers/__tests__/mcp-manage.handler.test.ts
+++ b/src/server/handlers/__tests__/mcp-manage.handler.test.ts
@@ -1,0 +1,1452 @@
+import path from "node:path";
+import type { Context } from "hono";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { ConfigManager } from "../../../config/index.js";
+import type { MCPServerConfig } from "../../../config/index.js";
+import { MCPErrorCode } from "../../errors/mcp-errors.js";
+import type { MCPServiceManager } from "../../lib/mcp";
+import type { EventBus } from "../../services/event-bus.service.js";
+import { MCPHandler, MCPServerConfigValidator } from "../mcp-manage.handler.js";
+
+// 创建模拟对象
+const createMockConfigManager = (): Partial<ConfigManager> => ({
+  getConfig: vi.fn().mockReturnValue({
+    mcpServers: {
+      existingService: {
+        command: "node",
+        args: ["server.js"],
+      },
+    },
+  }),
+  updateMcpServer: vi.fn(),
+  removeMcpServer: vi.fn(),
+});
+
+const createMockMCPServiceManager = (): Partial<MCPServiceManager> => ({
+  addServiceConfig: vi.fn(),
+  startService: vi.fn(),
+  stopService: vi.fn(),
+  removeServiceConfig: vi.fn(),
+  // MCPServiceManager 的其他模拟方法将在后续里程碑中添加
+});
+
+const createMockEventBus = (): Partial<EventBus> => ({
+  emitEvent: vi.fn(),
+});
+
+// 使用数组格式定义路径片段
+const testConfigDirParts =
+  process.platform === "win32"
+    ? ["C:", "test", "config", "dir"]
+    : ["/", "test", "config", "dir"];
+
+// 使用 path.resolve 生成平台相关的绝对路径
+const testConfigDir = path.resolve(...testConfigDirParts);
+
+// 辅助函数：生成预期的测试路径
+const getExpectedPath = (filename: string) =>
+  path.join(testConfigDir, filename);
+
+describe("MCPHandler", () => {
+  let handler: MCPHandler;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockEventBus: Partial<EventBus>;
+
+  beforeEach(() => {
+    // 重置所有模拟对象
+    vi.clearAllMocks();
+
+    mockConfigManager = createMockConfigManager();
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockEventBus = createMockEventBus();
+
+    // 创建处理器实例
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+  });
+
+  describe("构造函数和依赖注入", () => {
+    it("应该正确创建处理器实例", () => {
+      expect(handler).toBeInstanceOf(MCPHandler);
+      expect(handler).toBeDefined();
+    });
+
+    it("应该正确注入依赖", () => {
+      // 通过测试处理器创建成功间接验证依赖注入成功
+      expect(handler).toBeDefined();
+      expect(handler).toBeInstanceOf(MCPHandler);
+    });
+  });
+
+  describe("响应格式化方法", () => {
+    // 注意：由于响应格式化方法是 protected 的，我们不直接测试它们
+    // 它们会在实际的 API 方法中被间接测试
+    it("应该定义所有必需的 API 方法", () => {
+      expect(handler.addMCPServer).toBeDefined();
+      expect(handler.removeMCPServer).toBeDefined();
+      expect(handler.getMCPServerStatus).toBeDefined();
+      expect(handler.listMCPServers).toBeDefined();
+
+      // 验证这些方法都是函数
+      expect(typeof handler.addMCPServer).toBe("function");
+      expect(typeof handler.removeMCPServer).toBe("function");
+      expect(typeof handler.getMCPServerStatus).toBe("function");
+      expect(typeof handler.listMCPServers).toBe("function");
+    });
+  });
+
+  describe("错误处理机制", () => {
+    it("应该返回正确的错误代码格式", () => {
+      expect(MCPErrorCode.SERVER_ALREADY_EXISTS).toBe("SERVER_ALREADY_EXISTS");
+      expect(MCPErrorCode.SERVER_NOT_FOUND).toBe("SERVER_NOT_FOUND");
+      expect(MCPErrorCode.INVALID_CONFIG).toBe("INVALID_CONFIG");
+      expect(MCPErrorCode.CONNECTION_FAILED).toBe("CONNECTION_FAILED");
+      expect(MCPErrorCode.INTERNAL_ERROR).toBe("INTERNAL_ERROR");
+    });
+
+    it("应该包含所有必要的错误代码", () => {
+      const expectedCodes = [
+        "SERVER_ALREADY_EXISTS",
+        "SERVER_NOT_FOUND",
+        "INVALID_CONFIG",
+        "INVALID_SERVICE_NAME",
+        "CONNECTION_FAILED",
+        "CONNECTION_TIMEOUT",
+        "SERVICE_UNAVAILABLE",
+        "OPERATION_FAILED",
+        "REMOVE_FAILED",
+        "SYNC_FAILED",
+        "INTERNAL_ERROR",
+        "CONFIG_UPDATE_FAILED",
+      ];
+
+      for (const code of expectedCodes) {
+        expect(Object.values(MCPErrorCode)).toContain(code);
+      }
+    });
+  });
+});
+
+describe("addMCPServer", () => {
+  let handler: MCPHandler;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockEventBus: Partial<EventBus>;
+  let mockContext: Partial<Context>;
+  let originalConfigDir: string | undefined;
+
+  beforeEach(() => {
+    // 保存原始环境变量
+    originalConfigDir = process.env.XIAOZHI_CONFIG_DIR;
+
+    // 设置固定的测试配置目录
+    process.env.XIAOZHI_CONFIG_DIR = testConfigDir;
+
+    vi.clearAllMocks();
+
+    mockConfigManager = createMockConfigManager();
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockEventBus = createMockEventBus();
+
+    // mockConfigManager 和 mockMCPServiceManager 已经在 createMock 函数中配置了
+
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+
+    // 创建模拟 Context - 修复 mock 配置，返回真实的 Response 对象
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      json: vi.fn().mockImplementation((data: any, status?: number) => {
+        return new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      req: {
+        json: vi.fn(),
+      },
+      // 添加 HonoRequest 的必需属性
+      raw: new Request("http://localhost"),
+      routeIndex: 0,
+      path: "",
+      bodyCache: new Map(),
+      // 确保所有必需属性都有值
+      param: vi.fn(),
+      query: vi.fn(),
+      header: vi.fn(),
+      headerValues: vi.fn(),
+    } as any;
+  });
+
+  afterEach(() => {
+    // 恢复原始环境变量
+    if (originalConfigDir !== undefined) {
+      process.env.XIAOZHI_CONFIG_DIR = originalConfigDir;
+    } else {
+      process.env.XIAOZHI_CONFIG_DIR = undefined;
+    }
+  });
+
+  it("应该成功添加新的 MCP 服务", async () => {
+    const requestData = {
+      name: "new-service",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟成功的服务启动
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      ["new-service", mockService],
+    ]);
+
+    // 修复 mock 配置 - 确保初始配置不包含新服务，但 updateMcpServer 后包含
+    const currentConfig = {
+      mcpServers: {
+        existingService: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    };
+
+    mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
+    mockConfigManager.updateMcpServer = vi
+      .fn()
+      .mockImplementation((name: string, config: MCPServerConfig) => {
+        (currentConfig.mcpServers as Record<string, MCPServerConfig>)[name] =
+          config;
+      });
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    // 验证调用
+    expect(mockConfigManager.updateMcpServer).toHaveBeenCalledWith(
+      "new-service",
+      requestData.config
+    );
+    // 重构后 addServiceConfig 接受两个参数：name 和 config（config 不包含 name）
+    expect(mockMCPServiceManager.addServiceConfig).toHaveBeenCalledWith(
+      "new-service",
+      {
+        type: "stdio",
+        command: "node",
+        args: [getExpectedPath("server.js")],
+      }
+    );
+    expect(mockMCPServiceManager.startService).toHaveBeenCalledWith(
+      "new-service"
+    );
+
+    // 验证响应
+    expect(response.status).toBe(201);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe("new-service");
+    expect(responseData.data.status).toBe("connected");
+    expect(responseData.data.tools).toEqual(["tool1", "tool2"]);
+  });
+
+  it("应该拒绝无效的服务名称", async () => {
+    const requestData = {
+      name: "invalid@name",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("INVALID_SERVICE_NAME");
+    expect(responseData.error.message).toContain(
+      "服务名称只能包含字母、数字、下划线和连字符"
+    );
+  });
+
+  it("应该拒绝重复的服务名称", async () => {
+    const requestData = {
+      name: "existingService",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(409);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("SERVER_ALREADY_EXISTS");
+    expect(responseData.error.message).toBe("MCP 服务已存在");
+  });
+
+  it("应该拒绝无效的服务配置", async () => {
+    const requestData = {
+      name: "new-service",
+      config: {
+        command: "",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("INVALID_CONFIG");
+    expect(responseData.error.message).toBe("本地服务必须提供有效的命令");
+  });
+
+  it("应该处理服务启动失败的情况", async () => {
+    const requestData = {
+      name: "failing-service",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+    mockMCPServiceManager.startService = vi
+      .fn()
+      .mockRejectedValue(new Error("服务连接失败"));
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(500);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("CONNECTION_FAILED");
+    expect(responseData.error.message).toContain("服务连接失败");
+  });
+
+  it("应该处理配置更新失败的情况", async () => {
+    const requestData = {
+      name: "config-fail-service",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+    mockConfigManager.updateMcpServer = vi.fn().mockImplementation(() => {
+      throw new Error("服务配置验证失败");
+    });
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("INVALID_CONFIG");
+    expect(responseData.error.message).toBe("服务配置验证失败");
+  });
+
+  it("应该处理未连接的服务状态", async () => {
+    const requestData = {
+      name: "disconnected-service",
+      config: {
+        command: "node",
+        args: ["server.js"],
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟服务但未连接
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(false),
+      getTools: vi.fn().mockReturnValue([]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      ["disconnected-service", mockService],
+    ]);
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(201);
+    const responseData = await response.json();
+    expect(responseData.data.status).toBe("disconnected");
+    expect(responseData.data.connected).toBe(false);
+    expect(responseData.data.tools).toEqual([]);
+  });
+});
+
+describe("removeMCPServer", () => {
+  let handler: MCPHandler;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockEventBus: Partial<EventBus>;
+  let mockContext: Partial<Context>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = createMockConfigManager();
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockEventBus = createMockEventBus();
+
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+
+    // 创建模拟 Context
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      json: vi.fn().mockImplementation((data: any, status?: number) => {
+        return new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      param: vi.fn(),
+      req: {
+        param: vi.fn(),
+      },
+      raw: new Request("http://localhost"),
+      routeIndex: 0,
+      path: "",
+      bodyCache: new Map(),
+      query: vi.fn(),
+      header: vi.fn(),
+      headerValues: vi.fn(),
+    } as any;
+  });
+
+  it("应该成功移除存在的 MCP 服务", async () => {
+    const serverName = "existingService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 模拟服务存在且有工具
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    // 验证调用
+    expect(mockMCPServiceManager.stopService).toHaveBeenCalledWith(serverName);
+    expect(mockMCPServiceManager.removeServiceConfig).toHaveBeenCalledWith(
+      serverName
+    );
+    expect(mockConfigManager.removeMcpServer).toHaveBeenCalledWith(serverName);
+
+    // 验证响应
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe(serverName);
+    expect(responseData.data.operation).toBe("removed");
+    expect(responseData.data.affectedTools).toEqual(["tool1", "tool2"]);
+  });
+
+  it("应该拒绝无效的服务名称", async () => {
+    const invalidServerName = "invalid@name";
+    (mockContext as any).req = {
+      param: vi.fn().mockReturnValue(invalidServerName),
+    };
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("INVALID_SERVICE_NAME");
+    expect(responseData.error.message).toContain(
+      "服务名称只能包含字母、数字、下划线和连字符"
+    );
+  });
+
+  it("应该拒绝移除不存在的服务", async () => {
+    const nonExistentServer = "nonExistentService";
+    (mockContext as any).req = {
+      param: vi.fn().mockReturnValue(nonExistentServer),
+    };
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(404);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("SERVER_NOT_FOUND");
+    expect(responseData.error.message).toBe("MCP 服务不存在");
+  });
+
+  it("应该处理服务停止失败的情况", async () => {
+    const serverName = "failingService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 修改 mockConfigManager 让它认为这个服务存在
+    const originalGetConfig = mockConfigManager.getConfig;
+    mockConfigManager.getConfig = vi.fn().mockReturnValue({
+      mcpServers: {
+        [serverName]: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    });
+
+    // 模拟服务存在且有工具
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    // 模拟服务停止失败
+    mockMCPServiceManager.stopService = vi
+      .fn()
+      .mockRejectedValue(new Error("停止服务失败"));
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    // 即使停止失败，也应该继续执行配置移除
+    expect(mockMCPServiceManager.removeServiceConfig).toHaveBeenCalledWith(
+      serverName
+    );
+    expect(mockConfigManager.removeMcpServer).toHaveBeenCalledWith(serverName);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe(serverName);
+
+    // 恢复原始 mock
+    mockConfigManager.getConfig = originalGetConfig;
+  });
+
+  it("应该处理配置移除失败的情况", async () => {
+    const serverName = "configFailService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 模拟服务存在
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    // 修改配置管理器让它认为这个服务存在
+    const originalGetConfig = mockConfigManager.getConfig;
+    mockConfigManager.getConfig = vi.fn().mockReturnValue({
+      mcpServers: {
+        [serverName]: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    });
+
+    // 模拟配置移除失败
+    mockConfigManager.removeMcpServer = vi.fn().mockImplementation(() => {
+      throw new Error("配置更新失败");
+    });
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(500);
+    const responseData = await response.json();
+    expect(responseData.error.code).toBe("CONFIG_UPDATE_FAILED");
+    expect(responseData.error.message).toBe("配置更新失败");
+
+    // 恢复原始 getConfig
+    mockConfigManager.getConfig = originalGetConfig;
+  });
+
+  it("应该正确处理断开连接的服务", async () => {
+    const serverName = "disconnectedService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 修改 mockConfigManager 让它认为这个服务存在
+    const originalGetConfig = mockConfigManager.getConfig;
+    mockConfigManager.getConfig = vi.fn().mockReturnValue({
+      mcpServers: {
+        [serverName]: {
+          command: "node",
+          args: ["server.js"],
+        },
+      },
+    });
+
+    // 模拟断开连接的服务
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(false),
+      getTools: vi.fn().mockReturnValue([]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    const response = await handler.removeMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe(serverName);
+    expect(responseData.data.affectedTools).toEqual([]);
+
+    // 恢复原始 mock
+    mockConfigManager.getConfig = originalGetConfig;
+  });
+
+  it("应该验证路径参数获取的正确性", async () => {
+    const serverName = "testService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    await handler.removeMCPServer(mockContext as Context);
+
+    // 验证正确获取了路径参数
+    expect((mockContext as any).req.param).toHaveBeenCalledWith("serverName");
+  });
+});
+
+describe("MCPServerConfigValidator", () => {
+  describe("服务配置验证", () => {
+    it("应该验证有效的本地服务配置", () => {
+      const config: MCPServerConfig = {
+        command: "node",
+        args: ["server.js"],
+        env: { NODE_ENV: "production" },
+      };
+
+      const result = MCPServerConfigValidator.validateConfig(config);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("应该拒绝无效的配置对象", () => {
+      const result = MCPServerConfigValidator.validateConfig(null as any);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("配置必须是一个对象");
+    });
+
+    it("应该验证本地服务配置的必填字段", () => {
+      const config: MCPServerConfig = {
+        command: "",
+        args: ["server.js"],
+      };
+
+      const result = MCPServerConfigValidator.validateConfig(config);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("本地服务必须提供有效的命令");
+    });
+
+    it("应该验证远程服务配置的 URL", () => {
+      const config: MCPServerConfig = {
+        url: "invalid-url",
+      };
+
+      const result = MCPServerConfigValidator.validateConfig(config);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("URL 格式无效");
+    });
+
+    it("应该验证有效的远程服务配置", () => {
+      const config: MCPServerConfig = {
+        url: "https://example.com/mcp",
+      };
+
+      const result = MCPServerConfigValidator.validateConfig(config);
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("应该拒绝缺少必要字段的配置", () => {
+      const config = {} as MCPServerConfig;
+
+      const result = MCPServerConfigValidator.validateConfig(config);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("配置必须包含 command 或 url 字段");
+    });
+  });
+
+  describe("服务名称验证", () => {
+    it("应该验证有效的服务名称", () => {
+      const result =
+        MCPServerConfigValidator.validateServiceName("test-service");
+      expect(result.isValid).toBe(true);
+      expect(result.errors).toHaveLength(0);
+    });
+
+    it("应该拒绝空的服务名称", () => {
+      const result = MCPServerConfigValidator.validateServiceName("");
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("服务名称必须是非空字符串");
+    });
+
+    it("应该拒绝过长的服务名称", () => {
+      const longName = "a".repeat(51);
+      const result = MCPServerConfigValidator.validateServiceName(longName);
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain("服务名称长度必须在 1-50 个字符之间");
+    });
+
+    it("应该拒绝包含非法字符的服务名称", () => {
+      const result =
+        MCPServerConfigValidator.validateServiceName("test@service");
+      expect(result.isValid).toBe(false);
+      expect(result.errors).toContain(
+        "服务名称只能包含字母、数字、下划线和连字符"
+      );
+    });
+
+    it("应该接受包含合法字符的服务名称", () => {
+      const validNames = [
+        "test_service",
+        "test-service",
+        "test123",
+        "Test_Service",
+      ];
+      for (const name of validNames) {
+        const result = MCPServerConfigValidator.validateServiceName(name);
+        expect(result.isValid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+      }
+    });
+  });
+
+  describe("服务存在性检查", () => {
+    let mockConfigManager: Partial<ConfigManager>;
+
+    beforeEach(() => {
+      mockConfigManager = createMockConfigManager();
+    });
+
+    it("应该正确检测存在的服务", () => {
+      const exists = MCPServerConfigValidator.checkServiceExists(
+        "existingService",
+        mockConfigManager as ConfigManager
+      );
+      expect(exists).toBe(true);
+    });
+
+    it("应该正确检测不存在的服务", () => {
+      const exists = MCPServerConfigValidator.checkServiceExists(
+        "nonExistentService",
+        mockConfigManager as ConfigManager
+      );
+      expect(exists).toBe(false);
+    });
+  });
+});
+
+// 测试 getMCPServerStatus 方法
+describe("getMCPServerStatus", () => {
+  let handler: MCPHandler;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockContext: Partial<Context>;
+
+  beforeEach(() => {
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockConfigManager = createMockConfigManager();
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+
+    // 设置模拟的 Context
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      req: {
+        param: vi.fn(),
+        // 添加 HonoRequest 所需的其他属性
+        raw: undefined,
+        routeIndex: 0,
+        path: "",
+        bodyCache: undefined,
+        header: vi.fn(),
+        query: vi.fn(),
+        queryParam: vi.fn(),
+        paramData: {},
+      } as any,
+      json: vi.fn().mockImplementation((data, status) => ({
+        status: status || 200,
+        json: async () => data,
+      })),
+    };
+  });
+
+  it("应该成功获取已连接服务的状态", async () => {
+    const serverName = "existingService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 模拟已连接的服务
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }, { name: "tool2" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    const response = await handler.getMCPServerStatus(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe(serverName);
+    expect(responseData.data.status).toBe("connected");
+    expect(responseData.data.connected).toBe(true);
+    expect(responseData.data.tools).toEqual(["tool1", "tool2"]);
+  });
+
+  it("应该获取未连接服务的状态", async () => {
+    const serverName = "existingService";
+    (mockContext as any).req = { param: vi.fn().mockReturnValue(serverName) };
+
+    // 模拟未连接的服务
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(false),
+      getTools: vi.fn().mockReturnValue([]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      [serverName, mockService],
+    ]);
+
+    const response = await handler.getMCPServerStatus(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.name).toBe(serverName);
+    expect(responseData.data.status).toBe("disconnected");
+    expect(responseData.data.connected).toBe(false);
+    expect(responseData.data.tools).toEqual([]);
+  });
+
+  it("应该处理无效的服务名称", async () => {
+    const invalidServerName = "invalid@name";
+    (mockContext as any).req = {
+      param: vi.fn().mockReturnValue(invalidServerName),
+    };
+
+    const response = await handler.getMCPServerStatus(mockContext as Context);
+
+    expect(response.status).toBe(400);
+    const responseData = await response.json();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.code).toBe(MCPErrorCode.INVALID_SERVICE_NAME);
+  });
+
+  it("应该处理不存在的服务", async () => {
+    const nonExistentServer = "nonExistentService";
+    (mockContext as any).req = {
+      param: vi.fn().mockReturnValue(nonExistentServer),
+    };
+
+    const response = await handler.getMCPServerStatus(mockContext as Context);
+
+    expect(response.status).toBe(404);
+    const responseData = await response.json();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.code).toBe(MCPErrorCode.SERVER_NOT_FOUND);
+  });
+});
+
+// 测试 listMCPServers 方法
+describe("listMCPServers", () => {
+  let handler: MCPHandler;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockContext: Partial<Context>;
+
+  beforeEach(() => {
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockConfigManager = createMockConfigManager();
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+
+    // 设置模拟的 Context
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      json: vi.fn().mockImplementation((data, status) => ({
+        status: status || 200,
+        json: async () => data,
+      })),
+    };
+  });
+
+  it("应该成功列出所有服务", async () => {
+    // 模拟多个服务配置
+    (mockConfigManager as any).getConfig = vi.fn().mockReturnValue({
+      mcpServers: {
+        service1: { command: "node", args: ["server1.js"] },
+        service2: { url: "http://localhost:3001" },
+        service3: { command: "python", args: ["server3.py"] },
+      },
+    });
+
+    // 模拟服务状态
+    const mockService1 = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    const mockService2 = {
+      isConnected: vi.fn().mockReturnValue(false),
+      getTools: vi.fn().mockReturnValue([]),
+    };
+    // service3 不在 services Map 中（未启动）
+    (mockMCPServiceManager as any).services = new Map([
+      ["service1", mockService1],
+      ["service2", mockService2],
+    ]);
+
+    const response = await handler.listMCPServers(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.total).toBe(3);
+    expect(responseData.data.servers).toHaveLength(3);
+
+    // 验证服务1状态
+    const service1Status = responseData.data.servers.find(
+      (s: any) => s.name === "service1"
+    );
+    expect(service1Status.status).toBe("connected");
+    expect(service1Status.connected).toBe(true);
+    expect(service1Status.tools).toEqual(["tool1"]);
+
+    // 验证服务2状态
+    const service2Status = responseData.data.servers.find(
+      (s: any) => s.name === "service2"
+    );
+    expect(service2Status.status).toBe("disconnected");
+    expect(service2Status.connected).toBe(false);
+    expect(service2Status.tools).toEqual([]);
+
+    // 验证服务3状态（未启动）
+    const service3Status = responseData.data.servers.find(
+      (s: any) => s.name === "service3"
+    );
+    expect(service3Status.status).toBe("disconnected");
+    expect(service3Status.connected).toBe(false);
+    expect(service3Status.tools).toEqual([]);
+  });
+
+  it("应该处理空的mcpServers配置", async () => {
+    // 模拟空的 mcpServers 配置
+    (mockConfigManager as any).getConfig = vi.fn().mockReturnValue({
+      mcpServers: {},
+    });
+
+    const response = await handler.listMCPServers(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.total).toBe(0);
+    expect(responseData.data.servers).toHaveLength(0);
+  });
+
+  it("应该处理mcpServers配置不存在的情况", async () => {
+    // 模拟 mcpServers 配置不存在
+    (mockConfigManager as any).getConfig = vi.fn().mockReturnValue({});
+
+    const response = await handler.listMCPServers(mockContext as Context);
+
+    expect(response.status).toBe(200);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.total).toBe(0);
+    expect(responseData.data.servers).toHaveLength(0);
+  });
+
+  it("应该处理配置读取错误", async () => {
+    // 模拟配置读取错误
+    (mockConfigManager as any).getConfig = vi.fn().mockImplementation(() => {
+      throw new Error("配置读取失败");
+    });
+
+    const response = await handler.listMCPServers(mockContext as Context);
+
+    expect(response.status).toBe(500);
+    const responseData = await response.json();
+    expect(responseData.error).toBeDefined();
+    expect(responseData.error.code).toBe(MCPErrorCode.INTERNAL_ERROR);
+  });
+});
+
+// 测试集成：验证 addMCPServer 中的 type 字段标准化
+describe("addMCPServer with type field normalization", () => {
+  let handler: MCPHandler;
+  let mockConfigManager: Partial<ConfigManager>;
+  let mockMCPServiceManager: Partial<MCPServiceManager>;
+  let mockEventBus: Partial<EventBus>;
+  let mockContext: Partial<Context>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockConfigManager = createMockConfigManager();
+    mockMCPServiceManager = createMockMCPServiceManager();
+    mockEventBus = createMockEventBus();
+
+    handler = new MCPHandler(
+      mockMCPServiceManager as MCPServiceManager,
+      mockConfigManager as ConfigManager
+    );
+
+    mockContext = {
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // 添加 c.success 方法
+      success: vi
+        .fn()
+        .mockImplementation((data: unknown, message?: string, status = 200) => {
+          const response: {
+            success: true;
+            data?: unknown;
+            message?: string;
+          } = {
+            success: true,
+            message,
+          };
+          if (data !== undefined) {
+            response.data = data;
+          }
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }),
+      // 添加 c.fail 方法
+      fail: vi
+        .fn()
+        .mockImplementation(
+          (code: string, message: string, details?: any, status = 400) => {
+            return new Response(
+              JSON.stringify({
+                success: false,
+                error: {
+                  code,
+                  message,
+                  ...(details !== undefined && { details }),
+                },
+              }),
+              {
+                status,
+                headers: { "Content-Type": "application/json" },
+              }
+            );
+          }
+        ),
+      json: vi.fn().mockImplementation((data: any, status?: number) => {
+        return new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      req: {
+        json: vi.fn(),
+      },
+      raw: new Request("http://localhost"),
+      routeIndex: 0,
+      path: "",
+      bodyCache: new Map(),
+      param: vi.fn(),
+      query: vi.fn(),
+      header: vi.fn(),
+      headerValues: vi.fn(),
+    } as any;
+  });
+
+  it("应该自动转换 streamableHttp 为 http", async () => {
+    const requestData = {
+      name: "test-service",
+      config: {
+        type: "streamableHttp",
+        url: "https://example.com/mcp",
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟成功的服务启动
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      ["test-service", mockService],
+    ]);
+
+    const currentConfig = { mcpServers: {} };
+    mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
+    mockConfigManager.updateMcpServer = vi.fn();
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    // 验证调用使用了标准化后的配置
+    expect(mockConfigManager.updateMcpServer).toHaveBeenCalledWith(
+      "test-service",
+      expect.objectContaining({
+        type: "http", // 验证type字段被标准化
+        url: "https://example.com/mcp",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+  });
+
+  it("应该自动转换 streamable_http 为 http", async () => {
+    const requestData = {
+      name: "test-service",
+      config: {
+        type: "streamable_http",
+        url: "https://example.com/mcp",
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟成功的服务启动
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      ["test-service", mockService],
+    ]);
+
+    const currentConfig = { mcpServers: {} };
+    mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
+    mockConfigManager.updateMcpServer = vi.fn();
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    // 验证调用使用了标准化后的配置
+    expect(mockConfigManager.updateMcpServer).toHaveBeenCalledWith(
+      "test-service",
+      expect.objectContaining({
+        type: "http", // 验证type字段被标准化
+        url: "https://example.com/mcp",
+      })
+    );
+
+    expect(response.status).toBe(201);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+  });
+
+  it("应该保持无效的 type 字段原样但允许通过验证", async () => {
+    const requestData = {
+      name: "test-service",
+      config: {
+        type: "invalid-format",
+        url: "https://example.com/mcp",
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟成功的服务启动
+    const mockService = {
+      isConnected: vi.fn().mockReturnValue(true),
+      getTools: vi.fn().mockReturnValue([{ name: "tool1" }]),
+    };
+    (mockMCPServiceManager as any).services = new Map([
+      ["test-service", mockService],
+    ]);
+
+    const currentConfig = { mcpServers: {} };
+    mockConfigManager.getConfig = vi.fn().mockReturnValue(currentConfig);
+    mockConfigManager.updateMcpServer = vi.fn();
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    // 验证调用使用了保持原样的无效type字段
+    expect(mockConfigManager.updateMcpServer).toHaveBeenCalledWith(
+      "test-service",
+      expect.objectContaining({
+        type: "invalid-format", // 验证type字段保持原样
+        url: "https://example.com/mcp",
+      })
+    );
+
+    expect(response.status).toBe(500);
+  });
+
+  it("应该在批量添加中也支持 type 字段标准化", async () => {
+    const requestData = {
+      mcpServers: {
+        service1: {
+          type: "streamableHttp",
+          url: "https://example.com/mcp1",
+        },
+        service2: {
+          type: "streamable_http",
+          url: "https://example.com/mcp2",
+        },
+      },
+    };
+
+    (mockContext.req as any).json = vi.fn().mockResolvedValue(requestData);
+
+    // 模拟服务不存在
+    mockConfigManager.getConfig = vi.fn().mockReturnValue({ mcpServers: {} });
+
+    const response = await handler.addMCPServer(mockContext as Context);
+
+    expect(response.status).toBe(201);
+    const responseData = await response.json();
+    expect(responseData.success).toBe(true);
+    expect(responseData.data.addedCount).toBe(2);
+
+    // 验证两个服务都成功添加（说明type字段被正确标准化为http）
+    expect(responseData.data.results).toHaveLength(2);
+    expect(responseData.data.results[0].success).toBe(true);
+    expect(responseData.data.results[1].success).toBe(true);
+  });
+});

--- a/src/server/handlers/__tests__/mcp-tool-log.handler.test.ts
+++ b/src/server/handlers/__tests__/mcp-tool-log.handler.test.ts
@@ -1,0 +1,81 @@
+/**
+ * 工具调用日志 API 处理器简化测试
+ * 专注于基本功能验证
+ */
+
+import { describe, expect, it } from "vitest";
+import { PAGINATION_CONSTANTS } from "../../constants/api.constants.js";
+import { MCPToolLogHandler } from "../mcp-tool-log.handler.js";
+
+describe("MCPToolLogHandler - 基本功能测试", () => {
+  it("应该能够创建处理器实例", () => {
+    const handler = new MCPToolLogHandler();
+    expect(handler).toBeDefined();
+    expect(handler).toBeInstanceOf(MCPToolLogHandler);
+  });
+
+  it("应该能够解析和验证查询参数", () => {
+    const handler = new MCPToolLogHandler();
+    const parseAndValidateQueryParams = (
+      handler as any
+    ).parseAndValidateQueryParams.bind(handler);
+
+    const mockContext = {
+      req: {
+        query: () => ({
+          limit: "10",
+          toolName: "test_tool",
+          success: "true",
+        }),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    // 测试有效参数
+    const validResult = parseAndValidateQueryParams(mockContext);
+    expect(validResult.success).toBe(true);
+    expect(validResult.data).toEqual({
+      limit: 10,
+      toolName: "test_tool",
+      success: true,
+    });
+
+    // 测试无效参数
+    const invalidContext = {
+      req: {
+        query: () => ({
+          limit: "300", // 超出范围
+        }),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const invalidResult = parseAndValidateQueryParams(invalidContext);
+    expect(invalidResult.success).toBe(false);
+    expect(invalidResult.error).toBeDefined();
+    expect(Array.isArray(invalidResult.error)).toBe(true);
+    expect(invalidResult.error[0].message).toContain(
+      `limit 参数必须是 1-${PAGINATION_CONSTANTS.MAX_LIMIT} 之间的数字`
+    );
+  });
+});

--- a/src/server/handlers/__tests__/mcp-tool.core.test.ts
+++ b/src/server/handlers/__tests__/mcp-tool.core.test.ts
@@ -1,0 +1,380 @@
+/**
+ * MCPToolHandler 核心功能测试
+ * 测试核心业务逻辑和边界条件处理
+ */
+
+import type { Context } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configManager } from "../../../config/index.js";
+import { ToolType } from "../../types/toolApi.js";
+import { MCPToolHandler } from "../mcp-tool.handler.js";
+
+// 模拟 configManager
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    addCustomMCPTool: vi.fn(),
+    getCustomMCPTools: vi.fn(() => []),
+    getCozePlatformConfig: vi.fn(() => ({ token: "test-token" })),
+    validateCustomMCPTools: vi.fn(() => true),
+    configExists: vi.fn(() => true),
+    getConfigPath: vi.fn(() => "/test/config.json"),
+    updateCustomMCPTool: vi.fn(),
+    removeCustomMCPTool: vi.fn(),
+    getServerToolsConfig: vi.fn(),
+    updateServerToolsConfig: vi.fn(),
+  },
+}));
+
+// 模拟 MCPServiceManager - 在 Context 中提供
+const mockServiceManager = {
+  hasTool: vi.fn(() => false),
+  hasCustomMCPTool: vi.fn(() => false),
+  getCustomMCPTools: vi.fn(() => []),
+  getAllTools: vi.fn(() => []),
+  callTool: vi.fn(),
+  getStatus: vi.fn(() => ({
+    isRunning: true,
+    totalTools: 0,
+    availableTools: 0,
+    services: {},
+  })),
+  getConnectedServices: vi.fn(() => []),
+  stopService: vi.fn(),
+  startService: vi.fn(),
+};
+
+// 模拟 MCPCacheManager
+vi.mock("../../lib/mcp", () => ({
+  MCPCacheManager: vi.fn().mockImplementation(() => ({
+    getAllCachedTools: vi.fn().mockResolvedValue([]),
+  })) as any,
+}));
+
+describe("MCPToolHandler - 核心功能测试", () => {
+  let handler: MCPToolHandler;
+  let mockContext: Partial<Context>;
+
+  beforeEach(() => {
+    handler = new MCPToolHandler();
+    mockContext = {
+      req: {
+        json: vi.fn(),
+        query: vi.fn(),
+        param: vi.fn(),
+      } as any,
+      json: vi.fn(),
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      success: vi.fn((data: unknown, message?: string, status?: number) => {
+        return {
+          status: status || 200,
+          json: () => ({
+            success: true,
+            data,
+            message,
+          }),
+        };
+      }),
+      fail: vi.fn(
+        (code: string, message: string, details?: unknown, status?: number) => {
+          return {
+            status: status || 500,
+            json: () => ({
+              success: false,
+              error: {
+                code,
+                message,
+                details,
+              },
+            }),
+          };
+        }
+      ),
+    } as any;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("getCustomTools - 获取自定义工具列表", () => {
+    it("应该成功获取自定义工具列表", async () => {
+      const mockTools = [
+        {
+          name: "test-tool",
+          description: "测试工具",
+          inputSchema: { type: "object", properties: {} },
+          handler: {
+            type: "proxy" as const,
+            platform: "coze" as const,
+            config: {
+              workflow_id: "test-workflow-id",
+              api_key: "test-api-key",
+            },
+          },
+        },
+      ];
+
+      vi.mocked(configManager.getCustomMCPTools).mockReturnValue(mockTools);
+      vi.mocked(configManager.getConfigPath).mockReturnValue(
+        "/test/config.json"
+      );
+
+      await handler.getCustomTools(mockContext as Context);
+
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          tools: mockTools,
+          totalTools: 1,
+          configPath: "/test/config.json",
+        },
+        "获取自定义 MCP 工具列表成功"
+      );
+    });
+
+    it("应该处理配置文件不存在的情况", async () => {
+      vi.mocked(configManager.configExists).mockReturnValue(false);
+
+      await handler.getCustomTools(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_NOT_FOUND",
+        "配置文件不存在，请先运行 'xiaozhi init' 初始化配置",
+        undefined,
+        404
+      );
+    });
+
+    it("应该处理配置解析失败的情况", async () => {
+      vi.mocked(configManager.getCustomMCPTools).mockImplementation(() => {
+        throw new Error("配置解析失败");
+      });
+
+      await handler.getCustomTools(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIG_PARSE_ERROR",
+        "配置文件解析失败: 配置解析失败",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理工具验证失败的情况", async () => {
+      const mockTools = [
+        {
+          name: "invalid-tool",
+          description: "无效工具",
+          inputSchema: { type: "object", properties: {} },
+          handler: {
+            type: "proxy" as const,
+            platform: "coze" as const,
+            config: {
+              workflow_id: "test-workflow-id",
+              api_key: "test-api-key",
+            },
+          },
+        },
+      ];
+      vi.mocked(configManager.getCustomMCPTools).mockReturnValue(mockTools);
+      vi.mocked(configManager.validateCustomMCPTools).mockReturnValue(false);
+
+      await handler.getCustomTools(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_TOOL_CONFIG",
+        "自定义 MCP 工具配置验证失败，请检查配置文件中的工具定义",
+        undefined,
+        400
+      );
+    });
+
+    it("应该处理空工具列表的情况", async () => {
+      vi.mocked(configManager.getCustomMCPTools).mockReturnValue([]);
+
+      await handler.getCustomTools(mockContext as Context);
+
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          tools: [],
+          totalTools: 0,
+          configPath: "/test/config.json",
+        },
+        "未配置自定义 MCP 工具"
+      );
+    });
+  });
+
+  describe("handleNewFormatAddTool - 新格式工具添加", () => {
+    it("应该正确处理 MCP 类型的工具添加", async () => {
+      const requestBody = {
+        type: ToolType.MCP,
+        data: {
+          serviceName: "test-service",
+          toolName: "test-tool",
+        },
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+
+      // 模拟 configManager 方法以避免复杂的依赖
+      vi.mocked(configManager.addCustomMCPTool).mockImplementation(() => {});
+      vi.mocked(configManager.getServerToolsConfig).mockReturnValue({});
+      vi.mocked(configManager.updateServerToolsConfig).mockImplementation(
+        () => {}
+      );
+
+      // 模拟 MCPCacheManager
+      const { MCPCacheManager } = await import("../../lib/mcp");
+      const mockMCPCacheManager = vi.mocked(MCPCacheManager);
+      mockMCPCacheManager.mockImplementation(
+        () =>
+          ({
+            getAllCachedTools: vi.fn().mockResolvedValue([
+              {
+                name: "test-service__test-tool",
+                description: "测试工具",
+                inputSchema: { type: "object", properties: {} },
+              },
+            ]),
+          }) as any
+      );
+
+      await handler.addCustomTool(mockContext as Context);
+
+      // 通过检查成功响应验证请求是否正确处理
+      expect(mockContext.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: "test-service__test-tool",
+          toolType: "mcp",
+        }),
+        expect.stringContaining("添加成功")
+      );
+    });
+
+    it("应该正确处理 Coze 类型的工具添加", async () => {
+      const requestBody = {
+        type: ToolType.COZE,
+        data: {
+          workflow: {
+            workflow_id: "123456789",
+            workflow_name: "测试工作流",
+            app_id: "test-app-id",
+          },
+        },
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+
+      // 为 Coze 工作流处理模拟 configManager 方法
+      vi.mocked(configManager.addCustomMCPTool).mockImplementation(() => {});
+
+      await handler.addCustomTool(mockContext as Context);
+
+      // 通过检查成功响应验证请求是否正确处理
+      expect(mockContext.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          toolName: expect.any(String),
+          toolType: "coze",
+        }),
+        expect.stringContaining("添加成功")
+      );
+    });
+
+    it("应该拒绝无效的工具类型", async () => {
+      const requestBody = {
+        type: "INVALID_TYPE",
+        data: {},
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+
+      await handler.addCustomTool(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_TOOL_TYPE",
+        expect.stringContaining("不支持的工具类型"),
+        undefined,
+        400
+      );
+    });
+
+    it("应该处理未实现的工具类型", async () => {
+      const requestBody = {
+        type: ToolType.HTTP,
+        data: {},
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+
+      await handler.addCustomTool(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "TOOL_TYPE_NOT_IMPLEMENTED",
+        expect.stringContaining("暂未实现"),
+        undefined,
+        501
+      );
+    });
+  });
+
+  describe("updateCustomTool - 工具更新", () => {
+    it("应该验证工具名称", async () => {
+      mockContext.req!.param = vi.fn().mockReturnValue("");
+
+      await handler.updateCustomTool(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        "工具名称不能为空",
+        undefined,
+        400
+      );
+    });
+
+    it("应该验证请求体", async () => {
+      mockContext.req!.param = vi.fn().mockReturnValue("test-tool");
+      mockContext.req!.json = vi.fn().mockResolvedValue(null);
+
+      await handler.updateCustomTool(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        "请求体必须是有效对象",
+        undefined,
+        400
+      );
+    });
+
+    it("应该拒绝旧格式的更新请求", async () => {
+      const requestBody = {
+        workflow: { workflow_id: "test" },
+      };
+
+      mockContext.req!.param = vi.fn().mockReturnValue("test-tool");
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+
+      await handler.updateCustomTool(mockContext as Context);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        "更新操作只支持新格式的请求",
+        undefined,
+        400
+      );
+    });
+  });
+});

--- a/src/server/handlers/__tests__/mcp-tool.integration.test.ts
+++ b/src/server/handlers/__tests__/mcp-tool.integration.test.ts
@@ -1,0 +1,802 @@
+/**
+ * MCPToolHandler 单元测试
+ *
+ * ⚠️ 注意：这些是单元测试，不是真正的集成测试
+ * - 使用了大量的 Mock，不涉及真实的 HTTP 请求
+ * - 主要测试 handler 的基本调用流程
+ * - 不应作为防止回归 Bug 的唯一保障
+ *
+ * 真正的集成测试应该：
+ * - 启动真实的 WebServer
+ * - 发送真实的 HTTP 请求
+ * - 测试完整的端到端场景
+ * - 参考：mcp.handler.integration.test.ts
+ */
+
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+  vi,
+} from "vitest";
+import { configManager } from "../../../config/index.js";
+import { MCPToolHandler } from "../mcp-tool.handler.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("MCPToolHandler - 单元测试", () => {
+  let mcpToolHandler: MCPToolHandler;
+  let mockContext: any;
+  let mockServiceManager: any;
+  let originalConfig: any;
+
+  beforeAll(() => {
+    // 保存原始配置
+    originalConfig = {
+      getCustomMCPTools: configManager.getCustomMCPTools,
+      hasValidCustomMCPTools: configManager.hasValidCustomMCPTools,
+    };
+  });
+
+  afterAll(() => {
+    // 恢复原始配置
+    Object.assign(configManager, originalConfig);
+  });
+
+  beforeEach(() => {
+    mcpToolHandler = new MCPToolHandler();
+
+    // 初始化 Mock ServiceManager
+    mockServiceManager = {
+      hasCustomMCPTool: vi.fn(),
+      getCustomMCPTools: vi.fn(),
+      callTool: vi.fn().mockResolvedValue({
+        content: [{ type: "text", text: "工具调用成功" }],
+        isError: false,
+      }),
+      getAllTools: vi.fn(),
+    };
+
+    // Mock Hono context with dependency injection support
+    mockContext = {
+      req: {
+        json: vi.fn(),
+      },
+      // json 是底层方法，需要被 success/fail 调用
+      json: vi.fn((data: any, status?: number) => ({
+        status: status || 200,
+        data,
+      })),
+      // 添加依赖注入支持
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      // success 方法会调用 json
+      success: vi.fn(function (
+        this: any,
+        data: unknown,
+        message?: string,
+        status = 200
+      ) {
+        const response: any = {
+          success: true,
+          message,
+        };
+        if (data !== undefined) {
+          response.data = data;
+        }
+        // 调用被 mock 的 json 方法
+        return this.json(response, status);
+      }),
+      // fail 方法会调用 json
+      fail: vi.fn(function (
+        this: any,
+        code: string,
+        message: string,
+        details?: unknown,
+        status = 400
+      ) {
+        const response: any = {
+          success: false,
+          error: {
+            code,
+            message,
+          },
+        };
+        if (details !== undefined) {
+          response.error.details = details;
+        }
+        // 调用被 mock 的 json 方法
+        return this.json(response, status);
+      }),
+      // 添加其他可能需要的 Hono Context 方法
+      set: vi.fn(),
+      has: vi.fn(),
+      status: vi.fn(),
+    };
+
+    // Reset all mocks
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("不同类型的 customMCP handler 测试", () => {
+    it("应该支持 proxy 类型的 handler", async () => {
+      // 准备
+      const proxyToolConfig = {
+        name: "test_proxy_tool",
+        description: "测试代理工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            input: { type: "string" },
+          },
+          required: ["input"],
+        },
+        handler: {
+          type: "proxy",
+          platform: "coze",
+          config: {
+            workflow_id: "test_workflow_id",
+          },
+        },
+      };
+
+      const requestBody = {
+        serviceName: "customMCP",
+        toolName: "test_proxy_tool",
+        args: { input: "测试输入" },
+      };
+
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // 模拟 configManager
+      configManager.getCustomMCPTools = vi
+        .fn()
+        .mockReturnValue([proxyToolConfig]);
+      configManager.hasValidCustomMCPTools = vi.fn().mockReturnValue(true);
+
+      // 配置当前测试的 ServiceManager Mock
+      mockServiceManager.hasCustomMCPTool.mockReturnValue(true);
+      mockServiceManager.getCustomMCPTools.mockReturnValue([proxyToolConfig]);
+      mockServiceManager.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "代理工具调用成功" }],
+        isError: false,
+      });
+
+      // 执行
+      await mcpToolHandler.callTool(mockContext);
+
+      // 断言
+      expect(mockServiceManager.callTool).toHaveBeenCalledWith(
+        "test_proxy_tool",
+        { input: "测试输入" },
+        { timeout: 60000 }
+      );
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          content: [{ type: "text", text: "代理工具调用成功" }],
+          isError: false,
+        },
+        "工具调用成功"
+      );
+    });
+
+    it("应该支持 http 类型的 handler", async () => {
+      // Arrange
+      const httpToolConfig = {
+        name: "test_http_tool",
+        description: "测试HTTP工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            url: { type: "string" },
+            method: { type: "string", enum: ["GET", "POST"] },
+          },
+          required: ["url"],
+        },
+        handler: {
+          type: "http",
+          config: {
+            url: "https://api.example.com/test",
+            method: "POST",
+            headers: {
+              "Content-Type": "application/json",
+            },
+          },
+        },
+      };
+
+      const requestBody = {
+        serviceName: "customMCP",
+        toolName: "test_http_tool",
+        args: { url: "https://test.com", method: "GET" },
+      };
+
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Mock configManager
+      configManager.getCustomMCPTools = vi
+        .fn()
+        .mockReturnValue([httpToolConfig]);
+
+      // 配置当前测试的 ServiceManager Mock
+      mockServiceManager.hasCustomMCPTool.mockReturnValue(true);
+      mockServiceManager.getCustomMCPTools.mockReturnValue([httpToolConfig]);
+      mockServiceManager.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "HTTP工具调用成功" }],
+        isError: false,
+      });
+
+      // Act
+      await mcpToolHandler.callTool(mockContext);
+
+      // Assert
+      expect(mockServiceManager.callTool).toHaveBeenCalledWith(
+        "test_http_tool",
+        { url: "https://test.com", method: "GET" },
+        { timeout: 60000 }
+      );
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          content: [{ type: "text", text: "HTTP工具调用成功" }],
+          isError: false,
+        },
+        "工具调用成功"
+      );
+    });
+
+    it("应该支持 function 类型的 handler", async () => {
+      // Arrange
+      const functionToolConfig = {
+        name: "test_function_tool",
+        description: "测试函数工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            x: { type: "number" },
+            y: { type: "number" },
+          },
+          required: ["x", "y"],
+        },
+        handler: {
+          type: "function",
+          config: {
+            code: "function add(x, y) { return x + y; }",
+            functionName: "add",
+          },
+        },
+      };
+
+      const requestBody = {
+        serviceName: "customMCP",
+        toolName: "test_function_tool",
+        args: { x: 5, y: 3 },
+      };
+
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Mock configManager
+      configManager.getCustomMCPTools = vi
+        .fn()
+        .mockReturnValue([functionToolConfig]);
+
+      // 配置当前测试的 ServiceManager Mock
+      mockServiceManager.hasCustomMCPTool.mockReturnValue(true);
+      mockServiceManager.getCustomMCPTools.mockReturnValue([
+        functionToolConfig,
+      ]);
+      mockServiceManager.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "8" }],
+        isError: false,
+      });
+
+      // Act
+      await mcpToolHandler.callTool(mockContext);
+
+      // Assert
+      expect(mockServiceManager.callTool).toHaveBeenCalledWith(
+        "test_function_tool",
+        { x: 5, y: 3 },
+        { timeout: 60000 }
+      );
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          content: [{ type: "text", text: "8" }],
+          isError: false,
+        },
+        "工具调用成功"
+      );
+    });
+  });
+
+  describe("参数验证边界情况测试", () => {
+    it("应该正确处理复杂的 JSON Schema 验证", async () => {
+      // Arrange
+      const complexToolConfig = {
+        name: "complex_validation_tool",
+        description: "复杂参数验证工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            user: {
+              type: "object",
+              properties: {
+                name: { type: "string", minLength: 2, maxLength: 50 },
+                age: { type: "integer", minimum: 0, maximum: 150 },
+                email: { type: "string" },
+              },
+              required: ["name", "age"],
+            },
+            preferences: {
+              type: "array",
+              items: {
+                type: "string",
+                enum: ["option1", "option2", "option3"],
+              },
+              minItems: 1,
+              maxItems: 3,
+            },
+          },
+          required: ["user"],
+        },
+        handler: {
+          type: "function",
+          config: {
+            code: "function process(data) { return 'processed'; }",
+            functionName: "process",
+          },
+        },
+      };
+
+      const requestBody = {
+        serviceName: "customMCP",
+        toolName: "complex_validation_tool",
+        args: {
+          user: {
+            name: "A", // 太短，应该失败
+            age: 25,
+          },
+        },
+      };
+
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Mock configManager
+      configManager.getCustomMCPTools = vi
+        .fn()
+        .mockReturnValue([complexToolConfig]);
+
+      // 配置当前测试的 ServiceManager Mock
+      mockServiceManager.hasCustomMCPTool.mockReturnValue(true);
+      mockServiceManager.getCustomMCPTools.mockReturnValue([complexToolConfig]);
+
+      // Act
+      await mcpToolHandler.callTool(mockContext);
+
+      // Assert
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_ARGUMENTS",
+        expect.stringContaining("参数验证失败"),
+        undefined,
+        500
+      );
+    });
+
+    it("应该正确处理嵌套对象的参数验证", async () => {
+      // Arrange
+      const nestedToolConfig = {
+        name: "nested_validation_tool",
+        description: "嵌套参数验证工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            config: {
+              type: "object",
+              properties: {
+                database: {
+                  type: "object",
+                  properties: {
+                    host: { type: "string" },
+                    port: { type: "integer", minimum: 1, maximum: 65535 },
+                  },
+                  required: ["host", "port"],
+                },
+              },
+              required: ["database"],
+            },
+          },
+          required: ["config"],
+        },
+        handler: {
+          type: "function",
+          config: {
+            code: "function connect(config) { return 'connected'; }",
+            functionName: "connect",
+          },
+        },
+      };
+
+      const requestBody = {
+        serviceName: "customMCP",
+        toolName: "nested_validation_tool",
+        args: {
+          config: {
+            database: {
+              host: "localhost",
+              port: 3306,
+            },
+          },
+        },
+      };
+
+      mockContext.req.json.mockResolvedValue(requestBody);
+
+      // Mock configManager
+      configManager.getCustomMCPTools = vi
+        .fn()
+        .mockReturnValue([nestedToolConfig]);
+
+      // 配置当前测试的 ServiceManager Mock
+      mockServiceManager.hasCustomMCPTool.mockReturnValue(true);
+      mockServiceManager.getCustomMCPTools.mockReturnValue([nestedToolConfig]);
+      mockServiceManager.callTool.mockResolvedValue({
+        content: [{ type: "text", text: "connected" }],
+        isError: false,
+      });
+
+      // Act
+      await mcpToolHandler.callTool(mockContext);
+
+      // Assert
+      expect(mockServiceManager.callTool).toHaveBeenCalledWith(
+        "nested_validation_tool",
+        {
+          config: {
+            database: {
+              host: "localhost",
+              port: 3306,
+            },
+          },
+        },
+        { timeout: 60000 }
+      );
+      expect(mockContext.success).toHaveBeenCalledWith(
+        {
+          content: [{ type: "text", text: "connected" }],
+          isError: false,
+        },
+        "工具调用成功"
+      );
+    });
+  });
+
+  describe("addCustomTool", () => {
+    beforeEach(() => {
+      vi.spyOn(configManager, "addCustomMCPTool").mockImplementation(() => {});
+      vi.spyOn(configManager, "getCozePlatformConfig").mockReturnValue({
+        token: "test_token_123",
+      });
+      vi.spyOn(configManager, "getCustomMCPTools").mockReturnValue([]);
+      vi.spyOn(configManager, "validateCustomMCPTools").mockReturnValue(true);
+    });
+
+    it("应该成功添加自定义工具", async () => {
+      const mockWorkflow = {
+        workflow_id: "123",
+        workflow_name: "测试工作流",
+        description: "这是一个测试工作流",
+        icon_url: "",
+        app_id: "app_123",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123456,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: mockWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.stringMatching(/^[a-zA-Z]/),
+          description: mockWorkflow.description,
+          inputSchema: expect.objectContaining({
+            type: "object",
+            properties: expect.any(Object),
+          }),
+          handler: expect.objectContaining({
+            type: "proxy",
+            platform: "coze",
+            config: expect.objectContaining({
+              workflow_id: mockWorkflow.workflow_id,
+            }),
+          }),
+        })
+      );
+
+      expect(mockContext.success).toHaveBeenCalled();
+      const successCall = mockContext.success.mock.calls[0];
+      expect(successCall[0]).toHaveProperty("tool");
+      expect(successCall[1]).toContain("添加成功");
+    });
+
+    it("应该在工作流参数不完整时返回错误", async () => {
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: {
+          workflow_name: "测试工作流",
+          // 缺少 workflow_id
+        },
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        expect.stringContaining("workflow_id 不能为空"),
+        undefined,
+        400
+      );
+    });
+  });
+
+  describe("removeCustomTool", () => {
+    it("应该在工具名称为空时返回错误", async () => {
+      mockContext.req.param = vi.fn().mockReturnValue("");
+
+      const response = await mcpToolHandler.removeCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        "工具名称不能为空",
+        undefined,
+        400
+      );
+    });
+
+    it("应该在配置管理器抛出错误时返回错误响应", async () => {
+      mockContext.req.param = vi.fn().mockReturnValue("non_existent_tool");
+
+      // Mock configManager.getCustomMCPTools 返回空数组，确保不会找到要删除的工具
+      vi.spyOn(configManager, "getCustomMCPTools").mockReturnValue([]);
+
+      // Mock configManager 抛出错误
+      vi.spyOn(configManager, "removeCustomMCPTool").mockImplementation(() => {
+        throw new Error('工具 "non_existent_tool" 不存在');
+      });
+
+      const response = await mcpToolHandler.removeCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "TOOL_NOT_FOUND",
+        expect.stringContaining("不存在"),
+        undefined,
+        404
+      );
+    });
+  });
+
+  describe("数据验证", () => {
+    beforeEach(() => {
+      // Mock configManager methods
+      vi.spyOn(configManager, "getCustomMCPTools").mockReturnValue([]);
+      vi.spyOn(configManager, "validateCustomMCPTools").mockReturnValue(true);
+      vi.spyOn(configManager, "getCozePlatformConfig").mockReturnValue({
+        token: "test_token_123",
+      });
+    });
+
+    it("应该验证工作流数据完整性", async () => {
+      const incompleteWorkflow = {
+        workflow_name: "测试工作流",
+        // 缺少 workflow_id
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: incompleteWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_REQUEST",
+        "workflow_id 不能为空且必须是非空字符串",
+        undefined,
+        400
+      );
+    });
+
+    it("应该验证工作流ID格式", async () => {
+      const invalidWorkflow = {
+        workflow_id: "invalid_id",
+        workflow_name: "测试工作流",
+        description: "测试",
+        icon_url: "",
+        app_id: "app_123",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123456,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: invalidWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "VALIDATION_ERROR",
+        expect.stringContaining("工作流ID应为数字格式"),
+        undefined,
+        400
+      );
+    });
+
+    it("应该检查扣子API配置", async () => {
+      // Mock missing coze config
+      vi.spyOn(configManager, "getCozePlatformConfig").mockReturnValue(null);
+
+      const mockWorkflow = {
+        workflow_id: "123",
+        workflow_name: "测试工作流",
+        description: "测试",
+        icon_url: "",
+        app_id: "app_123",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123456,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: mockWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "CONFIGURATION_ERROR",
+        expect.stringContaining("扣子API Token"),
+        undefined,
+        422
+      );
+    });
+  });
+
+  describe("增强数据验证", () => {
+    beforeEach(() => {
+      // Mock configManager methods
+      vi.spyOn(configManager, "getCustomMCPTools").mockReturnValue([]);
+      vi.spyOn(configManager, "validateCustomMCPTools").mockReturnValue(true);
+      vi.spyOn(configManager, "getCozePlatformConfig").mockReturnValue({
+        token: "test_token_123",
+      });
+    });
+
+    it("应该验证工作流必需字段", async () => {
+      const incompleteWorkflow = {
+        workflow_id: "123",
+        workflow_name: "测试工作流",
+        // 缺少 app_id
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: incompleteWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "VALIDATION_ERROR",
+        expect.stringContaining("应用ID"),
+        undefined,
+        400
+      );
+    });
+
+    it("应该验证字段格式", async () => {
+      const invalidWorkflow = {
+        workflow_id: "123",
+        workflow_name: "测试工作流",
+        app_id: "invalid@app#id", // 无效的app_id格式
+        description: "测试",
+        icon_url: "",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123456,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: invalidWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "VALIDATION_ERROR",
+        expect.stringContaining("应用ID只能包含字母、数字、下划线和连字符"),
+        undefined,
+        400
+      );
+    });
+
+    it("应该验证字段长度限制", async () => {
+      const longNameWorkflow = {
+        workflow_id: "123",
+        workflow_name: "a".repeat(150), // 超过100字符限制
+        app_id: "app_123",
+        description: "测试",
+        icon_url: "",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123456,
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: longNameWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "VALIDATION_ERROR",
+        expect.stringContaining("工作流名称不能超过100个字符"),
+        undefined,
+        400
+      );
+    });
+
+    it("应该验证业务逻辑", async () => {
+      const invalidTimeWorkflow = {
+        workflow_id: "123",
+        workflow_name: "测试工作流",
+        app_id: "app_123",
+        description: "测试",
+        icon_url: "",
+        creator: { id: "user_123", name: "测试用户" },
+        created_at: 1699123456,
+        updated_at: 1699123400, // 更新时间早于创建时间
+      };
+
+      mockContext.req.json = vi.fn().mockResolvedValue({
+        workflow: invalidTimeWorkflow,
+      });
+
+      const response = await mcpToolHandler.addCustomTool(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "VALIDATION_ERROR",
+        expect.stringContaining("工作流的时间信息有误"),
+        undefined,
+        400
+      );
+    });
+  });
+});

--- a/src/server/handlers/__tests__/mcp-tool.parameter-config.test.ts
+++ b/src/server/handlers/__tests__/mcp-tool.parameter-config.test.ts
@@ -1,0 +1,257 @@
+/**
+ * MCPToolHandler 参数配置功能测试
+ * 测试第二阶段新增的参数配置功能
+ */
+
+import type { Context } from "hono";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { configManager } from "../../../config/index.js";
+import type {
+  CozeWorkflow,
+  WorkflowParameterConfig,
+} from "../../types/coze.js";
+import { MCPToolHandler } from "../mcp-tool.handler.js";
+
+// 模拟 configManager
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    addCustomMCPTool: vi.fn(),
+    getCustomMCPTools: vi.fn(() => []),
+    getCozePlatformConfig: vi.fn(() => ({ token: "test-token" })),
+    validateCustomMCPTools: vi.fn(() => true),
+  },
+}));
+
+describe("MCPToolHandler - 参数配置功能", () => {
+  let handler: MCPToolHandler;
+  let mockContext: Partial<Context>;
+
+  // 测试用的工作流数据
+  const mockWorkflow: CozeWorkflow = {
+    workflow_id: "123456789",
+    workflow_name: "测试工作流",
+    description: "这是一个测试工作流",
+    icon_url: "https://example.com/icon.png",
+    app_id: "test-app-456",
+    creator: {
+      id: "creator-789",
+      name: "测试创建者",
+    },
+    created_at: Date.now(),
+    updated_at: Date.now(),
+  };
+
+  // 测试用的参数配置
+  const mockParameterConfig: WorkflowParameterConfig = {
+    parameters: [
+      {
+        fieldName: "userName",
+        description: "用户名称",
+        type: "string",
+        required: true,
+      },
+      {
+        fieldName: "age",
+        description: "用户年龄",
+        type: "number",
+        required: false,
+      },
+      {
+        fieldName: "isActive",
+        description: "是否激活",
+        type: "boolean",
+        required: true,
+      },
+    ],
+  };
+
+  beforeEach(() => {
+    handler = new MCPToolHandler();
+    mockContext = {
+      req: {
+        json: vi.fn(),
+      } as any,
+      json: vi.fn(),
+      get: vi.fn((key: string) => {
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+      success: vi.fn((data: unknown, message?: string, status?: number) => {
+        return {
+          status: status || 200,
+          json: () => ({
+            success: true,
+            data,
+            message,
+          }),
+        };
+      }),
+      fail: vi.fn(
+        (code: string, message: string, details?: unknown, status?: number) => {
+          return {
+            status: status || 500,
+            json: () => ({
+              success: false,
+              error: {
+                code,
+                message,
+                details,
+              },
+            }),
+          };
+        }
+      ),
+    } as any;
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("addCustomTool - 参数配置支持", () => {
+    it("应该支持不带参数配置的请求（向后兼容）", async () => {
+      const requestBody = {
+        workflow: mockWorkflow,
+        customName: "测试工具",
+        customDescription: "测试描述",
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+      mockContext.json = vi.fn().mockReturnValue(new Response());
+
+      await handler.addCustomTool(mockContext as Context);
+
+      expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.any(String),
+          description: expect.any(String),
+          inputSchema: expect.objectContaining({
+            type: "object",
+            properties: expect.objectContaining({
+              input: expect.objectContaining({
+                type: "string",
+                description: "输入内容",
+              }),
+            }),
+            required: ["input"],
+          }),
+          handler: expect.any(Object),
+        })
+      );
+    });
+
+    it("应该支持带参数配置的请求", async () => {
+      const requestBody = {
+        workflow: mockWorkflow,
+        customName: "测试工具",
+        customDescription: "测试描述",
+        parameterConfig: mockParameterConfig,
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+      mockContext.json = vi.fn().mockReturnValue(new Response());
+
+      await handler.addCustomTool(mockContext as Context);
+
+      expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          name: expect.any(String),
+          description: expect.any(String),
+          inputSchema: expect.objectContaining({
+            type: "object",
+            properties: expect.objectContaining({
+              userName: expect.objectContaining({
+                type: "string",
+                description: "用户名称",
+              }),
+              age: expect.objectContaining({
+                type: "number",
+                description: "用户年龄",
+              }),
+              isActive: expect.objectContaining({
+                type: "boolean",
+                description: "是否激活",
+              }),
+            }),
+            required: ["userName", "isActive"],
+          }),
+          handler: expect.any(Object),
+        })
+      );
+    });
+
+    it("应该支持空参数配置", async () => {
+      const requestBody = {
+        workflow: mockWorkflow,
+        parameterConfig: { parameters: [] },
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+      mockContext.json = vi.fn().mockReturnValue(new Response());
+
+      await handler.addCustomTool(mockContext as Context);
+
+      // 空参数配置应该使用默认schema
+      expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputSchema: expect.objectContaining({
+            type: "object",
+            properties: expect.objectContaining({
+              input: expect.objectContaining({
+                type: "string",
+                description: "输入内容",
+              }),
+            }),
+            required: ["input"],
+          }),
+        })
+      );
+    });
+
+    it("应该正确处理只有可选参数的配置", async () => {
+      const optionalOnlyConfig: WorkflowParameterConfig = {
+        parameters: [
+          {
+            fieldName: "optionalParam",
+            description: "可选参数",
+            type: "string",
+            required: false,
+          },
+        ],
+      };
+
+      const requestBody = {
+        workflow: mockWorkflow,
+        parameterConfig: optionalOnlyConfig,
+      };
+
+      mockContext.req!.json = vi.fn().mockResolvedValue(requestBody);
+      mockContext.json = vi.fn().mockReturnValue(new Response());
+
+      await handler.addCustomTool(mockContext as Context);
+
+      expect(configManager.addCustomMCPTool).toHaveBeenCalledWith(
+        expect.objectContaining({
+          inputSchema: expect.objectContaining({
+            type: "object",
+            properties: expect.objectContaining({
+              optionalParam: expect.objectContaining({
+                type: "string",
+                description: "可选参数",
+              }),
+            }),
+            required: undefined, // 没有必填参数时应该是undefined
+          }),
+        })
+      );
+    });
+  });
+});

--- a/src/server/handlers/__tests__/mcp.handler.integration.test.ts
+++ b/src/server/handlers/__tests__/mcp.handler.integration.test.ts
@@ -1,0 +1,293 @@
+import { EventEmitter } from "node:events";
+import { afterAll, beforeAll, describe, expect, it, vi } from "vitest";
+import { WebServer } from "../../WebServer.js";
+
+// 模拟 configManager
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    configExists: vi.fn().mockReturnValue(true),
+    getConfig: vi.fn().mockReturnValue({}),
+    getMcpEndpoint: vi.fn().mockReturnValue(""),
+    getMcpServers: vi.fn().mockReturnValue({}),
+    updateMcpEndpoint: vi.fn(),
+    updateMcpServer: vi.fn(),
+    removeMcpServer: vi.fn(),
+    updateConnectionConfig: vi.fn(),
+    updateModelScopeConfig: vi.fn(),
+    updateWebUIConfig: vi.fn(),
+    getWebUIPort: vi.fn().mockReturnValue(3001),
+    setToolEnabled: vi.fn(),
+    removeServerToolsConfig: vi.fn(),
+    cleanupInvalidServerToolsConfig: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({}),
+    getConfigDir: vi.fn().mockReturnValue("/tmp"),
+    getLLMConfig: vi.fn(() => null),
+    isLLMConfigValid: vi.fn(() => false),
+    getTTSConfig: vi.fn(() => ({})),
+    getASRConfig: vi.fn(() => ({})),
+  },
+}));
+
+// Mock MCPMessageHandler 和 MCPServiceManager
+vi.mock("../../lib/mcp", () => ({
+  MCPMessageHandler: vi.fn().mockImplementation(() => ({
+    handleMessage: vi.fn().mockImplementation((message) => {
+      return Promise.resolve({
+        jsonrpc: "2.0",
+        result: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          serverInfo: { name: "xiaozhi-client", version: "1.0.0" },
+        },
+        id: message.id, // 返回请求中的 ID
+      });
+    }),
+  })),
+
+  MCPServiceManager: vi.fn().mockImplementation(() => {
+    const instance = {
+      start: vi.fn().mockResolvedValue(undefined),
+      stop: vi.fn().mockResolvedValue(undefined),
+      isRunning: true,
+      tools: new Map(),
+      services: new Map(),
+      on: vi.fn(),
+      off: vi.fn(),
+      emit: vi.fn(),
+      removeAllListeners: vi.fn(),
+      listTools: vi.fn().mockResolvedValue([]),
+      callTool: vi.fn().mockResolvedValue({ content: [] }),
+      addService: vi.fn(),
+      removeService: vi.fn(),
+      getServiceStatus: vi.fn().mockReturnValue("connected"),
+      getAllTools: vi.fn().mockReturnValue([]),
+      stopAllServices: vi.fn().mockResolvedValue(undefined),
+      whenReady: vi.fn().mockResolvedValue(undefined),
+    };
+    Object.setPrototypeOf(instance, EventEmitter.prototype);
+    return instance;
+  }),
+}));
+
+describe("MCPRouteHandler 集成测试", () => {
+  let webServer: WebServer;
+  let serverPort: number;
+  let baseUrl: string;
+
+  beforeAll(async () => {
+    // 使用随机端口避免冲突
+    serverPort = 9000 + Math.floor(Math.random() * 1000);
+    baseUrl = `http://localhost:${serverPort}`;
+
+    webServer = new WebServer(serverPort);
+    await webServer.start();
+
+    // 等待服务器完全启动
+    await new Promise((resolve) => setTimeout(resolve, 1000));
+  });
+
+  afterAll(async () => {
+    if (webServer) {
+      await webServer.stop();
+    }
+  });
+
+  describe("MCP 端点可用性", () => {
+    it("应该响应 /mcp 端点的 POST 请求", async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "MCP-Protocol-Version": "2024-11-05",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "initialize",
+          id: 1,
+          params: {
+            protocolVersion: "2024-11-05",
+            capabilities: {},
+            clientInfo: { name: "test-client", version: "1.0.0" },
+          },
+        }),
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.headers.get("content-type")).toBe("application/json");
+      expect(response.headers.get("mcp-protocol-version")).toBe("2024-11-05");
+
+      const result = await response.json();
+      expect(result).toHaveProperty("jsonrpc", "2.0");
+      expect(result).toHaveProperty("result");
+      expect(result).toHaveProperty("id", 1);
+    });
+  });
+
+  describe("错误处理", () => {
+    it("应该对无效的 JSON-RPC 返回 400", async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          invalid: "message",
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const result = await response.json();
+      expect(result).toHaveProperty("jsonrpc", "2.0");
+      expect(result).toHaveProperty("error");
+      expect(result.error.code).toBe(-32600);
+    });
+
+    it("应该对无效的 content-type 返回 400", async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "text/plain",
+        },
+        body: "invalid content",
+      });
+
+      expect(response.status).toBe(400);
+      const result = await response.json();
+      expect(result).toHaveProperty("jsonrpc", "2.0");
+      expect(result).toHaveProperty("error");
+      expect(result.error.code).toBe(-32600);
+    });
+
+    it("应该对格式错误的 JSON 返回 400", async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: "{ invalid json",
+      });
+
+      expect(response.status).toBe(400);
+      const result = await response.json();
+      expect(result).toHaveProperty("jsonrpc", "2.0");
+      expect(result).toHaveProperty("error");
+      expect(result.error.code).toBe(-32700);
+    });
+  });
+
+  describe("协议符合性", () => {
+    it("应该包含必需的 MCP 头", async () => {
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "ping",
+          id: "test-123",
+        }),
+      });
+
+      expect(response.headers.get("mcp-protocol-version")).toBe("2024-11-05");
+      expect(response.headers.get("content-type")).toBe("application/json");
+    });
+
+    it("应该处理不同的消息 ID 类型", async () => {
+      // 测试字符串 ID
+      let response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "ping",
+          id: "string-id",
+        }),
+      });
+
+      let result = await response.json();
+      expect(result.id).toBe("string-id");
+
+      // 测试数字 ID
+      response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "ping",
+          id: 42,
+        }),
+      });
+
+      result = await response.json();
+      expect(result.id).toBe(42);
+
+      // 测试 null ID
+      response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "ping",
+          id: null,
+        }),
+      });
+
+      result = await response.json();
+      expect(result.id).toBe(null);
+    });
+  });
+
+  describe("性能和限制", () => {
+    it("应该处理合理大小的消息", async () => {
+      const largeParams = {
+        data: "x".repeat(1000), // 1KB 数据
+      };
+
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "test",
+          id: 1,
+          params: largeParams,
+        }),
+      });
+
+      expect(response.status).toBe(200);
+    });
+
+    it("应该拒绝过大的消息", async () => {
+      const oversizedParams = {
+        data: "x".repeat(2 * 1024 * 1024), // 2MB 数据
+      };
+
+      const response = await fetch(`${baseUrl}/mcp`, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+        },
+        body: JSON.stringify({
+          jsonrpc: "2.0",
+          method: "test",
+          id: 1,
+          params: oversizedParams,
+        }),
+      });
+
+      expect(response.status).toBe(400);
+      const result = await response.json();
+      expect(result.error.code).toBe(-32600);
+      expect(result.error.message).toContain("too large");
+    });
+  });
+});

--- a/src/server/handlers/__tests__/mcp.handler.test.ts
+++ b/src/server/handlers/__tests__/mcp.handler.test.ts
@@ -1,0 +1,231 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPRouteHandler } from "../mcp.handler.js";
+
+// 模拟 MCPServiceManager - 在 Context 中提供
+const mockServiceManager = {
+  // 模拟服务管理器
+};
+
+// 模拟 MCPMessageHandler
+vi.mock("../../lib/mcp", () => ({
+  MCPMessageHandler: vi.fn().mockImplementation(() => ({
+    handleMessage: vi.fn().mockResolvedValue({
+      jsonrpc: "2.0",
+      result: { test: "response" },
+      id: 1,
+    }),
+  })),
+}));
+
+describe("MCPRouteHandler", () => {
+  let handler: MCPRouteHandler;
+
+  beforeEach(() => {
+    handler = new MCPRouteHandler({
+      maxMessageSize: 1024 * 1024,
+      enableMetrics: true,
+    });
+  });
+
+  afterEach(() => {
+    // 清理资源
+    handler.destroy();
+  });
+
+  it("应该创建 MCPRouteHandler 实例", () => {
+    expect(handler).toBeInstanceOf(MCPRouteHandler);
+  });
+
+  it("应该具有 getStatus 方法", () => {
+    const status = handler.getStatus();
+    expect(status).toHaveProperty("isInitialized");
+    expect(status).toHaveProperty("metrics");
+    expect(status).toHaveProperty("config");
+    expect(status.isInitialized).toBe(false);
+    expect(status.config.maxMessageSize).toBe(1024 * 1024);
+  });
+
+  it("应该处理有效的 JSON-RPC 消息的 POST 请求", async () => {
+    // 模拟 Context 对象
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          if (name === "content-type" || name === "Content-Type")
+            return "application/json";
+          if (
+            name === "mcp-protocol-version" ||
+            name === "MCP-Protocol-Version"
+          )
+            return "2024-11-05";
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            jsonrpc: "2.0",
+            method: "initialize",
+            id: 1,
+          })
+        ),
+      },
+      json: vi.fn((data: unknown, status?: number, headers?: any) => {
+        return new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: {
+            "Content-Type": "application/json",
+            ...headers,
+          },
+        });
+      }),
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const response = await handler.handlePost(mockContext as any);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(200);
+  });
+
+  it("应该拒绝无效 content-type 的 POST 请求", async () => {
+    const mockContext = {
+      req: {
+        header: vi.fn(() => "text/plain"),
+        query: vi.fn(() => undefined),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const response = await handler.handlePost(mockContext as any);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+  });
+
+  it("应该拒绝无效 JSON 的 POST 请求", async () => {
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          if (name === "content-type") return "application/json";
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue("invalid json"),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const response = await handler.handlePost(mockContext as any);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+  });
+
+  it("应该拒绝无效 JSON-RPC 格式的 POST 请求", async () => {
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          if (name === "content-type") return "application/json";
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue(
+          JSON.stringify({
+            // Missing jsonrpc and method fields
+            id: 1,
+          })
+        ),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const response = await handler.handlePost(mockContext as any);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+  });
+
+  it("应该拒绝超过最大消息大小的 POST 请求", async () => {
+    const largeMessage = "x".repeat(2 * 1024 * 1024); // 2MB 消息
+    const mockContext = {
+      req: {
+        header: vi.fn((name: string) => {
+          if (name === "content-type") return "application/json";
+          if (name === "content-length") return (2 * 1024 * 1024).toString();
+          return undefined;
+        }),
+        query: vi.fn(() => undefined),
+        text: vi.fn().mockResolvedValue(largeMessage),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    const response = await handler.handlePost(mockContext as any);
+    expect(response).toBeInstanceOf(Response);
+    expect(response.status).toBe(400);
+  });
+
+  it("应该正确处理 destroy 方法", () => {
+    expect(() => handler.destroy()).not.toThrow();
+  });
+});

--- a/src/server/handlers/__tests__/service.handler.test.ts
+++ b/src/server/handlers/__tests__/service.handler.test.ts
@@ -1,0 +1,605 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatusService } from "../../services/status.service.js";
+import { ServiceApiHandler } from "../service.handler.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("node:child_process", () => ({
+  spawn: vi.fn(),
+}));
+
+vi.mock("../../services/event-bus.service.js", () => ({
+  getEventBus: vi.fn().mockReturnValue({
+    emitEvent: vi.fn(),
+  }),
+}));
+
+describe("ServiceApiHandler", () => {
+  let handler: ServiceApiHandler;
+  let mockStatusService: StatusService;
+  let mockContext: any;
+  let mockSpawn: any;
+  let mockEventBus: any;
+  let mockMcpServiceManager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    // 模拟 StatusService
+    mockStatusService = {
+      updateRestartStatus: vi.fn(),
+    } as any;
+
+    // 模拟 MCPServiceManager
+    mockMcpServiceManager = {
+      getStatus: vi.fn().mockReturnValue({
+        isRunning: true,
+        mode: "daemon",
+        pid: 12345,
+      }),
+    };
+
+    // 模拟 Hono Context
+    mockContext = {
+      json: vi.fn().mockReturnValue(new Response()),
+      success: vi.fn().mockReturnValue(new Response()),
+      fail: vi.fn().mockReturnValue(new Response()),
+      req: {
+        json: vi.fn(),
+      },
+      get: vi.fn((key: string) => {
+        if (key === "mcpServiceManager") {
+          return mockMcpServiceManager;
+        }
+        if (key === "logger") {
+          return {
+            debug: vi.fn(),
+            info: vi.fn(),
+            error: vi.fn(),
+            warn: vi.fn(),
+          };
+        }
+        return undefined;
+      }),
+    };
+
+    // 模拟 spawn
+    mockSpawn = vi.fn().mockReturnValue({
+      unref: vi.fn(),
+    });
+    const { spawn } = await import("node:child_process");
+    vi.mocked(spawn).mockImplementation(mockSpawn);
+
+    // 模拟 EventBus
+    mockEventBus = {
+      emitEvent: vi.fn(),
+    };
+    const { getEventBus } = await import("../../services/event-bus.service.js");
+    vi.mocked(getEventBus).mockReturnValue(mockEventBus);
+
+    handler = new ServiceApiHandler(mockStatusService);
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.useRealTimers();
+  });
+
+  describe("constructor", () => {
+    it("应该使用正确的依赖项初始化", () => {
+      expect(handler).toBeInstanceOf(ServiceApiHandler);
+      expect(mockEventBus).toBeDefined();
+    });
+  });
+
+  describe("getServiceStatus", () => {
+    it("应该成功返回服务状态", async () => {
+      const mockStatus = {
+        isRunning: true,
+        pid: 12345,
+        uptime: 3600000,
+        memory: { rss: 50000000 },
+        mode: "daemon",
+      };
+      mockMcpServiceManager.getStatus.mockReturnValue(mockStatus);
+
+      await handler.getServiceStatus(mockContext);
+
+      expect(mockMcpServiceManager.getStatus).toHaveBeenCalledOnce();
+      expect(mockContext.success).toHaveBeenCalledWith(mockStatus);
+    });
+
+    it("应该处理服务状态错误", async () => {
+      const error = new Error("Status check failed");
+      mockMcpServiceManager.getStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      await handler.getServiceStatus(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "SERVICE_STATUS_READ_ERROR",
+        "Status check failed",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理非 Error 异常", async () => {
+      mockMcpServiceManager.getStatus.mockImplementation(() => {
+        throw "String error";
+      });
+
+      await handler.getServiceStatus(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "SERVICE_STATUS_READ_ERROR",
+        "获取服务状态失败",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("getServiceHealth", () => {
+    it("应该成功返回服务健康状态", async () => {
+      const originalUptime = process.uptime;
+      const originalMemoryUsage = process.memoryUsage;
+      const originalVersion = process.version;
+
+      process.uptime = vi.fn().mockReturnValue(3600);
+      process.memoryUsage = vi.fn().mockReturnValue({
+        rss: 50000000,
+        heapUsed: 30000000,
+        heapTotal: 40000000,
+        external: 5000000,
+        arrayBuffers: 1000000,
+      }) as any;
+      Object.defineProperty(process, "version", {
+        value: "v18.0.0",
+        writable: true,
+      });
+
+      await handler.getServiceHealth(mockContext);
+
+      expect(mockContext.success).toHaveBeenCalledWith({
+        status: "healthy",
+        timestamp: expect.any(Number),
+        uptime: 3600,
+        memory: {
+          rss: 50000000,
+          heapUsed: 30000000,
+          heapTotal: 40000000,
+          external: 5000000,
+          arrayBuffers: 1000000,
+        },
+        version: "v18.0.0",
+      });
+
+      // 恢复原始函数
+      process.uptime = originalUptime;
+      process.memoryUsage = originalMemoryUsage;
+      Object.defineProperty(process, "version", {
+        value: originalVersion,
+        writable: true,
+      });
+    });
+
+    it("应该处理健康检查错误", async () => {
+      const originalUptime = process.uptime;
+      process.uptime = vi.fn().mockImplementation(() => {
+        throw new Error("Uptime error");
+      });
+
+      await handler.getServiceHealth(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "SERVICE_HEALTH_READ_ERROR",
+        "Uptime error",
+        undefined,
+        500
+      );
+
+      // 恢复原始函数
+      process.uptime = originalUptime;
+    });
+  });
+
+  describe("startService", () => {
+    it("应该成功启动服务", async () => {
+      await handler.startService(mockContext);
+
+      expect(mockSpawn).toHaveBeenCalledWith("xiaozhi", ["start", "--daemon"], {
+        detached: true,
+        stdio: "ignore",
+        env: expect.objectContaining({
+          XIAOZHI_CONFIG_DIR: expect.any(String),
+        }),
+      });
+
+      expect(mockContext.success).toHaveBeenCalledWith(null, "启动请求已接收");
+    });
+
+    it("应该处理启动服务错误", async () => {
+      const error = new Error("Start failed");
+      mockSpawn.mockImplementation(() => {
+        throw error;
+      });
+
+      await handler.startService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "START_REQUEST_ERROR",
+        "Start failed",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理启动时的非 Error 异常", async () => {
+      mockSpawn.mockImplementation(() => {
+        throw "String error";
+      });
+
+      await handler.startService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "START_REQUEST_ERROR",
+        "处理启动请求失败",
+        undefined,
+        500
+      );
+    });
+
+    it("应该使用正确的环境变量", async () => {
+      const originalEnv = process.env.XIAOZHI_CONFIG_DIR;
+      process.env.XIAOZHI_CONFIG_DIR = "/custom/config/dir";
+
+      await handler.startService(mockContext);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["start", "--daemon"],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            XIAOZHI_CONFIG_DIR: "/custom/config/dir",
+          }),
+        })
+      );
+
+      // Restore original environment
+      if (originalEnv) {
+        process.env.XIAOZHI_CONFIG_DIR = originalEnv;
+      } else {
+        process.env.XIAOZHI_CONFIG_DIR = undefined;
+      }
+    });
+
+    it("should use current working directory when XIAOZHI_CONFIG_DIR is not set", async () => {
+      const originalEnv = process.env.XIAOZHI_CONFIG_DIR;
+      process.env.XIAOZHI_CONFIG_DIR = "";
+
+      await handler.startService(mockContext);
+
+      // Check that spawn was called with basic structure
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["start", "--daemon"],
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+          env: expect.any(Object),
+        })
+      );
+
+      // Check that the environment contains XIAOZHI_CONFIG_DIR
+      const spawnCall = mockSpawn.mock.calls[0];
+      const spawnOptions = spawnCall[2];
+      expect(spawnOptions.env).toHaveProperty("XIAOZHI_CONFIG_DIR");
+
+      // Restore original environment
+      if (originalEnv !== undefined) {
+        process.env.XIAOZHI_CONFIG_DIR = originalEnv;
+      } else {
+        process.env.XIAOZHI_CONFIG_DIR = undefined;
+      }
+    });
+  });
+
+  describe("stopService", () => {
+    it("should stop service successfully", async () => {
+      await handler.stopService(mockContext);
+
+      expect(mockSpawn).toHaveBeenCalledWith("xiaozhi", ["stop"], {
+        detached: true,
+        stdio: "ignore",
+        env: expect.objectContaining({
+          XIAOZHI_CONFIG_DIR: expect.any(String),
+        }),
+      });
+
+      expect(mockContext.success).toHaveBeenCalledWith(null, "停止请求已接收");
+    });
+
+    it("should handle stop service error", async () => {
+      const error = new Error("Stop failed");
+      mockSpawn.mockImplementation(() => {
+        throw error;
+      });
+
+      await handler.stopService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "STOP_REQUEST_ERROR",
+        "Stop failed",
+        undefined,
+        500
+      );
+    });
+
+    it("should handle non-Error exceptions in stop", async () => {
+      mockSpawn.mockImplementation(() => {
+        throw "String error";
+      });
+
+      await handler.stopService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "STOP_REQUEST_ERROR",
+        "处理停止请求失败",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("restartService", () => {
+    it("should restart service successfully", async () => {
+      await handler.restartService(mockContext);
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:requested",
+        expect.objectContaining({
+          source: "http-api",
+          serviceName: "unknown",
+          delay: 0,
+          attempt: 1,
+          timestamp: expect.any(Number),
+        })
+      );
+
+      expect(mockStatusService.updateRestartStatus).toHaveBeenCalledWith(
+        "restarting"
+      );
+
+      expect(mockContext.success).toHaveBeenCalledWith(null, "重启请求已接收");
+    });
+
+    it("should handle restart service error", async () => {
+      const error = new Error("Restart failed");
+      mockEventBus.emitEvent.mockImplementation(() => {
+        throw error;
+      });
+
+      await handler.restartService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "RESTART_REQUEST_ERROR",
+        "Restart failed",
+        undefined,
+        500
+      );
+    });
+
+    it("should handle non-Error exceptions in restart", async () => {
+      mockEventBus.emitEvent.mockImplementation(() => {
+        throw "String error";
+      });
+
+      await handler.restartService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "RESTART_REQUEST_ERROR",
+        "处理重启请求失败",
+        undefined,
+        500
+      );
+    });
+
+    it("should execute restart asynchronously for running service", async () => {
+      mockMcpServiceManager.getStatus.mockReturnValue({
+        isRunning: true,
+        mode: "daemon",
+        pid: 12345,
+      });
+
+      await handler.restartService(mockContext);
+
+      // Fast-forward the initial timeout to trigger executeRestart
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockMcpServiceManager.getStatus).toHaveBeenCalled();
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["restart", "--daemon"],
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+        })
+      );
+
+      // Fast-forward the success status timeout
+      await vi.advanceTimersByTimeAsync(5000);
+      expect(mockStatusService.updateRestartStatus).toHaveBeenCalledWith(
+        "completed"
+      );
+    });
+
+    it("should start service when not running during restart", async () => {
+      mockMcpServiceManager.getStatus.mockReturnValue({
+        isRunning: false,
+        mode: "daemon",
+        pid: null,
+      });
+
+      await handler.restartService(mockContext);
+
+      // Fast-forward the initial timeout to trigger executeRestart
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["start", "--daemon"],
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+        })
+      );
+    });
+
+    it("should handle restart execution error", async () => {
+      mockMcpServiceManager.getStatus.mockImplementation(() => {
+        throw new Error("Service manager error");
+      });
+
+      await handler.restartService(mockContext);
+
+      // Fast-forward the initial timeout to trigger executeRestart
+      await vi.advanceTimersByTimeAsync(500);
+
+      // Allow async error handling to complete
+      await vi.advanceTimersByTimeAsync(100);
+
+      expect(mockStatusService.updateRestartStatus).toHaveBeenCalledWith(
+        "failed",
+        "Service manager error"
+      );
+    });
+
+    it("should handle non-daemon mode restart", async () => {
+      mockMcpServiceManager.getStatus.mockReturnValue({
+        isRunning: true,
+        mode: "standalone",
+        pid: 12345,
+      });
+
+      await handler.restartService(mockContext);
+
+      // Fast-forward the initial timeout to trigger executeRestart
+      await vi.advanceTimersByTimeAsync(500);
+
+      // 注意：实际代码逻辑是始终使用 --daemon 模式
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["restart", "--daemon"],
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+        })
+      );
+    });
+  });
+
+  describe("environment handling", () => {
+    it("should preserve existing environment variables", async () => {
+      const originalPath = process.env.PATH;
+      process.env.CUSTOM_VAR = "test-value";
+
+      await handler.startService(mockContext);
+
+      expect(mockSpawn).toHaveBeenCalledWith(
+        "xiaozhi",
+        ["start", "--daemon"],
+        expect.objectContaining({
+          env: expect.objectContaining({
+            PATH: originalPath,
+            CUSTOM_VAR: "test-value",
+            XIAOZHI_CONFIG_DIR: expect.any(String),
+          }),
+        })
+      );
+
+      // 清理
+      process.env.CUSTOM_VAR = undefined;
+    });
+  });
+
+  describe("error handling edge cases", () => {
+    it("应该处理 spawn 返回 null", async () => {
+      mockSpawn.mockReturnValue(null);
+
+      await handler.startService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "START_REQUEST_ERROR",
+        "Cannot read properties of null (reading 'unref')",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理没有 unref 方法的 spawn 子进程", async () => {
+      mockSpawn.mockReturnValue({});
+
+      await handler.startService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "START_REQUEST_ERROR",
+        "child.unref is not a function",
+        undefined,
+        500
+      );
+    });
+
+    it("应该处理 unref 方法抛出错误", async () => {
+      mockSpawn.mockReturnValue({
+        unref: vi.fn().mockImplementation(() => {
+          throw new Error("Unref failed");
+        }),
+      });
+
+      await handler.startService(mockContext);
+
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "START_REQUEST_ERROR",
+        "Unref failed",
+        undefined,
+        500
+      );
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("应该处理多个并发的重启请求", async () => {
+      const promise1 = handler.restartService(mockContext);
+      const promise2 = handler.restartService(mockContext);
+
+      await Promise.all([promise1, promise2]);
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledTimes(2);
+      expect(mockStatusService.updateRestartStatus).toHaveBeenCalledTimes(2);
+      expect(mockContext.success).toHaveBeenCalledTimes(2);
+    });
+
+    it("应该处理服务管理器返回未定义状态", async () => {
+      mockMcpServiceManager.getStatus.mockReturnValue(undefined);
+
+      await handler.restartService(mockContext);
+
+      // Fast-forward the initial timeout
+      vi.advanceTimersByTime(500);
+
+      // Should still attempt to execute restart
+      expect(mockMcpServiceManager.getStatus).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/handlers/__tests__/static-file.handler.test.ts
+++ b/src/server/handlers/__tests__/static-file.handler.test.ts
@@ -1,0 +1,810 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { StaticFileHandler } from "../static-file.handler.js";
+
+// 模拟依赖
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+}));
+
+vi.mock("node:fs/promises", () => ({
+  readFile: vi.fn(),
+}));
+
+vi.mock("node:path", () => ({
+  dirname: vi.fn(),
+  join: vi.fn(),
+}));
+
+vi.mock("node:url", () => ({
+  fileURLToPath: vi.fn(),
+}));
+
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("StaticFileHandler", () => {
+  let staticFileHandler: StaticFileHandler;
+  let mockLogger: any;
+  let mockContext: any;
+  let mockExistsSync: any;
+  let mockReadFile: any;
+  let mockDirname: any;
+  let mockJoin: any;
+  let mockFileURLToPath: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 模拟 Logger
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { logger } = await import("../../Logger.js");
+    Object.assign(logger, mockLogger);
+
+    // 模拟 fs 函数
+    const fs = await import("node:fs");
+    const fsPromises = await import("node:fs/promises");
+    const path = await import("node:path");
+    const url = await import("node:url");
+
+    mockExistsSync = vi.mocked(fs.existsSync);
+    mockReadFile = vi.mocked(fsPromises.readFile);
+    mockDirname = vi.mocked(path.dirname);
+    mockJoin = vi.mocked(path.join);
+    mockFileURLToPath = vi.mocked(url.fileURLToPath);
+
+    // 设置默认模拟
+    mockFileURLToPath.mockReturnValue(
+      "/project/dist/handlers/StaticFileHandler.js"
+    );
+    mockDirname.mockReturnValue("/project/dist/handlers");
+    mockJoin.mockImplementation((...args: string[]) => args.join("/"));
+
+    // 模拟 Context
+    mockContext = {
+      req: {
+        url: "http://localhost:3000/",
+      },
+      // 添加 c.get 方法支持依赖注入
+      get: vi.fn((key: string) => {
+        if (key === "logger") return mockLogger;
+        return undefined;
+      }),
+      logger: mockLogger, // 向后兼容支持
+      text: vi.fn().mockImplementation((text, status, headers) => ({
+        status,
+        text,
+        headers: new Map(Object.entries(headers || {})),
+      })),
+      html: vi.fn().mockImplementation((html) => ({
+        status: 200,
+        html,
+        headers: new Map([["Content-Type", "text/html"]]),
+      })),
+      body: vi.fn().mockImplementation((body, status, headers) => ({
+        status,
+        body,
+        headers: new Map(Object.entries(headers || {})),
+      })),
+    };
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("应该使用正确的依赖项初始化", () => {
+      // 模拟 existsSync 为第一个路径返回 true
+      mockExistsSync.mockReturnValueOnce(true);
+
+      staticFileHandler = new StaticFileHandler();
+
+      expect(staticFileHandler).toBeInstanceOf(StaticFileHandler);
+      expect(mockLogger.debug).toHaveBeenCalled();
+    });
+
+    it("应该成功找到 web 路径", () => {
+      mockExistsSync.mockReturnValueOnce(true);
+
+      staticFileHandler = new StaticFileHandler();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("静态文件服务路径:")
+      );
+    });
+
+    it("应该处理未找到 web 路径的情况", () => {
+      mockExistsSync.mockReturnValue(false);
+
+      staticFileHandler = new StaticFileHandler();
+
+      expect(mockLogger.warn).toHaveBeenCalledWith("未找到静态文件目录");
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "尝试的路径:",
+        expect.any(Array)
+      );
+    });
+
+    it("应该处理初始化错误", () => {
+      mockFileURLToPath.mockImplementation(() => {
+        throw new Error("URL parsing failed");
+      });
+
+      staticFileHandler = new StaticFileHandler();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "初始化静态文件路径失败:",
+        expect.any(Error)
+      );
+    });
+  });
+
+  describe("handleStaticFile", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true); // For constructor
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该为根路径提供 index.html", async () => {
+      mockContext.req.url = "http://localhost:3000/";
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from("<html>Index</html>"));
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理静态文件请求: /");
+      expect(mockReadFile).toHaveBeenCalledWith(
+        expect.stringContaining("index.html")
+      );
+      expect(mockContext.text).toHaveBeenCalledWith("<html>Index</html>", 200, {
+        "Content-Type": "text/html",
+      });
+    });
+
+    it("应该以正确的内容类型提供 CSS 文件", async () => {
+      mockContext.req.url = "http://localhost:3000/styles.css";
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from("body { color: red; }"));
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.text).toHaveBeenCalledWith(
+        "body { color: red; }",
+        200,
+        { "Content-Type": "text/css" }
+      );
+    });
+
+    it("应该以正确的内容类型提供 JavaScript 文件", async () => {
+      mockContext.req.url = "http://localhost:3000/app.js";
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from("console.log('hello');"));
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.text).toHaveBeenCalledWith(
+        "console.log('hello');",
+        200,
+        { "Content-Type": "application/javascript" }
+      );
+    });
+
+    it("应该以正确的内容类型提供二进制文件", async () => {
+      mockContext.req.url = "http://localhost:3000/image.png";
+      mockExistsSync.mockReturnValue(true);
+      const binaryData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+      mockReadFile.mockResolvedValue(binaryData);
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.body).toHaveBeenCalledWith(
+        new Uint8Array(binaryData),
+        200,
+        {
+          "Content-Type": "image/png",
+        }
+      );
+    });
+
+    it("当 web 路径不可用时应该返回错误页面", async () => {
+      mockExistsSync.mockReturnValue(false); // 未找到 web 路径
+      staticFileHandler = new StaticFileHandler();
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.html).toHaveBeenCalledWith(
+        expect.stringContaining("找不到前端资源文件")
+      );
+    });
+
+    it("应该为 SPA 路由回退到 index.html", async () => {
+      mockContext.req.url = "http://localhost:3000/app/dashboard";
+      mockExistsSync
+        .mockReturnValueOnce(false) // 文件不存在
+        .mockReturnValueOnce(true); // index.html 存在
+      mockReadFile.mockResolvedValue(Buffer.from("<html>SPA</html>"));
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("SPA 回退到 index.html")
+      );
+      expect(mockContext.text).toHaveBeenCalledWith("<html>SPA</html>", 200, {
+        "Content-Type": "text/html",
+      });
+    });
+
+    it("当文件和 index.html 都不存在时应该返回 404", async () => {
+      mockContext.req.url = "http://localhost:3000/nonexistent.html";
+      mockExistsSync.mockReturnValue(false);
+
+      const response = await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        expect.stringContaining("文件不存在:")
+      );
+      expect(mockContext.text).toHaveBeenCalledWith("Not Found", 404);
+    });
+
+    it("应该处理 URL 解析错误", async () => {
+      // URL 解析错误发生在 try-catch 之前，所以我们需要以不同方式测试
+      // 错误将被抛出并由外部 try-catch 捕获
+      mockContext.req.url = "invalid-url";
+
+      try {
+        await staticFileHandler.handleStaticFile(mockContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(TypeError);
+        expect((error as Error).message).toContain("Invalid URL");
+      }
+    });
+  });
+
+  describe("getContentType", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true);
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该为 HTML 文件返回正确的内容类型", () => {
+      // 通过类型断言访问私有方法进行测试
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("index.html")).toBe("text/html");
+      expect(handler.getContentType("page.htm")).toBe("text/html");
+    });
+
+    it("应该为 JavaScript 文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("app.js")).toBe("application/javascript");
+      expect(handler.getContentType("module.mjs")).toBe(
+        "application/javascript"
+      );
+    });
+
+    it("应该为 CSS 文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("styles.css")).toBe("text/css");
+    });
+
+    it("应该为图片文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("image.png")).toBe("image/png");
+      expect(handler.getContentType("photo.jpg")).toBe("image/jpeg");
+      expect(handler.getContentType("photo.jpeg")).toBe("image/jpeg");
+      expect(handler.getContentType("animation.gif")).toBe("image/gif");
+      expect(handler.getContentType("icon.svg")).toBe("image/svg+xml");
+      expect(handler.getContentType("favicon.ico")).toBe("image/x-icon");
+    });
+
+    it("应该为字体文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("font.woff")).toBe("font/woff");
+      expect(handler.getContentType("font.woff2")).toBe("font/woff2");
+      expect(handler.getContentType("font.ttf")).toBe("font/ttf");
+      expect(handler.getContentType("font.eot")).toBe(
+        "application/vnd.ms-fontobject"
+      );
+    });
+
+    it("应该为文档文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("document.pdf")).toBe("application/pdf");
+      expect(handler.getContentType("data.json")).toBe("application/json");
+      expect(handler.getContentType("readme.txt")).toBe("text/plain");
+      expect(handler.getContentType("config.xml")).toBe("application/xml");
+    });
+
+    it("应该为归档文件返回正确的内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("archive.zip")).toBe("application/zip");
+      expect(handler.getContentType("backup.tar")).toBe("application/x-tar");
+      expect(handler.getContentType("compressed.gz")).toBe("application/gzip");
+    });
+
+    it("应该为未知扩展名返回默认内容类型", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("file.unknown")).toBe(
+        "application/octet-stream"
+      );
+      expect(handler.getContentType("file")).toBe("application/octet-stream");
+      expect(handler.getContentType("")).toBe("application/octet-stream");
+    });
+
+    it("应该处理包含多个点的文件名", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("jquery.min.js")).toBe(
+        "application/javascript"
+      );
+      expect(handler.getContentType("bootstrap.min.css")).toBe("text/css");
+      expect(handler.getContentType("config.prod.json")).toBe(
+        "application/json"
+      );
+    });
+
+    it("应该处理大写扩展名", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("IMAGE.PNG")).toBe("image/png");
+      expect(handler.getContentType("SCRIPT.JS")).toBe(
+        "application/javascript"
+      );
+      expect(handler.getContentType("STYLE.CSS")).toBe("text/css");
+    });
+  });
+
+  describe("createErrorPage", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true);
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该使用自定义消息创建错误页面", () => {
+      const handler = staticFileHandler as any;
+      const message = "Custom error message";
+
+      const response = handler.createErrorPage(mockContext, message);
+
+      expect(mockContext.html).toHaveBeenCalledWith(
+        expect.stringContaining(message)
+      );
+      expect(mockContext.html).toHaveBeenCalledWith(
+        expect.stringContaining("小智配置管理")
+      );
+      expect(mockContext.html).toHaveBeenCalledWith(
+        expect.stringContaining(
+          "cd apps/frontend && pnpm install && pnpm build"
+        )
+      );
+    });
+
+    it("应该创建具有 HTML 结构的错误页面", () => {
+      const handler = staticFileHandler as any;
+      const message = "Test error";
+
+      handler.createErrorPage(mockContext, message);
+
+      const htmlContent = mockContext.html.mock.calls[0][0];
+      expect(htmlContent).toContain("<!DOCTYPE html>");
+      expect(htmlContent).toContain("<html>");
+      expect(htmlContent).toContain("<head>");
+      expect(htmlContent).toContain("<body>");
+      expect(htmlContent).toContain("</html>");
+    });
+
+    it("应该在错误页面中包含 CSS 样式", () => {
+      const handler = staticFileHandler as any;
+      const message = "Test error";
+
+      handler.createErrorPage(mockContext, message);
+
+      const htmlContent = mockContext.html.mock.calls[0][0];
+      expect(htmlContent).toContain("<style>");
+      expect(htmlContent).toContain("font-family:");
+      expect(htmlContent).toContain(".error");
+      expect(htmlContent).toContain(".info");
+    });
+  });
+
+  describe("isWebPathAvailable", () => {
+    it("当 web 路径存在时应该返回 true", () => {
+      mockExistsSync.mockReturnValue(true);
+      staticFileHandler = new StaticFileHandler();
+
+      const result = staticFileHandler.isWebPathAvailable();
+
+      expect(result).toBe(true);
+    });
+
+    it("当 web 路径为 null 时应该返回 false", () => {
+      mockExistsSync.mockReturnValue(false);
+      staticFileHandler = new StaticFileHandler();
+
+      const result = staticFileHandler.isWebPathAvailable();
+
+      expect(result).toBe(false);
+    });
+
+    it("当 web 路径在文件系统中不存在时应该返回 false", () => {
+      mockExistsSync
+        .mockReturnValueOnce(true) // For constructor
+        .mockReturnValueOnce(false); // For isWebPathAvailable check
+      staticFileHandler = new StaticFileHandler();
+
+      const result = staticFileHandler.isWebPathAvailable();
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("getWebPath", () => {
+    it("当可用时应该返回 web 路径", () => {
+      mockExistsSync.mockReturnValue(true);
+      staticFileHandler = new StaticFileHandler();
+
+      const result = staticFileHandler.getWebPath();
+
+      expect(result).toBe("/project/dist/handlers/../../../frontend");
+    });
+
+    it("当 web 路径不可用时应该返回 null", () => {
+      mockExistsSync.mockReturnValue(false);
+      staticFileHandler = new StaticFileHandler();
+
+      const result = staticFileHandler.getWebPath();
+
+      expect(result).toBe(null);
+    });
+  });
+
+  describe("reinitializeWebPath", () => {
+    it("应该重新初始化 web 路径", () => {
+      mockExistsSync.mockReturnValue(false);
+      staticFileHandler = new StaticFileHandler();
+
+      // 清除之前的调用
+      mockLogger.debug.mockClear();
+      mockLogger.info.mockClear();
+      mockLogger.warn.mockClear();
+
+      // 模拟重新初始化时返回 true
+      mockExistsSync.mockReturnValueOnce(true);
+
+      staticFileHandler.reinitializeWebPath();
+
+      expect(mockLogger.debug).toHaveBeenCalled();
+    });
+  });
+
+  describe("serveFile", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true);
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该以字符串形式提供文本文件", async () => {
+      const handler = staticFileHandler as any;
+      const filePath = "/path/to/file.txt";
+      const contentType = "text/plain";
+      const fileContent = "Hello, World!";
+
+      mockReadFile.mockResolvedValue(Buffer.from(fileContent));
+
+      await handler.serveFile(mockContext, filePath, contentType);
+
+      expect(mockReadFile).toHaveBeenCalledWith(filePath);
+      expect(mockContext.text).toHaveBeenCalledWith(fileContent, 200, {
+        "Content-Type": contentType,
+      });
+    });
+
+    it("应该以字符串形式提供 JavaScript 文件", async () => {
+      const handler = staticFileHandler as any;
+      const filePath = "/path/to/app.js";
+      const contentType = "application/javascript";
+      const fileContent = "console.log('test');";
+
+      mockReadFile.mockResolvedValue(Buffer.from(fileContent));
+
+      await handler.serveFile(mockContext, filePath, contentType);
+
+      expect(mockContext.text).toHaveBeenCalledWith(fileContent, 200, {
+        "Content-Type": contentType,
+      });
+    });
+
+    it("应该以字符串形式提供 JSON 文件", async () => {
+      const handler = staticFileHandler as any;
+      const filePath = "/path/to/data.json";
+      const contentType = "application/json";
+      const fileContent = '{"key": "value"}';
+
+      mockReadFile.mockResolvedValue(Buffer.from(fileContent));
+
+      await handler.serveFile(mockContext, filePath, contentType);
+
+      expect(mockContext.text).toHaveBeenCalledWith(fileContent, 200, {
+        "Content-Type": contentType,
+      });
+    });
+
+    it("应该以 buffer 形式提供二进制文件", async () => {
+      const handler = staticFileHandler as any;
+      const filePath = "/path/to/image.png";
+      const contentType = "image/png";
+      const binaryData = Buffer.from([0x89, 0x50, 0x4e, 0x47]);
+
+      mockReadFile.mockResolvedValue(binaryData);
+
+      await handler.serveFile(mockContext, filePath, contentType);
+
+      expect(mockContext.body).toHaveBeenCalledWith(
+        new Uint8Array(binaryData),
+        200,
+        {
+          "Content-Type": contentType,
+        }
+      );
+    });
+
+    it("应该处理文件读取错误", async () => {
+      const handler = staticFileHandler as any;
+      const filePath = "/path/to/error.txt";
+      const contentType = "text/plain";
+      const error = new Error("File read failed");
+
+      mockReadFile.mockRejectedValue(error);
+
+      await expect(
+        handler.serveFile(mockContext, filePath, contentType)
+      ).rejects.toThrow("File read failed");
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        `读取文件失败: ${filePath}`,
+        error
+      );
+    });
+  });
+
+  describe("integration scenarios", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true);
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该处理完整的静态文件服务工作流程", async () => {
+      // 测试提供不同文件类型
+      const testCases = [
+        {
+          url: "http://localhost:3000/index.html",
+          content: "<html>Home</html>",
+          contentType: "text/html",
+        },
+        {
+          url: "http://localhost:3000/app.js",
+          content: "console.log('app');",
+          contentType: "application/javascript",
+        },
+        {
+          url: "http://localhost:3000/styles.css",
+          content: "body { margin: 0; }",
+          contentType: "text/css",
+        },
+      ];
+
+      for (const testCase of testCases) {
+        mockContext.req.url = testCase.url;
+        mockExistsSync.mockReturnValue(true);
+        mockReadFile.mockResolvedValue(Buffer.from(testCase.content));
+
+        await staticFileHandler.handleStaticFile(mockContext);
+
+        expect(mockContext.text).toHaveBeenCalledWith(testCase.content, 200, {
+          "Content-Type": testCase.contentType,
+        });
+      }
+    });
+
+    it("应该处理 SPA 路由工作流程", async () => {
+      const spaRoutes = [
+        "/app/dashboard",
+        "/user/profile",
+        "/settings/general",
+      ];
+
+      for (const route of spaRoutes) {
+        mockContext.req.url = `http://localhost:3000${route}`;
+        mockExistsSync
+          .mockReturnValueOnce(false) // 路由文件不存在
+          .mockReturnValueOnce(true); // index.html 存在
+        mockReadFile.mockResolvedValue(Buffer.from("<html>SPA App</html>"));
+
+        await staticFileHandler.handleStaticFile(mockContext);
+
+        expect(mockLogger.debug).toHaveBeenCalledWith(
+          expect.stringContaining("SPA 回退到 index.html")
+        );
+      }
+    });
+
+    it("应该优雅地处理错误场景", async () => {
+      // 测试各种错误条件
+      const errorCases = [
+        {
+          description: "file not found",
+          url: "http://localhost:3000/nonexistent.html",
+          expectedStatus: 404,
+          expectedText: "Not Found",
+          setupMock: () => mockExistsSync.mockReturnValue(false),
+        },
+      ];
+
+      for (const errorCase of errorCases) {
+        mockContext.req.url = errorCase.url;
+        errorCase.setupMock();
+
+        await staticFileHandler.handleStaticFile(mockContext);
+
+        expect(mockContext.text).toHaveBeenCalledWith(
+          errorCase.expectedText,
+          errorCase.expectedStatus
+        );
+      }
+    });
+  });
+
+  describe("edge cases and boundary conditions", () => {
+    beforeEach(() => {
+      mockExistsSync.mockReturnValueOnce(true);
+      staticFileHandler = new StaticFileHandler();
+    });
+
+    it("应该处理空文件", async () => {
+      mockContext.req.url = "http://localhost:3000/empty.txt";
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from(""));
+
+      await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.text).toHaveBeenCalledWith("", 200, {
+        "Content-Type": "text/plain",
+      });
+    });
+
+    it("应该处理文件名中包含特殊字符的文件", async () => {
+      const specialFiles = [
+        "文件名中文.html",
+        "file with spaces.js",
+        "file-with-dashes.css",
+        "file_with_underscores.json",
+        "file.with.dots.txt",
+      ];
+
+      for (const fileName of specialFiles) {
+        mockContext.req.url = `http://localhost:3000/${fileName}`;
+        mockExistsSync.mockReturnValue(true);
+        mockReadFile.mockResolvedValue(Buffer.from("content"));
+
+        await staticFileHandler.handleStaticFile(mockContext);
+
+        expect(mockReadFile).toHaveBeenCalled();
+      }
+    });
+
+    it("应该处理很长的文件路径", async () => {
+      const longPath = `/very/long/path/to/file/${"a".repeat(100)}.html`;
+      mockContext.req.url = `http://localhost:3000${longPath}`;
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from("<html>Long path</html>"));
+
+      await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.text).toHaveBeenCalledWith(
+        "<html>Long path</html>",
+        200,
+        { "Content-Type": "text/html" }
+      );
+    });
+
+    it("应该优雅地处理格式错误的 URL", async () => {
+      const malformedUrls = [
+        "not-a-url",
+        "http://",
+        "://localhost:3000/file.html",
+      ];
+
+      for (const url of malformedUrls) {
+        mockContext.req.url = url;
+
+        try {
+          await staticFileHandler.handleStaticFile(mockContext);
+        } catch (error) {
+          expect(error).toBeInstanceOf(TypeError);
+        }
+      }
+    });
+
+    it("应该处理并发请求", async () => {
+      const requests = Array.from({ length: 10 }, (_, i) => ({
+        url: `http://localhost:3000/file${i}.html`,
+        content: `<html>File ${i}</html>`,
+      }));
+
+      mockExistsSync.mockReturnValue(true);
+
+      const promises = requests.map((req) => {
+        mockContext.req.url = req.url;
+        mockReadFile.mockResolvedValue(Buffer.from(req.content));
+        return staticFileHandler.handleStaticFile(mockContext);
+      });
+
+      await Promise.all(promises);
+
+      expect(mockReadFile).toHaveBeenCalledTimes(10);
+    });
+
+    it("应该处理不同的路径分隔符", () => {
+      const handler = staticFileHandler as any;
+
+      // Test with different path formats
+      expect(handler.getContentType("path\\to\\file.js")).toBe(
+        "application/javascript"
+      );
+      expect(handler.getContentType("path/to/file.css")).toBe("text/css");
+    });
+
+    it("应该处理没有扩展名的文件", async () => {
+      mockContext.req.url = "http://localhost:3000/README";
+      mockExistsSync.mockReturnValue(true);
+      mockReadFile.mockResolvedValue(Buffer.from("README content"));
+
+      await staticFileHandler.handleStaticFile(mockContext);
+
+      expect(mockContext.body).toHaveBeenCalledWith(
+        expect.any(Uint8Array),
+        200,
+        {
+          "Content-Type": "application/octet-stream",
+        }
+      );
+    });
+
+    it("应该处理不区分大小写的文件扩展名", () => {
+      const handler = staticFileHandler as any;
+
+      expect(handler.getContentType("FILE.HTML")).toBe("text/html");
+      expect(handler.getContentType("Script.JS")).toBe(
+        "application/javascript"
+      );
+      expect(handler.getContentType("Style.CSS")).toBe("text/css");
+    });
+
+    it("应该处理路径遍历检测", () => {
+      // 直接测试路径遍历检测逻辑
+      const handler = staticFileHandler as any;
+
+      expect("../../../etc/passwd".includes("..")).toBe(true);
+      expect("normal/path/file.html".includes("..")).toBe(false);
+      expect("..\\..\\windows\\system32".includes("..")).toBe(true);
+    });
+  });
+});

--- a/src/server/handlers/__tests__/status.handler.test.ts
+++ b/src/server/handlers/__tests__/status.handler.test.ts
@@ -1,0 +1,1196 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { StatusService } from "../../services/status.service.js";
+import { StatusApiHandler } from "../status.handler.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe("StatusApiHandler 状态 API 处理器", () => {
+  let statusApiHandler: StatusApiHandler;
+  let mockStatusService: any;
+  let mockContext: any;
+  let mockLogger: any;
+
+  beforeEach(async () => {
+    // 首先设置模拟 logger
+    const { logger } = await import("../../Logger.js");
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    };
+    Object.assign(logger, mockLogger);
+
+    // 设置模拟 StatusService
+    mockStatusService = {
+      getFullStatus: vi.fn(),
+      getClientStatus: vi.fn(),
+      getRestartStatus: vi.fn(),
+      isClientConnected: vi.fn(),
+      getLastHeartbeat: vi.fn(),
+      getActiveMCPServers: vi.fn(),
+      updateClientInfo: vi.fn(),
+      setActiveMCPServers: vi.fn(),
+      reset: vi.fn(),
+    } as any;
+
+    // 设置模拟 Context
+    mockContext = {
+      get: vi.fn((key: string) => {
+        if (key === "logger") return mockLogger;
+        return undefined;
+      }),
+      logger: mockLogger, // 向后兼容
+      json: vi.fn((data, status) => {
+        const response = new Response(JSON.stringify(data), {
+          status: status || 200,
+          headers: { "Content-Type": "application/json" },
+        });
+        return response;
+      }),
+      success: vi.fn((data?: unknown, message?: string, status = 200) => {
+        const response = {
+          success: true,
+          data,
+          message,
+        };
+        return new Response(JSON.stringify(response), {
+          status,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+      fail: vi.fn(
+        (code: string, message: string, details?: unknown, status = 400) => {
+          const response = {
+            success: false,
+            error: {
+              code,
+              message,
+              ...(details !== undefined && { details }),
+            },
+          };
+          return new Response(JSON.stringify(response), {
+            status,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+      ),
+      req: {
+        json: vi.fn(),
+      },
+    } as any;
+
+    // 创建处理器实例
+    statusApiHandler = new StatusApiHandler(mockStatusService);
+  });
+
+  describe("构造函数", () => {
+    it("应该正确初始化处理器", () => {
+      expect(statusApiHandler).toBeInstanceOf(StatusApiHandler);
+      expect(mockLogger).toBeDefined();
+    });
+  });
+
+  describe("getStatus 获取完整状态", () => {
+    it("应该成功返回完整状态", async () => {
+      const mockStatus = {
+        client: { status: "connected", mcpEndpoint: "test-endpoint" },
+        restart: { status: "completed", timestamp: Date.now() },
+        servers: ["server1", "server2"],
+      };
+      mockStatusService.getFullStatus.mockReturnValue(mockStatus);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.getFullStatus).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取状态请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取状态成功");
+      expect(responseData).toEqual({
+        success: true,
+        data: mockStatus,
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理获取状态时的错误", async () => {
+      const error = new Error("状态服务不可用");
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.error).toHaveBeenCalledWith("获取状态失败:", error);
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "STATUS_READ_ERROR",
+          message: "状态服务不可用",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+
+    it("应该处理非 Error 类型的异常", async () => {
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw "字符串错误";
+      });
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      // handleError 会将非 Error 类型转换为字符串
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "STATUS_READ_ERROR",
+          message: "字符串错误",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("getClientStatus 获取客户端状态", () => {
+    it("应该成功返回客户端状态", async () => {
+      const mockClientStatus = {
+        status: "connected" as const,
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: ["server1"],
+        lastHeartbeat: Date.now(),
+      };
+      mockStatusService.getClientStatus.mockReturnValue(mockClientStatus);
+
+      const response = await statusApiHandler.getClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.getClientStatus).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取客户端状态请求");
+      expect(responseData).toEqual({
+        success: true,
+        data: mockClientStatus,
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理获取客户端状态时的错误", async () => {
+      const error = new Error("客户端状态不可用");
+      mockStatusService.getClientStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "获取客户端状态失败:",
+        error
+      );
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "CLIENT_STATUS_READ_ERROR",
+          message: "客户端状态不可用",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("getRestartStatus 获取重启状态", () => {
+    it("应该成功返回重启状态", async () => {
+      const mockRestartStatus = {
+        status: "completed" as const,
+        timestamp: Date.now(),
+      };
+      mockStatusService.getRestartStatus.mockReturnValue(mockRestartStatus);
+
+      const response = await statusApiHandler.getRestartStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.getRestartStatus).toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: true,
+        data: mockRestartStatus,
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理获取重启状态时的错误", async () => {
+      const error = new Error("重启状态不可用");
+      mockStatusService.getRestartStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getRestartStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "RESTART_STATUS_READ_ERROR",
+          message: "重启状态不可用",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("checkClientConnected 检查客户端连接", () => {
+    it("应该返回客户端已连接状态", async () => {
+      mockStatusService.isClientConnected.mockReturnValue(true);
+
+      const response = await statusApiHandler.checkClientConnected(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.isClientConnected).toHaveBeenCalled();
+      expect(mockLogger.debug).toHaveBeenCalledWith("客户端连接状态: true");
+      expect(responseData).toEqual({
+        success: true,
+        data: { connected: true },
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该返回客户端未连接状态", async () => {
+      mockStatusService.isClientConnected.mockReturnValue(false);
+
+      const response = await statusApiHandler.checkClientConnected(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.debug).toHaveBeenCalledWith("客户端连接状态: false");
+      expect(responseData).toEqual({
+        success: true,
+        data: { connected: false },
+      });
+    });
+
+    it("应该处理检查连接时的错误", async () => {
+      const error = new Error("连接检查失败");
+      mockStatusService.isClientConnected.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.checkClientConnected(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "CLIENT_CONNECTION_CHECK_ERROR",
+          message: "连接检查失败",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("getLastHeartbeat 获取最后心跳时间", () => {
+    it("应该成功返回最后心跳时间", async () => {
+      const mockHeartbeat = Date.now();
+      mockStatusService.getLastHeartbeat.mockReturnValue(mockHeartbeat);
+
+      const response = await statusApiHandler.getLastHeartbeat(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.getLastHeartbeat).toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: true,
+        data: { lastHeartbeat: mockHeartbeat },
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理获取心跳时间时的错误", async () => {
+      const error = new Error("心跳数据不可用");
+      mockStatusService.getLastHeartbeat.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getLastHeartbeat(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "HEARTBEAT_READ_ERROR",
+          message: "心跳数据不可用",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("getActiveMCPServers 获取活跃 MCP 服务器", () => {
+    it("应该成功返回活跃 MCP 服务器列表", async () => {
+      const mockServers = ["server1", "server2", "server3"];
+      mockStatusService.getActiveMCPServers.mockReturnValue(mockServers);
+
+      const response = await statusApiHandler.getActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.getActiveMCPServers).toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: true,
+        data: { servers: mockServers },
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理获取 MCP 服务器时的错误", async () => {
+      const error = new Error("MCP 服务器数据不可用");
+      mockStatusService.getActiveMCPServers.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "ACTIVE_MCP_SERVERS_READ_ERROR",
+          message: "MCP 服务器数据不可用",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("updateClientStatus 更新客户端状态", () => {
+    it("应该成功更新客户端状态", async () => {
+      const statusUpdate = {
+        status: "connected",
+        mcpEndpoint: "new-endpoint",
+        activeMCPServers: ["server1", "server2"],
+      };
+      mockContext.req.json.mockResolvedValue(statusUpdate);
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockContext.req.json).toHaveBeenCalled();
+      expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
+        statusUpdate,
+        "http-api"
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith("客户端状态更新成功");
+      // data 为 undefined 时不会添加 data 字段
+      expect(responseData).toEqual({
+        success: true,
+        message: "客户端状态更新成功",
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该拒绝无效的请求体", async () => {
+      mockContext.req.json.mockResolvedValue(null);
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.updateClientInfo).not.toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "INVALID_REQUEST_BODY",
+          message: "请求体必须是有效的状态对象",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该拒绝非对象类型的请求体", async () => {
+      mockContext.req.json.mockResolvedValue("invalid");
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.updateClientInfo).not.toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "INVALID_REQUEST_BODY",
+          message: "请求体必须是有效的状态对象",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该处理状态服务更新时的错误", async () => {
+      const statusUpdate = { status: "connected" };
+      const error = new Error("状态更新失败");
+      mockContext.req.json.mockResolvedValue(statusUpdate);
+      mockStatusService.updateClientInfo.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "更新客户端状态失败:",
+        error
+      );
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "CLIENT_STATUS_UPDATE_ERROR",
+          message: "状态更新失败",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该处理 JSON 解析错误", async () => {
+      const error = new Error("Invalid JSON");
+      mockContext.req.json.mockRejectedValue(error);
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      // parseJsonBody 会添加前缀："请求体必须是有效的状态对象: Invalid JSON"
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "CLIENT_STATUS_UPDATE_ERROR",
+          message: "请求体必须是有效的状态对象: Invalid JSON",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+  });
+
+  describe("setActiveMCPServers 设置活跃 MCP 服务器", () => {
+    it("应该成功设置活跃 MCP 服务器", async () => {
+      const servers = ["server1", "server2", "server3"];
+      mockContext.req.json.mockResolvedValue({ servers });
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockContext.req.json).toHaveBeenCalled();
+      expect(mockStatusService.setActiveMCPServers).toHaveBeenCalledWith(
+        servers
+      );
+      expect(mockLogger.info).toHaveBeenCalledWith("活跃 MCP 服务器设置成功");
+      // data 为 undefined 时不会添加 data 字段
+      expect(responseData).toEqual({
+        success: true,
+        message: "活跃 MCP 服务器设置成功",
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该拒绝非数组类型的 servers", async () => {
+      mockContext.req.json.mockResolvedValue({ servers: "invalid" });
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.setActiveMCPServers).not.toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "INVALID_REQUEST_BODY",
+          message: "servers 必须是字符串数组",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该拒绝缺少 servers 字段的请求", async () => {
+      mockContext.req.json.mockResolvedValue({});
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.setActiveMCPServers).not.toHaveBeenCalled();
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "INVALID_REQUEST_BODY",
+          message: "servers 必须是字符串数组",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该处理状态服务设置时的错误", async () => {
+      const servers = ["server1"];
+      const error = new Error("设置服务器失败");
+      mockContext.req.json.mockResolvedValue({ servers });
+      mockStatusService.setActiveMCPServers.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "设置活跃 MCP 服务器失败:",
+        error
+      );
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "ACTIVE_MCP_SERVERS_UPDATE_ERROR",
+          message: "设置服务器失败",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该处理 JSON 解析错误", async () => {
+      const error = new Error("Invalid JSON");
+      mockContext.req.json.mockRejectedValue(error);
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      // parseJsonBody 会添加前缀："请求体格式错误: Invalid JSON"
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "ACTIVE_MCP_SERVERS_UPDATE_ERROR",
+          message: "请求体格式错误: Invalid JSON",
+        },
+      });
+      expect(response.status).toBe(400);
+    });
+
+    it("应该接受空数组", async () => {
+      const servers: string[] = [];
+      mockContext.req.json.mockResolvedValue({ servers });
+
+      const response = await statusApiHandler.setActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.setActiveMCPServers).toHaveBeenCalledWith(
+        servers
+      );
+      // data 为 undefined 时不会添加 data 字段
+      expect(responseData).toEqual({
+        success: true,
+        message: "活跃 MCP 服务器设置成功",
+      });
+      expect(response.status).toBe(200);
+    });
+  });
+
+  describe("resetStatus 重置状态", () => {
+    it("应该成功重置状态", async () => {
+      const response = await statusApiHandler.resetStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.reset).toHaveBeenCalled();
+      expect(mockLogger.info).toHaveBeenCalledWith("处理重置状态请求");
+      expect(mockLogger.info).toHaveBeenCalledWith("状态重置成功");
+      // data 为 undefined 时不会添加 data 字段
+      expect(responseData).toEqual({
+        success: true,
+        message: "状态重置成功",
+      });
+      expect(response.status).toBe(200);
+    });
+
+    it("应该处理重置状态时的错误", async () => {
+      const error = new Error("重置失败");
+      mockStatusService.reset.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.resetStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockLogger.error).toHaveBeenCalledWith("重置状态失败:", error);
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "STATUS_RESET_ERROR",
+          message: "重置失败",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+
+    it("应该处理非 Error 类型的异常", async () => {
+      mockStatusService.reset.mockImplementation(() => {
+        throw "字符串错误";
+      });
+
+      const response = await statusApiHandler.resetStatus(mockContext);
+      const responseData = await response.json();
+
+      // handleError 会将非 Error 类型转换为字符串
+      expect(responseData).toEqual({
+        success: false,
+        error: {
+          code: "STATUS_RESET_ERROR",
+          message: "字符串错误",
+        },
+      });
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("响应格式验证", () => {
+    it("成功响应应该包含正确的结构", async () => {
+      const mockData = { test: "data" };
+      mockStatusService.getFullStatus.mockReturnValue(mockData);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toHaveProperty("success", true);
+      expect(responseData).toHaveProperty("data", mockData);
+      expect(responseData).not.toHaveProperty("error");
+    });
+
+    it("错误响应应该包含正确的结构", async () => {
+      const error = new Error("测试错误");
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toHaveProperty("success", false);
+      expect(responseData).toHaveProperty("error");
+      expect(responseData.error).toHaveProperty("code");
+      expect(responseData.error).toHaveProperty("message");
+    });
+
+    it("成功响应可以包含消息", async () => {
+      const response = await statusApiHandler.resetStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData).toHaveProperty("success", true);
+      expect(responseData).toHaveProperty("message", "状态重置成功");
+      // data 为 undefined 时不会添加 data 字段
+      expect(responseData).not.toHaveProperty("data");
+    });
+  });
+
+  describe("边界条件测试", () => {
+    it("应该处理空的状态数据", async () => {
+      mockStatusService.getFullStatus.mockReturnValue({});
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toEqual({});
+    });
+
+    it("应该处理 null 状态数据", async () => {
+      mockStatusService.getFullStatus.mockReturnValue(null);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toBeNull();
+    });
+
+    it("应该处理 undefined 状态数据", async () => {
+      mockStatusService.getFullStatus.mockReturnValue(undefined);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data).toBeUndefined();
+    });
+
+    it("应该处理大量的 MCP 服务器数据", async () => {
+      const largeServerList = Array.from(
+        { length: 1000 },
+        (_, i) => `server${i}`
+      );
+      mockStatusService.getActiveMCPServers.mockReturnValue(largeServerList);
+
+      const response = await statusApiHandler.getActiveMCPServers(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData.success).toBe(true);
+      expect(responseData.data.servers).toHaveLength(1000);
+    });
+
+    it("应该处理空的客户端状态更新", async () => {
+      mockContext.req.json.mockResolvedValue({});
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
+        {},
+        "http-api"
+      );
+      expect(responseData.success).toBe(true);
+    });
+
+    it("应该处理包含特殊字符的数据", async () => {
+      const specialData = {
+        status: "connected",
+        mcpEndpoint: "test://endpoint?param=value&other=测试",
+        activeMCPServers: ["server-1", "server_2", "server.3"],
+      };
+      mockContext.req.json.mockResolvedValue(specialData);
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
+        specialData,
+        "http-api"
+      );
+      expect(responseData.success).toBe(true);
+    });
+  });
+
+  describe("并发和性能测试", () => {
+    it("应该能够处理并发的状态查询请求", async () => {
+      const mockStatus = { test: "concurrent" };
+      mockStatusService.getFullStatus.mockReturnValue(mockStatus);
+
+      const promises = Array.from({ length: 10 }, () =>
+        statusApiHandler.getStatus(mockContext)
+      );
+
+      const responses = await Promise.all(promises);
+
+      expect(responses).toHaveLength(10);
+      for (const response of responses) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+        expect(data.data).toEqual(mockStatus);
+      }
+      expect(mockStatusService.getFullStatus).toHaveBeenCalledTimes(10);
+    });
+
+    it("应该能够处理并发的状态更新请求", async () => {
+      const statusUpdates = Array.from({ length: 5 }, (_, i) => ({
+        status: "connected",
+        mcpEndpoint: `endpoint-${i}`,
+      }));
+
+      mockContext.req.json
+        .mockResolvedValueOnce(statusUpdates[0])
+        .mockResolvedValueOnce(statusUpdates[1])
+        .mockResolvedValueOnce(statusUpdates[2])
+        .mockResolvedValueOnce(statusUpdates[3])
+        .mockResolvedValueOnce(statusUpdates[4]);
+
+      const promises = Array.from({ length: 5 }, () =>
+        statusApiHandler.updateClientStatus(mockContext)
+      );
+
+      const responses = await Promise.all(promises);
+
+      expect(responses).toHaveLength(5);
+      for (const response of responses) {
+        const data = await response.json();
+        expect(data.success).toBe(true);
+      }
+      expect(mockStatusService.updateClientInfo).toHaveBeenCalledTimes(5);
+    });
+
+    it("应该在高频请求下保持性能", async () => {
+      mockStatusService.isClientConnected.mockReturnValue(true);
+
+      const startTime = Date.now();
+      const promises = Array.from({ length: 100 }, () =>
+        statusApiHandler.checkClientConnected(mockContext)
+      );
+
+      await Promise.all(promises);
+      const endTime = Date.now();
+
+      expect(endTime - startTime).toBeLessThan(1000); // 应该在 1 秒内完成
+      expect(mockStatusService.isClientConnected).toHaveBeenCalledTimes(100);
+    });
+  });
+
+  describe("错误处理和恢复", () => {
+    it("应该在状态服务抛出异常后继续工作", async () => {
+      // 第一次调用失败
+      mockStatusService.getFullStatus
+        .mockImplementationOnce(() => {
+          throw new Error("临时错误");
+        })
+        .mockReturnValueOnce({ recovered: true });
+
+      // 第一次请求失败
+      const response1 = await statusApiHandler.getStatus(mockContext);
+      const data1 = await response1.json();
+      expect(data1.error).toBeDefined();
+
+      // 第二次请求成功
+      const response2 = await statusApiHandler.getStatus(mockContext);
+      const data2 = await response2.json();
+      expect(data2.success).toBe(true);
+      expect(data2.data).toEqual({ recovered: true });
+    });
+
+    it("应该正确处理状态服务方法不存在的情况", async () => {
+      // 模拟方法不存在
+      const brokenService = {} as StatusService;
+      const brokenHandler = new StatusApiHandler(brokenService);
+
+      const response = await brokenHandler.getStatus(mockContext);
+      const responseData = await response.json();
+
+      expect(responseData.error).toBeDefined();
+      expect(response.status).toBe(500);
+    });
+
+    it("应该处理 Context 对象异常", async () => {
+      const brokenLogger = {
+        get error() {
+          throw new Error("Context 错误");
+        },
+      };
+      const brokenContext = {
+        get: vi.fn(() => {
+          throw new Error("Context 错误");
+        }),
+        logger: brokenLogger,
+        success: vi.fn(),
+        fail: vi.fn(),
+        json: vi.fn(),
+        req: { json: vi.fn() },
+      } as any;
+
+      mockStatusService.getFullStatus.mockReturnValue({ test: "data" });
+
+      try {
+        await statusApiHandler.getStatus(brokenContext);
+      } catch (error) {
+        expect(error).toBeInstanceOf(Error);
+        expect((error as Error).message).toBe("Context 错误");
+      }
+    });
+  });
+
+  describe("日志记录验证", () => {
+    it("应该记录所有重要操作的日志", async () => {
+      mockStatusService.getFullStatus.mockReturnValue({ test: "data" });
+
+      await statusApiHandler.getStatus(mockContext);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith("处理获取状态请求");
+      expect(mockLogger.debug).toHaveBeenCalledWith("获取状态成功");
+    });
+
+    it("应该记录错误日志", async () => {
+      const error = new Error("测试错误");
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      await statusApiHandler.getStatus(mockContext);
+
+      expect(mockLogger.error).toHaveBeenCalledWith("获取状态失败:", error);
+    });
+
+    it("应该记录信息级别的日志", async () => {
+      const statusUpdate = { status: "connected" };
+      mockContext.req.json.mockResolvedValue(statusUpdate);
+
+      await statusApiHandler.updateClientStatus(mockContext);
+
+      expect(mockLogger.info).toHaveBeenCalledWith("客户端状态更新成功");
+    });
+  });
+
+  describe("集成测试", () => {
+    it("应该正确处理完整的状态管理工作流", async () => {
+      // 1. 初始状态查询
+      const initialStatus = {
+        client: {
+          status: "disconnected",
+          mcpEndpoint: "",
+          activeMCPServers: [],
+        },
+        restart: null,
+        servers: [],
+      };
+      mockStatusService.getFullStatus.mockReturnValue(initialStatus);
+
+      let response = await statusApiHandler.getStatus(mockContext);
+      let data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual(initialStatus);
+
+      // 2. 更新客户端状态
+      const clientUpdate = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: ["server1"],
+      };
+      mockContext.req.json.mockResolvedValue(clientUpdate);
+
+      response = await statusApiHandler.updateClientStatus(mockContext);
+      data = await response.json();
+      expect(data.success).toBe(true);
+
+      // 3. 设置 MCP 服务器
+      const servers = ["server1", "server2"];
+      mockContext.req.json.mockResolvedValue({ servers });
+
+      response = await statusApiHandler.setActiveMCPServers(mockContext);
+      data = await response.json();
+      expect(data.success).toBe(true);
+
+      // 4. 检查连接状态
+      mockStatusService.isClientConnected.mockReturnValue(true);
+
+      response = await statusApiHandler.checkClientConnected(mockContext);
+      data = await response.json();
+      expect(data.success).toBe(true);
+      expect(data.data.connected).toBe(true);
+
+      // 5. 重置状态
+      response = await statusApiHandler.resetStatus(mockContext);
+      data = await response.json();
+      expect(data.success).toBe(true);
+
+      // 验证所有服务调用
+      expect(mockStatusService.getFullStatus).toHaveBeenCalled();
+      expect(mockStatusService.updateClientInfo).toHaveBeenCalledWith(
+        clientUpdate,
+        "http-api"
+      );
+      expect(mockStatusService.setActiveMCPServers).toHaveBeenCalledWith(
+        servers
+      );
+      expect(mockStatusService.isClientConnected).toHaveBeenCalled();
+      expect(mockStatusService.reset).toHaveBeenCalled();
+    });
+
+    it("应该正确处理混合成功和失败的操作", async () => {
+      // 成功的操作
+      mockStatusService.getFullStatus.mockReturnValue({ test: "success" });
+      let response = await statusApiHandler.getStatus(mockContext);
+      let data = await response.json();
+      expect(data.success).toBe(true);
+
+      // 失败的操作
+      mockStatusService.getClientStatus.mockImplementation(() => {
+        throw new Error("服务不可用");
+      });
+      response = await statusApiHandler.getClientStatus(mockContext);
+      data = await response.json();
+      expect(data.error).toBeDefined();
+
+      // 再次成功的操作
+      mockStatusService.isClientConnected.mockReturnValue(false);
+      response = await statusApiHandler.checkClientConnected(mockContext);
+      data = await response.json();
+      expect(data.success).toBe(true);
+    });
+  });
+
+  describe("数据类型和格式验证", () => {
+    it("应该处理各种数据类型的状态", async () => {
+      const complexStatus = {
+        client: {
+          status: "connected",
+          mcpEndpoint: "test://endpoint",
+          activeMCPServers: ["server1", "server2"],
+          lastHeartbeat: 1234567890,
+          metadata: {
+            version: "1.0.0",
+            features: ["feature1", "feature2"],
+            config: { debug: true, timeout: 5000 },
+          },
+        },
+        restart: {
+          status: "completed",
+          timestamp: Date.now(),
+          duration: 1500,
+        },
+        servers: [
+          { name: "server1", status: "active", uptime: 3600 },
+          { name: "server2", status: "inactive", lastSeen: 1234567890 },
+        ],
+      };
+
+      mockStatusService.getFullStatus.mockReturnValue(complexStatus);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual(complexStatus);
+    });
+
+    it("应该处理包含特殊值的数据", async () => {
+      const specialStatus = {
+        nullValue: null,
+        undefinedValue: undefined,
+        emptyString: "",
+        emptyArray: [],
+        emptyObject: {},
+        zeroNumber: 0,
+        falseBoolean: false,
+        infinityNumber: Number.POSITIVE_INFINITY,
+        nanNumber: Number.NaN,
+      };
+
+      mockStatusService.getFullStatus.mockReturnValue(specialStatus);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      // JSON 序列化会处理这些特殊值
+      expect(data.data).toBeDefined();
+    });
+
+    it("应该正确验证 MCP 服务器数组的各种格式", async () => {
+      const testCases = [
+        { servers: [], expected: true },
+        { servers: ["server1"], expected: true },
+        { servers: ["server1", "server2", "server3"], expected: true },
+        { servers: null, expected: false },
+        { servers: undefined, expected: false },
+        { servers: "not-array", expected: false },
+        { servers: 123, expected: false },
+        { servers: {}, expected: false },
+      ];
+
+      for (const testCase of testCases) {
+        mockContext.req.json.mockResolvedValue(testCase);
+
+        const response =
+          await statusApiHandler.setActiveMCPServers(mockContext);
+        const data = await response.json();
+
+        if (testCase.expected) {
+          expect(data.success).toBe(true);
+        } else {
+          expect(data.error).toBeDefined();
+          expect(data.error.code).toBe("INVALID_REQUEST_BODY");
+        }
+      }
+    });
+  });
+
+  describe("HTTP 状态码验证", () => {
+    it("成功操作应该返回 200 状态码", async () => {
+      mockStatusService.getFullStatus.mockReturnValue({});
+
+      const response = await statusApiHandler.getStatus(mockContext);
+
+      expect(response.status).toBe(200);
+    });
+
+    it("客户端错误应该返回 400 状态码", async () => {
+      mockContext.req.json.mockResolvedValue(null);
+
+      const response = await statusApiHandler.updateClientStatus(mockContext);
+
+      expect(response.status).toBe(400);
+    });
+
+    it("服务器错误应该返回 500 状态码", async () => {
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw new Error("服务器内部错误");
+      });
+
+      const response = await statusApiHandler.getStatus(mockContext);
+
+      expect(response.status).toBe(500);
+    });
+
+    it("不同类型的错误应该返回正确的状态码", async () => {
+      // 400 错误 - 客户端请求错误
+      mockContext.req.json.mockResolvedValue({ servers: "invalid" });
+      let response = await statusApiHandler.setActiveMCPServers(mockContext);
+      expect(response.status).toBe(400);
+
+      // 500 错误 - 服务器内部错误
+      mockStatusService.reset.mockImplementation(() => {
+        throw new Error("内部错误");
+      });
+      response = await statusApiHandler.resetStatus(mockContext);
+      expect(response.status).toBe(500);
+    });
+  });
+
+  describe("内存和资源管理", () => {
+    it("应该正确处理大量数据而不造成内存泄漏", async () => {
+      const largeData = {
+        servers: Array.from({ length: 10000 }, (_, i) => `server-${i}`),
+        clients: Array.from({ length: 1000 }, (_, i) => ({
+          id: `client-${i}`,
+          status: "connected",
+          data: "x".repeat(1000), // 1KB per client
+        })),
+      };
+
+      mockStatusService.getFullStatus.mockReturnValue(largeData);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.data.servers).toHaveLength(10000);
+      expect(data.data.clients).toHaveLength(1000);
+    });
+
+    it("应该在多次调用后保持稳定", async () => {
+      mockStatusService.getFullStatus.mockReturnValue({ stable: true });
+
+      // 执行多次调用
+      for (let i = 0; i < 50; i++) {
+        const response = await statusApiHandler.getStatus(mockContext);
+        const data = await response.json();
+        expect(data.success).toBe(true);
+      }
+
+      expect(mockStatusService.getFullStatus).toHaveBeenCalledTimes(50);
+    });
+  });
+
+  describe("异步操作处理", () => {
+    it("应该正确处理异步状态服务调用", async () => {
+      // 模拟异步操作 - StatusService 的方法是同步的，所以直接返回值
+      const asyncData = { async: true };
+      mockStatusService.getFullStatus.mockReturnValue(asyncData);
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const data = await response.json();
+
+      expect(data.success).toBe(true);
+      expect(data.data).toEqual({ async: true });
+    });
+
+    it("应该处理异步操作中的错误", async () => {
+      // 模拟同步错误
+      const error = new Error("异步错误");
+      mockStatusService.getFullStatus.mockImplementation(() => {
+        throw error;
+      });
+
+      const response = await statusApiHandler.getStatus(mockContext);
+      const data = await response.json();
+
+      expect(data.error).toBeDefined();
+      expect(data.error.message).toBe("异步错误");
+    });
+  });
+});

--- a/src/server/handlers/__tests__/update.handler.test.ts
+++ b/src/server/handlers/__tests__/update.handler.test.ts
@@ -1,0 +1,427 @@
+import type { Context } from "hono";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "../../Logger.js";
+import { NPMManager } from "../../lib/npm";
+import { InstallLogStream } from "../../lib/npm/install-log-stream.js";
+import { UpdateApiHandler } from "../update.handler.js";
+
+// 模拟依赖
+vi.mock("../../lib/npm");
+vi.mock("../../Logger.js");
+vi.mock("../../services/event-bus.service.js");
+
+// Mock 类型定义
+interface MockNPMManager {
+  installVersion: ReturnType<typeof vi.fn>;
+}
+
+interface MockLogger {
+  info: ReturnType<typeof vi.fn>;
+  error: ReturnType<typeof vi.fn>;
+  warn: ReturnType<typeof vi.fn>;
+  debug: ReturnType<typeof vi.fn>;
+}
+
+interface MockEventBus {
+  emitEvent: ReturnType<typeof vi.fn>;
+  onEvent: ReturnType<typeof vi.fn>;
+}
+
+describe("UpdateApiHandler", () => {
+  let updateApiHandler: UpdateApiHandler;
+  let mockNPMManager: MockNPMManager;
+  let mockLogger: MockLogger;
+  let mockEventBus: MockEventBus;
+
+  const createMockContext = (overrides = {}) => ({
+    get: vi.fn((key: string) => {
+      if (key === "logger") return mockLogger;
+      return undefined;
+    }),
+    logger: mockLogger, // 向后兼容
+    req: {
+      json: vi.fn(),
+    },
+    json: vi.fn(),
+    success: vi.fn((data?: unknown, message?: string, status = 200) => {
+      const response = {
+        success: true,
+        data,
+        message,
+      };
+      return new Response(JSON.stringify(response), {
+        status,
+        headers: { "Content-Type": "application/json" },
+      });
+    }),
+    fail: vi.fn(
+      (code: string, message: string, details?: unknown, statusCode = 400) => {
+        const response = {
+          success: false,
+          error: {
+            code,
+            message,
+            ...(details !== undefined && { details }),
+          },
+        };
+        return new Response(JSON.stringify(response), {
+          status: statusCode,
+          headers: { "Content-Type": "application/json" },
+        });
+      }
+    ),
+    ...overrides,
+  });
+
+  beforeEach(async () => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // 设置模拟 logger
+    mockLogger = {
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+      debug: vi.fn(),
+    };
+    Object.assign(logger, mockLogger);
+
+    // 设置模拟 event bus
+    mockEventBus = {
+      emitEvent: vi.fn(),
+      onEvent: vi.fn(),
+    };
+    const { getEventBus } = await import("../../services/event-bus.service.js");
+    vi.mocked(getEventBus).mockReturnValue(
+      mockEventBus as unknown as ReturnType<typeof getEventBus>
+    );
+
+    // 设置模拟 NPMManager
+    mockNPMManager = {
+      installVersion: vi.fn(),
+    };
+    vi.mocked(NPMManager).mockImplementation(
+      () => mockNPMManager as unknown as NPMManager
+    );
+
+    // 创建处理器实例
+    updateApiHandler = new UpdateApiHandler();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("performUpdate", () => {
+    test("应该成功安装指定版本", async () => {
+      // 准备
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({ version: "1.7.9" }),
+        },
+      } as any);
+
+      mockNPMManager.installVersion.mockResolvedValue(undefined);
+
+      // 执行
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // 断言
+      expect(mockNPMManager.installVersion).toHaveBeenCalledWith(
+        "1.7.9",
+        expect.stringMatching(/^install-/)
+      );
+      expect(mockContext.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-/),
+          message: "安装已启动，请通过 SSE 日志流查看进度",
+        }),
+        "安装请求已接受"
+      );
+    });
+
+    test("应该拒绝空的版本号", async () => {
+      // 准备
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({ version: "" }),
+        },
+      } as any);
+
+      // 执行
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // 断言
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_VERSION",
+        "请求参数格式错误",
+        [
+          {
+            field: "version",
+            message: "版本号不能为空",
+          },
+        ],
+        400
+      );
+      expect(mockNPMManager.installVersion).not.toHaveBeenCalled();
+    });
+
+    test("应该拒绝缺少 version 字段的请求", async () => {
+      // Arrange
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({}),
+        },
+      } as any);
+
+      // Act
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_VERSION",
+        "请求参数格式错误",
+        [
+          {
+            field: "version",
+            message: "Invalid input: expected string, received undefined",
+          },
+        ],
+        400
+      );
+      expect(mockNPMManager.installVersion).not.toHaveBeenCalled();
+    });
+
+    test("应该拒绝 version 字段为 null 的请求", async () => {
+      // Arrange
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({ version: null }),
+        },
+      } as any);
+
+      // Act
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "INVALID_VERSION",
+        "请求参数格式错误",
+        [
+          {
+            field: "version",
+            message: "Invalid input: expected string, received null",
+          },
+        ],
+        400
+      );
+      expect(mockNPMManager.installVersion).not.toHaveBeenCalled();
+    });
+
+    test("应该处理 npm 安装失败的情况", async () => {
+      // Arrange
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({ version: "1.7.9" }),
+        },
+      } as any);
+
+      const installError = new Error("npm 安装失败");
+      mockNPMManager.installVersion.mockRejectedValue(installError);
+
+      // Act
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // 等待一下，让异步错误处理执行
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "安装过程失败:",
+        installError
+      );
+      // 由于安装是异步的，响应应该仍然是成功的
+      expect(mockContext.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-/),
+          message: "安装已启动，请通过 SSE 日志流查看进度",
+        }),
+        "安装请求已接受"
+      );
+    });
+
+    test("应该处理 JSON 解析错误", async () => {
+      // Arrange
+      const jsonError = new Error("Invalid JSON");
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockRejectedValue(jsonError),
+        },
+      } as any);
+
+      // Act
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // Assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "处理安装请求失败:",
+        expect.any(Error)
+      );
+      expect(mockContext.fail).toHaveBeenCalledWith(
+        "REQUEST_FAILED",
+        "请求体格式错误: Invalid JSON",
+        undefined,
+        500
+      );
+    });
+
+    test("应该处理非 Error 类型的错误", async () => {
+      // Arrange
+      const mockContext = createMockContext({
+        req: {
+          json: vi.fn().mockResolvedValue({ version: "1.7.9" }),
+        },
+      } as any);
+
+      const installError = "String error";
+      mockNPMManager.installVersion.mockRejectedValue(installError);
+
+      // Act
+      await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+      // 等待一下，让异步错误处理执行
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // Assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "安装过程失败:",
+        installError
+      );
+      // 由于安装是异步的，响应应该仍然是成功的
+      expect(mockContext.success).toHaveBeenCalledWith(
+        expect.objectContaining({
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-/),
+          message: "安装已启动，请通过 SSE 日志流查看进度",
+        }),
+        "安装请求已接受"
+      );
+    });
+  });
+
+  // ==================== SSE 日志流集成测试 ====================
+
+  describe("UpdateApiHandler - SSE 日志流集成", () => {
+    let updateApiHandler: UpdateApiHandler;
+    let logStream: InstallLogStream;
+
+    beforeEach(() => {
+      vi.clearAllMocks();
+
+      // 使用真实的 InstallLogStream 实例
+      logStream = new InstallLogStream();
+
+      // 创建处理器实例（注入真实 logStream）
+      updateApiHandler = new UpdateApiHandler(logStream);
+
+      // 设置模拟 logger
+      mockLogger = {
+        info: vi.fn(),
+        error: vi.fn(),
+        warn: vi.fn(),
+        debug: vi.fn(),
+      };
+      Object.assign(logger, mockLogger);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe("getInstallLogs", () => {
+      it("缺少 installId 参数时应返回 400 错误", async () => {
+        const mockContext = createMockContext({
+          req: { query: vi.fn().mockReturnValue(undefined) },
+        } as any);
+
+        const response = await updateApiHandler.getInstallLogs(
+          mockContext as unknown as Context
+        );
+
+        const body = await response.json();
+        expect(response.status).toBe(400);
+        expect(body.error.code).toBe("MISSING_INSTALL_ID");
+      });
+
+      it("installId 对应的会话不存在时应返回 404", async () => {
+        const mockContext = createMockContext({
+          req: { query: vi.fn().mockReturnValue("non-existent") },
+        } as any);
+
+        const response = await updateApiHandler.getInstallLogs(
+          mockContext as unknown as Context
+        );
+
+        const body = await response.json();
+        expect(response.status).toBe(404);
+        expect(body.error.code).toBe("INSTALL_NOT_FOUND");
+      });
+
+      it("会话存在时应返回 text/event-stream 类型的 Response", async () => {
+        // 先创建一个安装会话
+        logStream.startInstall({
+          version: "1.0.0",
+          installId: "test-sse-id",
+          timestamp: Date.now(),
+        });
+
+        const mockContext = createMockContext({
+          req: { query: vi.fn().mockReturnValue("test-sse-id") },
+        } as any);
+
+        const response = await updateApiHandler.getInstallLogs(
+          mockContext as unknown as Context
+        );
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get("Content-Type")).toBe("text/event-stream");
+        expect(response.headers.get("Cache-Control")).toContain("no-cache");
+        expect(response.headers.get("X-Accel-Buffering")).toBe("no");
+      });
+    });
+
+    describe("getLogStream", () => {
+      it("应返回注入的 InstallLogStream 实例", () => {
+        expect(updateApiHandler.getLogStream()).toBe(logStream);
+      });
+    });
+
+    describe("performUpdate 与 getInstallLogs 协作", () => {
+      it("performUpdate 应将生成的 installId 传递给 NPMManager", async () => {
+        const mockContext = createMockContext({
+          req: {
+            json: vi.fn().mockResolvedValue({ version: "1.7.9" }),
+          },
+        } as any);
+
+        mockNPMManager.installVersion.mockResolvedValue(undefined);
+
+        await updateApiHandler.performUpdate(mockContext as unknown as Context);
+
+        // 验证 installVersion 被调用且接收到了正确的 installId
+        expect(mockNPMManager.installVersion).toHaveBeenCalledWith(
+          "1.7.9",
+          expect.stringMatching(/^install-/)
+        );
+
+        // 验证响应包含 installId（前端可用它来连接 SSE）
+        const successCall = mockContext.success.mock.calls[0][0] as {
+          installId: string;
+        };
+        expect(successCall.installId).toMatch(/^install-/);
+      });
+    });
+  });
+});

--- a/src/server/handlers/base.handler.ts
+++ b/src/server/handlers/base.handler.ts
@@ -1,0 +1,67 @@
+import type { Context } from "hono";
+/**
+ * 抽象 API Handler 基类
+ * 提供便捷的辅助方法
+ * logger 通过 c.get("logger") 访问（Hono 推荐做法）
+ */
+import type { AppContext } from "../types/hono.context.js";
+
+export abstract class BaseHandler {
+  /**
+   * 统一错误处理方法
+   * 记录错误日志并返回格式化的错误响应
+   * @param c - Hono context
+   * @param error - 错误对象
+   * @param operation - 操作描述（用于日志）
+   * @param defaultCode - 默认错误码
+   * @param defaultMessage - 默认错误消息
+   * @param statusCode - HTTP 状态码（默认 500）
+   * @returns JSON 错误响应
+   */
+  protected handleError(
+    c: Context<AppContext>,
+    error: unknown,
+    operation: string,
+    defaultCode = "OPERATION_FAILED",
+    defaultMessage = "操作失败",
+    statusCode = 500
+  ): Response {
+    const errorMessage = error instanceof Error ? error.message : String(error);
+    const errorCode =
+      error instanceof Error && "code" in error
+        ? String((error as { code: unknown }).code)
+        : defaultCode;
+
+    c.get("logger").error(`${operation}失败:`, error);
+
+    return c.fail(
+      errorCode,
+      errorMessage || defaultMessage,
+      undefined,
+      statusCode
+    );
+  }
+
+  /**
+   * 解析 JSON 请求体
+   * @param c - Hono context
+   * @param errorMessage - 自定义错误消息前缀（默认"请求体格式错误"）
+   * @returns 解析后的 JSON 对象
+   * @throws 如果请求体不是有效的 JSON
+   */
+  protected async parseJsonBody<T>(
+    c: Context<AppContext>,
+    errorMessage = "请求体格式错误"
+  ): Promise<T> {
+    try {
+      return await c.req.json();
+    } catch (error) {
+      // 保留原始错误信息
+      const message =
+        error instanceof Error
+          ? `${errorMessage}: ${error.message}`
+          : errorMessage;
+      throw new Error(message);
+    }
+  }
+}

--- a/src/server/handlers/config.handler.ts
+++ b/src/server/handlers/config.handler.ts
@@ -1,0 +1,415 @@
+import type { Context } from "hono";
+import type { AppConfig } from "../../config/index.js";
+import { configManager } from "../../config/index.js";
+/**
+ * 配置 API HTTP 路由处理器
+ * 提供配置读取、配置更新等配置相关的 RESTful API 接口
+ */
+import type { AppContext } from "../types/hono.context.js";
+import {
+  createPromptFile,
+  deletePromptFile,
+  listPromptFiles,
+  readPromptFile,
+  updatePromptFile,
+} from "../utils/prompt-utils.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 配置 API 处理器
+ */
+export class ConfigApiHandler extends BaseHandler {
+  constructor() {
+    super();
+  }
+
+  /**
+   * 获取配置
+   * GET /api/config
+   */
+  async getConfig(c: Context<AppContext>): Promise<Response> {
+    const logger = c.get("logger");
+    try {
+      logger.debug("处理获取配置请求");
+      const config = configManager.getConfig();
+      logger.debug("获取配置成功");
+      return c.success(config);
+    } catch (error) {
+      logger.error("获取配置失败:", error);
+      return c.fail(
+        "CONFIG_READ_ERROR",
+        error instanceof Error ? error.message : "获取配置失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 更新配置
+   * PUT /api/config
+   */
+  async updateConfig(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理更新配置请求");
+      const newConfig: AppConfig = await c.req.json();
+
+      // 使用 configManager 的验证方法
+      configManager.validateConfig(newConfig);
+
+      // 使用 configManager 的批量更新方法
+      configManager.updateConfig(newConfig);
+
+      // 更新服务工具配置（单独处理，因为 updateConfig 只更新已存在的配置）
+      if (newConfig.mcpServerConfig) {
+        for (const [serverName, toolsConfig] of Object.entries(
+          newConfig.mcpServerConfig
+        )) {
+          for (const [toolName, toolConfig] of Object.entries(
+            toolsConfig.tools
+          )) {
+            configManager.setToolEnabled(
+              serverName,
+              toolName,
+              toolConfig.enable
+            );
+          }
+        }
+      }
+
+      c.get("logger").info("配置更新成功");
+      return c.success(undefined, "配置更新成功");
+    } catch (error) {
+      c.get("logger").error("配置更新失败:", error);
+      return c.fail(
+        "CONFIG_UPDATE_ERROR",
+        error instanceof Error ? error.message : "配置更新失败"
+      );
+    }
+  }
+
+  /**
+   * 获取 MCP 端点
+   * GET /api/config/mcp-endpoint
+   */
+  async getMcpEndpoint(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取 MCP 端点请求");
+      const endpoint = configManager.getMcpEndpoint();
+      c.get("logger").debug("获取 MCP 端点成功");
+      return c.success({ endpoint });
+    } catch (error) {
+      c.get("logger").error("获取 MCP 端点失败:", error);
+      return c.fail(
+        "MCP_ENDPOINT_READ_ERROR",
+        error instanceof Error ? error.message : "获取 MCP 端点失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取 MCP 端点列表
+   * GET /api/config/mcp-endpoints
+   */
+  async getMcpEndpoints(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取 MCP 端点列表请求");
+      const endpoints = configManager.getMcpEndpoints();
+      c.get("logger").debug("获取 MCP 端点列表成功");
+      return c.success({ endpoints });
+    } catch (error) {
+      c.get("logger").error("获取 MCP 端点列表失败:", error);
+      return c.fail(
+        "MCP_ENDPOINTS_READ_ERROR",
+        error instanceof Error ? error.message : "获取 MCP 端点列表失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取 MCP 服务配置
+   * GET /api/config/mcp-servers
+   */
+  async getMcpServers(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取 MCP 服务配置请求");
+      const servers = configManager.getMcpServers();
+      c.get("logger").debug("获取 MCP 服务配置成功");
+      return c.success({ servers });
+    } catch (error) {
+      c.get("logger").error("获取 MCP 服务配置失败:", error);
+      return c.fail(
+        "MCP_SERVERS_READ_ERROR",
+        error instanceof Error ? error.message : "获取 MCP 服务配置失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取连接配置
+   * GET /api/config/connection
+   */
+  async getConnectionConfig(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取连接配置请求");
+      const connection = configManager.getConnectionConfig();
+      c.get("logger").debug("获取连接配置成功");
+      return c.success({ connection });
+    } catch (error) {
+      c.get("logger").error("获取连接配置失败:", error);
+      return c.fail(
+        "CONNECTION_CONFIG_READ_ERROR",
+        error instanceof Error ? error.message : "获取连接配置失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 重新加载配置
+   * POST /api/config/reload
+   */
+  async reloadConfig(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理重新加载配置请求");
+      configManager.reloadConfig();
+      const config = configManager.getConfig();
+      c.get("logger").info("重新加载配置成功");
+      return c.success(config, "配置重新加载成功");
+    } catch (error) {
+      c.get("logger").error("重新加载配置失败:", error);
+      return c.fail(
+        "CONFIG_RELOAD_ERROR",
+        error instanceof Error ? error.message : "重新加载配置失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取配置文件路径
+   * GET /api/config/path
+   */
+  async getConfigPath(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取配置文件路径请求");
+      const path = configManager.getConfigPath();
+      c.get("logger").debug("获取配置文件路径成功");
+      return c.success({ path });
+    } catch (error) {
+      c.get("logger").error("获取配置文件路径失败:", error);
+      return c.fail(
+        "CONFIG_PATH_READ_ERROR",
+        error instanceof Error ? error.message : "获取配置文件路径失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 检查配置是否存在
+   * GET /api/config/exists
+   */
+  async checkConfigExists(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理检查配置是否存在请求");
+      const exists = configManager.configExists();
+      c.get("logger").debug(`配置存在检查结果: ${exists}`);
+      return c.success({ exists });
+    } catch (error) {
+      c.get("logger").error("检查配置是否存在失败:", error);
+      return c.fail(
+        "CONFIG_EXISTS_CHECK_ERROR",
+        error instanceof Error ? error.message : "检查配置是否存在失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取提示词文件列表
+   * GET /api/config/prompts
+   */
+  async getPromptFiles(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取提示词文件列表请求");
+      const prompts = listPromptFiles();
+      c.get("logger").debug(
+        `获取提示词文件列表成功，共 ${prompts.length} 个文件`
+      );
+      return c.success({ prompts });
+    } catch (error) {
+      c.get("logger").error("获取提示词文件列表失败:", error);
+      return c.fail(
+        "PROMPT_FILES_READ_ERROR",
+        error instanceof Error ? error.message : "获取提示词文件列表失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取提示词文件内容
+   * GET /api/config/prompts/content?path=./prompts/default.md
+   */
+  async getPromptFileContent(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取提示词文件内容请求");
+      const path = c.req.query("path");
+
+      if (!path) {
+        return c.fail("INVALID_REQUEST", "缺少 path 参数", undefined, 400);
+      }
+
+      const fileContent = readPromptFile(path);
+      c.get("logger").debug(`获取提示词文件内容成功: ${path}`);
+      return c.success(fileContent);
+    } catch (error) {
+      c.get("logger").error("获取提示词文件内容失败:", error);
+      return c.fail(
+        "PROMPT_FILE_READ_ERROR",
+        error instanceof Error ? error.message : "获取提示词文件内容失败",
+        undefined,
+        400
+      );
+    }
+  }
+
+  /**
+   * 更新提示词文件内容
+   * PUT /api/config/prompts/content
+   */
+  async updatePromptFileContent(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理更新提示词文件内容请求");
+      const body = await c.req.json();
+
+      // 验证请求体格式
+      if (!body || typeof body !== "object") {
+        return c.fail("INVALID_REQUEST", "请求体格式错误", undefined, 400);
+      }
+
+      const { path, content } = body;
+
+      // 验证 path 参数
+      if (!path || typeof path !== "string") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "path 参数必须是字符串",
+          undefined,
+          400
+        );
+      }
+
+      // 验证 content 参数
+      if (content === undefined || typeof content !== "string") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "content 参数必须是字符串",
+          undefined,
+          400
+        );
+      }
+
+      const fileContent = updatePromptFile(path, content);
+      c.get("logger").info(`更新提示词文件成功: ${path}`);
+      return c.success(fileContent, "提示词文件更新成功");
+    } catch (error) {
+      c.get("logger").error("更新提示词文件内容失败:", error);
+      return c.fail(
+        "PROMPT_FILE_UPDATE_ERROR",
+        error instanceof Error ? error.message : "更新提示词文件内容失败",
+        undefined,
+        400
+      );
+    }
+  }
+
+  /**
+   * 创建新的提示词文件
+   * POST /api/config/prompts/content
+   */
+  async createPromptFileContent(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理创建提示词文件请求");
+      const body = await c.req.json();
+
+      // 验证请求体格式
+      if (!body || typeof body !== "object") {
+        return c.fail("INVALID_REQUEST", "请求体格式错误", undefined, 400);
+      }
+
+      const { fileName, content } = body;
+
+      // 验证 fileName 参数
+      if (!fileName || typeof fileName !== "string") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "fileName 参数必须是字符串",
+          undefined,
+          400
+        );
+      }
+
+      // 验证 content 参数
+      if (content === undefined || typeof content !== "string") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "content 参数必须是字符串",
+          undefined,
+          400
+        );
+      }
+
+      const fileContent = createPromptFile(fileName, content);
+      c.get("logger").info(`创建提示词文件成功: ${fileName}`);
+      return c.success(fileContent, "提示词文件创建成功");
+    } catch (error) {
+      c.get("logger").error("创建提示词文件失败:", error);
+      return c.fail(
+        "PROMPT_FILE_CREATE_ERROR",
+        error instanceof Error ? error.message : "创建提示词文件失败",
+        undefined,
+        400
+      );
+    }
+  }
+
+  /**
+   * 删除提示词文件
+   * DELETE /api/config/prompts/content?path=./prompts/old-prompt.md
+   */
+  async deletePromptFileContent(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理删除提示词文件请求");
+      const path = c.req.query("path");
+
+      if (!path) {
+        return c.fail("INVALID_REQUEST", "缺少 path 参数", undefined, 400);
+      }
+
+      deletePromptFile(path);
+      c.get("logger").info(`删除提示词文件成功: ${path}`);
+      return c.success(undefined, "提示词文件删除成功");
+    } catch (error) {
+      c.get("logger").error("删除提示词文件失败:", error);
+      return c.fail(
+        "PROMPT_FILE_DELETE_ERROR",
+        error instanceof Error ? error.message : "删除提示词文件失败",
+        undefined,
+        400
+      );
+    }
+  }
+}

--- a/src/server/handlers/coze.handler.ts
+++ b/src/server/handlers/coze.handler.ts
@@ -1,0 +1,361 @@
+/**
+ * 扣子 API HTTP 路由处理器
+ * 提供扣子工作空间和工作流相关的 RESTful API 接口
+ */
+
+import type { Context } from "hono";
+import { configManager } from "../../config/index.js";
+import { CozeApiService } from "../lib/coze";
+import type { CozeWorkflowsParams } from "../types/coze";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 错误代码类型
+ */
+type CozeErrorCode =
+  | "AUTH_FAILED"
+  | "RATE_LIMITED"
+  | "TIMEOUT"
+  | "API_ERROR"
+  | "NETWORK_ERROR";
+
+/**
+ * 带 code 属性的错误接口
+ */
+interface ErrorWithCode {
+  code: CozeErrorCode;
+  message: string;
+  statusCode?: number;
+  response?: unknown;
+}
+
+/**
+ * 类型守卫函数：检查错误是否带有 code 属性
+ */
+function isErrorWithCode(error: unknown): error is ErrorWithCode {
+  if (!(error instanceof Error && "code" in error)) {
+    return false;
+  }
+
+  const code = (error as ErrorWithCode).code;
+  const validCodes: CozeErrorCode[] = [
+    "AUTH_FAILED",
+    "RATE_LIMITED",
+    "TIMEOUT",
+    "API_ERROR",
+    "NETWORK_ERROR",
+  ];
+
+  return typeof code === "string" && validCodes.includes(code as CozeErrorCode);
+}
+
+/**
+ * 获取扣子 API 服务实例
+ */
+function getCozeApiService(): CozeApiService {
+  const token = configManager.getCozeToken();
+
+  if (!token) {
+    throw new Error(
+      "扣子 API Token 未配置，请在配置文件中设置 platforms.coze.token"
+    );
+  }
+
+  return new CozeApiService(token);
+}
+
+/**
+ * 扣子 API 路由处理器类
+ */
+export class CozeHandler extends BaseHandler {
+  constructor() {
+    super();
+  }
+
+  /**
+   * 处理 Coze API 错误并返回标准化的响应
+   * @param c - Hono 上下文对象
+   * @param error - 捕获的错误对象
+   * @param operationName - 操作名称，用于日志和错误消息
+   * @returns 标准化的错误响应
+   */
+  private handleCozeApiError(
+    c: Context<AppContext>,
+    error: unknown,
+    operationName: string
+  ): Response {
+    c.get("logger").error(`${operationName}失败:`, error);
+
+    // 根据错误类型返回不同的响应
+    if (isErrorWithCode(error) && error.code === "AUTH_FAILED") {
+      return c.fail(
+        "AUTH_FAILED",
+        "扣子 API 认证失败，请检查 Token 配置",
+        undefined,
+        401
+      );
+    }
+
+    if (isErrorWithCode(error) && error.code === "RATE_LIMITED") {
+      return c.fail("RATE_LIMITED", "请求过于频繁，请稍后重试", undefined, 429);
+    }
+
+    if (isErrorWithCode(error) && error.code === "TIMEOUT") {
+      return c.fail("TIMEOUT", "请求超时，请稍后重试", undefined, 408);
+    }
+
+    const details =
+      process.env.NODE_ENV === "development" && error instanceof Error
+        ? error.stack
+        : undefined;
+
+    return c.fail(
+      "INTERNAL_ERROR",
+      error instanceof Error ? error.message : `${operationName}失败`,
+      details,
+      500
+    );
+  }
+
+  /**
+   * 获取工作空间列表
+   * GET /api/coze/workspaces
+   */
+  async getWorkspaces(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理获取工作空间列表请求");
+
+      // 检查扣子配置
+      if (!configManager.isCozeConfigValid()) {
+        c.get("logger").debug("扣子配置无效");
+        return c.fail(
+          "CONFIG_INVALID",
+          "扣子配置无效，请检查 platforms.coze.token 配置",
+          undefined,
+          400
+        );
+      }
+
+      const cozeApiService = getCozeApiService();
+
+      c.get("logger").info("调用 Coze API 获取工作空间列表");
+      const workspaces = await cozeApiService.getWorkspaces();
+      c.get("logger").info(`成功获取 ${workspaces.length} 个工作空间`);
+
+      return c.success({ workspaces });
+    } catch (error) {
+      return this.handleCozeApiError(c, error, "获取工作空间列表");
+    }
+  }
+
+  /**
+   * 获取工作流列表
+   * GET /api/coze/workflows?workspace_id=xxx&page_num=1&page_size=20
+   */
+  async getWorkflows(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理获取工作流列表请求");
+
+      // 检查扣子配置
+      if (!configManager.isCozeConfigValid()) {
+        c.get("logger").debug("扣子配置无效");
+        return c.fail(
+          "CONFIG_INVALID",
+          "扣子配置无效，请检查 platforms.coze.token 配置",
+          undefined,
+          400
+        );
+      }
+
+      // 解析查询参数
+      const workspace_id = c.req.query("workspace_id");
+      const page_num = Number.parseInt(c.req.query("page_num") || "1", 10);
+      const page_size = Number.parseInt(c.req.query("page_size") || "20", 10);
+
+      // 验证必需参数
+      if (!workspace_id) {
+        c.get("logger").warn("缺少 workspace_id 参数");
+        return c.fail(
+          "MISSING_PARAMETER",
+          "缺少必需参数: workspace_id",
+          undefined,
+          400
+        );
+      }
+
+      // 验证分页参数
+      if (page_num < 1 || page_num > 1000) {
+        return c.fail(
+          "INVALID_PARAMETER",
+          "page_num 必须在 1-1000 之间",
+          undefined,
+          400
+        );
+      }
+
+      if (page_size < 1 || page_size > 100) {
+        return c.fail(
+          "INVALID_PARAMETER",
+          "page_size 必须在 1-100 之间",
+          undefined,
+          400
+        );
+      }
+
+      const params: CozeWorkflowsParams = {
+        workspace_id,
+        page_num,
+        page_size,
+      };
+
+      const cozeApiService = getCozeApiService();
+
+      c.get("logger").info(
+        `开始获取工作空间 ${workspace_id} 的工作流列表，页码: ${page_num}，每页: ${page_size}`
+      );
+      const result = await cozeApiService.getWorkflows(params);
+      c.get("logger").info(
+        `成功获取工作空间 ${workspace_id} 的 ${result.items.length} 个工作流`
+      );
+
+      // 获取已添加的自定义工具列表，检查工作流是否已被添加为工具
+      const customMCPTools = configManager.getCustomMCPTools();
+
+      // 为每个工作流添加工具状态信息
+      const enhancedItems = result.items.map((item) => {
+        // 查找对应的自定义工具
+        const addedTool = customMCPTools.find(
+          (tool) =>
+            tool.handler.type === "proxy" &&
+            tool.handler.platform === "coze" &&
+            tool.handler.config.workflow_id === item.workflow_id
+        );
+
+        return {
+          ...item,
+          isAddedAsTool: !!addedTool,
+          toolName: addedTool?.name || null,
+        };
+      });
+
+      c.get("logger").info(
+        `工作流工具状态检查完成，共 ${enhancedItems.filter((item) => item.isAddedAsTool).length} 个工作流已添加为工具`
+      );
+
+      return c.success(
+        {
+          items: enhancedItems,
+          has_more: result.has_more,
+          page_num,
+          page_size,
+          total_count: result.items.length, // 当前页的数量
+        },
+        `成功获取 ${enhancedItems.length} 个工作流`
+      );
+    } catch (error) {
+      return this.handleCozeApiError(c, error, "获取工作流列表");
+    }
+  }
+
+  /**
+   * 清除扣子 API 缓存
+   * POST /api/coze/cache/clear
+   */
+  async clearCache(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理清除扣子 API 缓存请求");
+
+      // 检查扣子配置
+      if (!configManager.isCozeConfigValid()) {
+        c.get("logger").debug("扣子配置无效");
+        return c.fail(
+          "CONFIG_INVALID",
+          "扣子配置无效，请检查 platforms.coze.token 配置",
+          undefined,
+          400
+        );
+      }
+
+      const pattern = c.req.query("pattern"); // 可选的缓存模式参数
+
+      const cozeApiService = getCozeApiService();
+
+      const statsBefore = cozeApiService.getCacheStats();
+      c.get("logger").info(
+        `开始清除缓存${pattern ? ` (模式: ${pattern})` : ""}`
+      );
+
+      cozeApiService.clearCache(pattern);
+
+      const statsAfter = cozeApiService.getCacheStats();
+
+      c.get("logger").info(
+        `缓存清除完成，清除前: ${statsBefore.size} 项，清除后: ${statsAfter.size} 项`
+      );
+
+      return c.success(
+        {
+          cleared: statsBefore.size - statsAfter.size,
+          remaining: statsAfter.size,
+          pattern: pattern || "all",
+        },
+        "缓存清除成功"
+      );
+    } catch (error) {
+      c.get("logger").error("清除缓存失败:", error);
+
+      const details =
+        process.env.NODE_ENV === "development" && error instanceof Error
+          ? error.stack
+          : undefined;
+
+      return c.fail(
+        "INTERNAL_ERROR",
+        error instanceof Error ? error.message : "清除缓存失败",
+        details,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取缓存统计信息
+   * GET /api/coze/cache/stats
+   */
+  async getCacheStats(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理获取缓存统计信息请求");
+
+      // 检查扣子配置
+      if (!configManager.isCozeConfigValid()) {
+        c.get("logger").debug("扣子配置无效");
+        return c.fail(
+          "CONFIG_INVALID",
+          "扣子配置无效，请检查 platforms.coze.token 配置",
+          undefined,
+          400
+        );
+      }
+
+      const cozeApiService = getCozeApiService();
+      const stats = cozeApiService.getCacheStats();
+
+      return c.success(stats);
+    } catch (error) {
+      c.get("logger").error("获取缓存统计信息失败:", error);
+
+      const details =
+        process.env.NODE_ENV === "development" && error instanceof Error
+          ? error.stack
+          : undefined;
+
+      return c.fail(
+        "INTERNAL_ERROR",
+        error instanceof Error ? error.message : "获取缓存统计信息失败",
+        details,
+        500
+      );
+    }
+  }
+}

--- a/src/server/handlers/endpoint.handler.ts
+++ b/src/server/handlers/endpoint.handler.ts
@@ -1,0 +1,484 @@
+import type { Context } from "hono";
+import type { ConfigManager } from "../../config/index.js";
+import type {
+  ConnectionStatus,
+  EndpointManager,
+} from "../../endpoint/index.js";
+/**
+ * 接入点管理 Handler
+ *
+ * 负责处理接入点相关的 HTTP 请求，包括：
+ * - 接入点连接状态查询
+ * - 接入点连接和断开
+ * - 接入点状态管理
+ * - 接入点重连
+ * - 接入点验证
+ *
+ * @see ../../../endpoint/index.js - EndpointManager 实现
+ */
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import type { EventBus } from "../services/event-bus.service.js";
+import { getEventBus } from "../services/event-bus.service.js";
+import type { AppContext } from "../types/hono.context.js";
+
+/**
+ * 验证结果类型定义
+ */
+interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+/**
+ * 端点 API 处理器
+ * 支持通过 HTTP API 动态管理端点（添加、删除、连接、断开、查询状态）
+ * 端点变更会自动同步到配置文件，确保重启后状态保持一致
+ */
+export class EndpointHandler {
+  private logger: Logger;
+  private endpointManager: EndpointManager;
+  private configManager: ConfigManager;
+  private eventBus: EventBus;
+
+  constructor(endpointManager: EndpointManager, configManager: ConfigManager) {
+    this.logger = logger;
+    this.endpointManager = endpointManager;
+    this.configManager = configManager;
+    this.eventBus = getEventBus();
+  }
+
+  /**
+   * 从请求体中解析端点参数
+   * @param c Hono 上下文
+   * @param errorErrorCode 错误码，用于区分不同操作的错误
+   * @returns 解析结果，成功时包含 endpoint，失败时包含可直接返回的 Response
+   */
+  private async parseEndpointFromBody(
+    c: Context<AppContext>,
+    errorErrorCode: string
+  ): Promise<
+    { ok: true; endpoint: string } | { ok: false; response: Response }
+  > {
+    let body: { endpoint: string };
+    try {
+      body = await c.req.json();
+    } catch (error) {
+      this.logger.error("JSON解析失败:", error);
+      return {
+        ok: false,
+        response: c.fail(
+          errorErrorCode,
+          "JSON解析失败",
+          error instanceof Error ? error.message : undefined,
+          500
+        ),
+      };
+    }
+
+    const endpoint = body.endpoint;
+
+    // 验证端点参数
+    if (!endpoint || typeof endpoint !== "string") {
+      return {
+        ok: false,
+        response: c.fail("INVALID_ENDPOINT", "端点参数无效", undefined, 500),
+      };
+    }
+
+    return { ok: true, endpoint };
+  }
+
+  /**
+   * 验证端点 URL 格式
+   * @param endpoint 端点 URL
+   * @returns 验证结果
+   */
+  private validateEndpoint(endpoint: string): ValidationResult {
+    const errors: string[] = [];
+
+    if (!endpoint || typeof endpoint !== "string") {
+      errors.push("端点必须是非空字符串");
+      return { isValid: false, errors };
+    }
+
+    try {
+      new URL(endpoint);
+    } catch {
+      errors.push("端点 URL 格式无效");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  /**
+   * 获取接入点状态
+   * POST /api/endpoint/status
+   */
+  async getEndpointStatus(c: Context<AppContext>): Promise<Response> {
+    const parseResult = await this.parseEndpointFromBody(
+      c,
+      "ENDPOINT_STATUS_READ_ERROR"
+    );
+    if (!parseResult.ok) {
+      return parseResult.response;
+    }
+
+    const endpoint = parseResult.endpoint;
+    this.logger.debug(`处理获取接入点状态请求: ${endpoint}`);
+    try {
+      // 获取连接状态
+      const connectionStatus = this.endpointManager.getConnectionStatus();
+      const endpointStatus = connectionStatus.find(
+        (status: ConnectionStatus) => status.endpoint === endpoint
+      );
+
+      if (!endpointStatus) {
+        return c.fail("ENDPOINT_NOT_FOUND", "端点不存在", undefined, 500);
+      }
+
+      this.logger.debug(`获取接入点状态成功: ${endpoint}`);
+      return c.success(endpointStatus);
+    } catch (error) {
+      this.logger.error("获取接入点状态失败:", error);
+      return c.fail(
+        "ENDPOINT_STATUS_READ_ERROR",
+        error instanceof Error ? error.message : "获取接入点状态失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 连接指定接入点
+   * POST /api/endpoint/connect
+   */
+  async connectEndpoint(c: Context<AppContext>): Promise<Response> {
+    const parseResult = await this.parseEndpointFromBody(
+      c,
+      "ENDPOINT_CONNECT_ERROR"
+    );
+    if (!parseResult.ok) {
+      return parseResult.response;
+    }
+
+    const endpoint = parseResult.endpoint;
+    this.logger.info(`处理接入点连接请求: ${endpoint}`);
+    try {
+      // 获取端点实例
+      const endpointInstance = this.endpointManager.getEndpoint(endpoint);
+
+      if (!endpointInstance) {
+        return c.fail(
+          "ENDPOINT_NOT_FOUND",
+          "端点不存在，请先添加接入点",
+          undefined,
+          500
+        );
+      }
+
+      // 执行连接操作
+      await this.endpointManager.connect(endpoint);
+
+      // 获取连接后的状态
+      const updatedConnectionStatus =
+        this.endpointManager.getConnectionStatus();
+      const endpointStatus = updatedConnectionStatus.find(
+        (status: ConnectionStatus) => status.endpoint === endpoint
+      );
+
+      if (!endpointStatus) {
+        return c.fail(
+          "ENDPOINT_STATUS_NOT_FOUND",
+          "无法获取端点连接状态",
+          undefined,
+          500
+        );
+      }
+
+      // 发送连接成功事件
+      this.eventBus.emitEvent("endpoint:status:changed", {
+        endpoint,
+        connected: true,
+        operation: "connect",
+        success: true,
+        message: "接入点连接成功",
+        timestamp: Date.now(),
+        source: "http-api",
+      });
+
+      this.logger.info(`接入点连接成功: ${endpoint}`);
+      return c.success(endpointStatus);
+    } catch (error) {
+      this.logger.error("接入点连接失败:", error);
+      return c.fail(
+        "ENDPOINT_CONNECT_ERROR",
+        error instanceof Error ? error.message : "接入点连接失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 断开指定接入点
+   * POST /api/endpoint/disconnect
+   */
+  async disconnectEndpoint(c: Context<AppContext>): Promise<Response> {
+    const parseResult = await this.parseEndpointFromBody(
+      c,
+      "ENDPOINT_DISCONNECT_ERROR"
+    );
+    if (!parseResult.ok) {
+      return parseResult.response;
+    }
+
+    const endpoint = parseResult.endpoint;
+    this.logger.info(`处理接入点断开请求: ${endpoint}`);
+    try {
+      // 获取端点实例
+      const endpointInstance = this.endpointManager.getEndpoint(endpoint);
+
+      if (!endpointInstance) {
+        return c.fail("ENDPOINT_NOT_FOUND", "端点不存在", undefined, 500);
+      }
+
+      // 执行断开操作
+      await this.endpointManager.disconnect(endpoint);
+
+      // 获取断开后的状态
+      const updatedConnectionStatus =
+        this.endpointManager.getConnectionStatus();
+      const endpointStatus = updatedConnectionStatus.find(
+        (status: ConnectionStatus) => status.endpoint === endpoint
+      );
+
+      // 发送断开成功事件
+      this.eventBus.emitEvent("endpoint:status:changed", {
+        endpoint,
+        connected: false,
+        operation: "disconnect",
+        success: true,
+        message: "接入点断开成功",
+        timestamp: Date.now(),
+        source: "http-api",
+      });
+
+      this.logger.info(`接入点断开成功: ${endpoint}`);
+      const fallbackStatus: ConnectionStatus = {
+        endpoint,
+        connected: false,
+        initialized: true,
+      };
+      return c.success(endpointStatus || fallbackStatus);
+    } catch (error) {
+      this.logger.error("接入点断开失败:", error);
+      return c.fail(
+        "ENDPOINT_DISCONNECT_ERROR",
+        error instanceof Error ? error.message : "接入点断开失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 添加新接入点
+   * POST /api/endpoint/add
+   * 流程：验证 URL → 检查存在性 → 创建实例 → 添加到管理器 → 连接 → 更新配置
+   */
+  async addEndpoint(c: Context<AppContext>): Promise<Response> {
+    const parseResult = await this.parseEndpointFromBody(
+      c,
+      "ENDPOINT_ADD_ERROR"
+    );
+    if (!parseResult.ok) {
+      return parseResult.response;
+    }
+
+    const endpoint = parseResult.endpoint;
+    this.logger.info(`处理接入点添加请求: ${endpoint}`);
+
+    try {
+      // 1. 验证端点 URL 格式
+      const validation = this.validateEndpoint(endpoint);
+      if (!validation.isValid) {
+        return c.fail(
+          "INVALID_ENDPOINT_FORMAT",
+          validation.errors.join(", "),
+          undefined,
+          500
+        );
+      }
+
+      // 2. 检查端点是否已存在
+      const existingEndpoint = this.endpointManager.getEndpoint(endpoint);
+      if (existingEndpoint) {
+        return c.fail("ENDPOINT_ALREADY_EXISTS", "端点已存在", undefined, 500);
+      }
+
+      // 3. 添加端点到管理器（使用 URL 字符串）
+      this.endpointManager.addEndpoint(endpoint);
+      this.logger.debug(`端点已添加到管理器: ${endpoint}`);
+
+      // 4. 获取新添加的端点实例
+      const newEndpoint = this.endpointManager.getEndpoint(endpoint);
+      if (!newEndpoint) {
+        return c.fail(
+          "ENDPOINT_NOT_FOUND_AFTER_ADD",
+          "端点添加后未找到",
+          undefined,
+          500
+        );
+      }
+
+      // 5. 连接新端点
+      try {
+        await this.endpointManager.connect(endpoint);
+        this.logger.debug(`端点已连接: ${endpoint}`);
+      } catch (connectError) {
+        this.logger.warn(
+          `端点连接失败，但已添加到管理器: ${endpoint}`,
+          connectError
+        );
+        // 连接失败不中断流程，端点已添加但未连接
+      }
+
+      // 6. 更新配置文件
+      try {
+        this.configManager.addMcpEndpoint(endpoint);
+        this.logger.debug(`端点已添加到配置文件: ${endpoint}`);
+      } catch (configError) {
+        this.logger.error(`添加端点到配置文件失败: ${endpoint}`, configError);
+        // 配置更新失败，需要回滚：优先尝试断开连接，其次从管理器移除端点
+        try {
+          await newEndpoint.disconnect();
+          this.logger.debug(`回滚时已断开端点连接: ${endpoint}`);
+        } catch (disconnectError) {
+          // 断开失败只记录警告，不影响后续回滚流程
+          this.logger.warn(
+            `回滚时断开端点连接失败，将继续从管理器移除端点: ${endpoint}`,
+            disconnectError
+          );
+        }
+        // 从管理器移除端点
+        await this.endpointManager.removeEndpoint(newEndpoint);
+        throw configError;
+      }
+
+      // 8. 获取连接后的状态
+      const connectionStatus = this.endpointManager.getConnectionStatus();
+      const endpointStatus = connectionStatus.find(
+        (status: ConnectionStatus) => status.endpoint === endpoint
+      );
+
+      // 9. 发送事件通知
+      this.eventBus.emitEvent("endpoint:status:changed", {
+        endpoint,
+        connected: endpointStatus?.connected ?? false,
+        operation: "add",
+        success: true,
+        message: "接入点添加成功",
+        timestamp: Date.now(),
+        source: "http-api",
+      });
+
+      this.logger.info(`接入点添加成功: ${endpoint}`);
+
+      const defaultEndpointStatus = {
+        endpoint,
+        connected: false,
+        initialized: true,
+      };
+      return c.success(
+        endpointStatus || defaultEndpointStatus,
+        "接入点添加成功"
+      );
+    } catch (error) {
+      this.logger.error("添加接入点失败:", error);
+      return c.fail(
+        "ENDPOINT_ADD_ERROR",
+        error instanceof Error ? error.message : "添加接入点失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 移除接入点
+   * POST /api/endpoint/remove
+   * 流程：断开连接 → 从管理器移除 → 更新配置文件
+   */
+  async removeEndpoint(c: Context<AppContext>): Promise<Response> {
+    const parseResult = await this.parseEndpointFromBody(
+      c,
+      "ENDPOINT_REMOVE_ERROR"
+    );
+    if (!parseResult.ok) {
+      return parseResult.response;
+    }
+
+    const endpoint = parseResult.endpoint;
+    this.logger.info(`处理接入点移除请求: ${endpoint}`);
+
+    try {
+      // 检查端点是否存在
+      const endpointInstance = this.endpointManager.getEndpoint(endpoint);
+      if (!endpointInstance) {
+        return c.fail("ENDPOINT_NOT_FOUND", "端点不存在", undefined, 500);
+      }
+
+      // 记录断开前的连接状态
+      const wasConnected = endpointInstance.isConnected();
+
+      // 先从配置文件移除端点，确保配置与运行时状态保持一致
+      try {
+        this.configManager.removeMcpEndpoint(endpoint);
+        this.logger.debug(`端点已从配置文件中移除: ${endpoint}`);
+      } catch (error) {
+        this.logger.error(`从配置文件移除端点失败: ${endpoint}`, error);
+        // 配置更新失败是致命错误，中断移除操作
+        throw error;
+      }
+
+      // 再从管理器移除端点
+      // EndpointManager.removeEndpoint 内部会再次调用 disconnect（幂等操作）
+      // 并清理状态和发射 endpointRemoved 事件
+      await this.endpointManager.removeEndpoint(endpointInstance);
+      this.logger.debug(`端点已从管理器中移除: ${endpoint}`);
+
+      // 发送事件通知
+      this.eventBus.emitEvent("endpoint:status:changed", {
+        endpoint,
+        connected: false,
+        operation: "remove",
+        success: true,
+        message: "接入点移除成功",
+        timestamp: Date.now(),
+        source: "http-api",
+      });
+
+      this.logger.info(`接入点移除成功: ${endpoint}`);
+
+      return c.success(
+        {
+          endpoint,
+          operation: "removed",
+          wasConnected,
+        },
+        "接入点移除成功"
+      );
+    } catch (error) {
+      this.logger.error("移除接入点失败:", error);
+
+      return c.fail(
+        "ENDPOINT_REMOVE_ERROR",
+        error instanceof Error ? error.message : "移除接入点失败",
+        undefined,
+        500
+      );
+    }
+  }
+}

--- a/src/server/handlers/esp32.handler.ts
+++ b/src/server/handlers/esp32.handler.ts
@@ -1,0 +1,113 @@
+/**
+ * ESP32 设备处理器
+ * 处理 ESP32 设备相关的 HTTP 请求
+ *
+ * 作为薄适配层，将 Hono 请求委托给 ESP32DeviceManager 处理
+ */
+
+import type { Context } from "hono";
+import type {
+  ESP32DeviceManager,
+  ESP32DeviceReport,
+} from "../../esp32/index.js";
+import { ESP32ErrorCode } from "../../esp32/index.js";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * ESP32 设备处理器
+ * 仅处理硬件 OTA/配置请求
+ *
+ * 注意：设备采用自动激活模式，无需管理 API
+ */
+export class ESP32Handler extends BaseHandler {
+  private esp32Manager: ESP32DeviceManager;
+
+  constructor(esp32Manager: ESP32DeviceManager) {
+    super();
+    this.esp32Manager = esp32Manager;
+  }
+
+  /**
+   * 处理OTA/配置请求
+   * POST /
+   *
+   * 硬件API定义：根路径OTA接口
+   *
+   * 请求头：
+   * - Device-Id: 设备MAC地址
+   * - Client-Id: 设备UUID
+   *
+   * 请求体：
+   * ```json
+   * {
+   *   "application": {
+   *     "version": "1.0.0",
+   *     "board": {
+   *       "type": "ESP32-S3-BOX"
+   *     }
+   *   }
+   * }
+   * ```
+   */
+  async handleOTA(c: Context<AppContext>): Promise<Response> {
+    const logger = c.get("logger");
+
+    try {
+      // 获取设备ID和客户端ID
+      const deviceId = c.req.header("Device-Id") || c.req.header("device-id");
+      const clientId = c.req.header("Client-Id") || c.req.header("client-id");
+
+      if (!deviceId) {
+        return c.fail(
+          ESP32ErrorCode.MISSING_DEVICE_ID,
+          "缺少 Device-Id 请求头",
+          undefined,
+          400
+        );
+      }
+
+      // Client-Id 强制要求
+      if (!clientId) {
+        return c.fail(
+          ESP32ErrorCode.MISSING_DEVICE_ID,
+          "缺少 Client-Id 请求头",
+          undefined,
+          400
+        );
+      }
+
+      // 解析请求体
+      const report: ESP32DeviceReport = await this.parseJsonBody(
+        c,
+        "请求体格式错误"
+      );
+
+      logger.debug(`收到OTA请求: deviceId=${deviceId}, clientId=${clientId}`);
+
+      // 委托给设备管理器处理（支持从请求头获取设备型号，与 xiaozhi-esp32-server 保持一致）
+      const response = await this.esp32Manager.handleOTARequest(
+        deviceId,
+        clientId,
+        report,
+        // 可选：从请求头获取设备信息（优先级高于 body）
+        {
+          deviceModel:
+            c.req.header("device-model") ||
+            c.req.header("Device-Model") ||
+            undefined,
+          deviceVersion:
+            c.req.header("device-version") ||
+            c.req.header("Device-Version") ||
+            undefined,
+        },
+        c.req.header("host") // 传递 Host 头用于构建完整 WebSocket URL
+      );
+
+      logger.debug("OTA响应", { response });
+      return c.json(response);
+    } catch (error) {
+      return this.handleError(c, error, "处理OTA请求");
+    }
+  }
+}

--- a/src/server/handlers/index.ts
+++ b/src/server/handlers/index.ts
@@ -1,0 +1,45 @@
+/**
+ * HTTP 请求处理器模块
+ *
+ * 提供 Web API 的各种请求处理器，包括：
+ * - ConfigApiHandler: 配置管理 API（获取、更新配置等）
+ * - CozeHandler: 扣子（Coze）平台集成处理器
+ * - EndpointHandler: MCP 端点管理处理器
+ * - MCPRouteHandler: MCP 协议路由处理器（符合 Streamable HTTP 规范）
+ * - MCPHandler: MCP 服务管理处理器
+ * - ServiceApiHandler: 服务控制处理器（启动、停止、重启服务等）
+ * - StaticFileHandler: 静态文件服务处理器
+ * - StatusApiHandler: 状态查询处理器
+ * - MCPToolHandler: MCP 工具调用处理器
+ * - MCPToolLogHandler: MCP 工具调用日志处理器
+ * - TTSApiHandler: TTS 语音合成处理器
+ * - UpdateApiHandler: 更新管理处理器
+ * - VersionApiHandler: 版本信息处理器
+ *
+ * @example
+ * ```typescript
+ * import { ConfigApiHandler, MCPRouteHandler, StatusApiHandler } from '../handlers';
+ *
+ * // 使用配置处理器
+ * const configHandler = new ConfigApiHandler();
+ * const response = await configHandler.getConfig(context);
+ *
+ * // 使用 MCP 路由处理器
+ * const mcpHandler = new MCPRouteHandler({ maxMessageSize: 1024 * 1024 });
+ * const mcpResponse = await mcpHandler.handlePost(context);
+ * ```
+ */
+export * from "./config.handler.js";
+export { CozeHandler } from "./coze.handler.js";
+export { EndpointHandler } from "./endpoint.handler.js";
+export * from "./mcp.handler.js";
+export { MCPHandler } from "./mcp-manage.handler.js";
+export * from "./service.handler.js";
+export { StaticFileHandler } from "./static-file.handler.js";
+export * from "./status.handler.js";
+export * from "./mcp-tool.handler.js";
+export * from "./mcp-tool-log.handler.js";
+export * from "./update.handler.js";
+export * from "./version.handler.js";
+export { TTSApiHandler } from "./tts.handler.js";
+export { ESP32Handler } from "./esp32.handler.js";

--- a/src/server/handlers/mcp-manage.handler.ts
+++ b/src/server/handlers/mcp-manage.handler.ts
@@ -1,0 +1,1112 @@
+/**
+ * MCP 服务管理 API 处理器
+ *
+ * 负责处理 MCP 服务的动态管理操作，包括：
+ * - 服务的添加和删除（若需更新服务配置，请先删除后重新添加）
+ * - 服务的停止和资源清理
+ * - 服务状态查询
+ * - 服务工具信息查询
+ * - 配置验证和持久化
+ *
+ * 该处理器通过 MCPServiceManager 管理多个 MCP 服务实例，
+ * 并通过 EventBus 发布（发射）服务状态变化事件。
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Context } from "hono";
+import type { ConfigManager, MCPServerConfig } from "../../config/index.js";
+import { normalizeServiceConfig } from "../../config/index.js";
+import { TypeFieldNormalizer } from "../../mcp-core/index.js";
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import { ErrorCategory, MCPError, MCPErrorCode } from "../errors/mcp-errors.js";
+import type { MCPServiceManager } from "../lib/mcp";
+import type { MCPService } from "../lib/mcp";
+import { getEventBus } from "../services/event-bus.service.js";
+import type { AppContext } from "../types/hono.context.js";
+
+/**
+ * MCPServiceManager 扩展接口，用于访问私有属性
+ * 这个接口定义了我们需要访问但实际上是私有的属性
+ */
+interface MCPServiceManagerAccess {
+  services: Map<string, MCPService>;
+}
+
+/**
+ * 配置详情接口，包含时间戳
+ */
+interface ConfigDetails {
+  serverName?: string;
+  config?: MCPServerConfig;
+  tools?: string[];
+  timestamp?: string;
+  [key: string]: unknown; // 允许额外的属性
+}
+
+/**
+ * MCP 服务添加请求接口（单服务格式）
+ */
+export interface MCPServerAddRequest {
+  name: string;
+  config: MCPServerConfig;
+}
+
+/**
+ * MCP 服务批量添加请求接口（mcpServers 格式）
+ */
+export interface MCPServerBatchAddRequest {
+  mcpServers: Record<string, MCPServerConfig>;
+}
+
+/**
+ * MCP 服务添加操作结果
+ */
+export interface MCPServerAddResult {
+  name: string;
+  success: boolean;
+  error?: string;
+  config?: MCPServerConfig;
+  tools?: string[];
+  status?: string;
+}
+
+/**
+ * MCP 服务批量添加响应
+ */
+export interface MCPServerBatchAddResponse {
+  success: boolean;
+  message: string;
+  results: MCPServerAddResult[];
+  addedCount: number;
+  failedCount: number;
+}
+
+/**
+ * MCP 服务状态接口
+ */
+export interface MCPServerStatus {
+  name: string;
+  status: "connected" | "disconnected" | "connecting" | "error";
+  connected: boolean;
+  tools: string[];
+  lastUpdated?: string;
+  config: MCPServerConfig;
+}
+
+/**
+ * MCP 服务列表响应接口
+ */
+export interface MCPServerListResponse {
+  servers: MCPServerStatus[];
+  total: number;
+}
+
+/**
+ * 统一响应格式接口
+ * 从 types/api.response 导入，保持类型一致性
+ */
+export type {
+  ApiErrorResponse,
+  ApiSuccessResponse,
+} from "../types/api.response.js";
+
+/**
+ * 配置验证结果接口
+ */
+export interface ValidationResult {
+  isValid: boolean;
+  errors: string[];
+}
+
+/**
+ * MCP 服务 API 处理器
+ */
+export class MCPHandler {
+  protected logger: Logger;
+  private mcpServiceManager: MCPServiceManager;
+  private configManager: ConfigManager;
+  private statusCache: Map<string, MCPServerStatus>;
+
+  constructor(
+    mcpServiceManager: MCPServiceManager,
+    configManager: ConfigManager
+  ) {
+    this.logger = logger;
+    this.mcpServiceManager = mcpServiceManager;
+    this.configManager = configManager;
+    this.statusCache = new Map();
+  }
+
+  /**
+   * 处理错误并返回MCPError
+   */
+  protected handleError(
+    error: unknown,
+    operation: string,
+    context?: Record<string, unknown>
+  ): MCPError {
+    if (error instanceof MCPError) {
+      this.logger.error("MCPError", { error, operation, context });
+      return error;
+    }
+
+    if (error instanceof Error) {
+      let mcpError: MCPError;
+
+      // 根据错误消息和操作类型确定错误类型
+      if (
+        error.message.includes("服务不存在") ||
+        error.message.includes("not found")
+      ) {
+        mcpError = MCPError.configError(
+          MCPErrorCode.SERVER_NOT_FOUND,
+          error.message,
+          { operation, context }
+        );
+      } else if (
+        error.message.includes("已存在") ||
+        error.message.includes("already exists")
+      ) {
+        mcpError = MCPError.configError(
+          MCPErrorCode.SERVER_ALREADY_EXISTS,
+          error.message,
+          { operation, context }
+        );
+      } else if (
+        error.message.includes("配置") ||
+        error.message.includes("config")
+      ) {
+        mcpError = MCPError.configError(
+          MCPErrorCode.INVALID_CONFIG,
+          error.message,
+          { operation, context }
+        );
+      } else if (
+        error.message.includes("连接") ||
+        error.message.includes("connection")
+      ) {
+        mcpError = MCPError.connectionError(
+          MCPErrorCode.CONNECTION_FAILED,
+          error.message,
+          { operation, context }
+        );
+      } else {
+        mcpError = MCPError.systemError(
+          MCPErrorCode.INTERNAL_ERROR,
+          error.message,
+          { operation, context, stack: error.stack }
+        );
+      }
+
+      this.logger.error("MCPError", { error: mcpError, operation, context });
+      return mcpError;
+    }
+
+    // 处理未知错误类型
+    const mcpError = MCPError.systemError(
+      MCPErrorCode.INTERNAL_ERROR,
+      String(error),
+      { operation, context }
+    );
+    this.logger.error("MCPError", { error: mcpError, operation, context });
+    return mcpError;
+  }
+
+  /**
+   * 添加 MCP 服务
+   * POST /api/mcp-servers
+   * 支持两种格式：
+   * 1. 单服务格式：{ name: string, config: MCPServerConfig }
+   * 2. 批量格式：{ mcpServers: Record<string, MCPServerConfig> }
+   */
+  async addMCPServer(c: Context<AppContext>): Promise<Response> {
+    const startTime = Date.now();
+    const requestData = await c.req.json();
+
+    this.logger.info("addMCPServer", {
+      requestData,
+      method: "POST",
+      path: "/api/mcp-servers",
+    });
+
+    try {
+      // 检测请求格式
+      if ("mcpServers" in requestData) {
+        // 批量格式
+        const batchRequest = requestData as MCPServerBatchAddRequest;
+        const result = await this.addMCPServersBatch(batchRequest);
+
+        const duration = Date.now() - startTime;
+        this.logger.info("addMCPServer", {
+          batch: true,
+          addedCount: result.addedCount,
+          failedCount: result.failedCount,
+          duration,
+        });
+
+        return c.success(result, result.message, 201);
+      }
+      // 单服务格式
+      const singleRequest = requestData as MCPServerAddRequest;
+      const { name, config } = singleRequest;
+
+      const result = await this.addMCPServerSingle(name, config);
+
+      const duration = Date.now() - startTime;
+      this.logger.info("addMCPServer", {
+        serverName: name,
+        toolsCount: result.tools?.length || 0,
+        duration,
+        status: result.status,
+      });
+
+      return c.success(result, "MCP 服务添加成功", 201);
+    } catch (error) {
+      const mcpError = this.handleError(error, "addMCPServer", {
+        requestData,
+      });
+
+      // 根据错误类型确定HTTP状态码
+      let statusCode = 500;
+      if (mcpError.category === ErrorCategory.VALIDATION) {
+        statusCode = 400;
+      } else if (mcpError.category === ErrorCategory.CONFIGURATION) {
+        if (mcpError.code === MCPErrorCode.SERVER_ALREADY_EXISTS) {
+          statusCode = 409;
+        } else {
+          statusCode = 400;
+        }
+      } else if (mcpError.category === ErrorCategory.CONNECTION) {
+        statusCode = 500; // 测试期望连接失败返回500而不是503
+      }
+
+      return c.fail(
+        mcpError.code,
+        mcpError.message,
+        { error: mcpError.details },
+        statusCode
+      );
+    }
+  }
+
+  /**
+   * 处理单个 MCP 服务添加
+   */
+  private async addMCPServerSingle(
+    name: string,
+    config: MCPServerConfig
+  ): Promise<MCPServerStatus> {
+    this.logger.info("addMCPServerSingle", {
+      serverName: name,
+    });
+
+    // 标准化type字段格式（在try块外声明，确保catch块中可以访问）
+    const normalizedConfig = TypeFieldNormalizer.normalizeTypeField(
+      config
+    ) as MCPServerConfig;
+
+    try {
+      // 1. 验证服务名称
+      const nameValidation = MCPServerConfigValidator.validateServiceName(name);
+      if (!nameValidation.isValid) {
+        const validationError = MCPError.validationError(
+          MCPErrorCode.INVALID_SERVICE_NAME,
+          nameValidation.errors.join(", "),
+          { serverName: name, errors: nameValidation.errors }
+        );
+        this.logger.error("addMCPServerSingle", {
+          validationError,
+          serverName: name,
+          phase: "name_validation",
+        });
+        throw validationError;
+      }
+
+      // 2. 检查服务是否已存在
+      if (
+        MCPServerConfigValidator.checkServiceExists(name, this.configManager)
+      ) {
+        const existsError = MCPError.configError(
+          MCPErrorCode.SERVER_ALREADY_EXISTS,
+          "MCP 服务已存在",
+          { serverName: name }
+        );
+        this.logger.error("addMCPServerSingle", {
+          existsError,
+          serverName: name,
+          phase: "existence_check",
+        });
+        throw existsError;
+      }
+
+      // 3. 验证服务配置
+      const configValidation =
+        MCPServerConfigValidator.validateConfig(normalizedConfig);
+      if (!configValidation.isValid) {
+        const configError = MCPError.configError(
+          MCPErrorCode.INVALID_CONFIG,
+          configValidation.errors.join(", "),
+          {
+            serverName: name,
+            config: normalizedConfig,
+            errors: configValidation.errors,
+          }
+        );
+        this.logger.error("addMCPServerSingle", {
+          configError,
+          serverName: name,
+          phase: "config_validation",
+        });
+        throw configError;
+      }
+
+      // 5. 添加服务到配置管理器
+      this.configManager.updateMcpServer(name, normalizedConfig);
+      this.logger.debug("服务配置已添加到配置管理器", { serverName: name });
+
+      // 6. 添加服务到 MCPServiceManager 并启动服务
+      const mcpServiceConfig = normalizeServiceConfig(normalizedConfig);
+      // 使用两参数形式传递 name 和 config
+      this.mcpServiceManager.addServiceConfig(name, mcpServiceConfig);
+      await this.mcpServiceManager.startService(name);
+      this.logger.debug("服务已启动", { serverName: name });
+
+      // 6. 获取服务状态和工具列表
+      const serviceStatus = this.getServiceStatus(name);
+      const tools = this.getServiceTools(name);
+      const toolNames = tools.map((tool) => tool.name);
+
+      // 7. 发送事件通知
+      getEventBus().emitEvent("mcp:server:added", {
+        serverName: name,
+        config: normalizedConfig,
+        tools: toolNames,
+        timestamp: new Date(),
+      });
+
+      return {
+        ...serviceStatus,
+        tools: toolNames,
+      };
+    } catch (error) {
+      const mcpError = this.handleError(error, "addMCPServerSingle", {
+        serverName: name,
+        config: normalizedConfig,
+      });
+      this.logger.error("addMCPServerSingle", {
+        mcpError,
+        serverName: name,
+      });
+      throw mcpError;
+    }
+  }
+
+  /**
+   * 获取服务状态信息
+   */
+  private getServiceStatus(serverName: string): MCPServerStatus {
+    const config = this.configManager.getConfig();
+    const serverConfig = config.mcpServers[serverName];
+
+    if (!serverConfig) {
+      return {
+        name: serverName,
+        status: "disconnected",
+        connected: false,
+        tools: [],
+        config: {} as MCPServerConfig,
+      };
+    }
+
+    // 尝试从 MCPServiceManager 获取实际状态
+    try {
+      const managerAccess = this
+        .mcpServiceManager as unknown as MCPServiceManagerAccess;
+      const service = managerAccess.services.get(serverName);
+
+      if (service?.isConnected?.()) {
+        const currentTools = service.getTools().map((tool: Tool) => tool.name);
+        const status = {
+          name: serverName,
+          status: "connected" as const,
+          connected: true,
+          tools: currentTools,
+          lastUpdated: new Date().toISOString(),
+          config: serverConfig,
+        };
+
+        // 检查状态变化并发出事件
+        this.checkAndEmitStatusChange(serverName, status);
+        return status;
+      }
+    } catch (error) {
+      this.logger.debug(`获取服务 ${serverName} 状态时出错:`, error);
+    }
+
+    const status = {
+      name: serverName,
+      status: "disconnected" as const,
+      connected: false,
+      tools: [],
+      config: serverConfig,
+    };
+
+    // 检查状态变化并发出事件
+    this.checkAndEmitStatusChange(serverName, status);
+    return status;
+  }
+
+  /**
+   * 检查状态变化并发出事件
+   */
+  private checkAndEmitStatusChange(
+    serverName: string,
+    newStatus: MCPServerStatus
+  ): void {
+    // 获取之前的状态（简单的内存缓存）
+    const previousStatus = this.getPreviousStatus(serverName);
+
+    if (previousStatus && previousStatus.status !== newStatus.status) {
+      this.logger.info(
+        `服务 ${serverName} 状态变化: ${previousStatus.status} -> ${newStatus.status}`
+      );
+
+      // 发射状态变化事件
+      getEventBus().emitEvent("mcp:server:status_changed", {
+        serverName,
+        oldStatus: previousStatus.status,
+        newStatus: newStatus.status,
+        timestamp: new Date(),
+        reason:
+          newStatus.status === "connected"
+            ? "connection_established"
+            : "connection_lost",
+      });
+
+      // 如果工具列表发生变化，发出工具更新事件
+      if (previousStatus.tools !== newStatus.tools) {
+        const addedTools = newStatus.tools.filter(
+          (tool) => !previousStatus.tools.includes(tool)
+        );
+        const removedTools = previousStatus.tools.filter(
+          (tool) => !newStatus.tools.includes(tool)
+        );
+
+        if (addedTools.length > 0 || removedTools.length > 0) {
+          getEventBus().emitEvent("mcp:server:tools:updated", {
+            serverName,
+            tools: newStatus.tools,
+            addedTools,
+            removedTools,
+            timestamp: new Date(),
+          });
+        }
+      }
+    }
+
+    // 更新状态缓存
+    this.updateStatusCache(serverName, newStatus);
+  }
+
+  /**
+   * 获取之前的状态（简化实现）
+   */
+  private getPreviousStatus(serverName: string): MCPServerStatus | null {
+    // 这里使用一个简单的Map来缓存状态
+    // 在实际生产环境中，可能需要更持久化的缓存方案
+    return this.statusCache.get(serverName) || null;
+  }
+
+  /**
+   * 更新状态缓存
+   */
+  private updateStatusCache(serverName: string, status: MCPServerStatus): void {
+    this.statusCache.set(serverName, status);
+  }
+
+  /**
+   * 获取服务工具列表
+   */
+  private getServiceTools(serverName: string): Tool[] {
+    try {
+      const managerAccess = this
+        .mcpServiceManager as unknown as MCPServiceManagerAccess;
+      const service = managerAccess.services.get(serverName);
+
+      if (service?.getTools) {
+        return service.getTools();
+      }
+    } catch (error) {
+      this.logger.debug(`获取服务 ${serverName} 工具列表时出错:`, error);
+    }
+
+    return [];
+  }
+
+  /**
+   * 移除 MCP 服务
+   * DELETE /api/mcp-servers/:serverName
+   */
+  async removeMCPServer(c: Context<AppContext>): Promise<Response> {
+    try {
+      // 1. 从路径参数获取服务名称
+      const serverName = c.req.param("serverName");
+
+      // 验证参数存在性
+      if (!serverName) {
+        return c.fail(
+          MCPErrorCode.INVALID_SERVICE_NAME,
+          "服务名称不能为空",
+          {},
+          400
+        );
+      }
+
+      // 2. 验证服务名称
+      const nameValidation =
+        MCPServerConfigValidator.validateServiceName(serverName);
+      if (!nameValidation.isValid) {
+        return c.fail(
+          MCPErrorCode.INVALID_SERVICE_NAME,
+          nameValidation.errors.join(", "),
+          { serverName },
+          400
+        );
+      }
+
+      // 3. 检查服务是否存在
+      if (
+        !MCPServerConfigValidator.checkServiceExists(
+          serverName,
+          this.configManager
+        )
+      ) {
+        return c.fail(
+          MCPErrorCode.SERVER_NOT_FOUND,
+          "MCP 服务不存在",
+          { serverName },
+          404
+        );
+      }
+
+      // 4. 获取服务当前的工具列表（用于事件通知）
+      const currentTools = this.getServiceTools(serverName).map(
+        (tool) => tool.name
+      );
+
+      // 5. 停止服务并清理资源
+      try {
+        await this.mcpServiceManager.stopService(serverName);
+      } catch (error) {
+        this.logger.warn(`停止服务 ${serverName} 失败:`, error);
+        // 即使停止失败，也继续执行配置移除
+      }
+
+      // 6. 移除服务配置
+      this.mcpServiceManager.removeServiceConfig(serverName);
+      this.configManager.removeMcpServer(serverName);
+
+      // 7. 发送事件通知
+      getEventBus().emitEvent("mcp:server:removed", {
+        serverName,
+        affectedTools: currentTools,
+        timestamp: new Date(),
+      });
+
+      // 8. 返回成功响应
+      return c.success(
+        {
+          name: serverName,
+          operation: "removed",
+          affectedTools: currentTools,
+        },
+        "MCP 服务移除成功"
+      );
+    } catch (error) {
+      this.logger.error("移除 MCP 服务失败:", error);
+
+      // 处理不同类型的错误
+      if (error instanceof Error) {
+        if (error.message.includes("服务不存在")) {
+          return c.fail(
+            MCPErrorCode.SERVER_NOT_FOUND,
+            error.message,
+            undefined,
+            404
+          );
+        }
+
+        if (error.message.includes("配置更新")) {
+          return c.fail(
+            MCPErrorCode.CONFIG_UPDATE_FAILED,
+            error.message,
+            undefined,
+            500
+          );
+        }
+      }
+
+      // 其他未知错误
+      return c.fail(
+        MCPErrorCode.REMOVE_FAILED,
+        "移除 MCP 服务时发生错误",
+        { error: error instanceof Error ? error.message : String(error) },
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取 MCP 服务状态
+   * GET /api/mcp-servers/:serverName/status
+   */
+  async getMCPServerStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      // 1. 从路径参数获取服务名称
+      const serverName = c.req.param("serverName");
+
+      // 验证参数存在性
+      if (!serverName) {
+        return c.fail(
+          MCPErrorCode.INVALID_SERVICE_NAME,
+          "服务名称不能为空",
+          {},
+          400
+        );
+      }
+
+      // 2. 验证服务名称
+      const nameValidation =
+        MCPServerConfigValidator.validateServiceName(serverName);
+      if (!nameValidation.isValid) {
+        return c.fail(
+          MCPErrorCode.INVALID_SERVICE_NAME,
+          nameValidation.errors.join(", "),
+          { serverName },
+          400
+        );
+      }
+
+      // 3. 检查服务是否存在
+      if (
+        !MCPServerConfigValidator.checkServiceExists(
+          serverName,
+          this.configManager
+        )
+      ) {
+        return c.fail(
+          MCPErrorCode.SERVER_NOT_FOUND,
+          "MCP 服务不存在",
+          { serverName },
+          404
+        );
+      }
+
+      // 4. 获取服务状态
+      const serviceStatus = this.getServiceStatus(serverName);
+
+      // 5. 返回成功响应
+      return c.success(serviceStatus, "MCP 服务状态获取成功");
+    } catch (error) {
+      this.logger.error("获取 MCP 服务状态失败:", error);
+
+      // 处理不同类型的错误
+      if (error instanceof Error) {
+        if (error.message.includes("服务不存在")) {
+          return c.fail(
+            MCPErrorCode.SERVER_NOT_FOUND,
+            error.message,
+            undefined,
+            404
+          );
+        }
+      }
+
+      // 其他未知错误
+      return c.fail(
+        MCPErrorCode.INTERNAL_ERROR,
+        "获取 MCP 服务状态时发生内部错误",
+        { error: error instanceof Error ? error.message : String(error) },
+        500
+      );
+    }
+  }
+
+  /**
+   * 列出所有 MCP 服务
+   * GET /api/mcp-servers
+   */
+  async listMCPServers(c: Context<AppContext>): Promise<Response> {
+    try {
+      // 1. 获取所有配置的 MCP 服务
+      const config = this.configManager.getConfig();
+      const mcpServers = config.mcpServers || {};
+
+      // 2. 构建服务列表
+      const servers: MCPServerStatus[] = [];
+
+      for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
+        const serviceStatus = this.getServiceStatus(serverName);
+        servers.push(serviceStatus);
+      }
+
+      // 3. 构建响应数据
+      const listResponse: MCPServerListResponse = {
+        servers,
+        total: servers.length,
+      };
+
+      // 4. 返回成功响应
+      return c.success(listResponse, "MCP 服务列表获取成功");
+    } catch (error) {
+      this.logger.error("列出 MCP 服务失败:", error);
+
+      // 其他未知错误
+      return c.fail(
+        MCPErrorCode.INTERNAL_ERROR,
+        "列出 MCP 服务时发生内部错误",
+        { error: error instanceof Error ? error.message : String(error) },
+        500
+      );
+    }
+  }
+
+  /**
+   * 处理批量 MCP 服务添加
+   */
+  private async addMCPServersBatch(
+    batchRequest: MCPServerBatchAddRequest
+  ): Promise<MCPServerBatchAddResponse> {
+    const { mcpServers } = batchRequest;
+    const serverNames = Object.keys(mcpServers);
+
+    this.logger.info("addMCPServersBatch", {
+      serverCount: serverNames.length,
+      serverNames,
+    });
+
+    if (serverNames.length === 0) {
+      throw MCPError.validationError(
+        MCPErrorCode.INVALID_CONFIG,
+        "批量添加请求中的服务列表为空"
+      );
+    }
+
+    const results: MCPServerAddResult[] = [];
+    const successfullyAddedServers: string[] = [];
+
+    // 第一阶段：验证所有服务配置
+    const validationResult = this.validateBatchServers(mcpServers);
+    if (!validationResult.isValid) {
+      throw MCPError.validationError(
+        MCPErrorCode.INVALID_CONFIG,
+        validationResult.errors.join(", ")
+      );
+    }
+
+    try {
+      // 第二阶段：逐个添加服务，记录成功和失败
+      for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
+        // 标准化type字段格式（在try块外声明，确保catch块中可以访问）
+        const normalizedServerConfig = TypeFieldNormalizer.normalizeTypeField(
+          serverConfig
+        ) as MCPServerConfig;
+
+        try {
+          const result = await this.addMCPServerSingle(
+            serverName,
+            normalizedServerConfig
+          );
+
+          results.push({
+            name: serverName,
+            success: true,
+            config: normalizedServerConfig,
+            tools: result.tools,
+            status: result.status,
+          });
+
+          successfullyAddedServers.push(serverName);
+
+          this.logger.debug("批量添加：服务添加成功", {
+            serverName,
+            toolsCount: result.tools?.length || 0,
+          });
+        } catch (error) {
+          const mcpError = this.handleError(error, "addMCPServersBatch", {
+            serverName,
+            serverConfig: normalizedServerConfig,
+          });
+
+          results.push({
+            name: serverName,
+            success: false,
+            error: mcpError.message,
+            config: normalizedServerConfig,
+          });
+
+          this.logger.warn("批量添加：服务添加失败", {
+            serverName,
+            error: mcpError.message,
+          });
+        }
+      }
+
+      // 第三阶段：统计结果
+      const addedCount = successfullyAddedServers.length;
+      const failedCount = serverNames.length - addedCount;
+
+      // 第四阶段：如果完全失败，抛出异常；部分成功则返回结果
+      if (addedCount === 0) {
+        throw MCPError.configError(
+          MCPErrorCode.ADD_FAILED,
+          "批量添加失败：所有服务都无法添加"
+        );
+      }
+
+      // 发送批量添加事件
+      getEventBus().emitEvent("mcp:server:batch_added", {
+        totalServers: serverNames.length,
+        addedCount,
+        failedCount,
+        successfullyAddedServers,
+        results,
+        timestamp: new Date(),
+      });
+
+      const response: MCPServerBatchAddResponse = {
+        success: addedCount > 0,
+        message:
+          addedCount === serverNames.length
+            ? `批量添加成功：已添加 ${addedCount} 个服务`
+            : `批量添加部分成功：成功添加 ${addedCount} 个服务，失败 ${failedCount} 个服务`,
+        results,
+        addedCount,
+        failedCount,
+      };
+
+      this.logger.info("addMCPServersBatch", {
+        totalServers: serverNames.length,
+        addedCount,
+        failedCount,
+      });
+
+      return response;
+    } catch (error) {
+      // 如果发生未处理的错误，尝试回滚已成功添加的服务
+      if (successfullyAddedServers.length > 0) {
+        await this.rollbackBatchAdd(successfullyAddedServers);
+      }
+
+      if (error instanceof MCPError) {
+        throw error;
+      }
+      throw MCPError.systemError(
+        MCPErrorCode.INTERNAL_ERROR,
+        `批量添加过程中发生错误: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * 验证批量服务配置
+   */
+  private validateBatchServers(
+    mcpServers: Record<string, MCPServerConfig>
+  ): ValidationResult {
+    const errors: string[] = [];
+
+    if (!mcpServers || typeof mcpServers !== "object") {
+      errors.push("mcpServers 必须是一个对象");
+      return { isValid: false, errors };
+    }
+
+    const serverNames = Object.keys(mcpServers);
+    if (serverNames.length === 0) {
+      errors.push("mcpServers 对象不能为空");
+      return { isValid: false, errors };
+    }
+
+    if (serverNames.length > 50) {
+      errors.push("批量添加的服务数量不能超过 50 个");
+      return { isValid: false, errors };
+    }
+
+    // 验证每个服务
+    for (const [serverName, serverConfig] of Object.entries(mcpServers)) {
+      // 验证服务名称
+      const nameValidation =
+        MCPServerConfigValidator.validateServiceName(serverName);
+      if (!nameValidation.isValid) {
+        errors.push(
+          `服务 "${serverName}" 名称无效: ${nameValidation.errors.join(", ")}`
+        );
+        continue;
+      }
+
+      // 检查是否已存在
+      if (
+        MCPServerConfigValidator.checkServiceExists(
+          serverName,
+          this.configManager
+        )
+      ) {
+        errors.push(`服务 "${serverName}" 已存在`);
+        continue;
+      }
+
+      // 标准化type字段格式
+      const normalizedServerConfig = TypeFieldNormalizer.normalizeTypeField(
+        serverConfig
+      ) as MCPServerConfig;
+
+      // 验证配置
+      const configValidation = MCPServerConfigValidator.validateConfig(
+        normalizedServerConfig
+      );
+      if (!configValidation.isValid) {
+        errors.push(
+          `服务 "${serverName}" 配置无效: ${configValidation.errors.join(", ")}`
+        );
+      }
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  /**
+   * 回滚批量添加的服务
+   */
+  private async rollbackBatchAdd(serverNames: string[]): Promise<void> {
+    this.logger.info("开始回滚批量添加的服务", { serverNames });
+
+    const rollbackResults: string[] = [];
+    const rollbackFailures: string[] = [];
+
+    for (const serverName of serverNames) {
+      try {
+        // 停止服务
+        try {
+          await this.mcpServiceManager.stopService(serverName);
+        } catch (error) {
+          this.logger.warn(`回滚时停止服务 ${serverName} 失败:`, error);
+        }
+
+        // 移除服务配置
+        this.mcpServiceManager.removeServiceConfig(serverName);
+        this.configManager.removeMcpServer(serverName);
+
+        rollbackResults.push(serverName);
+
+        // 发送回滚事件
+        getEventBus().emitEvent("mcp:server:rollback", {
+          serverName,
+          timestamp: new Date(),
+        });
+      } catch (error) {
+        const mcpError = this.handleError(error, "rollbackBatchAdd", {
+          serverName,
+        });
+        rollbackFailures.push(serverName);
+
+        this.logger.error(`回滚服务 ${serverName} 失败:`, mcpError.message);
+      }
+    }
+
+    if (rollbackFailures.length > 0) {
+      this.logger.warn("批量添加回滚部分失败", {
+        totalServers: serverNames.length,
+        rollbackedCount: rollbackResults.length,
+        failedCount: rollbackFailures.length,
+        failedServers: rollbackFailures,
+      });
+    } else {
+      this.logger.info("批量添加回滚成功", {
+        totalServers: serverNames.length,
+        rollbackedCount: rollbackResults.length,
+      });
+    }
+  }
+}
+
+/**
+ * MCP 服务配置验证工具命名空间
+ */
+export namespace MCPServerConfigValidator {
+  /**
+   * 验证服务配置
+   */
+  export function validateConfig(config: MCPServerConfig): ValidationResult {
+    const errors: string[] = [];
+
+    // 验证配置基本结构
+    if (!config || typeof config !== "object") {
+      errors.push("配置必须是一个对象");
+      return { isValid: false, errors };
+    }
+
+    // 根据类型验证配置
+    if ("command" in config) {
+      // LocalMCPServerConfig
+      if (!config.command || typeof config.command !== "string") {
+        errors.push("本地服务必须提供有效的命令");
+      }
+      if (config.args && !Array.isArray(config.args)) {
+        errors.push("参数必须是数组");
+      }
+      if (config.env && typeof config.env !== "object") {
+        errors.push("环境变量必须是对象");
+      }
+    } else if ("url" in config) {
+      // SSEMCPServerConfig 或 StreamableHTTPMCPServerConfig
+      if (!config.url || typeof config.url !== "string") {
+        errors.push("远程服务必须提供有效的 URL");
+      }
+      try {
+        new URL(config.url);
+      } catch {
+        errors.push("URL 格式无效");
+      }
+    } else {
+      errors.push("配置必须包含 command 或 url 字段");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  /**
+   * 验证服务名称
+   */
+  export function validateServiceName(name: string): ValidationResult {
+    const errors: string[] = [];
+
+    if (!name || typeof name !== "string") {
+      errors.push("服务名称必须是非空字符串");
+      return { isValid: false, errors };
+    }
+
+    if (name.length < 1 || name.length > 50) {
+      errors.push("服务名称长度必须在 1-50 个字符之间");
+    }
+
+    if (!/^[a-zA-Z0-9_-]+$/.test(name)) {
+      errors.push("服务名称只能包含字母、数字、下划线和连字符");
+    }
+
+    return { isValid: errors.length === 0, errors };
+  }
+
+  /**
+   * 检查服务是否已存在
+   */
+  export function checkServiceExists(
+    name: string,
+    configManager: ConfigManager
+  ): boolean {
+    const config = configManager.getConfig();
+    return config.mcpServers && name in config.mcpServers;
+  }
+}

--- a/src/server/handlers/mcp-tool-log.handler.ts
+++ b/src/server/handlers/mcp-tool-log.handler.ts
@@ -1,0 +1,163 @@
+/**
+ * 工具调用日志 API 处理器
+ * 负责处理工具调用日志相关的 HTTP API 请求
+ */
+
+import type { Context } from "hono";
+import { z } from "zod";
+import { PAGINATION_CONSTANTS } from "../constants/api.constants.js";
+import type { ToolCallQuery } from "../lib/mcp/log.js";
+import { ToolCallLogService } from "../lib/mcp/log.js";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 工具调用查询参数 Zod Schema
+ */
+const ToolCallQuerySchema = z
+  .object({
+    limit: z
+      .string()
+      .optional()
+      .transform((val) => (val ? Number.parseInt(val, 10) : undefined))
+      .refine(
+        (val) =>
+          val === undefined ||
+          (val >= 1 && val <= PAGINATION_CONSTANTS.MAX_LIMIT),
+        {
+          message: `limit 参数必须是 1-${PAGINATION_CONSTANTS.MAX_LIMIT} 之间的数字`,
+        }
+      ),
+    offset: z
+      .string()
+      .optional()
+      .transform((val) => (val ? Number.parseInt(val, 10) : undefined))
+      .refine((val) => val === undefined || val >= 0, {
+        message: "offset 参数必须是非负数",
+      }),
+    toolName: z.string().optional(),
+    serverName: z.string().optional(),
+    success: z
+      .string()
+      .optional()
+      .transform((val) => (val ? val.toLowerCase() === "true" : undefined)),
+    startDate: z
+      .string()
+      .optional()
+      .refine(
+        (val) => {
+          if (!val) return true;
+          const date = Date.parse(val);
+          return !Number.isNaN(date);
+        },
+        {
+          message: "startDate 参数格式无效",
+        }
+      ),
+    endDate: z
+      .string()
+      .optional()
+      .refine(
+        (val) => {
+          if (!val) return true;
+          const date = Date.parse(val);
+          return !Number.isNaN(date);
+        },
+        {
+          message: "endDate 参数格式无效",
+        }
+      ),
+  })
+  .refine(
+    (data) => {
+      if (!data.startDate || !data.endDate) return true;
+      return new Date(data.startDate) <= new Date(data.endDate);
+    },
+    {
+      message: "startDate 不能晚于 endDate",
+      path: ["startDate"],
+    }
+  );
+
+/**
+ * 工具调用日志 API 处理器
+ */
+export class MCPToolLogHandler extends BaseHandler {
+  private toolCallLogService: ToolCallLogService;
+
+  constructor() {
+    super();
+    this.toolCallLogService = new ToolCallLogService();
+  }
+
+  /**
+   * 解析和验证查询参数
+   */
+  private parseAndValidateQueryParams(c: Context<AppContext>): {
+    success: boolean;
+    data?: ToolCallQuery;
+    error?: Array<{ field: string; message: string }>;
+  } {
+    const query = c.req.query();
+    const result = ToolCallQuerySchema.safeParse(query);
+
+    if (!result.success) {
+      return {
+        success: false,
+        error: result.error.issues.map((err) => ({
+          field: err.path.join("."),
+          message: err.message,
+        })),
+      };
+    }
+
+    return {
+      success: true,
+      data: result.data as ToolCallQuery,
+    };
+  }
+
+  /**
+   * 获取工具调用日志
+   */
+  async getToolCallLogs(c: Context<AppContext>): Promise<Response> {
+    try {
+      const validation = this.parseAndValidateQueryParams(c);
+
+      if (!validation.success) {
+        return c.fail(
+          "INVALID_QUERY_PARAMETERS",
+          "查询参数格式错误",
+          validation.error,
+          400
+        );
+      }
+
+      const result = await this.toolCallLogService.getToolCallLogs(
+        validation.data!
+      );
+
+      c.get("logger").debug(
+        `API: 返回 ${result.records.length} 条工具调用日志记录`
+      );
+      return c.success(result);
+    } catch (error) {
+      c.get("logger").error("获取工具调用日志失败:", error);
+
+      const message = error instanceof Error ? error.message : "未知错误";
+      if (message.includes("不存在")) {
+        return c.fail("LOG_FILE_NOT_FOUND", message, undefined, 404);
+      }
+      if (message.includes("无法读取")) {
+        return c.fail("LOG_FILE_READ_ERROR", message, undefined, 500);
+      }
+
+      return c.fail(
+        "INTERNAL_ERROR",
+        "获取工具调用日志失败",
+        { details: message },
+        500
+      );
+    }
+  }
+}

--- a/src/server/handlers/mcp-tool.handler.ts
+++ b/src/server/handlers/mcp-tool.handler.ts
@@ -1,0 +1,2743 @@
+/**
+ * MCP 工具调用 API 处理器
+ * 处理通过 HTTP API 调用 MCP 工具的请求
+ */
+
+import Ajv from "ajv";
+import dayjs from "dayjs";
+import type { Context } from "hono";
+import { configManager } from "../../config/index.js";
+import type { CustomMCPTool, ProxyHandlerConfig } from "../../config/index.js";
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import { HTTP_TIMEOUTS } from "../constants/timeout.constants.js";
+import { MCPError, MCPErrorCode } from "../errors/mcp-errors.js";
+import { MCPCacheManager } from "../lib/mcp";
+import type { MCPServiceManager } from "../lib/mcp";
+import type { EnhancedToolInfo } from "../lib/mcp/types.js";
+import type { CozeWorkflow, WorkflowParameterConfig } from "../types/coze.js";
+import type { AppContext } from "../types/hono.context.js";
+import type {
+  AddCustomToolRequest,
+  AddToolResponse,
+  CozeWorkflowData,
+  MCPToolData,
+} from "../types/toolApi.js";
+import { ToolType } from "../types/toolApi.js";
+import type { CustomMCPToolWithStats, JSONSchema } from "../types/toolApi.js";
+import { type ToolSortField, sortTools } from "../utils/toolSorters";
+
+/**
+ * 工具调用请求接口
+ */
+interface ToolCallRequest {
+  serviceName: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+/**
+ * 添加自定义工具请求接口（向后兼容）
+ * @deprecated 使用新的 AddCustomToolRequest 类型定义
+ */
+interface LegacyAddCustomToolRequest {
+  workflow: CozeWorkflow;
+  customName?: string;
+  customDescription?: string;
+  parameterConfig?: WorkflowParameterConfig;
+}
+
+/**
+ * MCP 工具调用 API 处理器
+ */
+export class MCPToolHandler {
+  // 预编译的正则表达式常量，避免在频繁调用时重复创建
+  private static readonly UNDERSCORE_TRIM_REGEX = /^_+|_+$/g;
+  private static readonly LETTER_START_REGEX = /^[a-zA-Z]/;
+  private static readonly CHINESE_CHAR_REGEX = /[\u4e00-\u9fa5]/;
+  private static readonly DIGITS_ONLY_REGEX = /^\d+$/;
+  private static readonly ALPHANUMERIC_UNDERSCORE_REGEX = /^[a-zA-Z0-9_-]+$/;
+  private static readonly IDENTIFIER_REGEX = /^[a-zA-Z_][a-zA-Z0-9_]*$/;
+
+  private logger: Logger;
+  private ajv: Ajv;
+  private static readonly TOOL_TYPE_VALUES = Object.values(ToolType);
+
+  constructor() {
+    this.logger = logger;
+    this.ajv = new Ajv({ allErrors: true, verbose: true });
+  }
+
+  /**
+   * 调用 MCP 工具
+   * POST /api/tools/call
+   */
+  async callTool(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理工具调用请求");
+
+      // 解析请求体
+      const requestBody: ToolCallRequest = await c.req.json();
+      const { serviceName, toolName, args } = requestBody;
+
+      // 验证请求参数
+      if (!serviceName || !toolName) {
+        return c.fail(
+          "INVALID_REQUEST",
+          "serviceName 和 toolName 是必需的参数",
+          undefined,
+          400
+        );
+      }
+
+      c.get("logger").info(
+        `准备调用工具: ${serviceName}/${toolName}，参数:`,
+        JSON.stringify(args)
+      );
+
+      // 从 Context 中获取 MCPServiceManager 实例
+      const serviceManager = c.get("mcpServiceManager");
+
+      if (!serviceManager) {
+        return c.fail(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化。请检查服务状态。",
+          undefined,
+          503
+        );
+      }
+
+      // 验证服务和工具是否存在
+      await this.validateServiceAndTool(serviceManager, serviceName, toolName);
+
+      // 对于 customMCP 工具，进行参数验证
+      if (serviceName === "customMCP") {
+        await this.validateCustomMCPArguments(
+          serviceManager,
+          toolName,
+          args || {}
+        );
+      }
+
+      // 调用工具 - 特殊处理 customMCP 服务
+      let result: unknown;
+      if (serviceName === "customMCP") {
+        // 对于 customMCP 服务，直接使用 toolName 调用，传递长运行任务超时
+        result = await serviceManager.callTool(toolName, args || {}, {
+          timeout: HTTP_TIMEOUTS.LONG_RUNNING,
+        });
+      } else {
+        // 对于标准 MCP 服务，使用 serviceName__toolName 格式，保持8秒超时
+        const toolKey = `${serviceName}__${toolName}`;
+        result = await serviceManager.callTool(toolKey, args || {});
+      }
+
+      // c.get("logger").debug(`工具调用成功: ${serviceName}/${toolName}`);
+
+      return c.success(result, "工具调用成功");
+    } catch (error) {
+      c.get("logger").error("工具调用失败:", error);
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      let errorCode = "TOOL_CALL_ERROR";
+
+      // 根据错误类型设置不同的错误码
+      if (errorMessage.includes("不存在")) {
+        errorCode = "SERVICE_OR_TOOL_NOT_FOUND";
+      } else if (
+        errorMessage.includes("未启动") ||
+        errorMessage.includes("未连接")
+      ) {
+        errorCode = "SERVICE_NOT_AVAILABLE";
+      } else if (errorMessage.includes("已被禁用")) {
+        errorCode = "TOOL_DISABLED";
+      } else if (errorMessage.includes("参数验证失败")) {
+        errorCode = "INVALID_ARGUMENTS";
+      } else if (
+        errorMessage.includes("CustomMCP") ||
+        errorMessage.includes("customMCP")
+      ) {
+        errorCode = "CUSTOM_MCP_ERROR";
+      } else if (
+        errorMessage.includes("工作流调用失败") ||
+        errorMessage.includes("API 请求失败")
+      ) {
+        errorCode = "EXTERNAL_API_ERROR";
+      } else if (errorMessage.includes("超时")) {
+        errorCode = "TIMEOUT_ERROR";
+      }
+
+      return c.fail(errorCode, errorMessage, undefined, 500);
+    }
+  }
+
+  /**
+   * 获取自定义 MCP 工具列表
+   * GET /api/tools/custom
+   */
+  async getCustomTools(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理获取自定义 MCP 工具列表请求");
+
+      // 检查配置文件是否存在
+      if (!configManager.configExists()) {
+        return c.fail(
+          "CONFIG_NOT_FOUND",
+          "配置文件不存在，请先运行 'xiaozhi init' 初始化配置",
+          undefined,
+          404
+        );
+      }
+
+      // 获取自定义 MCP 工具列表
+      let customTools: CustomMCPTool[] = [];
+      let configPath = "";
+
+      try {
+        customTools = configManager.getCustomMCPTools();
+        configPath = configManager.getConfigPath();
+      } catch (error) {
+        c.get("logger").error("读取自定义 MCP 工具配置失败:", error);
+        return c.fail(
+          "CONFIG_PARSE_ERROR",
+          `配置文件解析失败: ${error instanceof Error ? error.message : "未知错误"}`,
+          undefined,
+          500
+        );
+      }
+
+      // 检查是否配置了自定义 MCP 工具
+      if (!customTools || customTools.length === 0) {
+        c.get("logger").info("未配置自定义 MCP 工具");
+        return c.success(
+          {
+            tools: [],
+            totalTools: 0,
+            configPath,
+          },
+          "未配置自定义 MCP 工具"
+        );
+      }
+
+      // 验证工具配置的有效性
+      const isValid = configManager.validateCustomMCPTools(customTools);
+      if (!isValid) {
+        c.get("logger").warn("自定义 MCP 工具配置验证失败");
+        return c.fail(
+          "INVALID_TOOL_CONFIG",
+          "自定义 MCP 工具配置验证失败，请检查配置文件中的工具定义",
+          undefined,
+          400
+        );
+      }
+
+      c.get("logger").info(
+        `获取自定义 MCP 工具列表成功，共 ${customTools.length} 个工具`
+      );
+
+      return c.success(
+        {
+          tools: customTools,
+          totalTools: customTools.length,
+          configPath,
+        },
+        "获取自定义 MCP 工具列表成功"
+      );
+    } catch (error) {
+      c.get("logger").error("获取自定义 MCP 工具列表失败:", error);
+
+      return c.fail(
+        "GET_CUSTOM_TOOLS_ERROR",
+        error instanceof Error ? error.message : "获取自定义 MCP 工具列表失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取可用工具列表
+   * GET /api/tools/list?status=enabled|disabled|all&sortBy=name
+   *
+   * @param status 筛选状态：'enabled'（已启用）、'disabled'（未启用）、'all'（全部，默认）
+   * @param sortBy 排序字段：'name'（工具名称，默认）、'enabled'（启用状态）、'usageCount'（使用次数）、'lastUsedTime'（最近使用时间）
+   */
+  async listTools(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取工具列表请求");
+
+      // 获取筛选参数
+      const status =
+        (c.req.query("status") as "enabled" | "disabled" | "all") || "all";
+
+      // 解析排序参数并验证
+      const sortByParam = c.req.query("sortBy");
+      const validSortFields: ToolSortField[] = [
+        "name",
+        "enabled",
+        "usageCount",
+        "lastUsedTime",
+      ];
+      const sortBy = validSortFields.includes(sortByParam as ToolSortField)
+        ? (sortByParam as ToolSortField)
+        : "name";
+
+      // 如果提供了无效的排序字段，返回错误
+      if (
+        sortByParam &&
+        !validSortFields.includes(sortByParam as ToolSortField)
+      ) {
+        return c.fail(
+          "INVALID_SORT_FIELD",
+          `无效的排序字段: ${sortByParam}。支持的排序字段: ${validSortFields.join(", ")}`,
+          undefined,
+          400
+        );
+      }
+
+      // 从 Context 中获取 MCPServiceManager 实例
+      const serviceManager = c.get("mcpServiceManager");
+      if (!serviceManager) {
+        return c.fail(
+          "SERVICE_NOT_INITIALIZED",
+          "MCP 服务管理器未初始化。请检查服务状态。",
+          undefined,
+          503
+        );
+      }
+
+      let rawTools: EnhancedToolInfo[] = serviceManager.getAllTools(status);
+
+      // 应用排序
+      rawTools = sortTools(rawTools, { field: sortBy });
+
+      // 转换为 CustomMCPToolWithStats 格式（使用共享类型）
+      const tools: CustomMCPToolWithStats[] = rawTools.map(
+        (tool: EnhancedToolInfo) => ({
+          name: tool.name,
+          description: tool.description,
+          inputSchema: tool.inputSchema,
+          handler: {
+            type: "mcp",
+            config: {
+              serviceName: tool.serviceName,
+              toolName: tool.originalName,
+            },
+          },
+          enabled: tool.enabled,
+          usageCount: tool.usageCount,
+          lastUsedTime: tool.lastUsedTime,
+        })
+      );
+
+      // 返回对象格式的响应
+      const responseData = {
+        list: tools,
+        total: tools.length,
+      };
+
+      return c.success(responseData, `获取工具列表成功（${status}）`);
+    } catch (error) {
+      c.get("logger").error("获取工具列表失败:", error);
+
+      return c.fail("GET_TOOLS_FAILED", "获取工具列表失败", undefined, 500);
+    }
+  }
+
+  /**
+   * 验证服务和工具是否存在
+   * @private
+   */
+  private async validateServiceAndTool(
+    serviceManager: MCPServiceManager,
+    serviceName: string,
+    toolName: string
+  ): Promise<void> {
+    // 特殊处理 customMCP 服务
+    if (serviceName === "customMCP") {
+      // 验证 customMCP 工具是否存在
+      if (!serviceManager.hasCustomMCPTool(toolName)) {
+        const availableTools = serviceManager
+          .getCustomMCPTools()
+          .map((tool) => tool.name);
+
+        if (availableTools.length === 0) {
+          throw MCPError.validationError(
+            MCPErrorCode.TOOL_NOT_FOUND,
+            `customMCP 工具 '${toolName}' 不存在。当前没有配置任何 customMCP 工具。请检查 xiaozhi.config.json 中的 customMCP 配置。`
+          );
+        }
+
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_NOT_FOUND,
+          `customMCP 工具 '${toolName}' 不存在。可用的 customMCP 工具: ${availableTools.join(", ")}。请使用 'xiaozhi mcp list' 查看所有可用工具。`
+        );
+      }
+
+      // 验证 customMCP 工具配置是否有效
+      try {
+        const customTools = serviceManager.getCustomMCPTools();
+        const targetTool = customTools.find((tool) => tool.name === toolName);
+
+        if (targetTool && !targetTool.description) {
+          this.logger.warn(`customMCP 工具 '${toolName}' 缺少描述信息`);
+        }
+
+        if (targetTool && !targetTool.inputSchema) {
+          this.logger.warn(`customMCP 工具 '${toolName}' 缺少输入参数定义`);
+        }
+      } catch (error) {
+        this.logger.error(
+          `验证 customMCP 工具 '${toolName}' 配置时出错:`,
+          error
+        );
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `customMCP 工具 '${toolName}' 配置验证失败。请检查配置文件中的工具定义。`
+        );
+      }
+
+      return;
+    }
+  }
+
+  /**
+   * 验证 customMCP 工具的参数
+   * @private
+   */
+  private async validateCustomMCPArguments(
+    serviceManager: MCPServiceManager,
+    toolName: string,
+    args: Record<string, unknown>
+  ): Promise<void> {
+    try {
+      // 获取工具的 inputSchema
+      const customTools = serviceManager.getCustomMCPTools();
+      const targetTool = customTools.find((tool) => tool.name === toolName);
+
+      if (!targetTool) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_NOT_FOUND,
+          `customMCP 工具 '${toolName}' 不存在`
+        );
+      }
+
+      // 如果工具没有定义 inputSchema，跳过验证
+      if (!targetTool.inputSchema) {
+        this.logger.warn(
+          `customMCP 工具 '${toolName}' 没有定义 inputSchema，跳过参数验证`
+        );
+        return;
+      }
+
+      // 使用 AJV 验证参数
+      const validate = this.ajv.compile(targetTool.inputSchema);
+      const valid = validate(args);
+
+      if (!valid) {
+        // 构建详细的错误信息
+        const errors = validate.errors || [];
+        const errorMessages = errors.map((error) => {
+          const path = error.instancePath || error.schemaPath || "";
+          const message = error.message || "未知错误";
+
+          if (error.keyword === "required") {
+            const missingProperty = error.params?.missingProperty || "未知字段";
+            return `缺少必需参数: ${missingProperty}`;
+          }
+
+          if (error.keyword === "type") {
+            const expectedType = error.params?.type || "未知类型";
+            return `参数 ${path} 类型错误，期望: ${expectedType}`;
+          }
+
+          if (error.keyword === "enum") {
+            const allowedValues = error.params?.allowedValues || [];
+            return `参数 ${path} 值无效，允许的值: ${allowedValues.join(", ")}`;
+          }
+
+          return `参数 ${path} ${message}`;
+        });
+
+        const errorMessage = `参数验证失败: ${errorMessages.join("; ")}`;
+        this.logger.error(
+          `customMCP 工具 '${toolName}' 参数验证失败:`,
+          errorMessage
+        );
+
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          errorMessage
+        );
+      }
+
+      this.logger.debug(`customMCP 工具 '${toolName}' 参数验证通过`);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes("参数验证失败")) {
+        throw error;
+      }
+
+      this.logger.error(`验证 customMCP 工具 '${toolName}' 参数时出错:`, error);
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        `参数验证过程中发生错误: ${error instanceof Error ? error.message : "未知错误"}`
+      );
+    }
+  }
+
+  /**
+   * 添加自定义 MCP 工具
+   * POST /api/tools/custom
+   * 支持多种工具类型：MCP 工具、Coze 工作流等
+   */
+  async addCustomTool(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理添加自定义工具请求");
+
+      const requestBody = await c.req.json();
+
+      // 检查是否为新格式的请求
+      if (this.isNewFormatRequest(requestBody)) {
+        // 新格式：支持多种工具类型
+        return await this.handleNewFormatAddTool(
+          c,
+          requestBody as AddCustomToolRequest
+        );
+      }
+      // 旧格式：向后兼容
+      return await this.handleLegacyFormatAddTool(
+        c,
+        requestBody as LegacyAddCustomToolRequest
+      );
+    } catch (error) {
+      c.get("logger").error("添加自定义工具失败:", error);
+
+      // 根据错误类型返回不同的HTTP状态码和错误信息
+      const { code, message, status } = this.handleAddToolError(error);
+      return c.fail(code, message, undefined, status);
+    }
+  }
+
+  /**
+   * 判断是否为新格式的请求
+   */
+  private isNewFormatRequest(body: unknown): body is AddCustomToolRequest {
+    return (
+      body !== null &&
+      typeof body === "object" &&
+      !Array.isArray(body) &&
+      "type" in body &&
+      "data" in body
+    );
+  }
+
+  /**
+   * 处理新格式的添加工具请求
+   */
+  private async handleNewFormatAddTool(
+    c: Context<AppContext>,
+    request: AddCustomToolRequest
+  ): Promise<Response> {
+    const { type, data } = request;
+
+    c.get("logger").info(`处理新格式工具添加请求，类型: ${type}`);
+
+    // 验证工具类型
+    if (!MCPToolHandler.TOOL_TYPE_VALUES.includes(type)) {
+      return c.fail(
+        "INVALID_TOOL_TYPE",
+        `不支持的工具类型: ${type}。支持的类型: ${MCPToolHandler.TOOL_TYPE_VALUES.join(", ")}`,
+        undefined,
+        400
+      );
+    }
+
+    // 根据工具类型分发处理
+    switch (type) {
+      case ToolType.MCP:
+        return await this.handleAddMCPTool(c, data as MCPToolData);
+
+      case ToolType.COZE:
+        return await this.handleAddCozeTool(c, data as CozeWorkflowData);
+
+      case ToolType.HTTP:
+      case ToolType.FUNCTION: {
+        return c.fail(
+          "TOOL_TYPE_NOT_IMPLEMENTED",
+          `工具类型 ${type} 暂未实现，请使用 MCP 或 Coze 类型`,
+          undefined,
+          501
+        );
+      }
+
+      default: {
+        return c.fail(
+          "UNKNOWN_TOOL_TYPE",
+          `未知的工具类型: ${type}`,
+          undefined,
+          400
+        );
+      }
+    }
+  }
+
+  /**
+   * 处理旧格式的添加工具请求（向后兼容）
+   */
+  private async handleLegacyFormatAddTool(
+    c: Context<AppContext>,
+    request: LegacyAddCustomToolRequest
+  ): Promise<Response> {
+    c.get("logger").info("处理旧格式工具添加请求（向后兼容）");
+
+    const { workflow, customName, customDescription, parameterConfig } =
+      request;
+
+    // 边界条件预检查
+    const preCheckResult = this.performPreChecks(
+      workflow,
+      customName,
+      customDescription
+    );
+    if (preCheckResult) {
+      return c.fail(
+        preCheckResult.code,
+        preCheckResult.message,
+        undefined,
+        preCheckResult.status
+      );
+    }
+
+    // 转换工作流为工具配置
+    const tool = this.convertWorkflowToTool(
+      workflow,
+      customName,
+      customDescription,
+      parameterConfig
+    );
+
+    // 添加工具到配置
+    configManager.addCustomMCPTool(tool);
+
+    c.get("logger").info(`成功添加自定义工具: ${tool.name}`);
+
+    return c.success({ tool }, `工具 "${tool.name}" 添加成功`);
+  }
+
+  /**
+   * 处理添加 MCP 工具
+   */
+  private async handleAddMCPTool(
+    c: Context<AppContext>,
+    data: MCPToolData
+  ): Promise<Response> {
+    const { serviceName, toolName, customName, customDescription } = data;
+
+    c.get("logger").info(`处理添加 MCP 工具: ${serviceName}/${toolName}`);
+
+    // 验证必需字段
+    if (!serviceName || !toolName) {
+      return c.fail(
+        "MISSING_REQUIRED_FIELD",
+        "serviceName 和 toolName 是必需字段",
+        undefined,
+        400
+      );
+    }
+
+    // 从 Context 中获取 MCPServiceManager 实例
+    const serviceManager = c.get("mcpServiceManager");
+    if (!serviceManager) {
+      return c.fail(
+        "SERVICE_NOT_INITIALIZED",
+        "MCP 服务管理器未初始化。请检查服务状态。",
+        undefined,
+        503
+      );
+    }
+
+    // 验证服务和工具是否存在
+    try {
+      await this.validateServiceAndTool(serviceManager, serviceName, toolName);
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return c.fail("SERVICE_OR_TOOL_NOT_FOUND", errorMessage, undefined, 404);
+    }
+
+    // 从缓存中获取工具信息
+    const cacheManager = new MCPCacheManager();
+    const cachedTools = await cacheManager.getAllCachedTools();
+
+    // 查找对应的工具
+    const fullToolName = `${serviceName}__${toolName}`;
+    const cachedTool = cachedTools.find((tool) => tool.name === fullToolName);
+
+    if (!cachedTool) {
+      return c.fail(
+        "TOOL_NOT_FOUND",
+        `在缓存中未找到工具: ${serviceName}/${toolName}`,
+        undefined,
+        404
+      );
+    }
+
+    // 生成工具名称
+    const finalToolName = customName || fullToolName;
+
+    // 检查工具名称是否已存在
+    const existingTools = configManager.getCustomMCPTools();
+    const existingNames = new Set(existingTools.map((tool) => tool.name));
+
+    if (existingNames.has(finalToolName)) {
+      return c.fail(
+        "TOOL_NAME_CONFLICT",
+        `工具名称 "${finalToolName}" 已存在，请使用不同的自定义名称`,
+        undefined,
+        409
+      );
+    }
+
+    // 创建 CustomMCPTool 配置
+    const tool: CustomMCPTool = {
+      name: finalToolName,
+      description:
+        customDescription ||
+        cachedTool.description ||
+        `MCP 工具: ${serviceName}/${toolName}`,
+      inputSchema: cachedTool.inputSchema || {},
+      handler: {
+        type: "mcp",
+        config: {
+          serviceName,
+          toolName,
+        },
+      },
+      stats: {
+        usageCount: 0,
+        lastUsedTime: dayjs().format("YYYY-MM-DD HH:mm:ss"),
+      },
+    };
+
+    // 添加工具到配置
+    configManager.addCustomMCPTool(tool);
+
+    // 对于 MCP 工具，需要在 mcpServerConfig 中同步启用
+    c.get("logger").info(
+      `检测到 MCP 工具添加，同步启用 mcpServerConfig 中的工具: ${serviceName}/${toolName}`
+    );
+
+    // 获取当前的服务工具配置
+    const serverToolsConfig = configManager.getServerToolsConfig(serviceName);
+
+    if (serverToolsConfig?.toolName) {
+      // 更新配置，启用该工具
+      serverToolsConfig[toolName].enable = true;
+
+      // 保存更新后的配置
+      configManager.updateServerToolsConfig(serviceName, serverToolsConfig);
+
+      c.get("logger").info(
+        `已同步启用 mcpServerConfig 中的工具: ${serviceName}/${toolName}`
+      );
+    }
+
+    c.get("logger").info(`成功添加 MCP 工具: ${finalToolName}`);
+
+    const responseData: AddToolResponse = {
+      tool,
+      toolName: finalToolName,
+      toolType: ToolType.MCP,
+      addedAt: dayjs().format("YYYY-MM-DD HH:mm:ss"),
+    };
+
+    return c.success(responseData, `MCP 工具 "${finalToolName}" 添加成功`);
+  }
+
+  /**
+   * 处理添加 Coze 工具
+   */
+  private async handleAddCozeTool(
+    c: Context<AppContext>,
+    data: CozeWorkflowData
+  ): Promise<Response> {
+    const { workflow, customName, customDescription, parameterConfig } = data;
+
+    c.get("logger").info(`处理添加 Coze 工具: ${workflow.workflow_name}`);
+
+    // 边界条件预检查
+    const preCheckResult = this.performPreChecks(
+      workflow,
+      customName,
+      customDescription
+    );
+    if (preCheckResult) {
+      return c.fail(
+        preCheckResult.code,
+        preCheckResult.message,
+        undefined,
+        preCheckResult.status
+      );
+    }
+
+    // 转换工作流为工具配置
+    const tool = this.convertWorkflowToTool(
+      workflow,
+      customName,
+      customDescription,
+      parameterConfig
+    );
+
+    // 添加工具到配置
+    configManager.addCustomMCPTool(tool);
+
+    c.get("logger").info(`成功添加 Coze 工具: ${tool.name}`);
+
+    const responseData: AddToolResponse = {
+      tool,
+      toolName: tool.name,
+      toolType: ToolType.COZE,
+      addedAt: dayjs().format("YYYY-MM-DD HH:mm:ss"),
+    };
+
+    return c.success(responseData, `Coze 工具 "${tool.name}" 添加成功`);
+  }
+
+  /**
+   * 更新自定义 MCP 工具配置
+   * PUT /api/tools/custom/:toolName
+   */
+  async updateCustomTool(c: Context<AppContext>): Promise<Response> {
+    try {
+      const toolName = c.req.param("toolName");
+
+      if (!toolName) {
+        return c.fail("INVALID_REQUEST", "工具名称不能为空", undefined, 400);
+      }
+
+      c.get("logger").info(`处理更新自定义工具配置请求: ${toolName}`);
+
+      const requestBody = await c.req.json();
+
+      // 验证请求体
+      if (!requestBody || typeof requestBody !== "object") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "请求体必须是有效对象",
+          undefined,
+          400
+        );
+      }
+
+      // 检查是否为新格式的请求
+      if (this.isNewFormatRequest(requestBody)) {
+        // 新格式：支持多种工具类型
+        return await this.handleNewFormatUpdateTool(
+          c,
+          toolName,
+          requestBody as AddCustomToolRequest
+        );
+      }
+
+      // 旧格式不支持更新操作
+      return c.fail(
+        "INVALID_REQUEST",
+        "更新操作只支持新格式的请求",
+        undefined,
+        400
+      );
+    } catch (error) {
+      c.get("logger").error("更新自定义工具配置失败:", error);
+
+      // 根据错误类型返回不同的HTTP状态码和错误信息
+      const { code, message, status } = this.handleUpdateToolError(error);
+      return c.fail(code, message, undefined, status);
+    }
+  }
+
+  /**
+   * 处理新格式的更新工具请求
+   */
+  private async handleNewFormatUpdateTool(
+    c: Context<AppContext>,
+    toolName: string,
+    request: AddCustomToolRequest
+  ): Promise<Response> {
+    const { type, data } = request;
+
+    c.get("logger").info(`处理新格式工具更新请求，类型: ${type}`);
+
+    // 验证工具类型
+    if (!MCPToolHandler.TOOL_TYPE_VALUES.includes(type)) {
+      return c.fail(
+        "INVALID_TOOL_TYPE",
+        `不支持的工具类型: ${type}。支持的类型: ${MCPToolHandler.TOOL_TYPE_VALUES.join(", ")}`,
+        undefined,
+        400
+      );
+    }
+
+    // 根据工具类型分发处理
+    switch (type) {
+      case ToolType.COZE:
+        return await this.handleUpdateCozeTool(
+          c,
+          toolName,
+          data as CozeWorkflowData
+        );
+
+      case ToolType.MCP:
+      case ToolType.HTTP:
+      case ToolType.FUNCTION: {
+        return c.fail(
+          "TOOL_TYPE_NOT_IMPLEMENTED",
+          `工具类型 ${type} 暂不支持更新操作，目前仅支持 Coze 类型`,
+          undefined,
+          501
+        );
+      }
+
+      default: {
+        return c.fail(
+          "UNKNOWN_TOOL_TYPE",
+          `未知的工具类型: ${type}`,
+          undefined,
+          400
+        );
+      }
+    }
+  }
+
+  /**
+   * 处理更新 Coze 工具
+   */
+  private async handleUpdateCozeTool(
+    c: Context<AppContext>,
+    toolName: string,
+    data: CozeWorkflowData
+  ): Promise<Response> {
+    const { workflow, customName, customDescription, parameterConfig } = data;
+
+    c.get("logger").info(`处理更新 Coze 工具: ${toolName}`);
+
+    // 验证工具是否存在
+    const existingTools = configManager.getCustomMCPTools();
+    const existingTool = existingTools.find((tool) => tool.name === toolName);
+
+    if (!existingTool) {
+      return c.fail(
+        "TOOL_NOT_FOUND",
+        `工具 "${toolName}" 不存在`,
+        undefined,
+        404
+      );
+    }
+
+    // 验证是否为 Coze 工具
+    if (
+      existingTool.handler.type !== "proxy" ||
+      existingTool.handler.platform !== "coze"
+    ) {
+      return c.fail(
+        "INVALID_TOOL_TYPE",
+        `工具 "${toolName}" 不是 Coze 工作流工具，不支持参数配置更新`,
+        undefined,
+        400
+      );
+    }
+
+    // 如果前端提供的 workflow 中没有 workflow_id，尝试从现有工具中获取
+    if (!workflow.workflow_id && existingTool.handler?.config?.workflow_id) {
+      workflow.workflow_id = existingTool.handler.config.workflow_id;
+    }
+
+    // 如果还没有 workflow_id，尝试从其他字段获取
+    if (!workflow.workflow_id && workflow.app_id) {
+      // 对于某些场景，app_id 可以作为替代标识
+      // 但我们仍然需要 workflow_id 用于 Coze API 调用
+      c.get("logger").warn(
+        `工作流 ${toolName} 缺少 workflow_id，这可能会影响某些功能`
+      );
+    }
+
+    // 验证工作流数据完整性
+    this.validateWorkflowUpdateData(workflow);
+
+    // 更新工具的 inputSchema
+    const updatedInputSchema = this.generateInputSchema(
+      workflow,
+      parameterConfig
+    );
+
+    // 构建更新后的工具配置
+    const updatedTool: CustomMCPTool = {
+      ...existingTool,
+      description: customDescription || existingTool.description,
+      inputSchema: updatedInputSchema,
+    };
+
+    // 更新工具配置
+    configManager.updateCustomMCPTool(toolName, updatedTool);
+
+    c.get("logger").info(`成功更新 Coze 工具: ${toolName}`);
+
+    const responseData = {
+      tool: updatedTool,
+      toolName: toolName,
+      toolType: ToolType.COZE,
+      updatedAt: dayjs().format("YYYY-MM-DD HH:mm:ss"),
+    };
+
+    return c.success(responseData, `Coze 工具 "${toolName}" 配置更新成功`);
+  }
+
+  /**
+   * 处理更新工具时的错误
+   */
+  private handleUpdateToolError(error: unknown): {
+    code: string;
+    message: string;
+    status: number;
+  } {
+    const errorMessage =
+      error instanceof Error ? error.message : "更新自定义工具配置失败";
+
+    // 工具不存在错误 (404)
+    if (errorMessage.includes("不存在") || errorMessage.includes("未找到")) {
+      return {
+        code: "TOOL_NOT_FOUND",
+        message: `${errorMessage}。请检查工具名称是否正确`,
+        status: 404,
+      };
+    }
+
+    // 工具类型错误 (400)
+    if (
+      errorMessage.includes("工具类型") ||
+      errorMessage.includes("INVALID_TOOL_TYPE")
+    ) {
+      return {
+        code: "INVALID_TOOL_TYPE",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 参数错误 (400)
+    if (errorMessage.includes("不能为空") || errorMessage.includes("无效")) {
+      return {
+        code: "INVALID_REQUEST",
+        message: `${errorMessage}。请提供有效的工具配置数据`,
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (errorMessage.includes("配置") || errorMessage.includes("权限")) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查配置文件权限和格式是否正确`,
+        status: 422,
+      };
+    }
+
+    // 未实现功能错误 (501)
+    if (
+      errorMessage.includes("未实现") ||
+      errorMessage.includes("NOT_IMPLEMENTED")
+    ) {
+      return {
+        code: "TOOL_TYPE_NOT_IMPLEMENTED",
+        message: errorMessage,
+        status: 501,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "UPDATE_CUSTOM_TOOL_ERROR",
+      message: `更新工具配置失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 删除自定义 MCP 工具
+   * DELETE /api/tools/custom/:toolName
+   */
+  async removeCustomTool(c: Context<AppContext>): Promise<Response> {
+    try {
+      const toolName = c.req.param("toolName");
+
+      if (!toolName) {
+        return c.fail("INVALID_REQUEST", "工具名称不能为空", undefined, 400);
+      }
+
+      c.get("logger").info(`处理删除自定义工具请求: ${toolName}`);
+
+      // 在删除之前，检查是否为 MCP 工具，如果是则需要在 mcpServerConfig 中同步禁用
+      const existingTools = configManager.getCustomMCPTools();
+      const toolToDelete = existingTools.find((tool) => tool.name === toolName);
+
+      if (toolToDelete && toolToDelete.handler.type === "mcp") {
+        // 这是 MCP 工具，需要在 mcpServerConfig 中同步禁用
+        const mcpConfig = toolToDelete.handler.config;
+        if (mcpConfig.serviceName && mcpConfig.toolName) {
+          c.get("logger").info(
+            `检测到 MCP 工具删除，同步禁用 mcpServerConfig 中的工具: ${mcpConfig.serviceName}/${mcpConfig.toolName}`
+          );
+
+          // 获取当前的服务工具配置
+          const serverToolsConfig = configManager.getServerToolsConfig(
+            mcpConfig.serviceName
+          );
+
+          if (serverToolsConfig?.[mcpConfig.toolName]) {
+            // 更新配置，禁用该工具
+            serverToolsConfig[mcpConfig.toolName].enable = false;
+
+            // 保存更新后的配置
+            configManager.updateServerToolsConfig(
+              mcpConfig.serviceName,
+              serverToolsConfig
+            );
+
+            c.get("logger").info(
+              `已同步禁用 mcpServerConfig 中的工具: ${mcpConfig.serviceName}/${mcpConfig.toolName}`
+            );
+          }
+        }
+      }
+
+      // 从配置中删除工具
+      configManager.removeCustomMCPTool(toolName);
+
+      c.get("logger").info(`成功删除自定义工具: ${toolName}`);
+
+      return c.success(null, `工具 "${toolName}" 删除成功`);
+    } catch (error) {
+      c.get("logger").error("删除自定义工具失败:", error);
+
+      // 根据错误类型返回不同的HTTP状态码和错误信息
+      const { code, message, status } = this.handleRemoveToolError(error);
+      return c.fail(code, message, undefined, status);
+    }
+  }
+
+  /**
+   * 将扣子工作流转换为自定义 MCP 工具
+   */
+  private convertWorkflowToTool(
+    workflow: CozeWorkflow,
+    customName?: string,
+    customDescription?: string,
+    parameterConfig?: WorkflowParameterConfig
+  ): CustomMCPTool {
+    // 验证工作流数据完整性
+    this.validateWorkflowData(workflow);
+
+    // 生成工具名称（处理冲突）
+    const baseName =
+      customName || this.sanitizeToolName(workflow.workflow_name);
+    const toolName = this.resolveToolNameConflict(baseName);
+
+    // 生成工具描述
+    const description = this.generateToolDescription(
+      workflow,
+      customDescription
+    );
+
+    // 生成输入参数结构
+    const inputSchema = this.generateInputSchema(workflow, parameterConfig);
+
+    // 配置 HTTP 处理器
+    const handler = this.createHttpHandler(workflow);
+
+    // 创建工具配置
+    const tool: CustomMCPTool = {
+      name: toolName,
+      description,
+      inputSchema,
+      handler,
+    };
+
+    // 验证生成的工具配置
+    this.validateGeneratedTool(tool);
+
+    return tool;
+  }
+
+  /**
+   * 规范化工具名称
+   */
+  private sanitizeToolName(name: string): string {
+    if (!name || typeof name !== "string") {
+      return "coze_workflow_unnamed";
+    }
+
+    // 去除首尾空格
+    let sanitized = name.trim();
+
+    if (!sanitized) {
+      return "coze_workflow_empty";
+    }
+
+    // 将中文转换为拼音或英文描述（简化处理）
+    sanitized = this.convertChineseToEnglish(sanitized);
+
+    // 移除特殊字符，只保留字母、数字和下划线
+    sanitized = sanitized.replace(/[^a-zA-Z0-9_]/g, "_");
+
+    // 移除连续的下划线
+    sanitized = sanitized.replace(/_+/g, "_");
+
+    // 移除开头和结尾的下划线
+    sanitized = sanitized.replace(MCPToolHandler.UNDERSCORE_TRIM_REGEX, "");
+
+    // 确保以字母开头
+    if (!MCPToolHandler.LETTER_START_REGEX.test(sanitized)) {
+      sanitized = `coze_workflow_${sanitized}`;
+    }
+
+    // 限制长度（保留足够空间给数字后缀）
+    if (sanitized.length > 45) {
+      sanitized = sanitized.substring(0, 45);
+    }
+
+    // 确保不为空
+    if (!sanitized) {
+      sanitized = "coze_workflow_tool";
+    }
+
+    return sanitized;
+  }
+
+  /**
+   * 简单的中文到英文转换（可以扩展为更复杂的拼音转换）
+   */
+  private convertChineseToEnglish(text: string): string {
+    // 常见中文词汇的映射
+    const chineseToEnglishMap: Record<string, string> = {
+      工作流: "workflow",
+      测试: "test",
+      数据: "data",
+      处理: "process",
+      分析: "analysis",
+      生成: "generate",
+      查询: "query",
+      搜索: "search",
+      转换: "convert",
+      计算: "calculate",
+      统计: "statistics",
+      报告: "report",
+      文档: "document",
+      图片: "image",
+      视频: "video",
+      音频: "audio",
+      文本: "text",
+      翻译: "translate",
+      识别: "recognize",
+      检测: "detect",
+      监控: "monitor",
+      管理: "manage",
+      配置: "config",
+      设置: "setting",
+      用户: "user",
+      系统: "system",
+      服务: "service",
+      接口: "api",
+      数据库: "database",
+      网络: "network",
+      安全: "security",
+      备份: "backup",
+      恢复: "restore",
+      同步: "sync",
+      导入: "import",
+      导出: "export",
+      上传: "upload",
+      下载: "download",
+    };
+
+    let result = text;
+
+    // 替换常见中文词汇
+    for (const [chinese, english] of Object.entries(chineseToEnglishMap)) {
+      result = result.replace(new RegExp(chinese, "g"), english);
+    }
+
+    // 如果还有中文字符，用拼音前缀替代
+    if (MCPToolHandler.CHINESE_CHAR_REGEX.test(result)) {
+      result = `chinese_${result}`;
+    }
+
+    return result;
+  }
+
+  /**
+   * 验证工作流数据完整性
+   */
+  private validateWorkflowData(workflow: CozeWorkflow): void {
+    if (!workflow) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流数据不能为空"
+      );
+    }
+
+    // 验证必需字段
+    this.validateRequiredFields(workflow);
+
+    // 验证字段格式
+    this.validateFieldFormats(workflow);
+
+    // 验证字段长度
+    this.validateFieldLengths(workflow);
+
+    // 验证业务逻辑
+    this.validateBusinessLogic(workflow);
+  }
+
+  /**
+   * 验证工作流更新数据完整性
+   * 用于更新场景，只验证关键字段
+   */
+  private validateWorkflowUpdateData(workflow: Partial<CozeWorkflow>): void {
+    if (!workflow) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流数据不能为空"
+      );
+    }
+
+    // 对于更新操作，我们采用更灵活的验证策略
+    // 因为这可能是参数配置更新，而不是工作流本身更新
+
+    // 如果提供了 workflow_id，验证其格式
+    if (workflow.workflow_id) {
+      if (
+        typeof workflow.workflow_id !== "string" ||
+        workflow.workflow_id.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流ID必须是非空字符串"
+        );
+      }
+
+      // 验证工作流ID格式（数字字符串）
+      if (!MCPToolHandler.DIGITS_ONLY_REGEX.test(workflow.workflow_id)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流ID格式无效，应为数字字符串"
+        );
+      }
+    }
+
+    // 如果存在 workflow_name，验证其格式
+    if (workflow.workflow_name) {
+      if (
+        typeof workflow.workflow_name !== "string" ||
+        workflow.workflow_name.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流名称必须是非空字符串"
+        );
+      }
+
+      // 验证工作流名称长度
+      if (workflow.workflow_name.length > 100) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "工作流名称过长，不能超过100个字符"
+        );
+      }
+    }
+
+    // 如果存在 app_id，验证其格式
+    if (workflow.app_id) {
+      if (
+        typeof workflow.app_id !== "string" ||
+        workflow.app_id.trim() === ""
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID必须是非空字符串"
+        );
+      }
+
+      // 验证应用ID格式
+      if (!MCPToolHandler.ALPHANUMERIC_UNDERSCORE_REGEX.test(workflow.app_id)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID格式无效，只能包含字母、数字、下划线和连字符"
+        );
+      }
+
+      // 验证应用ID长度
+      if (workflow.app_id.length > 50) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "应用ID过长，不能超过50个字符"
+        );
+      }
+    }
+
+    // 对于参数配置更新，workflow_id 可能不是必需的
+    // 因为实际的工作流ID已经存储在工具配置中
+    // 我们主要验证存在字段的格式，而不是强制要求所有字段都存在
+  }
+
+  /**
+   * 验证必需字段
+   */
+  private validateRequiredFields(workflow: CozeWorkflow): void {
+    const requiredFields = [
+      { field: "workflow_id", name: "工作流ID" },
+      { field: "workflow_name", name: "工作流名称" },
+      { field: "app_id", name: "应用ID" },
+    ];
+
+    for (const { field, name } of requiredFields) {
+      const value = workflow[field as keyof CozeWorkflow];
+      if (!value || typeof value !== "string" || value.trim() === "") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `${name}不能为空且必须是非空字符串`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证字段格式
+   */
+  private validateFieldFormats(workflow: CozeWorkflow): void {
+    // 验证工作流ID格式（数字字符串）
+    if (!MCPToolHandler.DIGITS_ONLY_REGEX.test(workflow.workflow_id)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工作流ID格式无效，应为数字字符串"
+      );
+    }
+
+    // 验证应用ID格式
+    if (!MCPToolHandler.ALPHANUMERIC_UNDERSCORE_REGEX.test(workflow.app_id)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "应用ID格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+
+    // 验证图标URL格式（如果存在）
+    if (workflow.icon_url?.trim()) {
+      try {
+        new URL(workflow.icon_url);
+      } catch {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "图标URL格式无效"
+        );
+      }
+    }
+
+    // 验证时间戳格式
+    if (
+      workflow.created_at &&
+      (!Number.isInteger(workflow.created_at) || workflow.created_at <= 0)
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "创建时间格式无效，应为正整数时间戳"
+      );
+    }
+
+    if (
+      workflow.updated_at &&
+      (!Number.isInteger(workflow.updated_at) || workflow.updated_at <= 0)
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "更新时间格式无效，应为正整数时间戳"
+      );
+    }
+  }
+
+  /**
+   * 验证字段长度
+   */
+  private validateFieldLengths(workflow: CozeWorkflow): void {
+    const lengthLimits = [
+      { field: "workflow_name", name: "工作流名称", max: 100 },
+      { field: "description", name: "工作流描述", max: 500 },
+      { field: "app_id", name: "应用ID", max: 50 },
+    ];
+
+    for (const { field, name, max } of lengthLimits) {
+      const value = workflow[field as keyof CozeWorkflow] as string;
+      if (value && value.length > max) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `${name}过长，不能超过${max}个字符`
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证业务逻辑
+   */
+  private validateBusinessLogic(workflow: CozeWorkflow): void {
+    // 验证创建者信息
+    if (workflow.creator) {
+      if (!workflow.creator.id || typeof workflow.creator.id !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "创建者ID不能为空且必须是字符串"
+        );
+      }
+      if (!workflow.creator.name || typeof workflow.creator.name !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "创建者名称不能为空且必须是字符串"
+        );
+      }
+    }
+
+    // 验证时间逻辑
+    if (
+      workflow.created_at &&
+      workflow.updated_at &&
+      workflow.updated_at < workflow.created_at
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "更新时间不能早于创建时间"
+      );
+    }
+
+    // 验证工作流名称不能包含敏感词
+    const sensitiveWords = [
+      "admin",
+      "root",
+      "system",
+      "config",
+      "password",
+      "token",
+    ];
+    const lowerName = workflow.workflow_name.toLowerCase();
+    for (const word of sensitiveWords) {
+      if (lowerName.includes(word)) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `工作流名称不能包含敏感词: ${word}`
+        );
+      }
+    }
+  }
+
+  /**
+   * 解决工具名称冲突
+   */
+  private resolveToolNameConflict(baseName: string): string {
+    const existingTools = configManager.getCustomMCPTools();
+    const existingNames = new Set(existingTools.map((tool) => tool.name));
+
+    let finalName = baseName;
+    let counter = 1;
+
+    // 如果名称已存在，添加数字后缀
+    while (existingNames.has(finalName)) {
+      finalName = `${baseName}_${counter}`;
+      counter++;
+
+      // 防止无限循环
+      if (counter > 999) {
+        throw MCPError.operationError(
+          MCPErrorCode.OPERATION_FAILED,
+          `无法为工具生成唯一名称，基础名称: ${baseName}`
+        );
+      }
+    }
+
+    return finalName;
+  }
+
+  /**
+   * 生成工具描述
+   */
+  private generateToolDescription(
+    workflow: CozeWorkflow,
+    customDescription?: string
+  ): string {
+    if (customDescription) {
+      return customDescription;
+    }
+
+    if (workflow.description?.trim()) {
+      return workflow.description.trim();
+    }
+
+    // 生成默认描述
+    return `扣子工作流工具: ${workflow.workflow_name}`;
+  }
+
+  /**
+   * 创建HTTP处理器配置
+   */
+  private createHttpHandler(workflow: CozeWorkflow): ProxyHandlerConfig {
+    // 验证扣子API配置
+    this.validateCozeApiConfig();
+
+    return {
+      type: "proxy",
+      platform: "coze",
+      config: {
+        workflow_id: workflow.workflow_id,
+      },
+    };
+  }
+
+  /**
+   * 验证扣子API配置
+   */
+  private validateCozeApiConfig(): void {
+    // 检查是否配置了扣子token
+    const cozeConfig = configManager.getCozePlatformConfig();
+    if (!cozeConfig || !cozeConfig.token) {
+      throw MCPError.configError(
+        MCPErrorCode.INVALID_CONFIG,
+        "未配置扣子API Token，请先在配置中设置 platforms.coze.token"
+      );
+    }
+  }
+
+  /**
+   * 验证生成的工具配置
+   */
+  private validateGeneratedTool(tool: CustomMCPTool): void {
+    // 基础结构验证
+    this.validateToolStructure(tool);
+
+    // 使用configManager的验证方法
+    if (!configManager.validateCustomMCPTools([tool])) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "生成的工具配置验证失败，请检查工具定义"
+      );
+    }
+
+    // JSON Schema验证
+    this.validateJsonSchema(tool.inputSchema);
+
+    // HTTP处理器验证
+    if (tool.handler) {
+      this.validateProxyHandler(tool.handler as ProxyHandlerConfig);
+    }
+  }
+
+  /**
+   * 验证工具基础结构
+   */
+  private validateToolStructure(tool: CustomMCPTool): void {
+    if (!tool || typeof tool !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具配置必须是有效对象"
+      );
+    }
+
+    // 验证必需字段
+    const requiredFields = ["name", "description", "inputSchema", "handler"];
+    for (const field of requiredFields) {
+      if (!(field in tool) || tool[field as keyof CustomMCPTool] == null) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          `工具配置缺少必需字段: ${field}`
+        );
+      }
+    }
+
+    // 验证字段类型
+    if (typeof tool.name !== "string" || tool.name.trim() === "") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具名称必须是非空字符串"
+      );
+    }
+
+    if (
+      typeof tool.description !== "string" ||
+      tool.description.trim() === ""
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具描述必须是非空字符串"
+      );
+    }
+
+    if (typeof tool.inputSchema !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须是对象"
+      );
+    }
+
+    if (typeof tool.handler !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "处理器配置必须是对象"
+      );
+    }
+  }
+
+  /**
+   * 验证HTTP处理器配置
+   */
+  private validateProxyHandler(handler: ProxyHandlerConfig): void {
+    if (!handler || typeof handler !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "HTTP处理器配置不能为空"
+      );
+    }
+
+    // 验证处理器类型
+    if (handler.type !== "proxy") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "处理器类型必须是'proxy'"
+      );
+    }
+
+    if (handler.platform === "coze") {
+      if (!handler.config.workflow_id) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Coze处理器必须包含有效的workflow_id"
+        );
+      }
+    } else {
+      throw MCPError.configError(
+        MCPErrorCode.INVALID_CONFIG,
+        "不支持的工作流平台"
+      );
+    }
+  }
+
+  /**
+   * 验证认证配置
+   */
+  private validateAuthConfig(auth: { type: string; token?: string }): void {
+    if (!auth || typeof auth !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "认证配置必须是对象"
+      );
+    }
+
+    if (!auth.type || typeof auth.type !== "string") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "认证类型不能为空"
+      );
+    }
+
+    const validAuthTypes = ["bearer", "basic", "api_key"];
+    if (!validAuthTypes.includes(auth.type)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        `认证类型必须是以下之一: ${validAuthTypes.join(", ")}`
+      );
+    }
+
+    // 验证token格式
+    if (auth.type === "bearer") {
+      if (!auth.token || typeof auth.token !== "string") {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Bearer认证必须包含有效的token"
+        );
+      }
+
+      // 验证token格式（应该是环境变量引用或实际token）
+      if (
+        !auth.token.startsWith("${") &&
+        !MCPToolHandler.ALPHANUMERIC_UNDERSCORE_REGEX.test(auth.token)
+      ) {
+        throw MCPError.validationError(
+          MCPErrorCode.TOOL_VALIDATION_FAILED,
+          "Bearer token格式无效"
+        );
+      }
+    }
+  }
+
+  /**
+   * 验证请求体模板
+   */
+  private validateBodyTemplate(bodyTemplate: string): void {
+    if (typeof bodyTemplate !== "string") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "请求体模板必须是字符串"
+      );
+    }
+
+    try {
+      JSON.parse(bodyTemplate);
+    } catch {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "请求体模板必须是有效的JSON格式"
+      );
+    }
+
+    // 验证模板变量格式
+    const templateVars = bodyTemplate.match(/\{\{[^}]+\}\}/g);
+    if (templateVars) {
+      for (const templateVar of templateVars) {
+        const varName = templateVar.slice(2, -2).trim();
+        if (!varName || !MCPToolHandler.IDENTIFIER_REGEX.test(varName)) {
+          throw MCPError.validationError(
+            MCPErrorCode.TOOL_VALIDATION_FAILED,
+            `模板变量格式无效: ${templateVar}`
+          );
+        }
+      }
+    }
+  }
+
+  /**
+   * 验证JSON Schema格式
+   */
+  private validateJsonSchema(schema: JSONSchema): void {
+    if (!schema || typeof schema !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须是有效的对象"
+      );
+    }
+
+    if (!schema.type || schema.type !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构的type必须是'object'"
+      );
+    }
+
+    if (!schema.properties || typeof schema.properties !== "object") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构必须包含properties字段"
+      );
+    }
+
+    // 验证required字段
+    if (schema.required && !Array.isArray(schema.required)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "输入参数结构的required字段必须是数组"
+      );
+    }
+  }
+
+  /**
+   * 生成输入参数结构
+   */
+  private generateInputSchema(
+    workflow: CozeWorkflow,
+    parameterConfig?: WorkflowParameterConfig
+  ): JSONSchema {
+    // 如果提供了参数配置，使用参数配置生成schema
+    if (parameterConfig && parameterConfig.parameters.length > 0) {
+      return this.generateInputSchemaFromConfig(parameterConfig);
+    }
+
+    // 否则使用默认的基础参数结构
+    const baseSchema = {
+      type: "object",
+      properties: {
+        input: {
+          type: "string",
+          description: "输入内容",
+        },
+      },
+      required: ["input"],
+      additionalProperties: false,
+    };
+
+    return baseSchema;
+  }
+
+  /**
+   * 根据参数配置生成输入参数结构
+   */
+  private generateInputSchemaFromConfig(
+    parameterConfig: WorkflowParameterConfig
+  ): JSONSchema {
+    const properties: Record<string, unknown> = {};
+    const required: string[] = [];
+
+    for (const param of parameterConfig.parameters) {
+      properties[param.fieldName] = {
+        type: param.type,
+        description: param.description,
+      };
+
+      if (param.required) {
+        required.push(param.fieldName);
+      }
+    }
+
+    return {
+      type: "object",
+      properties,
+      required: required.length > 0 ? required : undefined,
+      additionalProperties: false,
+    };
+  }
+
+  /**
+   * 处理添加工具时的错误
+   */
+  private handleAddToolError(error: unknown): {
+    code: string;
+    message: string;
+    status: number;
+  } {
+    const errorMessage =
+      error instanceof Error ? error.message : "添加自定义工具失败";
+
+    // 工具类型错误 (400)
+    if (
+      errorMessage.includes("工具类型") ||
+      errorMessage.includes("TOOL_TYPE")
+    ) {
+      return {
+        code: "INVALID_TOOL_TYPE",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 缺少必需字段错误 (400)
+    if (
+      errorMessage.includes("必需字段") ||
+      errorMessage.includes("MISSING_REQUIRED_FIELD")
+    ) {
+      return {
+        code: "MISSING_REQUIRED_FIELD",
+        message: errorMessage,
+        status: 400,
+      };
+    }
+
+    // 工具或服务不存在错误 (404)
+    if (
+      errorMessage.includes("不存在") ||
+      errorMessage.includes("NOT_FOUND") ||
+      errorMessage.includes("未找到")
+    ) {
+      return {
+        code: "SERVICE_OR_TOOL_NOT_FOUND",
+        message: errorMessage,
+        status: 404,
+      };
+    }
+
+    // 服务未初始化错误 (503)
+    if (
+      errorMessage.includes("未初始化") ||
+      errorMessage.includes("SERVICE_NOT_INITIALIZED")
+    ) {
+      return {
+        code: "SERVICE_NOT_INITIALIZED",
+        message: errorMessage,
+        status: 503,
+      };
+    }
+
+    // 工具名称冲突错误 (409)
+    if (
+      errorMessage.includes("已存在") ||
+      errorMessage.includes("冲突") ||
+      errorMessage.includes("TOOL_NAME_CONFLICT")
+    ) {
+      return {
+        code: "TOOL_NAME_CONFLICT",
+        message: `${errorMessage}。建议：1) 使用自定义名称；2) 删除现有同名工具后重试`,
+        status: 409,
+      };
+    }
+
+    // 数据验证错误 (400)
+    if (this.isValidationError(errorMessage)) {
+      return {
+        code: "VALIDATION_ERROR",
+        message: this.formatValidationError(errorMessage),
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (
+      errorMessage.includes("配置") ||
+      errorMessage.includes("token") ||
+      errorMessage.includes("API") ||
+      errorMessage.includes("CONFIGURATION_ERROR")
+    ) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查：1) 相关配置是否正确；2) 网络连接是否正常；3) 配置文件权限是否正确`,
+        status: 422,
+      };
+    }
+
+    // 资源限制错误 (429)
+    if (
+      errorMessage.includes("资源限制") ||
+      errorMessage.includes("RESOURCE_LIMIT_EXCEEDED")
+    ) {
+      return {
+        code: "RESOURCE_LIMIT_EXCEEDED",
+        message: errorMessage,
+        status: 429,
+      };
+    }
+
+    // 未实现功能错误 (501)
+    if (
+      errorMessage.includes("未实现") ||
+      errorMessage.includes("NOT_IMPLEMENTED")
+    ) {
+      return {
+        code: "TOOL_TYPE_NOT_IMPLEMENTED",
+        message: errorMessage,
+        status: 501,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "ADD_CUSTOM_TOOL_ERROR",
+      message: `添加工具失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 处理删除工具时的错误
+   */
+  private handleRemoveToolError(error: unknown): {
+    code: string;
+    message: string;
+    status: number;
+  } {
+    const errorMessage =
+      error instanceof Error ? error.message : "删除自定义工具失败";
+
+    // 工具不存在错误 (404)
+    if (errorMessage.includes("不存在") || errorMessage.includes("未找到")) {
+      return {
+        code: "TOOL_NOT_FOUND",
+        message: `${errorMessage}。请检查工具名称是否正确，或刷新页面查看最新的工具列表`,
+        status: 404,
+      };
+    }
+
+    // 参数错误 (400)
+    if (errorMessage.includes("不能为空") || errorMessage.includes("无效")) {
+      return {
+        code: "INVALID_REQUEST",
+        message: `${errorMessage}。请提供有效的工具名称`,
+        status: 400,
+      };
+    }
+
+    // 配置错误 (422)
+    if (errorMessage.includes("配置") || errorMessage.includes("权限")) {
+      return {
+        code: "CONFIGURATION_ERROR",
+        message: `${errorMessage}。请检查配置文件权限和格式是否正确`,
+        status: 422,
+      };
+    }
+
+    // 系统错误 (500)
+    return {
+      code: "REMOVE_CUSTOM_TOOL_ERROR",
+      message: `删除工具失败：${errorMessage}。请稍后重试，如问题持续存在请联系管理员`,
+      status: 500,
+    };
+  }
+
+  /**
+   * 判断是否为数据验证错误
+   */
+  private isValidationError(errorMessage: string): boolean {
+    const validationKeywords = [
+      "不能为空",
+      "必须是",
+      "格式无效",
+      "过长",
+      "过短",
+      "验证失败",
+      "无效",
+      "不符合",
+      "超过",
+      "少于",
+      "敏感词",
+      "时间",
+      "URL",
+    ];
+
+    return validationKeywords.some((keyword) => errorMessage.includes(keyword));
+  }
+
+  /**
+   * 格式化验证错误信息
+   */
+  private formatValidationError(errorMessage: string): string {
+    // 为常见的验证错误提供更友好的提示
+    const errorMappings: Record<string, string> = {
+      工作流ID不能为空: "请提供有效的工作流ID",
+      工作流名称不能为空: "请提供有效的工作流名称",
+      应用ID不能为空: "请提供有效的应用ID",
+      工作流ID格式无效: "工作流ID应为数字格式，请检查工作流配置",
+      应用ID格式无效: "应用ID只能包含字母、数字、下划线和连字符",
+      工作流名称过长: "工作流名称不能超过100个字符，请缩短名称",
+      工作流描述过长: "工作流描述不能超过500个字符，请缩短描述",
+      图标URL格式无效: "请提供有效的图标URL地址",
+      更新时间不能早于创建时间: "工作流的时间信息有误，请检查工作流数据",
+      敏感词: "工作流名称包含敏感词汇，请修改后重试",
+    };
+
+    // 查找匹配的错误映射
+    for (const [key, value] of Object.entries(errorMappings)) {
+      if (errorMessage.includes(key)) {
+        return value;
+      }
+    }
+
+    return errorMessage;
+  }
+
+  /**
+   * 执行边界条件预检查
+   */
+  private performPreChecks(
+    workflow: unknown,
+    customName?: string,
+    customDescription?: string
+  ): { code: string; message: string; status: number } | null {
+    // 检查基础参数
+    const basicCheckResult = this.checkBasicParameters(
+      workflow,
+      customName,
+      customDescription
+    );
+    if (basicCheckResult) return basicCheckResult;
+
+    // 检查系统状态
+    const systemCheckResult = this.checkSystemStatus();
+    if (systemCheckResult) return systemCheckResult;
+
+    // 检查资源限制
+    const resourceCheckResult = this.checkResourceLimits();
+    if (resourceCheckResult) return resourceCheckResult;
+
+    return null; // 所有检查通过
+  }
+
+  /**
+   * 检查基础参数
+   */
+  private checkBasicParameters(
+    workflow: unknown,
+    customName?: string,
+    customDescription?: string
+  ): { code: string; message: string; status: number } | null {
+    // 检查workflow参数
+    if (!workflow) {
+      return {
+        code: "INVALID_REQUEST",
+        message: "请求体中缺少 workflow 参数",
+        status: 400,
+      };
+    }
+
+    if (typeof workflow !== "object") {
+      return {
+        code: "INVALID_REQUEST",
+        message: "workflow 参数必须是对象类型",
+        status: 400,
+      };
+    }
+
+    // 类型守卫：确保 workflow 不是数组
+    if (!Array.isArray(workflow)) {
+      const workflowObj = workflow as Record<string, unknown>;
+
+      // 检查必需字段
+      if (
+        !workflowObj.workflow_id ||
+        typeof workflowObj.workflow_id !== "string" ||
+        !workflowObj.workflow_id.trim()
+      ) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "workflow_id 不能为空且必须是非空字符串",
+          status: 400,
+        };
+      }
+
+      if (
+        !workflowObj.workflow_name ||
+        typeof workflowObj.workflow_name !== "string" ||
+        !workflowObj.workflow_name.trim()
+      ) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "workflow_name 不能为空且必须是非空字符串",
+          status: 400,
+        };
+      }
+    }
+
+    // 检查自定义参数
+    if (customName !== undefined) {
+      if (typeof customName !== "string") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 必须是字符串类型",
+          status: 400,
+        };
+      }
+
+      if (customName.trim() === "") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 不能为空字符串",
+          status: 400,
+        };
+      }
+
+      if (customName.length > 50) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customName 长度不能超过50个字符",
+          status: 400,
+        };
+      }
+    }
+
+    if (customDescription !== undefined) {
+      if (typeof customDescription !== "string") {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customDescription 必须是字符串类型",
+          status: 400,
+        };
+      }
+
+      if (customDescription.length > 200) {
+        return {
+          code: "INVALID_REQUEST",
+          message: "customDescription 长度不能超过200个字符",
+          status: 400,
+        };
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * 检查系统状态
+   */
+  private checkSystemStatus(): {
+    code: string;
+    message: string;
+    status: number;
+  } | null {
+    // 检查扣子API配置
+    try {
+      const cozeConfig = configManager.getCozePlatformConfig();
+      if (!cozeConfig || !cozeConfig.token) {
+        return {
+          code: "CONFIGURATION_ERROR",
+          message:
+            "未配置扣子API Token。请在系统设置中配置 platforms.coze.token",
+          status: 422,
+        };
+      }
+
+      // 检查token格式
+      if (
+        typeof cozeConfig.token !== "string" ||
+        cozeConfig.token.trim() === ""
+      ) {
+        return {
+          code: "CONFIGURATION_ERROR",
+          message: "扣子API Token格式无效。请检查配置中的 platforms.coze.token",
+          status: 422,
+        };
+      }
+    } catch (error) {
+      return {
+        code: "SYSTEM_ERROR",
+        message: "系统配置检查失败，请稍后重试",
+        status: 500,
+      };
+    }
+
+    return null;
+  }
+
+  /**
+   * 检查资源限制
+   */
+  private checkResourceLimits(): {
+    code: string;
+    message: string;
+    status: number;
+  } | null {
+    try {
+      // 检查现有工具数量限制
+      const existingTools = configManager.getCustomMCPTools();
+      const maxTools = 100; // 设置最大工具数量限制
+
+      if (existingTools.length >= maxTools) {
+        return {
+          code: "RESOURCE_LIMIT_EXCEEDED",
+          message: `已达到最大工具数量限制 (${maxTools})。请删除一些不需要的工具后重试`,
+          status: 429,
+        };
+      }
+
+      // 检查配置文件大小（简单估算）
+      const configSizeEstimate = JSON.stringify(existingTools).length;
+      const maxConfigSize = 1024 * 1024; // 1MB限制
+
+      if (configSizeEstimate > maxConfigSize) {
+        return {
+          code: "PAYLOAD_TOO_LARGE",
+          message: "配置文件过大。请删除一些不需要的工具以释放空间",
+          status: 413,
+        };
+      }
+    } catch (error) {
+      // 资源检查失败不应阻止操作，只记录警告
+      this.logger.warn("资源限制检查失败:", error);
+    }
+
+    return null;
+  }
+
+  /**
+   * 统一的 MCP 工具管理接口
+   * POST /api/tools/mcp/manage
+   * 支持 action: enable | disable | status | toggle
+   */
+  async manageMCPTool(c: Context<AppContext>): Promise<Response> {
+    try {
+      const requestBody = await c.req.json();
+      const { action, serverName, toolName, description } = requestBody;
+
+      // 验证 action 参数
+      if (!action || typeof action !== "string") {
+        return c.fail(
+          "INVALID_REQUEST",
+          "action 参数不能为空且必须是字符串",
+          undefined,
+          400
+        );
+      }
+
+      const validActions = ["enable", "disable", "status", "toggle"];
+      if (!validActions.includes(action)) {
+        return c.fail(
+          "INVALID_ACTION",
+          `无效的 action: ${action}。支持的 action: ${validActions.join(", ")}`,
+          undefined,
+          400
+        );
+      }
+
+      // 验证服务名和工具名
+      this.validateToolIdentifier(serverName, toolName);
+
+      // 根据不同的 action 执行相应操作
+      switch (action) {
+        case "enable":
+          return this.handleEnableTool(c, serverName, toolName, description);
+        case "disable":
+          return this.handleDisableTool(c, serverName, toolName);
+        case "status":
+          return this.handleGetToolStatus(c, serverName, toolName);
+        case "toggle":
+          return this.handleToggleTool(c, serverName, toolName);
+        default: {
+          return c.fail(
+            "INVALID_ACTION",
+            `未实现的 action: ${action}`,
+            undefined,
+            400
+          );
+        }
+      }
+    } catch (error) {
+      c.get("logger").error("管理 MCP 工具失败:", error);
+      const errorMessage =
+        error instanceof Error ? error.message : "管理 MCP 工具失败";
+      return c.fail("TOOL_MANAGE_ERROR", errorMessage, undefined, 500);
+    }
+  }
+
+  /**
+   * 获取服务工具列表
+   * POST /api/tools/mcp/list
+   */
+  async listMCPTools(c: Context<AppContext>): Promise<Response> {
+    try {
+      const requestBody = await c.req.json();
+      const { serverName, includeUsageStats } = requestBody;
+
+      // 如果指定了服务名，获取该服务的工具列表
+      if (serverName) {
+        return this.handleListServerTools(c, serverName, includeUsageStats);
+      }
+
+      // 否则获取所有服务的工具列表
+      return this.handleListAllTools(c, includeUsageStats);
+    } catch (error) {
+      c.get("logger").error("获取工具列表失败:", error);
+      return c.fail(
+        "GET_TOOL_LIST_ERROR",
+        error instanceof Error ? error.message : "获取工具列表失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 处理启用工具
+   */
+  private async handleEnableTool(
+    c: Context<AppContext>,
+    serverName: string,
+    toolName: string,
+    description?: string
+  ): Promise<Response> {
+    // 验证服务存在性
+    await this.validateServiceAndToolExistence(serverName, toolName);
+
+    // 设置工具为启用状态
+    configManager.setToolEnabled(serverName, toolName, true, description);
+
+    // 获取更新后的工具配置
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+    const toolConfig = toolsConfig[toolName];
+
+    c.get("logger").info(`工具已启用: ${serverName}/${toolName}`);
+
+    return c.success(
+      {
+        serverName,
+        toolName,
+        enabled: true,
+        description: toolConfig?.description || description || "",
+      },
+      `工具 "${serverName}__${toolName}" 启用成功`
+    );
+  }
+
+  /**
+   * 处理禁用工具
+   */
+  private async handleDisableTool(
+    c: Context<AppContext>,
+    serverName: string,
+    toolName: string
+  ): Promise<Response> {
+    // 验证服务存在性
+    await this.validateServiceAndToolExistence(serverName, toolName);
+
+    // 设置工具为禁用状态
+    configManager.setToolEnabled(serverName, toolName, false);
+
+    c.get("logger").info(`工具已禁用: ${serverName}/${toolName}`);
+
+    return c.success(
+      {
+        serverName,
+        toolName,
+        enabled: false,
+      },
+      `工具 "${serverName}__${toolName}" 禁用成功`
+    );
+  }
+
+  /**
+   * 处理获取工具状态
+   */
+  private async handleGetToolStatus(
+    c: Context<AppContext>,
+    serverName: string,
+    toolName: string
+  ): Promise<Response> {
+    // 获取工具配置
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+    const toolConfig = toolsConfig[toolName];
+
+    if (!toolConfig) {
+      return c.fail(
+        "TOOL_NOT_FOUND",
+        `工具 "${serverName}__${toolName}" 不存在或未配置`,
+        undefined,
+        404
+      );
+    }
+
+    return c.success(
+      {
+        serverName,
+        toolName,
+        enabled: toolConfig.enable !== false,
+        description: toolConfig.description || "",
+        usageCount: toolConfig.usageCount,
+        lastUsedTime: toolConfig.lastUsedTime,
+      },
+      "工具状态获取成功"
+    );
+  }
+
+  /**
+   * 处理切换工具状态
+   */
+  private async handleToggleTool(
+    c: Context<AppContext>,
+    serverName: string,
+    toolName: string
+  ): Promise<Response> {
+    // 验证服务存在性
+    await this.validateServiceAndToolExistence(serverName, toolName);
+
+    // 获取当前状态
+    const currentEnabled = configManager.isToolEnabled(serverName, toolName);
+
+    // 切换状态
+    const newEnabled = !currentEnabled;
+    configManager.setToolEnabled(serverName, toolName, newEnabled);
+
+    c.get("logger").info(
+      `工具状态已切换: ${serverName}/${toolName} -> ${newEnabled}`
+    );
+
+    return c.success(
+      {
+        serverName,
+        toolName,
+        enabled: newEnabled,
+      },
+      `工具 "${serverName}__${toolName}" 已${newEnabled ? "启用" : "禁用"}`
+    );
+  }
+
+  /**
+   * 处理获取指定服务的工具列表
+   */
+  private async handleListServerTools(
+    c: Context<AppContext>,
+    serverName: string,
+    includeUsageStats?: boolean
+  ): Promise<Response> {
+    // 检查服务是否存在
+    const mcpServers = configManager.getMcpServers();
+    if (!mcpServers[serverName]) {
+      return c.fail(
+        "SERVICE_NOT_FOUND",
+        `MCP 服务 "${serverName}" 不存在`,
+        undefined,
+        404
+      );
+    }
+
+    // 获取工具配置
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+    const tools = Object.entries(toolsConfig).map(([toolName, toolConfig]) => {
+      const result: Record<string, unknown> = {
+        toolName,
+        enabled: toolConfig.enable !== false,
+        description: toolConfig.description || "",
+      };
+
+      if (includeUsageStats) {
+        result.usageCount = toolConfig.usageCount;
+        result.lastUsedTime = toolConfig.lastUsedTime;
+      }
+
+      return result;
+    });
+
+    const enabledCount = tools.filter((t) => t.enabled).length;
+    const disabledCount = tools.length - enabledCount;
+
+    return c.success(
+      {
+        serverName,
+        tools,
+        total: tools.length,
+        enabledCount,
+        disabledCount,
+      },
+      "获取工具列表成功"
+    );
+  }
+
+  /**
+   * 处理获取所有服务的工具列表
+   */
+  private async handleListAllTools(
+    c: Context<AppContext>,
+    includeUsageStats?: boolean
+  ): Promise<Response> {
+    const mcpServerConfig = configManager.getMcpServerConfig();
+
+    // 定义工具信息接口
+    interface ToolInfo {
+      toolName: string;
+      enabled: boolean;
+      description: string;
+      usageCount?: number;
+      lastUsedTime?: string;
+    }
+
+    // 定义服务器工具信息接口
+    interface ServerToolsInfo {
+      serverName: string;
+      tools: ToolInfo[];
+      total: number;
+      enabledCount: number;
+      disabledCount: number;
+    }
+
+    // 定义返回结果接口
+    interface AllToolsResult {
+      servers: ServerToolsInfo[];
+      totalTools: number;
+      totalEnabled: number;
+      totalDisabled: number;
+    }
+
+    const result: AllToolsResult = {
+      servers: [],
+      totalTools: 0,
+      totalEnabled: 0,
+      totalDisabled: 0,
+    };
+
+    for (const [serverName, serverConfig] of Object.entries(mcpServerConfig)) {
+      const tools: ToolInfo[] = Object.entries(serverConfig.tools || {}).map(
+        ([toolName, toolConfig]) => {
+          const toolInfo: ToolInfo = {
+            toolName,
+            enabled: toolConfig.enable !== false,
+            description: toolConfig.description || "",
+          };
+
+          if (includeUsageStats) {
+            toolInfo.usageCount = toolConfig.usageCount;
+            toolInfo.lastUsedTime = toolConfig.lastUsedTime;
+          }
+
+          return toolInfo;
+        }
+      );
+
+      const enabledCount = tools.filter((t) => t.enabled).length;
+
+      result.servers.push({
+        serverName,
+        tools,
+        total: tools.length,
+        enabledCount,
+        disabledCount: tools.length - enabledCount,
+      });
+
+      result.totalTools += tools.length;
+      result.totalEnabled += enabledCount;
+      result.totalDisabled += tools.length - enabledCount;
+    }
+
+    return c.success(result, "获取所有工具列表成功");
+  }
+
+  /**
+   * 验证工具标识符
+   */
+  private validateToolIdentifier(serverName: string, toolName: string): void {
+    if (
+      !serverName ||
+      typeof serverName !== "string" ||
+      serverName.trim() === ""
+    ) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "服务名称不能为空"
+      );
+    }
+
+    if (!toolName || typeof toolName !== "string" || toolName.trim() === "") {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具名称不能为空"
+      );
+    }
+
+    // 验证服务名称格式
+    if (!MCPToolHandler.ALPHANUMERIC_UNDERSCORE_REGEX.test(serverName)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "服务名称格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+
+    // 验证工具名称格式
+    if (!MCPToolHandler.ALPHANUMERIC_UNDERSCORE_REGEX.test(toolName)) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_VALIDATION_FAILED,
+        "工具名称格式无效，只能包含字母、数字、下划线和连字符"
+      );
+    }
+  }
+
+  /**
+   * 验证服务和工具是否存在
+   */
+  private async validateServiceAndToolExistence(
+    serverName: string,
+    toolName: string
+  ): Promise<void> {
+    // 检查服务是否存在
+    const mcpServers = configManager.getMcpServers();
+    if (!mcpServers[serverName]) {
+      throw MCPError.validationError(
+        MCPErrorCode.SERVER_NOT_FOUND,
+        `MCP 服务 "${serverName}" 不存在`
+      );
+    }
+
+    // 检查工具是否在服务中存在
+    const toolsConfig = configManager.getServerToolsConfig(serverName);
+    if (!toolsConfig[toolName]) {
+      throw MCPError.validationError(
+        MCPErrorCode.TOOL_NOT_FOUND,
+        `工具 "${toolName}" 在服务 "${serverName}" 中不存在或未配置`
+      );
+    }
+  }
+}

--- a/src/server/handlers/mcp.handler.ts
+++ b/src/server/handlers/mcp.handler.ts
@@ -1,0 +1,366 @@
+/**
+ * MCP 路由处理器
+ * 处理符合 MCP Streamable HTTP 规范的单一 /mcp 端点
+ * 支持 POST 请求（JSON-RPC 消息）
+ */
+
+import type { Context } from "hono";
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import {
+  HTTP_CONTENT_TYPES,
+  HTTP_ERROR_MESSAGES,
+  HTTP_HEADERS,
+  HTTP_STATUS_CODES,
+  JSONRPC_VERSION,
+  MCP_PROTOCOL_VERSIONS,
+  MCP_SUPPORTED_PROTOCOL_VERSIONS,
+  MESSAGE_SIZE_LIMITS,
+} from "../constants/index.js";
+import type { MCPServiceManager } from "../lib/mcp";
+import { MCPMessageHandler } from "../lib/mcp";
+import type { AppContext } from "../types/hono.context.js";
+import type { MCPMessage } from "../types/mcp.js";
+
+/**
+ * MCP 路由处理器配置接口
+ */
+interface MCPRouteHandlerConfig {
+  maxMessageSize?: number;
+  enableMetrics?: boolean;
+}
+
+/**
+ * 连接统计信息
+ */
+interface ConnectionMetrics {
+  totalMessages: number;
+  errorCount: number;
+  averageResponseTime: number;
+}
+
+/**
+ * MCP 路由处理器
+ * 实现符合 MCP Streamable HTTP 规范的单一端点处理（仅 POST 模式）
+ */
+export class MCPRouteHandler {
+  private logger: Logger;
+  private mcpMessageHandler: MCPMessageHandler | null = null;
+  private config: {
+    maxMessageSize: number;
+    enableMetrics: boolean;
+  };
+  private metrics: ConnectionMetrics;
+
+  constructor(config: MCPRouteHandlerConfig = {}) {
+    this.logger = logger;
+    this.config = {
+      maxMessageSize: config.maxMessageSize ?? MESSAGE_SIZE_LIMITS.DEFAULT,
+      enableMetrics: config.enableMetrics ?? true,
+    };
+
+    this.metrics = {
+      totalMessages: 0,
+      errorCount: 0,
+      averageResponseTime: 0,
+    };
+
+    this.logger.debug("MCPRouteHandler 初始化完成", {
+      maxMessageSize: this.config.maxMessageSize,
+      enableMetrics: this.config.enableMetrics,
+    });
+  }
+
+  /**
+   * 获取 MCP 服务管理器实例
+   * 优先从 Context 获取，如果不存在则从 WebServer 获取
+   */
+  private getMCPServiceManager(c: Context): MCPServiceManager {
+    // 首先尝试从 Context 获取
+    const serviceManager = c.get("mcpServiceManager");
+    if (serviceManager) {
+      return serviceManager;
+    }
+
+    // 如果 Context 中没有，则从 WebServer 获取
+    const webServer = c.get("webServer");
+    if (!webServer) {
+      throw new Error("WebServer 未在 Context 中找到，请检查中间件配置");
+    }
+
+    const mcpServiceManager = webServer.getMCPServiceManager();
+    this.logger.debug(
+      "MCPServiceManager 从 WebServer 获取（Context 中未找到）"
+    );
+
+    return mcpServiceManager;
+  }
+
+  /**
+   * 初始化 MCP 消息处理器
+   */
+  private async initializeMessageHandler(c: Context): Promise<void> {
+    if (this.mcpMessageHandler) {
+      return;
+    }
+
+    try {
+      const serviceManager = this.getMCPServiceManager(c);
+      this.mcpMessageHandler = new MCPMessageHandler(serviceManager);
+      this.logger.debug("MCP 消息处理器初始化成功");
+    } catch (error) {
+      this.logger.error("MCP 消息处理器初始化失败:", error);
+      this.metrics.errorCount++;
+      throw error;
+    }
+  }
+
+  /**
+   * 处理 POST 请求（JSON-RPC 消息）
+   * 符合 MCP Streamable HTTP 规范
+   */
+  async handlePost(c: Context<AppContext>): Promise<Response> {
+    const startTime = Date.now();
+    let messageId: string | number | null = null;
+
+    try {
+      this.logger.debug("处理 MCP POST 请求");
+
+      // 验证请求大小
+      const contentLength = c.req.header(HTTP_HEADERS.CONTENT_LENGTH);
+      if (
+        contentLength &&
+        Number.parseInt(contentLength) > this.config.maxMessageSize
+      ) {
+        this.metrics.errorCount++;
+        return this.createErrorResponse(
+          -32600,
+          `${HTTP_ERROR_MESSAGES.REQUEST_TOO_LARGE}: Maximum size is ${this.config.maxMessageSize} bytes`
+        );
+      }
+
+      // 验证 Content-Type
+      const contentType = c.req.header(HTTP_HEADERS.CONTENT_TYPE);
+      if (!contentType?.includes(HTTP_CONTENT_TYPES.APPLICATION_JSON)) {
+        this.metrics.errorCount++;
+        return this.createErrorResponse(
+          -32600,
+          `${HTTP_ERROR_MESSAGES.INVALID_REQUEST}: ${HTTP_ERROR_MESSAGES.INVALID_CONTENT_TYPE}`
+        );
+      }
+
+      // 验证 MCP 协议版本头（可选）
+      // 支持多种大小写格式的协议版本头
+      const protocolVersion =
+        c.req.header("mcp-protocol-version") ||
+        c.req.header(HTTP_HEADERS.MCP_PROTOCOL_VERSION) ||
+        c.req.header("Mcp-Protocol-Version");
+      if (
+        protocolVersion &&
+        !MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(
+          protocolVersion as (typeof MCP_SUPPORTED_PROTOCOL_VERSIONS)[number]
+        )
+      ) {
+        this.logger.warn(
+          `不支持的 MCP 协议版本: ${protocolVersion}，支持的版本: ${MCP_SUPPORTED_PROTOCOL_VERSIONS.join(
+            ", "
+          )}`
+        );
+      }
+
+      // 解析请求体
+      let message: MCPMessage;
+      try {
+        const rawBody = await c.req.text();
+        if (rawBody.length > this.config.maxMessageSize) {
+          this.metrics.errorCount++;
+          return this.createErrorResponse(
+            -32600,
+            `Message too large: Maximum size is ${this.config.maxMessageSize} bytes`,
+            null
+          );
+        }
+        message = JSON.parse(rawBody);
+        messageId = message.id || null;
+      } catch (error) {
+        this.metrics.errorCount++;
+        return this.createErrorResponse(
+          -32700,
+          HTTP_ERROR_MESSAGES.PARSE_ERROR
+        );
+      }
+
+      // 验证 JSON-RPC 格式
+      if (!this.validateMessage(message)) {
+        this.metrics.errorCount++;
+        return this.createErrorResponse(
+          -32600,
+          `${HTTP_ERROR_MESSAGES.INVALID_REQUEST}: Message does not conform to JSON-RPC ${JSONRPC_VERSION}`,
+          messageId
+        );
+      }
+
+      // 初始化消息处理器
+      await this.initializeMessageHandler(c);
+
+      // 处理消息
+      if (!this.mcpMessageHandler) {
+        throw new Error("消息处理器初始化失败");
+      }
+      const response = await this.mcpMessageHandler.handleMessage(message);
+
+      // 更新统计信息
+      this.metrics.totalMessages++;
+      const responseTime = Date.now() - startTime;
+      this.metrics.averageResponseTime =
+        (this.metrics.averageResponseTime * (this.metrics.totalMessages - 1) +
+          responseTime) /
+        this.metrics.totalMessages;
+
+      this.logger.debug("MCP POST 请求处理成功", {
+        method: message.method,
+        messageId: messageId,
+        responseTime: responseTime,
+        isNotification: response === null,
+      });
+
+      // 对于通知消息，返回 204 No Content
+      if (response === null) {
+        return new Response(null, {
+          status: HTTP_STATUS_CODES.NO_CONTENT,
+          headers: {
+            [HTTP_HEADERS.MCP_PROTOCOL_VERSION]: MCP_PROTOCOL_VERSIONS.DEFAULT,
+            [HTTP_HEADERS.X_RESPONSE_TIME]: responseTime.toString(),
+          },
+        });
+      }
+
+      // 返回 JSON-RPC 响应
+      return c.json(response, HTTP_STATUS_CODES.OK, {
+        [HTTP_HEADERS.CONTENT_TYPE]: HTTP_CONTENT_TYPES.APPLICATION_JSON,
+        [HTTP_HEADERS.MCP_PROTOCOL_VERSION]: MCP_PROTOCOL_VERSIONS.DEFAULT,
+        [HTTP_HEADERS.X_RESPONSE_TIME]: responseTime.toString(),
+      });
+    } catch (error) {
+      this.metrics.errorCount++;
+      const responseTime = Date.now() - startTime;
+
+      this.logger.error("处理 MCP POST 请求时出错:", {
+        error: error instanceof Error ? error.message : String(error),
+        messageId: messageId,
+        responseTime: responseTime,
+        stack: error instanceof Error ? error.stack : undefined,
+      });
+
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      return this.createErrorResponse(
+        -32603,
+        `${HTTP_ERROR_MESSAGES.INTERNAL_ERROR}: ${errorMessage}`,
+        messageId
+      );
+    }
+  }
+
+  /**
+   * 验证 JSON-RPC 消息格式
+   */
+  private validateMessage(message: unknown): message is MCPMessage {
+    if (!message || typeof message !== "object") {
+      this.logger.debug("消息验证失败: 不是对象");
+      return false;
+    }
+
+    // 类型守卫：确保 message 是对象类型
+    const msg = message as Record<string, unknown>;
+
+    if (msg.jsonrpc !== JSONRPC_VERSION) {
+      this.logger.debug("消息验证失败: jsonrpc 版本不正确", {
+        jsonrpc: msg.jsonrpc,
+      });
+      return false;
+    }
+
+    if (!msg.method || typeof msg.method !== "string") {
+      this.logger.debug("消息验证失败: method 字段无效", {
+        method: msg.method,
+      });
+      return false;
+    }
+
+    // 验证 id 字段（如果存在）
+    if (
+      msg.id !== undefined &&
+      typeof msg.id !== "string" &&
+      typeof msg.id !== "number" &&
+      msg.id !== null
+    ) {
+      this.logger.debug("消息验证失败: id 字段类型无效", { id: msg.id });
+      return false;
+    }
+
+    // 验证 params 字段（如果存在）
+    if (msg.params !== undefined && typeof msg.params !== "object") {
+      this.logger.debug("消息验证失败: params 字段类型无效", {
+        params: msg.params,
+      });
+      return false;
+    }
+
+    return true;
+  }
+
+  /**
+   * 创建错误响应
+   */
+  private createErrorResponse(
+    code: number,
+    message: string,
+    id?: string | number | null
+  ): Response {
+    // 确保ID不为空，如果为空或未提供则生成默认ID
+    const responseId = id ?? `error-${Date.now()}`;
+
+    const errorResponse = {
+      jsonrpc: JSONRPC_VERSION,
+      error: {
+        code,
+        message,
+      },
+      id: responseId,
+    };
+
+    return new Response(JSON.stringify(errorResponse), {
+      status: HTTP_STATUS_CODES.BAD_REQUEST,
+      headers: {
+        [HTTP_HEADERS.CONTENT_TYPE]: HTTP_CONTENT_TYPES.APPLICATION_JSON,
+        [HTTP_HEADERS.MCP_PROTOCOL_VERSION]: MCP_PROTOCOL_VERSIONS.DEFAULT,
+      },
+    });
+  }
+
+  /**
+   * 获取连接状态
+   */
+  getStatus() {
+    return {
+      isInitialized: this.mcpMessageHandler !== null,
+      metrics: this.config.enableMetrics ? this.metrics : undefined,
+      config: {
+        maxMessageSize: this.config.maxMessageSize,
+      },
+    };
+  }
+
+  /**
+   * 销毁处理器，清理所有资源
+   */
+  destroy(): void {
+    this.logger.info("正在销毁 MCPRouteHandler");
+
+    // 清理消息处理器
+    this.mcpMessageHandler = null;
+
+    this.logger.info("MCPRouteHandler 销毁完成");
+  }
+}

--- a/src/server/handlers/service.handler.ts
+++ b/src/server/handlers/service.handler.ts
@@ -1,0 +1,233 @@
+/**
+ * 服务 API HTTP 路由处理器
+ * 提供服务启动、停止、重启等相关的 RESTful API 接口
+ */
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
+import type { Context } from "hono";
+import { logger } from "../Logger.js";
+import type { Logger } from "../Logger.js";
+import { SERVICE_RESTART_DELAYS } from "../constants/timeout.constants.js";
+import type { MCPServiceManager } from "../lib/mcp";
+import type { EventBus } from "../services/event-bus.service.js";
+import { getEventBus } from "../services/event-bus.service.js";
+import type { StatusService } from "../services/status.service.js";
+import type { AppContext } from "../types/hono.context.js";
+import { requireMCPServiceManager } from "../types/hono.context.js";
+
+/**
+ * 服务 API 处理器
+ */
+export class ServiceApiHandler {
+  private logger: Logger;
+  private statusService: StatusService;
+  private eventBus: EventBus;
+
+  constructor(statusService: StatusService) {
+    this.logger = logger;
+    this.statusService = statusService;
+    this.eventBus = getEventBus();
+  }
+
+  /**
+   * 通用的 xiaozhi 进程启动方法
+   * @param args 命令行参数（如 ["start", "--daemon"]）
+   * @returns 启动的子进程
+   */
+  private spawnXiaozhiProcess(args: string[]): ChildProcess {
+    const child = spawn("xiaozhi", args, {
+      detached: true,
+      stdio: "ignore",
+      env: {
+        ...process.env,
+        XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
+      },
+    });
+
+    child.unref();
+    this.logger.info(`MCP 服务命令已发送: xiaozhi ${args.join(" ")}`);
+
+    return child;
+  }
+
+  /**
+   * 重启服务
+   * POST /api/services/restart
+   */
+  async restartService(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理服务重启请求");
+
+      // 发射重启请求事件
+      this.eventBus.emitEvent("service:restart:requested", {
+        serviceName: "unknown", // 由于是HTTP API触发的，服务名未知
+        source: "http-api",
+        delay: 0,
+        attempt: 1,
+        timestamp: Date.now(),
+      });
+
+      // 更新重启状态
+      this.statusService.updateRestartStatus("restarting");
+
+      // 从 Context 获取 MCP 服务管理器
+      const mcpServiceManager = requireMCPServiceManager(c);
+
+      // 异步执行重启，不阻塞响应
+      setTimeout(async () => {
+        try {
+          await this.executeRestart(mcpServiceManager);
+          // 服务重启需要一些时间，延迟发送成功状态
+          setTimeout(() => {
+            this.statusService.updateRestartStatus("completed");
+          }, SERVICE_RESTART_DELAYS.SUCCESS_NOTIFICATION_DELAY);
+        } catch (error) {
+          c.get("logger").error("服务重启失败:", error);
+          this.statusService.updateRestartStatus(
+            "failed",
+            error instanceof Error ? error.message : "未知错误"
+          );
+        }
+      }, SERVICE_RESTART_DELAYS.EXECUTION_DELAY);
+
+      return c.success(null, "重启请求已接收");
+    } catch (error) {
+      c.get("logger").error("处理重启请求失败:", error);
+      return c.fail(
+        "RESTART_REQUEST_ERROR",
+        error instanceof Error ? error.message : "处理重启请求失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 执行服务重启
+   * @param mcpServiceManager MCP 服务管理器实例
+   */
+  private async executeRestart(
+    mcpServiceManager: MCPServiceManager
+  ): Promise<void> {
+    this.logger.info("正在重启 MCP 服务...");
+
+    try {
+      // 获取当前服务状态
+      const status = mcpServiceManager.getStatus();
+
+      if (!status.isRunning) {
+        this.logger.warn("MCP 服务未运行，尝试启动服务");
+
+        // 如果服务未运行，尝试启动服务
+        this.spawnXiaozhiProcess(["start", "--daemon"]);
+        return;
+      }
+
+      // 执行重启命令，始终使用 daemon 模式
+      this.spawnXiaozhiProcess(["restart", "--daemon"]);
+    } catch (error) {
+      this.logger.error("重启服务失败:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 停止服务
+   * POST /api/services/stop
+   */
+  async stopService(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理服务停止请求");
+
+      // 执行停止命令
+      this.spawnXiaozhiProcess(["stop"]);
+
+      return c.success(null, "停止请求已接收");
+    } catch (error) {
+      c.get("logger").error("处理停止请求失败:", error);
+      return c.fail(
+        "STOP_REQUEST_ERROR",
+        error instanceof Error ? error.message : "处理停止请求失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 启动服务
+   * POST /api/services/start
+   */
+  async startService(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理服务启动请求");
+
+      // 执行启动命令
+      this.spawnXiaozhiProcess(["start", "--daemon"]);
+
+      return c.success(null, "启动请求已接收");
+    } catch (error) {
+      c.get("logger").error("处理启动请求失败:", error);
+      return c.fail(
+        "START_REQUEST_ERROR",
+        error instanceof Error ? error.message : "处理启动请求失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取服务状态
+   * GET /api/services/status
+   */
+  async getServiceStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取服务状态请求");
+
+      const mcpServiceManager = requireMCPServiceManager(c);
+      const status = mcpServiceManager.getStatus();
+
+      c.get("logger").debug("获取服务状态成功");
+      return c.success(status);
+    } catch (error) {
+      c.get("logger").error("获取服务状态失败:", error);
+      return c.fail(
+        "SERVICE_STATUS_READ_ERROR",
+        error instanceof Error ? error.message : "获取服务状态失败",
+        undefined,
+        500
+      );
+    }
+  }
+
+  /**
+   * 获取服务健康状态
+   * GET /api/services/health
+   */
+  async getServiceHealth(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取服务健康状态请求");
+
+      // 简单的健康检查
+      const health = {
+        status: "healthy",
+        timestamp: Date.now(),
+        uptime: process.uptime(),
+        memory: process.memoryUsage(),
+        version: process.version,
+      };
+
+      c.get("logger").debug("获取服务健康状态成功");
+      return c.success(health);
+    } catch (error) {
+      c.get("logger").error("获取服务健康状态失败:", error);
+      return c.fail(
+        "SERVICE_HEALTH_READ_ERROR",
+        error instanceof Error ? error.message : "获取服务健康状态失败",
+        undefined,
+        500
+      );
+    }
+  }
+}

--- a/src/server/handlers/static-file.handler.ts
+++ b/src/server/handlers/static-file.handler.ts
@@ -1,0 +1,297 @@
+/**
+ * 静态文件 HTTP 路由处理器
+ * 负责处理前端静态资源的请求和响应，支持多种构建路径的自动识别和文件访问
+ */
+import { existsSync } from "node:fs";
+import { readFile } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+import type { Context } from "hono";
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import { HTTP_CONTENT_TYPES, HTTP_STATUS_CODES } from "../constants/index.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 静态文件处理器
+ */
+export class StaticFileHandler extends BaseHandler {
+  private logger: Logger;
+  private webPath: string | null = null;
+
+  constructor() {
+    super();
+    this.logger = logger;
+    this.initializeWebPath();
+  }
+
+  /**
+   * 初始化 Web 路径
+   */
+  private initializeWebPath(): void {
+    try {
+      // 获取当前文件所在目录
+      const __dirname = dirname(fileURLToPath(import.meta.url));
+
+      logger.debug(`当前文件目录: ${__dirname}`);
+
+      // 确定web目录路径
+      // 支持 Nx 构建的 dist/frontend 目录结构
+      const possibleWebPaths = [
+        // Nx 构建的主要路径：dist/frontend/
+        // 对于 dist/backend/handlers/StaticFileHandler.js -> ../../../frontend
+        // 对于 dist/backend/cli.js -> ../../frontend
+        // 对于 dist/cli.js -> ../frontend
+        join(__dirname, "..", "..", "..", "frontend"),
+        join(__dirname, "..", "..", "frontend"),
+        join(__dirname, "..", "frontend"),
+
+        // 兼容旧构建路径：从 dist 目录向上查找 apps/frontend/dist
+        join(__dirname, "..", "..", "apps", "frontend", "dist"),
+        join(__dirname, "..", "apps", "frontend", "dist"),
+
+        // 备用路径：查找未构建的 apps/frontend 目录（开发模式）
+        join(__dirname, "..", "..", "apps", "frontend"),
+        join(__dirname, "..", "apps", "frontend"),
+
+        // 兼容路径：保持对旧 web 目录的支持（向后兼容）
+        join(__dirname, "..", "..", "web", "dist"),
+        join(__dirname, "..", "web", "dist"),
+
+        // 备用兼容路径：查找未构建的 web 目录（开发模式）
+        join(__dirname, "..", "..", "web"),
+        join(__dirname, "..", "web"),
+
+        // 兜底路径：从源码目录查找（开发模式下的源码执行）
+        join(__dirname, "..", "..", "..", "apps", "frontend", "dist"),
+        join(__dirname, "..", "..", "..", "apps", "frontend"),
+        join(__dirname, "..", "..", "..", "web", "dist"),
+        join(__dirname, "..", "..", "..", "web"),
+      ];
+
+      // 查找第一个存在的路径
+      this.webPath =
+        possibleWebPaths.find((p) => {
+          const exists = existsSync(p);
+          logger.debug(`检查路径 ${p}: ${exists ? "存在" : "不存在"}`);
+          return exists;
+        }) || null;
+
+      if (this.webPath) {
+        logger.debug(`静态文件服务路径: ${this.webPath}`);
+      } else {
+        logger.warn("未找到静态文件目录");
+        logger.debug("尝试的路径:", possibleWebPaths);
+      }
+    } catch (error) {
+      logger.error("初始化静态文件路径失败:", error);
+    }
+  }
+
+  /**
+   * 处理静态文件请求
+   * GET /*
+   */
+  async handleStaticFile(c: Context): Promise<Response> {
+    const pathname = new URL(c.req.url).pathname;
+
+    try {
+      c.logger.debug(`处理静态文件请求: ${pathname}`);
+
+      if (!this.webPath) {
+        return this.createErrorPage(c, "找不到前端资源文件");
+      }
+
+      // 处理路径
+      let filePath = pathname;
+      if (filePath === "/") {
+        filePath = "/index.html";
+      }
+
+      // 安全性检查：防止路径遍历
+      if (filePath.includes("..")) {
+        c.logger.warn(`路径遍历攻击尝试: ${filePath}`);
+        return c.text("Forbidden", HTTP_STATUS_CODES.FORBIDDEN);
+      }
+
+      const fullPath = join(this.webPath, filePath);
+
+      // 检查文件是否存在
+      if (!existsSync(fullPath)) {
+        // 对于 SPA，返回 index.html
+        const indexPath = join(this.webPath, "index.html");
+        if (existsSync(indexPath)) {
+          c.logger.debug(`SPA 回退到 index.html: ${pathname}`);
+          return this.serveFile(c, indexPath, HTTP_CONTENT_TYPES.TEXT_HTML);
+        }
+
+        c.logger.debug(`文件不存在: ${fullPath}`);
+        return c.text("Not Found", HTTP_STATUS_CODES.NOT_FOUND);
+      }
+
+      // 确定 Content-Type
+      const contentType = this.getContentType(fullPath);
+
+      c.logger.debug(`服务静态文件: ${fullPath}, Content-Type: ${contentType}`);
+      return this.serveFile(c, fullPath, contentType);
+    } catch (error) {
+      c.logger.error(`服务静态文件错误 (${pathname}):`, error);
+      return c.text(
+        "Internal Server Error",
+        HTTP_STATUS_CODES.INTERNAL_SERVER_ERROR
+      );
+    }
+  }
+
+  /**
+   * 服务文件
+   */
+  private async serveFile(
+    c: Context,
+    filePath: string,
+    contentType: string
+  ): Promise<Response> {
+    try {
+      const content = await readFile(filePath);
+
+      // 对于文本文件，返回字符串；对于二进制文件，返回 ArrayBuffer
+      if (
+        contentType.startsWith("text/") ||
+        contentType.includes("javascript") ||
+        contentType.includes("json")
+      ) {
+        return c.text(content.toString(), 200, { "Content-Type": contentType });
+      }
+
+      return c.body(new Uint8Array(content), 200, {
+        "Content-Type": contentType,
+      });
+    } catch (error) {
+      logger.error(`读取文件失败: ${filePath}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 获取文件的 Content-Type
+   */
+  private getContentType(filePath: string): string {
+    const ext = filePath.split(".").pop()?.toLowerCase();
+
+    const contentTypes: Record<string, string> = {
+      html: HTTP_CONTENT_TYPES.TEXT_HTML,
+      htm: HTTP_CONTENT_TYPES.TEXT_HTML,
+      js: HTTP_CONTENT_TYPES.APPLICATION_JAVASCRIPT,
+      mjs: HTTP_CONTENT_TYPES.APPLICATION_JAVASCRIPT,
+      css: HTTP_CONTENT_TYPES.TEXT_CSS,
+      json: HTTP_CONTENT_TYPES.APPLICATION_JSON,
+      png: "image/png",
+      jpg: "image/jpeg",
+      jpeg: "image/jpeg",
+      gif: "image/gif",
+      svg: "image/svg+xml",
+      ico: "image/x-icon",
+      woff: "font/woff",
+      woff2: "font/woff2",
+      ttf: "font/ttf",
+      eot: "application/vnd.ms-fontobject",
+      pdf: HTTP_CONTENT_TYPES.APPLICATION_PDF,
+      txt: HTTP_CONTENT_TYPES.TEXT_PLAIN,
+      xml: HTTP_CONTENT_TYPES.APPLICATION_XML,
+      zip: HTTP_CONTENT_TYPES.APPLICATION_ZIP,
+      tar: "application/x-tar",
+      gz: "application/gzip",
+    };
+
+    return (
+      contentTypes[ext || ""] || HTTP_CONTENT_TYPES.APPLICATION_OCTET_STREAM
+    );
+  }
+
+  /**
+   * 创建错误页面
+   */
+  private createErrorPage(c: Context, message: string): Response {
+    const errorHtml = `
+      <!DOCTYPE html>
+      <html>
+      <head>
+        <title>小智配置管理</title>
+        <meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <style>
+          body {
+            font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+            max-width: 800px;
+            margin: 50px auto;
+            padding: 20px;
+            line-height: 1.6;
+            color: #333;
+          }
+          .error {
+            color: #e53e3e;
+            background: #fed7d7;
+            padding: 20px;
+            border-radius: 8px;
+            border-left: 4px solid #e53e3e;
+          }
+          .info {
+            background: #e6f3ff;
+            padding: 20px;
+            border-radius: 8px;
+            border-left: 4px solid #0066cc;
+            margin-top: 20px;
+          }
+          pre {
+            background: #f5f5f5;
+            padding: 10px;
+            border-radius: 4px;
+            overflow-x: auto;
+          }
+          h1 {
+            color: #2d3748;
+            margin-bottom: 20px;
+          }
+        </style>
+      </head>
+      <body>
+        <h1>小智配置管理</h1>
+        <div class="error">
+          <p><strong>错误：</strong>${message}</p>
+        </div>
+        <div class="info">
+          <p><strong>解决方案：</strong></p>
+          <p>请先构建前端项目：</p>
+          <pre>cd apps/frontend && pnpm install && pnpm build</pre>
+          <p><em>如果上面的路径不存在，可以尝试旧路径：</em></p>
+          <pre>cd web && pnpm install && pnpm build</pre>
+          <p>然后重新启动服务器。</p>
+        </div>
+      </body>
+      </html>
+    `;
+
+    return c.html(errorHtml);
+  }
+
+  /**
+   * 检查静态文件目录是否存在
+   */
+  isWebPathAvailable(): boolean {
+    return this.webPath !== null && existsSync(this.webPath);
+  }
+
+  /**
+   * 获取静态文件目录路径
+   */
+  getWebPath(): string | null {
+    return this.webPath;
+  }
+
+  /**
+   * 重新初始化 Web 路径
+   */
+  reinitializeWebPath(): void {
+    this.initializeWebPath();
+  }
+}

--- a/src/server/handlers/status.handler.ts
+++ b/src/server/handlers/status.handler.ts
@@ -1,0 +1,226 @@
+import type { Context } from "hono";
+/**
+ * 状态 API HTTP 路由处理器
+ * 提供客户端状态、服务状态、心跳等状态相关的 RESTful API 接口
+ */
+import type { StatusService } from "../services/status.service.js";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 状态 API 处理器
+ */
+export class StatusApiHandler extends BaseHandler {
+  private statusService: StatusService;
+
+  constructor(statusService: StatusService) {
+    super();
+    this.statusService = statusService;
+  }
+
+  /**
+   * 获取完整状态
+   * GET /api/status
+   */
+  async getStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取状态请求");
+      const status = this.statusService.getFullStatus();
+      c.get("logger").debug("获取状态成功");
+      return c.success(status);
+    } catch (error) {
+      return this.handleError(c, error, "获取状态", "STATUS_READ_ERROR");
+    }
+  }
+
+  /**
+   * 获取客户端状态
+   * GET /api/status/client
+   */
+  async getClientStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取客户端状态请求");
+      const clientStatus = this.statusService.getClientStatus();
+      c.get("logger").debug("获取客户端状态成功");
+      return c.success(clientStatus);
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "获取客户端状态",
+        "CLIENT_STATUS_READ_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 获取重启状态
+   * GET /api/status/restart
+   */
+  async getRestartStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取重启状态请求");
+      const restartStatus = this.statusService.getRestartStatus();
+      c.get("logger").debug("获取重启状态成功");
+      return c.success(restartStatus);
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "获取重启状态",
+        "RESTART_STATUS_READ_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 检查客户端是否连接
+   * GET /api/status/connected
+   */
+  async checkClientConnected(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理检查客户端连接请求");
+      const connected = this.statusService.isClientConnected();
+      c.get("logger").debug(`客户端连接状态: ${connected}`);
+      return c.success({ connected });
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "检查客户端连接",
+        "CLIENT_CONNECTION_CHECK_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 获取最后心跳时间
+   * GET /api/status/heartbeat
+   */
+  async getLastHeartbeat(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取最后心跳时间请求");
+      const lastHeartbeat = this.statusService.getLastHeartbeat();
+      c.get("logger").debug("获取最后心跳时间成功");
+      return c.success({ lastHeartbeat });
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "获取最后心跳时间",
+        "HEARTBEAT_READ_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 获取活跃的 MCP 服务器列表
+   * GET /api/status/mcp-servers
+   */
+  async getActiveMCPServers(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取活跃 MCP 服务器请求");
+      const servers = this.statusService.getActiveMCPServers();
+      c.get("logger").debug("获取活跃 MCP 服务器成功");
+      return c.success({ servers });
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "获取活跃 MCP 服务器",
+        "ACTIVE_MCP_SERVERS_READ_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 更新客户端状态
+   * PUT /api/status/client
+   */
+  async updateClientStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理更新客户端状态请求");
+      const statusUpdate = await this.parseJsonBody<Record<string, unknown>>(
+        c,
+        "请求体必须是有效的状态对象"
+      );
+
+      // 验证请求体
+      if (!statusUpdate || typeof statusUpdate !== "object") {
+        return c.fail(
+          "INVALID_REQUEST_BODY",
+          "请求体必须是有效的状态对象",
+          undefined,
+          400
+        );
+      }
+
+      this.statusService.updateClientInfo(statusUpdate, "http-api");
+      c.get("logger").info("客户端状态更新成功");
+
+      return c.success(undefined, "客户端状态更新成功");
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "更新客户端状态",
+        "CLIENT_STATUS_UPDATE_ERROR",
+        "更新客户端状态失败",
+        400
+      );
+    }
+  }
+
+  /**
+   * 设置活跃的 MCP 服务器列表
+   * PUT /api/status/mcp-servers
+   */
+  async setActiveMCPServers(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理设置活跃 MCP 服务器请求");
+      const { servers } = await this.parseJsonBody<{ servers: string[] }>(
+        c,
+        "请求体格式错误"
+      );
+
+      // 验证请求体
+      if (!Array.isArray(servers)) {
+        return c.fail(
+          "INVALID_REQUEST_BODY",
+          "servers 必须是字符串数组",
+          undefined,
+          400
+        );
+      }
+
+      this.statusService.setActiveMCPServers(servers);
+      c.get("logger").info("活跃 MCP 服务器设置成功");
+
+      return c.success(undefined, "活跃 MCP 服务器设置成功");
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "设置活跃 MCP 服务器",
+        "ACTIVE_MCP_SERVERS_UPDATE_ERROR",
+        "设置活跃 MCP 服务器失败",
+        400
+      );
+    }
+  }
+
+  /**
+   * 重置状态
+   * POST /api/status/reset
+   */
+  async resetStatus(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理重置状态请求");
+      this.statusService.reset();
+      c.get("logger").info("状态重置成功");
+      return c.success(undefined, "状态重置成功");
+    } catch (error) {
+      return this.handleError(c, error, "重置状态", "STATUS_RESET_ERROR");
+    }
+  }
+}

--- a/src/server/handlers/tts.handler.ts
+++ b/src/server/handlers/tts.handler.ts
@@ -1,0 +1,218 @@
+/**
+ * TTS API HTTP 路由处理器
+ * 提供语音合成 RESTful API 接口
+ */
+
+import type { Context } from "hono";
+import { createTTS } from "univoice";
+import { configManager } from "../../config/index.js";
+import { mapClusterToResourceId } from "../../esp32/index.js";
+import { TTS_VOICES, getVoiceScenes } from "../constants/voices.js";
+import type { AppContext } from "../types/hono.context.js";
+import type { VoiceInfo, VoicesResponse } from "../types/index.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 允许的 encoding 值白名单
+ */
+const ALLOWED_ENCODINGS = [
+  "mp3",
+  "wav",
+  "ogg",
+  "flac",
+  "pcm",
+  "opus",
+  "ogg_opus",
+] as const;
+
+type AllowedEncoding = (typeof ALLOWED_ENCODINGS)[number];
+
+/**
+ * encoding 到 MIME Content-Type 的映射
+ * 部分值不对应标准 MIME 类型，需要显式映射
+ */
+const ENCODING_TO_MIME: Record<AllowedEncoding, string> = {
+  mp3: "audio/mpeg",
+  wav: "audio/wav",
+  ogg: "audio/ogg",
+  flac: "audio/flac",
+  pcm: "audio/pcm",
+  opus: "audio/opus",
+  ogg_opus: "audio/ogg",
+};
+
+/**
+ * encoding 到文件扩展名的映射
+ */
+const ENCODING_TO_EXT: Record<AllowedEncoding, string> = {
+  mp3: "mp3",
+  wav: "wav",
+  ogg: "ogg",
+  flac: "flac",
+  pcm: "pcm",
+  opus: "opus",
+  ogg_opus: "ogg",
+};
+
+/**
+ * TTS 合成请求体
+ */
+interface TTSRequestBody {
+  /** 要转换的文本 */
+  text: string;
+  /** 应用 ID（可选，从配置读取） */
+  appid?: string;
+  /** 访问令牌（可选，从配置读取） */
+  accessToken?: string;
+  /** 声音类型（可选，从配置读取） */
+  voice_type?: string;
+  /** 编码格式（可选，默认 wav） */
+  encoding?: string;
+  /** 集群类型（可选） */
+  cluster?: string;
+  /** WebSocket 端点（可选） */
+  endpoint?: string;
+}
+
+/**
+ * TTS API 路由处理器类
+ */
+export class TTSApiHandler extends BaseHandler {
+  constructor() {
+    super();
+  }
+
+  /**
+   * 语音合成
+   * POST /api/tts
+   */
+  async synthesize(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("处理语音合成请求");
+
+      // 解析请求参数
+      const body = await this.parseJsonBody<TTSRequestBody>(c);
+
+      // 验证必需参数
+      if (!body.text) {
+        c.get("logger").warn("缺少 text 参数");
+        return c.fail(
+          "MISSING_PARAMETER",
+          "缺少必需参数: text",
+          undefined,
+          400
+        );
+      }
+
+      // 获取 TTS 配置作为默认值
+      const ttsConfig = configManager.getTTSConfig();
+
+      // 优先从请求参数读取，否则从配置读取
+      const appid = body.appid || ttsConfig.appid;
+      const accessToken = body.accessToken || ttsConfig.accessToken;
+      const voice_type = body.voice_type || ttsConfig.voice_type;
+      const cluster = body.cluster || ttsConfig.cluster;
+      const endpoint = body.endpoint || ttsConfig.endpoint;
+      const encoding = body.encoding || ttsConfig.encoding || "wav";
+
+      // 运行时校验 encoding 值
+      if (!ALLOWED_ENCODINGS.includes(encoding as AllowedEncoding)) {
+        c.get("logger").warn(`不支持的 encoding 参数: ${encoding}`);
+        return c.fail(
+          "INVALID_PARAMETER",
+          `不支持的 encoding 参数: ${encoding}，允许值: ${ALLOWED_ENCODINGS.join(", ")}`,
+          undefined,
+          400
+        );
+      }
+
+      const safeEncoding = encoding as AllowedEncoding;
+
+      // 验证必需的 TTS 参数
+      if (!appid) {
+        c.get("logger").warn("缺少 appid 参数");
+        return c.fail(
+          "MISSING_PARAMETER",
+          "缺少 appid 参数，请提供或配置 tts.appid",
+          undefined,
+          400
+        );
+      }
+
+      if (!accessToken) {
+        c.get("logger").warn("缺少 accessToken 参数");
+        return c.fail(
+          "MISSING_PARAMETER",
+          "缺少 accessToken 参数，请提供或配置 tts.accessToken",
+          undefined,
+          400
+        );
+      }
+
+      if (!voice_type) {
+        c.get("logger").warn("缺少 voice_type 参数");
+        return c.fail(
+          "MISSING_PARAMETER",
+          "缺少 voice_type 参数，请提供或配置 tts.voice_type",
+          undefined,
+          400
+        );
+      }
+
+      // 创建 TTS 客户端（使用 univoice SDK）
+      const tts = createTTS({
+        provider: "doubao",
+        appId: appid!,
+        accessToken: accessToken!,
+        voice: voice_type!,
+        format: safeEncoding,
+        resourceId: mapClusterToResourceId(cluster),
+        sampleRate: 24000,
+        ...(endpoint && { baseUrl: endpoint }),
+      });
+
+      c.get("logger").info(
+        `开始语音合成: text=${body.text.substring(0, 20)}..., voice_type=${voice_type}`
+      );
+
+      // 调用 TTS 合成（非流式）
+      const response = await tts.synthesize({ text: body.text });
+      const audioData = response.audio;
+
+      c.get("logger").info(`语音合成成功: audioSize=${audioData.length} bytes`);
+
+      // 返回音频数据，使用正确的 MIME 类型和文件扩展名
+      return new Response(Buffer.from(audioData), {
+        headers: {
+          "Content-Type": ENCODING_TO_MIME[safeEncoding],
+          "Content-Disposition": `attachment; filename="tts_${Date.now()}.${ENCODING_TO_EXT[safeEncoding]}"`,
+        },
+      });
+    } catch (error) {
+      return this.handleError(c, error, "语音合成");
+    }
+  }
+
+  /**
+   * 获取可用音色列表
+   * GET /api/tts/voices
+   */
+  async getVoices(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").info("获取音色列表");
+
+      const voices: VoiceInfo[] = TTS_VOICES;
+      const scenes = getVoiceScenes();
+
+      const response: VoicesResponse = {
+        voices,
+        total: voices.length,
+        scenes,
+      };
+
+      return c.success(response);
+    } catch (error) {
+      return this.handleError(c, error, "获取音色列表");
+    }
+  }
+}

--- a/src/server/handlers/update.handler.ts
+++ b/src/server/handlers/update.handler.ts
@@ -1,0 +1,163 @@
+import type { Context } from "hono";
+import { z } from "zod";
+/**
+ * 更新 API HTTP 路由处理器
+ * 提供版本更新和 NPM 包安装相关的 RESTful API 接口
+ *
+ * 支持两种模式：
+ * - POST /api/update：触发安装，返回 installId
+ * - GET /api/install/logs?installId=xxx：SSE 日志流式推送
+ */
+import { InstallLogStream, NPMManager } from "../lib/npm";
+import { getEventBus } from "../services/event-bus.service.js";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+// 版本号请求格式验证
+const UpdateRequestSchema = z.object({
+  version: z.string().min(1, "版本号不能为空"),
+});
+
+/**
+ * 更新 API 处理器
+ */
+export class UpdateApiHandler extends BaseHandler {
+  private npmManager: NPMManager;
+  private eventBus = getEventBus();
+  private activeInstalls: Map<string, boolean> = new Map();
+  private logStream: InstallLogStream;
+
+  constructor(logStream?: InstallLogStream) {
+    super();
+    this.logStream = logStream ?? new InstallLogStream();
+    this.npmManager = new NPMManager(this.eventBus, this.logStream);
+  }
+
+  /**
+   * 获取日志流实例（供外部访问）
+   */
+  getLogStream(): InstallLogStream {
+    return this.logStream;
+  }
+
+  /**
+   * 执行版本更新
+   * POST /api/update
+   * Body: { version: string }
+   * Response: { success, data: { version, installId }, message }
+   */
+  async performUpdate(c: Context<AppContext>): Promise<Response> {
+    try {
+      const body = await this.parseJsonBody<{ version: string }>(
+        c,
+        "请求体格式错误"
+      );
+
+      // 使用 zod 进行参数验证
+      const parseResult = UpdateRequestSchema.safeParse(body);
+      if (!parseResult.success) {
+        return c.fail(
+          "INVALID_VERSION",
+          "请求参数格式错误",
+          parseResult.error.issues.map((err) => ({
+            field: err.path.join("."),
+            message: err.message,
+          })),
+          400
+        );
+      }
+
+      const { version } = parseResult.data;
+
+      // 检查是否有正在进行的安装
+      const hasActiveInstall = Array.from(this.activeInstalls.values()).some(
+        (v) => v
+      );
+      if (hasActiveInstall) {
+        return c.fail(
+          "INSTALL_IN_PROGRESS",
+          "已有安装进程正在进行，请等待完成后再试",
+          undefined,
+          409
+        );
+      }
+
+      const logger = c.get("logger");
+
+      // 生成 installId（在 handler 层生成，确保能立即返回给前端）
+      const installId = `install-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+      this.activeInstalls.set(installId, true);
+
+      // 异步启动安装（不阻塞响应）
+      this.npmManager
+        .installVersion(version, installId)
+        .then(() => {
+          // 安装成功，保持标记 1 分钟供 SSE 消费者连接
+          setTimeout(() => {
+            this.activeInstalls.delete(installId);
+          }, 60_000);
+        })
+        .catch((error) => {
+          logger.error("安装过程失败:", error);
+          this.activeInstalls.delete(installId);
+        });
+
+      return c.success(
+        {
+          version,
+          installId,
+          message: "安装已启动，请通过 SSE 日志流查看进度",
+        },
+        "安装请求已接受"
+      );
+    } catch (error) {
+      return this.handleError(c, error, "处理安装请求", "REQUEST_FAILED");
+    }
+  }
+
+  /**
+   * SSE 安装日志流端点
+   * GET /api/install/logs?installId=xxx
+   *
+   * 返回 text/event-stream 格式的实时安装日志。
+   * 前端使用 EventSource API 订阅此端点。
+   */
+  async getInstallLogs(c: Context<AppContext>): Promise<Response> {
+    const installId = c.req.query("installId");
+
+    if (!installId) {
+      return c.fail(
+        "MISSING_INSTALL_ID",
+        "缺少 installId 参数",
+        undefined,
+        400
+      );
+    }
+
+    // 检查安装会话是否存在
+    if (!this.logStream.hasSession(installId)) {
+      return c.fail(
+        "INSTALL_NOT_FOUND",
+        "未找到对应的安装任务，请先发起安装请求",
+        undefined,
+        404
+      );
+    }
+
+    // 创建 SSE 流
+    const stream = this.logStream.createSSEStream(installId);
+    if (!stream) {
+      return c.fail("STREAM_ERROR", "无法创建日志流", undefined, 500);
+    }
+
+    // 返回 SSE 响应
+    return new Response(stream, {
+      headers: {
+        "Content-Type": "text/event-stream",
+        "Cache-Control": "no-cache, no-transform",
+        Connection: "keep-alive",
+        "X-Accel-Buffering": "no", // 禁用 Nginx 缓冲
+      },
+    });
+  }
+}

--- a/src/server/handlers/version.handler.ts
+++ b/src/server/handlers/version.handler.ts
@@ -1,0 +1,149 @@
+import type { Context } from "hono";
+import { VersionUtils } from "../../utils/version.js";
+/**
+ * 版本 API HTTP 路由处理器
+ * 提供版本信息查询、可用版本列表获取、版本检查等相关的 RESTful API 接口
+ */
+import { NPMManager } from "../lib/npm";
+import type { AppContext } from "../types/hono.context.js";
+import { BaseHandler } from "./base.handler.js";
+
+/**
+ * 版本 API 处理器
+ */
+export class VersionApiHandler extends BaseHandler {
+  /**
+   * 获取版本信息
+   * GET /api/version
+   */
+  async getVersion(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取版本信息请求");
+
+      // 使用 VersionUtils 获取完整版本信息
+      const versionInfo = VersionUtils.getVersionInfo();
+
+      c.get("logger").debug("获取版本信息成功:", versionInfo);
+
+      return c.success(versionInfo);
+    } catch (error) {
+      return this.handleError(c, error, "获取版本信息", "VERSION_READ_ERROR");
+    }
+  }
+
+  /**
+   * 获取版本号（简化接口）
+   * GET /api/version/simple
+   */
+  async getVersionSimple(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取版本号请求");
+
+      const version = VersionUtils.getVersion();
+      c.get("logger").debug(`获取版本号成功: ${version}`);
+
+      return c.success({ version });
+    } catch (error) {
+      return this.handleError(c, error, "获取版本号", "VERSION_READ_ERROR");
+    }
+  }
+
+  /**
+   * 清除版本缓存
+   * POST /api/version/cache/clear
+   */
+  async clearVersionCache(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理清除版本缓存请求");
+
+      VersionUtils.clearCache();
+      c.get("logger").info("版本缓存已清除");
+
+      return c.success(undefined, "版本缓存已清除");
+    } catch (error) {
+      return this.handleError(c, error, "清除版本缓存", "CACHE_CLEAR_ERROR");
+    }
+  }
+
+  /**
+   * 获取可用版本列表
+   * GET /api/version/available?type=stable|rc|beta|all
+   */
+  async getAvailableVersions(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理获取可用版本列表请求");
+
+      // 获取查询参数
+      const type = (c.req.query("type") as unknown) || "stable";
+
+      // 验证版本类型参数
+      const validTypes = ["stable", "rc", "beta", "all"];
+      if (!validTypes.includes(type as string)) {
+        return c.fail(
+          "INVALID_VERSION_TYPE",
+          `无效的版本类型: ${type}。支持的类型: ${validTypes.join(", ")}`,
+          undefined,
+          400
+        );
+      }
+
+      const npmManager = new NPMManager();
+      const versions = await npmManager.getAvailableVersions(type as string);
+
+      c.get("logger").debug(
+        `获取到 ${versions.length} 个可用版本 (类型: ${type})`
+      );
+
+      return c.success({
+        versions,
+        type,
+        total: versions.length,
+      });
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "获取可用版本列表",
+        "VERSIONS_FETCH_ERROR"
+      );
+    }
+  }
+
+  /**
+   * 检查最新版本
+   * GET /api/version/latest
+   */
+  async checkLatestVersion(c: Context<AppContext>): Promise<Response> {
+    try {
+      c.get("logger").debug("处理检查最新版本请求");
+
+      const npmManager = new NPMManager();
+      const result = await npmManager.checkForLatestVersion();
+
+      c.get("logger").debug("版本检查结果:", result);
+
+      if (result.error) {
+        // 如果有错误，但仍返回部分信息
+        return c.success({
+          currentVersion: result.currentVersion,
+          latestVersion: result.latestVersion,
+          hasUpdate: result.hasUpdate,
+          error: result.error,
+        });
+      }
+
+      return c.success({
+        currentVersion: result.currentVersion,
+        latestVersion: result.latestVersion,
+        hasUpdate: result.hasUpdate,
+      });
+    } catch (error) {
+      return this.handleError(
+        c,
+        error,
+        "检查最新版本",
+        "LATEST_VERSION_CHECK_ERROR"
+      );
+    }
+  }
+}

--- a/src/server/lib/coze/client.ts
+++ b/src/server/lib/coze/client.ts
@@ -1,0 +1,32 @@
+/**
+ * 扣子 API 客户端封装
+ * 提供统一的客户端创建和配置
+ */
+
+import { CozeAPI } from "../../lib/coze";
+import config from "./config";
+
+export type Language = "zh" | "en";
+
+/**
+ * 创建 Coze API 客户端
+ * @param token - API 访问令牌
+ * @param language - API 环境语言，默认为 "zh"（中文），可选 "en"（英文）
+ */
+export function createCozeClient(
+  token: string,
+  language: Language = "zh"
+): CozeAPI {
+  if (!token || typeof token !== "string" || token.trim() === "") {
+    throw new Error("扣子 API Token 不能为空");
+  }
+
+  const env = config[language] || config.zh;
+
+  return new CozeAPI({
+    baseURL: env.COZE_BASE_URL,
+    token: token.trim(),
+    baseWsURL: env.COZE_BASE_WS_URL,
+    debug: false,
+  });
+}

--- a/src/server/lib/coze/config.ts
+++ b/src/server/lib/coze/config.ts
@@ -1,0 +1,33 @@
+/**
+ * 扣子 API 环境配置
+ *
+ * 提供扣子 API 的不同环境配置（中文环境和英文环境）
+ *
+ * @example
+ * ```typescript
+ * import config from "../../lib/coze/config";
+ *
+ * // 获取中文环境配置（默认）
+ * const zhEnv = config.zh;
+ * console.log(zhEnv.COZE_BASE_URL); // "https://api.coze.cn"
+ *
+ * // 获取英文环境配置
+ * const enEnv = config.en;
+ * console.log(enEnv.COZE_BASE_URL); // "https://api.coze.com"
+ * ```
+ *
+ * @remarks
+ * - 中文环境（zh）：适用于中国大陆用户，使用 .cn 域名
+ * - 英文环境（en）：适用于国际用户，使用 .com 域名
+ * - 该配置被 `../lib/coze/client.ts` 中的 `createCozeClient` 函数使用
+ */
+export default {
+  zh: {
+    COZE_BASE_URL: "https://api.coze.cn",
+    COZE_BASE_WS_URL: "wss://ws.coze.cn",
+  },
+  en: {
+    COZE_BASE_URL: "https://api.coze.com",
+    COZE_BASE_WS_URL: "wss://ws.coze.com",
+  },
+};

--- a/src/server/lib/coze/index.ts
+++ b/src/server/lib/coze/index.ts
@@ -1,0 +1,24 @@
+/**
+ * 扣子（Coze）API 集成模块
+ *
+ * 提供与扣子平台集成的完整功能，包括：
+ * - config: 扣子 API 环境配置（中英文环境）
+ * - @coze/api: 扣子官方 SDK 的完整导出
+ * - createCozeClient: 创建扣子 API 客户端的工厂函数
+ * - CozeApiService: 扣子 API 服务的封装类
+ *
+ * @example
+ * ```typescript
+ * import { CozeApiService, createCozeClient, config } from '../../lib/coze';
+ *
+ * // 使用预配置的服务
+ * const service = new CozeApiService('your-token');
+ *
+ * // 或者创建自定义客户端
+ * const client = createCozeClient('your-token', 'zh');
+ * ```
+ */
+export { default as config } from "./config";
+export * from "@coze/api";
+export { createCozeClient } from "./client";
+export { CozeApiService } from "./service";

--- a/src/server/lib/coze/service.ts
+++ b/src/server/lib/coze/service.ts
@@ -1,0 +1,160 @@
+/**
+ * 扣子 API 服务类
+ * 负责与扣子 API 的交互，包括工作空间和工作流的获取
+ */
+
+import NodeCache from "node-cache";
+import type { RunWorkflowData, WorkSpace } from "../../lib/coze";
+import type {
+  CozeWorkflowsData,
+  CozeWorkflowsParams,
+  CozeWorkflowsResponse,
+} from "../../types/coze";
+import { createCozeClient } from "./client";
+
+/**
+ * 扣子 API 服务类
+ */
+export class CozeApiService {
+  private cache: NodeCache;
+  private token: string; // 保留 token 字段用于可能的后续扩展（如 token 刷新）
+  private client: ReturnType<typeof createCozeClient>;
+
+  constructor(token: string) {
+    this.token = token.trim();
+    this.client = createCozeClient(this.token);
+
+    // 初始化缓存
+    this.cache = new NodeCache({
+      stdTTL: 5 * 60, // 默认5分钟（工作流缓存使用此默认值）
+    });
+  }
+
+  /**
+   * 获取工作空间列表
+   */
+  async getWorkspaces(): Promise<WorkSpace[]> {
+    try {
+      const cacheKey = "workspaces";
+      const cached = this.cache.get<WorkSpace[]>(cacheKey);
+      if (cached) return cached;
+
+      const { workspaces = [] } = await this.client.workspaces.list();
+
+      // 设置缓存，过期时间30分钟
+      this.cache.set(cacheKey, workspaces, 30 * 60);
+
+      return workspaces;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`获取工作空间列表失败: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * 获取工作流列表
+   */
+  async getWorkflows(params: CozeWorkflowsParams): Promise<CozeWorkflowsData> {
+    try {
+      const { workspace_id, page_num = 1, page_size = 20 } = params;
+
+      if (!workspace_id || typeof workspace_id !== "string") {
+        throw new Error("工作空间ID不能为空");
+      }
+
+      const cacheKey = `workflows:${workspace_id}:${page_num}:${page_size}`;
+      const cached = this.cache.get<CozeWorkflowsData>(cacheKey);
+      if (cached) return cached;
+
+      const response = await this.client.get<
+        CozeWorkflowsParams,
+        CozeWorkflowsResponse
+      >("/v1/workflows", {
+        workspace_id,
+        page_num,
+        page_size,
+        workflow_mode: "workflow",
+      });
+
+      const result = response.data;
+
+      // 设置缓存，使用默认的5分钟过期时间
+      this.cache.set(cacheKey, result);
+
+      return result;
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`获取工作流列表失败: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * 运行工作流
+   * @param workflowId - 工作流ID
+   * @param parameters - 参数
+   * @returns 运行工作流数据
+   */
+  async callWorkflow(
+    workflowId: string,
+    parameters: Record<string, unknown>
+  ): Promise<RunWorkflowData> {
+    try {
+      return await this.client.workflows.runs.create({
+        workflow_id: workflowId,
+        parameters,
+      });
+    } catch (error) {
+      const errorMessage =
+        error instanceof Error ? error.message : String(error);
+      throw new Error(`运行工作流失败: ${errorMessage}`);
+    }
+  }
+
+  /**
+   * 清除缓存
+   * @param pattern 可选的模式字符串，清除所有以该模式开头的缓存键
+   */
+  clearCache(pattern?: string): void {
+    if (!pattern) {
+      // 清除所有缓存
+      this.cache.flushAll();
+      return;
+    }
+
+    // node-cache 不支持模式匹配，需要手动实现
+    // 使用前缀匹配，避免意外匹配
+    const keys = this.cache.keys();
+    const keysToDelete = keys.filter((key) => key.startsWith(pattern));
+    this.cache.del(keysToDelete);
+  }
+
+  /**
+   * 获取缓存统计信息
+   */
+  getCacheStats(): {
+    size: number;
+    keys: string[];
+    hits: number;
+    misses: number;
+    hitRate: number;
+    ksize: number;
+    vsize: number;
+  } {
+    const stats = this.cache.getStats();
+    const keys = this.cache.keys();
+    const totalRequests = stats.hits + stats.misses;
+    const hitRate = totalRequests > 0 ? stats.hits / totalRequests : 0;
+
+    return {
+      size: stats.keys,
+      keys,
+      hits: stats.hits,
+      misses: stats.misses,
+      hitRate,
+      ksize: stats.ksize,
+      vsize: stats.vsize,
+    };
+  }
+}

--- a/src/server/lib/mcp/__tests__/cache.test.ts
+++ b/src/server/lib/mcp/__tests__/cache.test.ts
@@ -1,0 +1,357 @@
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { resolve } from "node:path";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPToolsCache } from "../cache";
+import { MCPCacheManager } from "../cache";
+import type { InternalMCPServiceConfig } from "../types";
+import { MCPTransportType } from "../types";
+
+// 模拟 logger
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn().mockReturnValue({
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    }),
+  },
+}));
+
+describe("MCPCacheManager", () => {
+  let cacheManager: MCPCacheManager;
+  let testCachePath: string;
+  let originalEnv: string | undefined;
+
+  // 测试数据
+  const mockTools: Tool[] = [
+    {
+      name: "add",
+      description: "Add two numbers",
+      inputSchema: {
+        type: "object",
+        properties: {
+          a: { type: "number" },
+          b: { type: "number" },
+        },
+        required: ["a", "b"],
+      },
+    },
+    {
+      name: "subtract",
+      description: "Subtract two numbers",
+      inputSchema: {
+        type: "object",
+        properties: {
+          a: { type: "number" },
+          b: { type: "number" },
+        },
+        required: ["a", "b"],
+      },
+    },
+  ];
+
+  const mockConfig: InternalMCPServiceConfig = {
+    name: "calculator",
+    type: MCPTransportType.STDIO,
+    command: "node",
+    args: ["./calculator.js"],
+    env: { NODE_ENV: "test" },
+  };
+
+  beforeEach(() => {
+    // 设置测试环境
+    originalEnv = process.env.XIAOZHI_CONFIG_DIR;
+    const testDir = "/tmp/xiaozhi-test";
+    process.env.XIAOZHI_CONFIG_DIR = testDir;
+
+    // 确保测试目录存在
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+
+    cacheManager = new MCPCacheManager();
+    testCachePath = resolve(testDir, "xiaozhi.cache.json");
+
+    // 清理可能存在的测试文件
+    if (existsSync(testCachePath)) {
+      unlinkSync(testCachePath);
+    }
+  });
+
+  afterEach(() => {
+    // 恢复环境变量
+    if (originalEnv !== undefined) {
+      process.env.XIAOZHI_CONFIG_DIR = originalEnv;
+    } else {
+      process.env.XIAOZHI_CONFIG_DIR = undefined;
+    }
+
+    // 清理测试文件
+    if (existsSync(testCachePath)) {
+      unlinkSync(testCachePath);
+    }
+  });
+
+  describe("ensureCacheFile", () => {
+    it("应该创建缓存文件如果不存在", async () => {
+      expect(existsSync(testCachePath)).toBe(false);
+
+      await cacheManager.ensureCacheFile();
+
+      expect(existsSync(testCachePath)).toBe(true);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.version).toBe("1.0.0");
+      expect(cache.mcpServers).toEqual({});
+      expect(cache.metadata.totalWrites).toBe(0);
+      expect(cache.metadata.createdAt).toBeDefined();
+    });
+
+    it("应该不覆盖已存在的缓存文件", async () => {
+      // 创建一个现有的缓存文件
+      const existingCache: MCPToolsCache = {
+        version: "1.0.0",
+        mcpServers: {
+          test: {
+            tools: [],
+            lastUpdated: "2023-01-01 00:00:00",
+            serverConfig: mockConfig,
+            configHash: "test-hash",
+            version: "1.0.0",
+          },
+        },
+        metadata: {
+          lastGlobalUpdate: "2023-01-01 00:00:00",
+          totalWrites: 5,
+          createdAt: "2023-01-01 00:00:00",
+        },
+      };
+
+      writeFileSync(testCachePath, JSON.stringify(existingCache, null, 2));
+
+      await cacheManager.ensureCacheFile();
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.metadata.totalWrites).toBe(5);
+      expect(cache.mcpServers.test).toBeDefined();
+    });
+  });
+
+  describe("writeCacheEntry", () => {
+    it("应该成功写入缓存条目", async () => {
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+
+      expect(existsSync(testCachePath)).toBe(true);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.mcpServers.calculator).toBeDefined();
+      expect(cache.mcpServers.calculator.tools).toHaveLength(2);
+      expect(cache.mcpServers.calculator.tools[0].name).toBe("add");
+      expect(cache.mcpServers.calculator.tools[1].name).toBe("subtract");
+      expect(cache.mcpServers.calculator.configHash).toBeDefined();
+      expect(cache.mcpServers.calculator.lastUpdated).toBeDefined();
+      expect(cache.metadata.totalWrites).toBe(1);
+    });
+
+    it("应该更新现有的缓存条目", async () => {
+      // 首次写入
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+
+      // 更新工具列表
+      const updatedTools: Tool[] = [
+        {
+          name: "multiply",
+          description: "Multiply two numbers",
+          inputSchema: { type: "object" },
+        },
+      ];
+
+      await cacheManager.writeCacheEntry(
+        "calculator",
+        updatedTools,
+        mockConfig
+      );
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.mcpServers.calculator.tools).toHaveLength(1);
+      expect(cache.mcpServers.calculator.tools[0].name).toBe("multiply");
+      expect(cache.metadata.totalWrites).toBe(2);
+    });
+
+    it("应该处理空工具列表", async () => {
+      await cacheManager.writeCacheEntry("empty-service", [], mockConfig);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.mcpServers["empty-service"].tools).toHaveLength(0);
+      expect(cache.metadata.totalWrites).toBe(1);
+    });
+
+    it("应该处理写入错误而不抛出异常", async () => {
+      // 创建一个无效的缓存目录路径
+      const invalidCacheManager = new MCPCacheManager();
+      // 通过 Object.defineProperty 安全地设置私有属性，模拟无效路径场景
+      // 避免使用 any 类型，保持类型安全
+      Object.defineProperty(invalidCacheManager, "cachePath", {
+        value: "/invalid/path/cache.json",
+        writable: true,
+        configurable: true,
+      });
+
+      // 应该不抛出异常
+      await expect(
+        invalidCacheManager.writeCacheEntry("test", mockTools, mockConfig)
+      ).resolves.not.toThrow();
+    });
+  });
+
+  describe("getStats", () => {
+    it("应该返回正确的缓存统计信息", async () => {
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+      await cacheManager.writeCacheEntry("datetime", [], {
+        ...mockConfig,
+        name: "datetime",
+      } as InternalMCPServiceConfig);
+
+      const stats = await cacheManager.getStats();
+
+      expect(stats).toBeDefined();
+      expect(stats?.totalWrites).toBe(2);
+      expect(stats?.serverCount).toBe(2);
+      expect(stats?.cacheFileSize).toBeGreaterThan(0);
+      expect(stats?.lastUpdate).toBeDefined();
+    });
+
+    it("应该处理不存在的缓存文件", async () => {
+      const stats = await cacheManager.getStats();
+
+      expect(stats).toBeDefined();
+      expect(stats?.totalWrites).toBe(0);
+      expect(stats?.serverCount).toBe(0);
+    });
+  });
+
+  describe("配置哈希生成", () => {
+    it("应该为相同配置生成相同哈希", async () => {
+      const config1: InternalMCPServiceConfig = {
+        name: "test",
+        type: MCPTransportType.STDIO,
+        command: "node",
+        args: ["test.js"],
+      };
+
+      const config2: InternalMCPServiceConfig = {
+        name: "test",
+        type: MCPTransportType.STDIO,
+        command: "node",
+        args: ["test.js"],
+      };
+
+      await cacheManager.writeCacheEntry("test1", mockTools, config1);
+      await cacheManager.writeCacheEntry("test2", mockTools, config2);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.mcpServers.test1.configHash).toBe(
+        cache.mcpServers.test2.configHash
+      );
+    });
+
+    it("应该为不同配置生成不同哈希", async () => {
+      const config1: InternalMCPServiceConfig = {
+        name: "test",
+        type: MCPTransportType.STDIO,
+        command: "node",
+        args: ["test1.js"],
+      };
+
+      const config2: InternalMCPServiceConfig = {
+        name: "test",
+        type: MCPTransportType.STDIO,
+        command: "node",
+        args: ["test2.js"],
+      };
+
+      await cacheManager.writeCacheEntry("test1", mockTools, config1);
+      await cacheManager.writeCacheEntry("test2", mockTools, config2);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.mcpServers.test1.configHash).not.toBe(
+        cache.mcpServers.test2.configHash
+      );
+    });
+  });
+
+  describe("原子写入", () => {
+    it("应该使用临时文件进行原子写入", async () => {
+      const tempPath = `${testCachePath}.tmp`;
+
+      // 确保临时文件不存在
+      expect(existsSync(tempPath)).toBe(false);
+
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+
+      // 写入完成后临时文件应该被清理
+      expect(existsSync(tempPath)).toBe(false);
+      expect(existsSync(testCachePath)).toBe(true);
+    });
+  });
+
+  describe("缓存文件验证", () => {
+    it("应该处理损坏的缓存文件", async () => {
+      // 创建一个损坏的缓存文件
+      writeFileSync(testCachePath, "invalid json content");
+
+      // 应该能够处理并重新创建缓存
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.version).toBe("1.0.0");
+      expect(cache.mcpServers.calculator).toBeDefined();
+    });
+
+    it("应该处理结构无效的缓存文件", async () => {
+      // 创建一个结构无效的缓存文件
+      const invalidCache = {
+        version: "1.0.0",
+        // 缺少必要字段
+      };
+
+      writeFileSync(testCachePath, JSON.stringify(invalidCache));
+
+      await cacheManager.writeCacheEntry("calculator", mockTools, mockConfig);
+
+      const cacheContent = readFileSync(testCachePath, "utf8");
+      const cache = JSON.parse(cacheContent) as MCPToolsCache;
+
+      expect(cache.metadata).toBeDefined();
+      expect(cache.mcpServers).toBeDefined();
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/config-adapter.integration.test.ts
+++ b/src/server/lib/mcp/__tests__/config-adapter.integration.test.ts
@@ -1,0 +1,550 @@
+/**
+ * ConfigAdapter 和 MCPService 集成测试
+ * 验证两个组件的协同工作和类型推断一致性
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  getConfigTypeDescription,
+  normalizeServiceConfig,
+  normalizeServiceConfigBatch,
+} from "../../../../config/index.js";
+import type {
+  HTTPMCPServerConfig,
+  LocalMCPServerConfig,
+  MCPServerConfig,
+  SSEMCPServerConfig,
+  StreamableHTTPMCPServerConfig,
+} from "../../../../config/index.js";
+import { MCPService, MCPTransportType } from "../../../lib/mcp";
+
+// 统一的mockLogger定义
+let mockLogger: any;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockLogger = {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  };
+});
+
+describe("ConfigAdapter 和 MCPService 集成测试", () => {
+  describe("类型推断一致性测试", () => {
+    it("ConfigAdapter 和 MCPService 应该对相同的配置推断出相同的类型", () => {
+      const testCases = [
+        {
+          name: "简单 SSE 服务",
+          url: "https://example.com/sse",
+          expectedType: MCPTransportType.SSE,
+        },
+        {
+          name: "高德地图 SSE 服务",
+          url: "https://mcp.amap.com/sse?key=1ec31da021b2702787841ea4ee822de3",
+          expectedType: MCPTransportType.SSE,
+        },
+        {
+          name: "复杂 ModelScope SSE 服务",
+          url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+          expectedType: MCPTransportType.SSE,
+        },
+        {
+          name: "简单 MCP 服务",
+          url: "https://example.com/mcp",
+          expectedType: MCPTransportType.HTTP,
+        },
+        {
+          name: "复杂 ModelScope MCP 服务",
+          url: "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/mcp",
+          expectedType: MCPTransportType.HTTP,
+        },
+        {
+          name: "其他 API 服务",
+          url: "https://example.com/api/v1/tools",
+          expectedType: MCPTransportType.HTTP,
+        },
+        {
+          name: "根路径服务",
+          url: "https://example.com/",
+          expectedType: MCPTransportType.HTTP,
+        },
+      ];
+
+      for (const testCase of testCases) {
+        // ConfigAdapter 推断
+        const legacyConfig: MCPServerConfig = { url: testCase.url };
+        const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+        // MCPService 推断
+        const mcpServiceConfig = { name: testCase.name, url: testCase.url };
+        const mcpService = new MCPService(mcpServiceConfig);
+        const mcpServiceResult = mcpService.getConfig();
+
+        // 验证两个组件的推断结果一致
+        expect(configAdapterResult.type).toBe(testCase.expectedType);
+        expect(mcpServiceResult.type).toBe(testCase.expectedType);
+        expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+      }
+    });
+
+    it("应该正确处理本地 stdio 配置的一致性", () => {
+      const testCases = [
+        {
+          name: "Node.js 服务",
+          command: "node",
+          args: ["server.js"],
+          expectedType: MCPTransportType.STDIO,
+        },
+        {
+          name: "Python 服务",
+          command: "python",
+          args: ["-m", "server"],
+          expectedType: MCPTransportType.STDIO,
+        },
+        {
+          name: "NPX 服务",
+          command: "npx",
+          args: ["-y", "@amap/amap-maps-mcp-server"],
+          expectedType: MCPTransportType.STDIO,
+        },
+      ];
+
+      for (const testCase of testCases) {
+        // ConfigAdapter 处理
+        const legacyConfig: LocalMCPServerConfig = {
+          command: testCase.command,
+          args: testCase.args,
+        };
+        const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+        // MCPService 处理
+        const mcpServiceConfig = {
+          name: testCase.name,
+          command: testCase.command,
+          args: testCase.args,
+        };
+        const mcpService = new MCPService(mcpServiceConfig);
+        const mcpServiceResult = mcpService.getConfig();
+
+        // 验证两个组件的处理结果一致
+        expect(configAdapterResult.type).toBe(testCase.expectedType);
+        expect(mcpServiceResult.type).toBe(testCase.expectedType);
+        expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+        expect(configAdapterResult.command).toBe(testCase.command);
+        expect(mcpServiceResult.command).toBe(testCase.command);
+      }
+    });
+  });
+
+  describe("显式类型配置一致性测试", () => {
+    it("应该正确处理显式指定的 SSE 类型", () => {
+      const legacyConfig: SSEMCPServerConfig = {
+        type: "sse",
+        url: "https://example.com/mcp", // 这个 URL 会推断为 MCP，但显式指定为 SSE
+      };
+
+      const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+      const mcpServiceConfig = {
+        name: "explicit-sse",
+        type: MCPTransportType.SSE,
+        url: "https://example.com/mcp",
+      };
+      const mcpService = new MCPService(mcpServiceConfig);
+      const mcpServiceResult = mcpService.getConfig();
+
+      expect(configAdapterResult.type).toBe(MCPTransportType.SSE);
+      expect(mcpServiceResult.type).toBe(MCPTransportType.SSE);
+      expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+    });
+
+    it("应该正确处理显式指定的 streamable-http 类型", () => {
+      const legacyConfig: StreamableHTTPMCPServerConfig = {
+        type: "streamable-http",
+        url: "https://example.com/sse", // 这个 URL 会推断为 SSE，但显式指定为 HTTP
+      };
+
+      const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+      const mcpServiceConfig = {
+        name: "explicit-http",
+        type: MCPTransportType.HTTP,
+        url: "https://example.com/sse",
+      };
+      const mcpService = new MCPService(mcpServiceConfig);
+      const mcpServiceResult = mcpService.getConfig();
+
+      expect(configAdapterResult.type).toBe(MCPTransportType.HTTP);
+      expect(mcpServiceResult.type).toBe(MCPTransportType.HTTP);
+      expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+    });
+  });
+
+  describe("批量配置转换一致性测试", () => {
+    it("应该正确批量转换配置并保持类型一致性", () => {
+      const legacyConfigs: Record<string, MCPServerConfig> = {
+        "node-calculator": {
+          command: "node",
+          args: ["calculator.js"],
+        },
+        "sse-service": {
+          type: "sse",
+          url: "https://example.com/sse",
+        },
+        "modelscope-sse": {
+          url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+        },
+        "modelscope-mcp": {
+          url: "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/mcp",
+        },
+        "amap-maps": {
+          url: "https://mcp.amap.com/sse?key=1ec31da021b2702787841ea4ee822de3",
+        },
+      };
+
+      // ConfigAdapter 批量转换
+      const batchResult = normalizeServiceConfigBatch(legacyConfigs);
+
+      // 验证每个服务的类型推断
+      expect(batchResult["node-calculator"].type).toBe(MCPTransportType.STDIO);
+      expect(batchResult["sse-service"].type).toBe(MCPTransportType.SSE);
+      expect(batchResult["modelscope-sse"].type).toBe(MCPTransportType.SSE);
+      expect(batchResult["modelscope-mcp"].type).toBe(MCPTransportType.HTTP);
+      expect(batchResult["amap-maps"].type).toBe(MCPTransportType.SSE);
+
+      // 逐个验证与 MCPService 的一致性
+      for (const [serviceName, legacyConfig] of Object.entries(legacyConfigs)) {
+        const configAdapterConfig = batchResult[serviceName];
+
+        // 为 MCPService 创建对应的配置
+        const mcpServiceConfig: any = { name: serviceName };
+        if ("command" in legacyConfig) {
+          mcpServiceConfig.command = legacyConfig.command;
+          mcpServiceConfig.args = legacyConfig.args;
+        } else {
+          mcpServiceConfig.url = legacyConfig.url;
+          if ("type" in legacyConfig) {
+            mcpServiceConfig.type =
+              legacyConfig.type === "sse"
+                ? MCPTransportType.SSE
+                : MCPTransportType.HTTP;
+          }
+        }
+
+        const mcpService = new MCPService(mcpServiceConfig);
+        const mcpServiceConfigResult = mcpService.getConfig();
+
+        // 验证类型一致性
+        expect(configAdapterConfig.type).toBe(mcpServiceConfigResult.type);
+      }
+    });
+  });
+
+  describe("配置描述功能一致性测试", () => {
+    it("getConfigTypeDescription 应该与推断的类型一致", () => {
+      const testCases = [
+        {
+          config: {
+            command: "node",
+            args: ["server.js"],
+          } as LocalMCPServerConfig,
+          expectedType: MCPTransportType.STDIO,
+          expectedDescriptionIncludes: ["本地进程", "node"],
+        },
+        {
+          config: {
+            type: "sse",
+            url: "https://example.com/sse",
+          } as SSEMCPServerConfig,
+          expectedType: MCPTransportType.SSE,
+          expectedDescriptionIncludes: ["SSE", "https://example.com/sse"],
+        },
+        {
+          config: {
+            type: "http",
+            url: "https://example.com/mcp",
+          } as HTTPMCPServerConfig,
+          expectedType: MCPTransportType.HTTP,
+          expectedDescriptionIncludes: ["HTTP", "https://example.com/mcp"],
+        },
+        {
+          config: {
+            url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+          } as MCPServerConfig,
+          expectedType: MCPTransportType.SSE,
+          expectedDescriptionIncludes: ["SSE", "ModelScope"],
+        },
+      ];
+
+      for (const testCase of testCases) {
+        const description = getConfigTypeDescription(testCase.config);
+
+        // 验证描述包含预期的关键词
+        for (const keyword of testCase.expectedDescriptionIncludes) {
+          expect(description).toContain(keyword);
+        }
+
+        // 通过 ConfigAdapter 验证类型推断
+        const adapterResult = normalizeServiceConfig(testCase.config);
+        expect(adapterResult.type).toBe(testCase.expectedType);
+      }
+    });
+  });
+
+  describe("异常处理一致性测试", () => {
+    it("应该一致地处理无效配置", () => {
+      const invalidConfigs = [
+        { name: "empty-config", config: {} as any },
+        { name: "null-config", config: null as any },
+        { name: "invalid-url-config", config: { url: "not-a-valid-url" } },
+      ];
+
+      for (const { name, config } of invalidConfigs) {
+        // ConfigAdapter 处理
+        let adapterError: Error | null = null;
+        let adapterResult: any = null;
+
+        try {
+          adapterResult = normalizeServiceConfig(config);
+        } catch (error) {
+          adapterError = error as Error;
+        }
+
+        // MCPService 处理
+        let serviceError: Error | null = null;
+        let serviceResult: any = null;
+
+        try {
+          const service = new MCPService({ name, ...config });
+          serviceResult = service.getConfig();
+        } catch (error) {
+          serviceError = error as Error;
+        }
+
+        // 验证错误处理的一致性
+        if (adapterError && serviceError) {
+          // 两个都应该抛出错误
+          expect(adapterError).toBeInstanceOf(Error);
+          expect(serviceError).toBeInstanceOf(Error);
+        } else if (adapterResult && serviceResult) {
+          // 两个都应该成功处理
+          expect(adapterResult.type).toBeDefined();
+          expect(serviceResult.type).toBeDefined();
+          expect(adapterResult.type).toBe(serviceResult.type);
+        } else {
+          // 至少一个处理失败了，这种情况不应该发生
+          throw new Error(`不一致的处理结果: ${name}`);
+        }
+      }
+    });
+  });
+
+  describe("端到端工作流程测试", () => {
+    it("应该支持完整的配置转换和服务创建流程", () => {
+      // 模拟真实的配置场景
+      const userConfigs = {
+        // 本地计算器服务
+        calculator: {
+          command: "node",
+          args: ["./mcpServers/calculator.js"],
+        } as LocalMCPServerConfig,
+
+        // 高德地图服务
+        amap: {
+          url: "https://mcp.amap.com/sse?key=1ec31da021b2702787841ea4ee822de3",
+        } as MCPServerConfig,
+
+        // ModelScope 搜索服务
+        search: {
+          url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+        } as MCPServerConfig,
+
+        // ModelScope 推理服务
+        inference: {
+          url: "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/mcp",
+        } as MCPServerConfig,
+
+        // 显式指定的 SSE 服务
+        explicitSse: {
+          type: "sse",
+          url: "https://api.example.com/custom-endpoint",
+        } as SSEMCPServerConfig,
+      };
+
+      // 第一步：批量转换配置
+      const convertedConfigs = normalizeServiceConfigBatch(userConfigs);
+
+      // 验证转换结果
+      expect(convertedConfigs.calculator.type).toBe(MCPTransportType.STDIO);
+      expect(convertedConfigs.amap.type).toBe(MCPTransportType.SSE);
+      expect(convertedConfigs.search.type).toBe(MCPTransportType.SSE);
+      expect(convertedConfigs.inference.type).toBe(MCPTransportType.HTTP);
+      expect(convertedConfigs.explicitSse.type).toBe(MCPTransportType.SSE);
+
+      // 第二步：使用转换后的配置创建 MCPService 实例
+      const services: Record<string, MCPService> = {};
+
+      for (const [serviceName, config] of Object.entries(convertedConfigs)) {
+        // 创建包含 name 的配置对象（InternalMCPServiceConfig）
+        const serviceConfig = { name: serviceName, ...config };
+        services[serviceName] = new MCPService(serviceConfig);
+      }
+
+      // 第三步：验证所有服务都能正确获取配置
+      for (const [serviceName, service] of Object.entries(services)) {
+        const serviceConfig = service.getConfig();
+
+        // 验证配置完整性
+        expect(serviceConfig.type).toBeDefined();
+
+        // 验证类型一致性
+        expect(serviceConfig.type).toBe(convertedConfigs[serviceName].type);
+
+        // 根据类型验证必需字段
+        if (serviceConfig.type === MCPTransportType.STDIO) {
+          expect(serviceConfig.command).toBeDefined();
+        } else {
+          expect(serviceConfig.url).toBeDefined();
+        }
+      }
+
+      // 第四步：验证配置描述功能
+      for (const [serviceName, originalConfig] of Object.entries(userConfigs)) {
+        const description = getConfigTypeDescription(originalConfig);
+        expect(typeof description).toBe("string");
+        expect(description.length).toBeGreaterThan(0);
+
+        // 验证描述包含相关信息，但不一定包含服务名称
+        if ("command" in originalConfig) {
+          expect(description).toContain("本地进程");
+        } else if ("url" in originalConfig) {
+          expect(description).toContain(originalConfig.url);
+        }
+      }
+    });
+
+    it("应该支持动态配置更新场景", () => {
+      // 模拟配置更新场景
+      const initialConfig = {
+        url: "https://example.com/api/v1",
+      };
+
+      // 初始转换和服务创建
+      const initialConverted = normalizeServiceConfig(initialConfig);
+      // 创建包含 name 的配置对象（InternalMCPServiceConfig）
+      const initialServiceConfig = {
+        name: "dynamic-service",
+        ...initialConverted,
+      };
+      const initialService = new MCPService(initialServiceConfig);
+
+      expect(initialConverted.type).toBe(MCPTransportType.HTTP);
+      expect(initialService.getConfig().type).toBe(MCPTransportType.HTTP);
+
+      // 配置更新为 SSE 端点
+      const updatedConfig = {
+        url: "https://example.com/sse",
+      };
+
+      const updatedConverted = normalizeServiceConfig(updatedConfig);
+      // 创建包含 name 的配置对象（InternalMCPServiceConfig）
+      const updatedServiceConfig = {
+        name: "dynamic-service",
+        ...updatedConverted,
+      };
+      const updatedService = new MCPService(updatedServiceConfig);
+
+      expect(updatedConverted.type).toBe(MCPTransportType.SSE);
+      expect(updatedService.getConfig().type).toBe(MCPTransportType.SSE);
+
+      // 验证更新前后的类型不同
+      expect(initialConverted.type).not.toBe(updatedConverted.type);
+    });
+  });
+
+  describe("性能和边界测试", () => {
+    it("应该高效处理大量配置", () => {
+      // 创建大量测试配置
+      const largeConfigSet: Record<string, MCPServerConfig> = {};
+      const serviceCount = 100;
+
+      for (let i = 0; i < serviceCount; i++) {
+        const serviceType = i % 3;
+        switch (serviceType) {
+          case 0:
+            largeConfigSet[`stdio-${i}`] = {
+              command: "node",
+              args: [`service-${i}.js`],
+            };
+            break;
+          case 1:
+            largeConfigSet[`sse-${i}`] = {
+              url: `https://example.com/service-${i}/sse`,
+            };
+            break;
+          case 2:
+            largeConfigSet[`http-${i}`] = {
+              url: `https://example.com/service-${i}/mcp`,
+            };
+            break;
+        }
+      }
+
+      // 批量转换应该在合理时间内完成
+      const startTime = performance.now();
+      const batchResult = normalizeServiceConfigBatch(largeConfigSet);
+      const endTime = performance.now();
+
+      // 验证转换时间（应该少于1秒）
+      expect(endTime - startTime).toBeLessThan(1000);
+
+      // 验证结果完整性
+      expect(Object.keys(batchResult)).toHaveLength(serviceCount);
+
+      // 验证类型分布
+      let stdioCount = 0;
+      let sseCount = 0;
+      let httpCount = 0;
+
+      for (const config of Object.values(batchResult)) {
+        switch (config.type) {
+          case MCPTransportType.STDIO:
+            stdioCount++;
+            break;
+          case MCPTransportType.SSE:
+            sseCount++;
+            break;
+          case MCPTransportType.HTTP:
+            httpCount++;
+            break;
+        }
+      }
+
+      expect(stdioCount).toBe(34); // i%3=0 有 34 个服务
+      expect(sseCount).toBe(33); // i%3=1 有 33 个服务
+      expect(httpCount).toBe(33); // i%3=2 有 33 个服务
+    });
+
+    it("应该处理极长的 URL", () => {
+      const longPath = `${"/a".repeat(1000)}/sse`;
+      const longUrl = `https://example.com${longPath}`;
+
+      const config = { url: longUrl };
+
+      // ConfigAdapter 应该能处理
+      const adapterResult = normalizeServiceConfig(config);
+      expect(adapterResult.type).toBe(MCPTransportType.SSE);
+
+      // MCPService 应该能处理
+      const service = new MCPService({
+        name: "long-url-service",
+        url: longUrl,
+      });
+      const serviceResult = service.getConfig();
+      expect(serviceResult.type).toBe(MCPTransportType.SSE);
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/custom.basic.test.ts
+++ b/src/server/lib/mcp/__tests__/custom.basic.test.ts
@@ -1,0 +1,335 @@
+/**
+ * CustomMCPHandler 基础功能测试
+ * 专门测试 Coze 工作流功能
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CustomMCPTool } from "../../../../config/index.js";
+import type { EventBus } from "../../../services/event-bus.service.js";
+import { getEventBus } from "../../../services/event-bus.service.js";
+import { CustomMCPHandler } from "../custom.js";
+
+// Mock logger
+vi.mock("../../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  },
+}));
+
+// Mock configManager
+vi.mock("../../../../config/index.js", () => ({
+  configManager: {
+    getCustomMCPTools: vi.fn(),
+    getCustomMCPConfig: vi.fn(),
+    updateCustomMCPTools: vi.fn(),
+    addCustomMCPTools: vi.fn(),
+    getConfig: vi.fn().mockReturnValue({
+      platforms: {
+        coze: {
+          token: "test-token",
+        },
+      },
+    }),
+  },
+}));
+
+// Mock MCPCacheManager
+vi.mock("../MCPCacheManager.js", () => {
+  class MockMCPCacheManager {
+    async loadExistingCache() {
+      return {
+        version: "1.0.0",
+        mcpServers: {},
+        metadata: {
+          lastGlobalUpdate: new Date().toISOString(),
+          totalWrites: 0,
+          createdAt: new Date().toISOString(),
+        },
+        customMCPResults: {},
+      };
+    }
+
+    async saveCache() {}
+    async getCustomMCPStatistics() {
+      return { total: 0, active: 0, expired: 0 };
+    }
+    async cleanupCustomMCPResults() {
+      return { cleaned: 0, total: 0 };
+    }
+    cleanup() {}
+  }
+
+  return { MCPCacheManager: MockMCPCacheManager };
+});
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("CustomMCPHandler 基础功能测试", () => {
+  let customMCPHandler: CustomMCPHandler;
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 获取事件总线
+    eventBus = getEventBus();
+
+    // 创建 CustomMCPHandler 实例
+    customMCPHandler = new CustomMCPHandler();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("工具管理功能测试", () => {
+    it("应该正确初始化和加载 Coze 工具", () => {
+      // 创建 Coze 代理工具
+      const testTools: CustomMCPTool[] = [
+        {
+          name: "test_tool_1",
+          description: "测试 Coze 工具 1",
+          inputSchema: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+            },
+          },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: {
+              workflow_id: "test-workflow-1",
+              base_url: "https://api.coze.cn",
+            },
+          },
+        },
+        {
+          name: "test_tool_2",
+          description: "测试 Coze 工具 2",
+          inputSchema: {
+            type: "object",
+            properties: {
+              data: { type: "string" },
+            },
+          },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: {
+              workflow_id: "test-workflow-2",
+              base_url: "https://api.coze.cn",
+            },
+          },
+        },
+        {
+          name: "non_coze_tool",
+          description: "非 Coze 工具（应被过滤）",
+          inputSchema: { type: "object" },
+          handler: {
+            type: "function",
+            module: "test.js",
+            function: "test",
+          },
+        },
+      ];
+
+      customMCPHandler.initialize(testTools);
+
+      // 应该只加载 Coze 工具
+      expect(customMCPHandler.getToolCount()).toBe(2);
+      expect(customMCPHandler.hasTool("test_tool_1")).toBe(true);
+      expect(customMCPHandler.hasTool("test_tool_2")).toBe(true);
+      expect(customMCPHandler.hasTool("non_coze_tool")).toBe(false);
+    });
+
+    it("应该正确获取所有工具名称", () => {
+      const testTools: CustomMCPTool[] = [
+        {
+          name: "tool_a",
+          description: "Coze 工具 A",
+          inputSchema: { type: "object" },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: { workflow_id: "workflow-a" },
+          },
+        },
+        {
+          name: "tool_b",
+          description: "Coze 工具 B",
+          inputSchema: { type: "object" },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: { workflow_id: "workflow-b" },
+          },
+        },
+      ];
+
+      customMCPHandler.initialize(testTools);
+
+      const toolNames = customMCPHandler.getToolNames();
+      expect(toolNames).toContain("tool_a");
+      expect(toolNames).toContain("tool_b");
+      expect(toolNames).toHaveLength(2);
+    });
+
+    it("应该返回正确的工具列表（MCP格式）", () => {
+      const testTool: CustomMCPTool = {
+        name: "test_tool",
+        description: "测试工具",
+        inputSchema: {
+          type: "object",
+          properties: {
+            param1: { type: "string" },
+          },
+        },
+        handler: {
+          type: "proxy",
+          platform: "coze",
+          config: { workflow_id: "test-workflow" },
+        },
+      };
+
+      customMCPHandler.initialize([testTool]);
+
+      const tools = customMCPHandler.getTools();
+
+      expect(tools).toHaveLength(1);
+      expect(tools[0].name).toBe("test_tool");
+      expect(tools[0].description).toBe("测试工具");
+      expect(tools[0].inputSchema).toEqual({
+        type: "object",
+        properties: {
+          param1: { type: "string" },
+        },
+      });
+    });
+
+    it("应该能够获取工具详细信息", () => {
+      const testTool: CustomMCPTool = {
+        name: "detailed_tool",
+        description: "详细工具信息",
+        inputSchema: { type: "object" },
+        handler: {
+          type: "proxy",
+          platform: "coze",
+          config: { workflow_id: "detailed-workflow" },
+        },
+      };
+
+      customMCPHandler.initialize([testTool]);
+
+      const toolInfo = customMCPHandler.getToolInfo("detailed_tool");
+      expect(toolInfo).toBeDefined();
+      expect(toolInfo?.name).toBe("detailed_tool");
+      expect(toolInfo?.description).toBe("详细工具信息");
+    });
+
+    it("应该清空现有工具并重新加载", () => {
+      // 第一次初始化
+      customMCPHandler.initialize([
+        {
+          name: "tool1",
+          description: "工具 1",
+          inputSchema: { type: "object" },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: { workflow_id: "workflow-1" },
+          },
+        },
+      ]);
+      expect(customMCPHandler.getToolCount()).toBe(1);
+
+      // 第二次初始化（应该清空现有工具）
+      customMCPHandler.initialize([
+        {
+          name: "tool2",
+          description: "工具 2",
+          inputSchema: { type: "object" },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: { workflow_id: "workflow-2" },
+          },
+        },
+      ]);
+      expect(customMCPHandler.getToolCount()).toBe(1);
+      expect(customMCPHandler.hasTool("tool1")).toBe(false);
+      expect(customMCPHandler.hasTool("tool2")).toBe(true);
+    });
+  });
+
+  describe("错误处理测试", () => {
+    it("应该处理工具不存在错误", async () => {
+      await expect(
+        customMCPHandler.callTool("non-existent-tool", {})
+      ).rejects.toThrow("未找到工具: non-existent-tool");
+    });
+  });
+
+  describe("资源清理测试", () => {
+    it("应该正确清理资源", () => {
+      const testTool: CustomMCPTool = {
+        name: "cleanup_tool",
+        description: "清理测试工具",
+        inputSchema: { type: "object" },
+        handler: {
+          type: "proxy",
+          platform: "coze",
+          config: { workflow_id: "cleanup-workflow" },
+        },
+      };
+
+      customMCPHandler.initialize([testTool]);
+      expect(customMCPHandler.getToolCount()).toBe(1);
+
+      // 清理资源
+      customMCPHandler.cleanup();
+
+      // 验证资源被清理
+      expect(customMCPHandler.getToolCount()).toBe(0);
+    });
+
+    it("应该能够多次调用清理而不出错", () => {
+      expect(() => {
+        customMCPHandler.cleanup();
+        customMCPHandler.cleanup();
+        customMCPHandler.cleanup();
+      }).not.toThrow();
+    });
+  });
+
+  describe("配置更新响应测试", () => {
+    it("应该在配置更新处理失败时记录错误", async () => {
+      const { logger } = await import("../../../Logger.js");
+
+      // Mock initialize 方法抛出异常
+      vi.spyOn(customMCPHandler, "initialize").mockImplementation(() => {
+        throw new Error("重新初始化失败");
+      });
+
+      // 发射配置更新事件
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      // 等待异步处理
+      await new Promise((resolve) => setTimeout(resolve, 10));
+
+      // 验证错误被记录
+      expect(logger.error).toHaveBeenCalledWith(
+        "[CustomMCP] 配置更新处理失败:",
+        expect.any(Error)
+      );
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/custom.timeout.test.ts
+++ b/src/server/lib/mcp/__tests__/custom.timeout.test.ts
@@ -1,0 +1,193 @@
+/**
+ * CustomMCPHandler 基础测试
+ * 测试基本功能和资源管理
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CustomMCPTool } from "../../../../config/index.js";
+import { CustomMCPHandler } from "../custom.js";
+
+// 类型定义：测试用到的私有方法签名
+// 使用类型断言来访问私有方法（仅用于测试）
+type TestableCustomMCPHandler = {
+  generateCacheKey(
+    toolName: string,
+    arguments_: Record<string, unknown>
+  ): string;
+};
+
+// Mock logger
+vi.mock("../../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  },
+}));
+
+// Mock configManager
+vi.mock("../../../../config/index.js", () => ({
+  configManager: {
+    getCustomMCPTools: vi.fn(),
+    getCustomMCPConfig: vi.fn(),
+    updateCustomMCPTools: vi.fn(),
+    addCustomMCPTools: vi.fn(),
+    getConfig: vi.fn().mockReturnValue({
+      platforms: {
+        coze: {
+          token: "test-token",
+        },
+      },
+    }),
+  },
+}));
+
+// Mock MCPCacheManager
+vi.mock("../MCPCacheManager.js", () => {
+  class MockMCPCacheManager {
+    async loadExistingCache() {
+      return {
+        version: "1.0.0",
+        mcpServers: {},
+        metadata: {
+          lastGlobalUpdate: new Date().toISOString(),
+          totalWrites: 0,
+          createdAt: new Date().toISOString(),
+        },
+        customMCPResults: {},
+      };
+    }
+
+    async saveCache() {}
+    async getCustomMCPStatistics() {
+      return { total: 0, active: 0, expired: 0 };
+    }
+    async cleanupCustomMCPResults() {
+      return { cleaned: 0, total: 0 };
+    }
+    cleanup() {}
+  }
+
+  return { MCPCacheManager: MockMCPCacheManager };
+});
+
+// Mock global fetch
+global.fetch = vi.fn();
+
+describe("CustomMCPHandler 基础测试", () => {
+  let customMCPHandler: CustomMCPHandler;
+  let handlerWithPrivateMethods: TestableCustomMCPHandler;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    // 创建 CustomMCPHandler 实例
+    customMCPHandler = new CustomMCPHandler();
+    // 类型转换以访问私有方法（仅用于测试）
+    handlerWithPrivateMethods =
+      customMCPHandler as unknown as TestableCustomMCPHandler;
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    customMCPHandler.cleanup();
+  });
+
+  describe("缓存管理测试", () => {
+    it("应该正确生成缓存键", async () => {
+      const cacheKey1 = handlerWithPrivateMethods.generateCacheKey(
+        "test_tool",
+        { param: "value1" }
+      );
+      const cacheKey2 = handlerWithPrivateMethods.generateCacheKey(
+        "test_tool",
+        { param: "value2" }
+      );
+      const cacheKey3 = handlerWithPrivateMethods.generateCacheKey(
+        "test_tool",
+        { param: "value1" }
+      );
+
+      expect(cacheKey1).not.toBe(cacheKey2);
+      expect(cacheKey1).toBe(cacheKey3); // 相同参数应该生成相同的键
+      expect(typeof cacheKey1).toBe("string");
+    });
+  });
+
+  describe("性能和资源管理测试", () => {
+    it("应该提供正确的工具统计信息", () => {
+      const testTools: CustomMCPTool[] = [
+        {
+          name: "slow_tool",
+          description: "慢速测试工具",
+          inputSchema: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+            },
+          },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: {
+              workflow_id: "slow_workflow_id",
+            },
+          },
+        },
+        {
+          name: "fast_tool",
+          description: "快速测试工具",
+          inputSchema: {
+            type: "object",
+            properties: {
+              message: { type: "string" },
+            },
+          },
+          handler: {
+            type: "proxy",
+            platform: "coze",
+            config: {
+              workflow_id: "fast_workflow_id",
+            },
+          },
+        },
+      ];
+
+      customMCPHandler.initialize(testTools);
+
+      expect(customMCPHandler.getToolCount()).toBe(2);
+      expect(customMCPHandler.hasTool("slow_tool")).toBe(true);
+      expect(customMCPHandler.hasTool("fast_tool")).toBe(true);
+
+      const toolNames = customMCPHandler.getToolNames();
+      expect(toolNames).toContain("slow_tool");
+      expect(toolNames).toContain("fast_tool");
+      expect(toolNames).toHaveLength(2);
+    });
+
+    it("应该能够正常清理资源", () => {
+      expect(() => customMCPHandler.cleanup()).not.toThrow();
+
+      // 清理后工具数量应该为0
+      expect(customMCPHandler.getToolCount()).toBe(0);
+    });
+
+    it("应该能够多次清理资源而不出错", () => {
+      expect(() => {
+        customMCPHandler.cleanup();
+        customMCPHandler.cleanup();
+        customMCPHandler.cleanup();
+      }).not.toThrow();
+    });
+  });
+
+  describe("错误处理测试", () => {
+    it("应该处理工具不存在错误", async () => {
+      await expect(
+        customMCPHandler.callTool("non_existent_tool", {})
+      ).rejects.toThrow("未找到工具: non_existent_tool");
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/environment-variables.integration.test.ts
+++ b/src/server/lib/mcp/__tests__/environment-variables.integration.test.ts
@@ -1,0 +1,123 @@
+/**
+ * 环境变量传递集成测试
+ * 验证 MCP 服务环境变量传递修复是否正确工作
+ */
+
+import { describe, expect, it } from "vitest";
+import { normalizeServiceConfig } from "../../../../config/index.js";
+import type { LocalMCPServerConfig } from "../../../../config/index.js";
+import { MCPTransportType } from "../../../lib/mcp";
+
+describe("环境变量传递集成测试", () => {
+  describe("配置转换", () => {
+    it("应该正确传递环境变量从用户配置到 MCPServiceConfig", () => {
+      // 1. 模拟用户配置（类似 xiaozhi.config.json 中的配置）
+      const userConfig: LocalMCPServerConfig = {
+        command: "npx",
+        args: ["-y", "@amap/amap-maps-mcp-server"],
+        env: {
+          AMAP_MAPS_API_KEY: "1ec31da021b2702787841ea4ee822de3",
+          NODE_ENV: "production",
+        },
+      };
+
+      // 2. 通过 ConfigAdapter 转换配置
+      const mcpServiceConfig = normalizeServiceConfig(userConfig);
+
+      // 3. 验证转换后的配置包含环境变量（符合 MCP 官方标准，不包含 name）
+      expect(mcpServiceConfig).toEqual({
+        type: MCPTransportType.STDIO,
+        command: "npx",
+        args: ["-y", "@amap/amap-maps-mcp-server"],
+        env: {
+          AMAP_MAPS_API_KEY: "1ec31da021b2702787841ea4ee822de3",
+          NODE_ENV: "production",
+        },
+      });
+    });
+
+    it("应该处理没有环境变量的配置", () => {
+      const userConfig: LocalMCPServerConfig = {
+        command: "node",
+        args: ["calculator.js"],
+        // 没有 env 字段
+      };
+
+      const mcpServiceConfig = normalizeServiceConfig(userConfig);
+
+      expect(mcpServiceConfig.env).toBeUndefined();
+      expect(mcpServiceConfig.command).toBe("node");
+      expect(mcpServiceConfig.args).toEqual([
+        expect.stringContaining("calculator.js"),
+      ]);
+    });
+
+    it("应该处理空的环境变量对象", () => {
+      const userConfig: LocalMCPServerConfig = {
+        command: "python",
+        args: ["server.py"],
+        env: {}, // 空的环境变量对象
+      };
+
+      const mcpServiceConfig = normalizeServiceConfig(userConfig);
+
+      expect(mcpServiceConfig.env).toEqual({});
+      expect(mcpServiceConfig.command).toBe("python");
+      expect(mcpServiceConfig.args).toEqual([
+        expect.stringContaining("server.py"),
+      ]);
+    });
+
+    it("应该处理多个环境变量", () => {
+      const userConfig: LocalMCPServerConfig = {
+        command: "node",
+        args: ["complex-server.js"],
+        env: {
+          API_KEY: "secret-key",
+          DATABASE_URL: "postgresql://localhost:5432/db",
+          DEBUG: "true",
+          PORT: "3000",
+        },
+      };
+
+      const mcpServiceConfig = normalizeServiceConfig(userConfig);
+
+      expect(mcpServiceConfig.env).toEqual({
+        API_KEY: "secret-key",
+        DATABASE_URL: "postgresql://localhost:5432/db",
+        DEBUG: "true",
+        PORT: "3000",
+      });
+      expect(mcpServiceConfig.command).toBe("node");
+      expect(mcpServiceConfig.args).toEqual([
+        expect.stringContaining("complex-server.js"),
+      ]);
+    });
+  });
+
+  describe("真实场景模拟", () => {
+    it("应该模拟 amap-maps 服务的完整配置流程", () => {
+      // 模拟用户在 xiaozhi.config.json 中的实际配置
+      const amapConfig: LocalMCPServerConfig = {
+        command: "npx",
+        args: ["-y", "@amap/amap-maps-mcp-server"],
+        env: {
+          AMAP_MAPS_API_KEY: "1ec31da021b2702787841ea4ee822de3",
+        },
+      };
+
+      // 完整的配置转换流程
+      const serviceConfig = normalizeServiceConfig(amapConfig);
+
+      // 验证配置转换结果（符合 MCP 官方标准，不包含 name 字段）
+      expect(serviceConfig).toEqual({
+        type: MCPTransportType.STDIO,
+        command: "npx",
+        args: ["-y", "@amap/amap-maps-mcp-server"],
+        env: {
+          AMAP_MAPS_API_KEY: "1ec31da021b2702787841ea4ee822de3",
+        },
+      });
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/inference-consistency.test.ts
+++ b/src/server/lib/mcp/__tests__/inference-consistency.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import { normalizeServiceConfig } from "../../../../config/index.js";
+import { MCPService, MCPTransportType } from "../../../lib/mcp";
+
+describe("MCPService 和 ConfigAdapter 推断逻辑一致性测试", () => {
+  const testCases = [
+    {
+      name: "简单 SSE 路径",
+      url: "https://example.com/sse",
+      expectedType: MCPTransportType.SSE,
+    },
+    {
+      name: "复杂 ModelScope SSE 路径",
+      url: "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+      expectedType: MCPTransportType.SSE,
+    },
+    {
+      name: "高德地图 SSE 路径",
+      url: "https://mcp.amap.com/sse?key=1ec31da021b2702787841ea4ee822de3",
+      expectedType: MCPTransportType.SSE,
+    },
+    {
+      name: "简单 MCP 路径",
+      url: "https://example.com/mcp",
+      expectedType: MCPTransportType.HTTP,
+    },
+    {
+      name: "复杂 ModelScope MCP 路径",
+      url: "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/mcp",
+      expectedType: MCPTransportType.HTTP,
+    },
+    {
+      name: "其他 API 路径",
+      url: "https://example.com/api/v1/tools",
+      expectedType: MCPTransportType.HTTP,
+    },
+    {
+      name: "根路径",
+      url: "https://example.com/",
+      expectedType: MCPTransportType.HTTP,
+    },
+  ];
+
+  for (const { name, url, expectedType } of testCases) {
+    it(`对于 ${name}，两个组件应该推断出相同的类型: ${expectedType}`, () => {
+      // ConfigAdapter 推断
+      const legacyConfig = { url };
+      const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+      // MCPService 推断
+      const mcpServiceConfig = { name: "test-service", url };
+      const mcpService = new MCPService(mcpServiceConfig);
+      const mcpServiceResult = mcpService.getConfig();
+
+      // 验证两个组件的推断结果一致
+      expect(configAdapterResult.type).toBe(expectedType);
+      expect(mcpServiceResult.type).toBe(expectedType);
+      expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+    });
+  }
+
+  it("应该正确处理无效 URL", () => {
+    const invalidUrl = "not-a-valid-url";
+
+    // ConfigAdapter 处理无效 URL
+    const legacyConfig = { url: invalidUrl };
+    const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+    // MCPService 处理无效 URL
+    const mcpServiceConfig = { name: "invalid-service", url: invalidUrl };
+    const mcpService = new MCPService(mcpServiceConfig);
+    const mcpServiceResult = mcpService.getConfig();
+
+    // 两个组件都应该默认推断为 STREAMABLE_HTTP
+    expect(configAdapterResult.type).toBe(MCPTransportType.HTTP);
+    expect(mcpServiceResult.type).toBe(MCPTransportType.HTTP);
+    expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+  });
+
+  it("应该优先使用显式指定的类型", () => {
+    const explicitConfig = {
+      name: "explicit-service",
+      url: "https://example.com/sse", // 这个 URL 应该推断为 SSE
+      type: MCPTransportType.HTTP, // 但显式指定为 STREAMABLE_HTTP
+    };
+
+    // ConfigAdapter 处理显式类型
+    const legacyConfig = {
+      url: explicitConfig.url,
+      type: "streamable-http" as const,
+    };
+    const configAdapterResult = normalizeServiceConfig(legacyConfig);
+
+    // MCPService 处理显式类型
+    const mcpService = new MCPService(explicitConfig);
+    const mcpServiceResult = mcpService.getConfig();
+
+    // 两个组件都应该使用显式指定的类型
+    expect(configAdapterResult.type).toBe(MCPTransportType.HTTP);
+    expect(mcpServiceResult.type).toBe(MCPTransportType.HTTP);
+    expect(configAdapterResult.type).toBe(mcpServiceResult.type);
+  });
+});

--- a/src/server/lib/mcp/__tests__/log.test.ts
+++ b/src/server/lib/mcp/__tests__/log.test.ts
@@ -1,0 +1,771 @@
+/**
+ * MCP 工具调用日志模块测试
+ * 包含 ToolCallLogger 和 ToolCallLogService 的测试
+ */
+
+import {
+  existsSync,
+  mkdtempSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import * as fs from "node:fs/promises";
+import * as os from "node:os";
+import * as path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { PathUtils } from "../../../utils/path-utils.js";
+import {
+  type ToolCallLogConfig,
+  ToolCallLogService,
+  ToolCallLogger,
+  type ToolCallRecord,
+} from "../log.js";
+
+// ==================== ToolCallLogger 测试 ====================
+
+describe("ToolCallLogger", () => {
+  // 使用 PathUtils 获取跨平台兼容的临时目录
+  const getTestDir = () => {
+    const baseTempDir = PathUtils.getTempDir();
+    return path.join(baseTempDir, "xiaozhi-test-logger");
+  };
+
+  let testDir: string;
+  let logFilePath: string;
+  let toolCallLogger: ToolCallLogger;
+  let config: ToolCallLogConfig;
+
+  beforeEach(async () => {
+    testDir = getTestDir();
+    logFilePath = path.join(testDir, "tool-calls.jsonl");
+
+    try {
+      // 确保测试目录存在
+      await fs.mkdir(testDir, { recursive: true });
+
+      // 清理可能存在的日志文件
+      if (existsSync(logFilePath)) {
+        await fs.unlink(logFilePath);
+      }
+
+      config = {
+        maxRecords: 5,
+        logFilePath: logFilePath,
+      };
+
+      toolCallLogger = new ToolCallLogger(config, testDir);
+    } catch (error) {
+      // 如果目录创建失败，尝试使用当前工作目录
+      console.warn("无法创建临时目录，使用当前工作目录作为备选:", error);
+      testDir = path.join(process.cwd(), "tool-call-logger");
+      logFilePath = path.join(testDir, "tool-calls.jsonl");
+
+      await fs.mkdir(testDir, { recursive: true });
+
+      config = {
+        maxRecords: 5,
+        logFilePath: logFilePath,
+      };
+
+      toolCallLogger = new ToolCallLogger(config, testDir);
+    }
+  });
+
+  afterEach(async () => {
+    // 清理测试文件和目录，增强错误处理
+    try {
+      if (logFilePath && existsSync(logFilePath)) {
+        await fs.unlink(logFilePath);
+      }
+
+      // 清理可能存在的测试文件
+      if (testDir) {
+        const testFile = path.join(testDir, ".xiaozhi-write-test");
+        if (existsSync(testFile)) {
+          await fs.unlink(testFile);
+        }
+
+        // 尝试删除目录（仅在目录为空时）
+        try {
+          await fs.rmdir(testDir);
+        } catch (rmdirError) {
+          // 如果目录不为空或有其他权限问题，跳过删除
+          console.debug("跳过目录删除:", rmdirError);
+        }
+      }
+    } catch (error) {
+      // 忽略清理错误，避免影响其他测试
+      console.debug("清理测试文件时出错:", error);
+    }
+  });
+
+  describe("constructor", () => {
+    it("应该使用正确的配置初始化", () => {
+      expect(toolCallLogger.getMaxRecords()).toBe(5);
+      expect(toolCallLogger.getLogFilePath()).toBe(logFilePath);
+    });
+
+    it("应该在未提供配置时使用默认值", () => {
+      const defaultLogger = new ToolCallLogger({}, testDir);
+      expect(defaultLogger.getMaxRecords()).toBe(100);
+    });
+
+    it("应该在未提供路径时生成默认日志文件路径", () => {
+      const defaultLogger = new ToolCallLogger({}, testDir);
+      // 预期路径应该被规范化
+      const expectedPath = path.resolve(
+        path.normalize(path.join(testDir, "tool-calls.jsonl"))
+      );
+      expect(defaultLogger.getLogFilePath()).toBe(expectedPath);
+    });
+  });
+
+  describe("recordToolCall", () => {
+    it("应该成功记录工具调用", async () => {
+      // 调用记录方法应该不会抛出错误
+      await expect(
+        toolCallLogger.recordToolCall({
+          toolName: "test_tool",
+          success: true,
+        })
+      ).resolves.toBeUndefined();
+    });
+
+    it("应该创建日志文件并记录第一次工具调用", async () => {
+      const record = {
+        timestamp: Date.now(),
+        toolName: "calculator_add",
+        arguments: { a: 5, b: 3 },
+        result: { content: [{ type: "text", text: "8" }] },
+        success: true,
+        duration: 45,
+      };
+
+      await toolCallLogger.recordToolCall(record);
+
+      // 如果文件路径有效且可写，检查文件是否被创建
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          // 只有当权限允许时才检查文件存在性
+          if (fileExists) {
+            // 检查文件内容是否为有效的 JSON 格式
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim());
+
+            if (logLines.length > 0) {
+              // 每行都应该是有效的 JSON
+              for (const line of logLines) {
+                expect(() => JSON.parse(line)).not.toThrow();
+              }
+
+              // 检查是否包含工具调用记录
+              const logData = JSON.parse(logLines[0]);
+              expect(logData.toolName).toBe("calculator_add");
+              expect(logData.success).toBe(true);
+              expect(logData.duration).toBe(45);
+            }
+          }
+        } catch (error) {
+          // 如果文件操作失败（例如权限问题），跳过文件内容检查
+          console.warn("跳过文件内容检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功（不抛出异常）
+      expect(true).toBe(true);
+    });
+
+    it("应该追加多条记录", async () => {
+      const record1 = {
+        timestamp: Date.now(),
+        toolName: "calculator_add",
+        arguments: { a: 5, b: 3 },
+        success: true,
+        duration: 45,
+      };
+
+      const record2 = {
+        timestamp: Date.now() + 60000,
+        toolName: "calculator_multiply",
+        arguments: { a: 4, b: 6 },
+        success: true,
+        duration: 32,
+      };
+
+      await toolCallLogger.recordToolCall(record1);
+      await toolCallLogger.recordToolCall(record2);
+
+      // 只有当文件路径有效且可写时才检查文件内容
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          if (fileExists) {
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim());
+
+            if (logLines.length >= 2) {
+              expect(logLines.length).toBeGreaterThanOrEqual(2);
+
+              // 检查第一条记录
+              const logData1 = JSON.parse(logLines[0]);
+              expect(logData1.toolName).toBe("calculator_add");
+
+              // 检查第二条记录
+              const logData2 = JSON.parse(logLines[1]);
+              expect(logData2.toolName).toBe("calculator_multiply");
+            }
+          }
+        } catch (error) {
+          console.warn("跳过多记录检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功
+      expect(true).toBe(true);
+    });
+
+    it("应该优雅地处理错误", async () => {
+      // 创建一个带有无效文件路径的 logger 来模拟错误
+      const invalidLogger = new ToolCallLogger(
+        {
+          maxRecords: 5,
+          logFilePath: "/invalid/path/file.json",
+        },
+        testDir
+      );
+
+      const record = {
+        timestamp: Date.now(),
+        toolName: "test_tool",
+        success: true,
+      };
+
+      // 即使路径无效也不应该抛出异常
+      await expect(
+        invalidLogger.recordToolCall(record)
+      ).resolves.toBeUndefined();
+    });
+
+    it("应该记录失败的工具调用", async () => {
+      const failedRecord = {
+        timestamp: Date.now(),
+        toolName: "failing_tool",
+        arguments: { input: "test" },
+        result: null,
+        success: false,
+        duration: 123,
+        error: "Something went wrong",
+      };
+
+      await toolCallLogger.recordToolCall(failedRecord);
+
+      // 只有当文件路径有效且可写时才检查文件内容
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          if (fileExists) {
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim());
+
+            if (logLines.length > 0) {
+              const logData = JSON.parse(logLines[0]);
+              expect(logData.toolName).toBe("failing_tool");
+              expect(logData.success).toBe(false);
+              expect(logData.error).toBe("Something went wrong");
+              expect(logData.duration).toBe(123);
+            }
+          }
+        } catch (error) {
+          console.warn("跳过失败工具调用记录检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功
+      expect(true).toBe(true);
+    });
+
+    it("应该通过删除旧记录来强制执行 maxRecords 限制", async () => {
+      const limitedLogger = new ToolCallLogger(
+        { maxRecords: 3, logFilePath: logFilePath },
+        testDir
+      );
+
+      // 记录 5 次工具调用（超过限制 3）
+      for (let i = 1; i <= 5; i++) {
+        await limitedLogger.recordToolCall({
+          toolName: `tool_${i}`,
+          success: true,
+          duration: i * 10,
+        });
+      }
+
+      // 只有当文件路径有效且可写时才检查文件内容
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          if (fileExists) {
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim() !== "");
+
+            if (logLines.length > 0) {
+              // 应该只有最新的 3 条记录
+              expect(logLines.length).toBeLessThanOrEqual(3);
+
+              // 检查最旧的记录是否被删除（如果我们有所有记录）
+              if (logLines.length === 3) {
+                const remainingToolNames = logLines.map(
+                  (line) => JSON.parse(line).toolName
+                );
+                expect(remainingToolNames).toEqual([
+                  "tool_3",
+                  "tool_4",
+                  "tool_5",
+                ]);
+              }
+            }
+          }
+        } catch (error) {
+          console.warn("跳过记录限制检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功
+      expect(true).toBe(true);
+    });
+
+    it("应该在达到限制时保持 maxRecords 的数量", async () => {
+      const limitedLogger = new ToolCallLogger(
+        { maxRecords: 2, logFilePath: logFilePath },
+        testDir
+      );
+
+      // 记录恰好 2 次工具调用（匹配限制）
+      await limitedLogger.recordToolCall({
+        toolName: "first_tool",
+        success: true,
+        duration: 50,
+      });
+
+      await limitedLogger.recordToolCall({
+        toolName: "second_tool",
+        success: true,
+        duration: 60,
+      });
+
+      // 只有当文件路径有效且可写时才检查文件内容
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          if (fileExists) {
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim() !== "");
+
+            if (logLines.length > 0) {
+              // 应该恰好有 2 条记录（或至少 1 条如果某些操作被跳过）
+              expect(logLines.length).toBeGreaterThanOrEqual(1);
+              expect(logLines.length).toBeLessThanOrEqual(2);
+
+              // 如果我们有预期的记录数量，检查工具名称
+              if (logLines.length === 2) {
+                const toolNames = logLines.map(
+                  (line) => JSON.parse(line).toolName
+                );
+                expect(toolNames).toEqual(["first_tool", "second_tool"]);
+              }
+            }
+          }
+        } catch (error) {
+          console.warn("跳过记录限制检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功
+      expect(true).toBe(true);
+    });
+  });
+
+  describe("控制台输出", () => {
+    it("应该向控制台输出格式化消息", async () => {
+      const record = {
+        timestamp: Date.now(),
+        toolName: "test_tool",
+        success: true,
+        duration: 50,
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await toolCallLogger.recordToolCall(record);
+
+      // 检查是否调用了控制台日志
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[工具调用]",
+        expect.objectContaining({
+          message: expect.stringContaining("✅ test_tool (50ms)"),
+        })
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("应该为失败的调用显示失败表情符号", async () => {
+      const record = {
+        timestamp: Date.now(),
+        toolName: "failing_tool",
+        success: false,
+        duration: 30,
+      };
+
+      const consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+
+      await toolCallLogger.recordToolCall(record);
+
+      // 检查是否调用了控制台日志
+      expect(consoleSpy).toHaveBeenCalledWith(
+        "[工具调用]",
+        expect.objectContaining({
+          message: expect.stringContaining("❌ failing_tool (30ms)"),
+        })
+      );
+
+      consoleSpy.mockRestore();
+    });
+  });
+
+  describe("文件格式", () => {
+    it("应该输出有效的 JSON 格式", async () => {
+      const record = {
+        timestamp: Date.now(),
+        toolName: "test_tool",
+        arguments: { param1: "value1", param2: 42 },
+        result: { output: "success" },
+        success: true,
+        duration: 100,
+      };
+
+      await toolCallLogger.recordToolCall(record);
+
+      // 只有当文件路径有效且可写时才检查文件内容
+      if (
+        logFilePath &&
+        !logFilePath.includes("NUL") &&
+        !logFilePath.includes("dev/null")
+      ) {
+        try {
+          const fileExists = existsSync(logFilePath);
+          if (fileExists) {
+            const fileContent = await fs.readFile(logFilePath, "utf8");
+            const logLines = fileContent
+              .trim()
+              .split("\n")
+              .filter((line) => line.trim());
+
+            if (logLines.length > 0) {
+              const logData = JSON.parse(logLines[0]);
+
+              // 验证 JSON 结构
+              expect(logData).toHaveProperty("toolName", "test_tool");
+              expect(logData).toHaveProperty("success", true);
+              expect(logData).toHaveProperty("duration", 100);
+              expect(logData).toHaveProperty("timestamp");
+              expect(typeof logData.timestamp).toBe("number");
+              expect(logData).toHaveProperty("arguments");
+              expect(logData).toHaveProperty("result");
+              expect(logData.arguments).toEqual({
+                param1: "value1",
+                param2: 42,
+              });
+              expect(logData.result).toEqual({ output: "success" });
+            }
+          }
+        } catch (error) {
+          console.warn("跳过JSON格式检查，可能是权限问题:", error);
+        }
+      }
+
+      // 无论如何，记录操作都应该成功
+      expect(true).toBe(true);
+    });
+  });
+});
+
+// ==================== ToolCallLogService 测试 ====================
+
+describe("ToolCallLogService", () => {
+  let toolCallLogService: ToolCallLogService;
+  let tempDir: string;
+  let logFilePath: string;
+
+  beforeEach(() => {
+    // 创建临时目录
+    tempDir = mkdtempSync(path.join(os.tmpdir(), "tool-call-test-"));
+    logFilePath = path.join(tempDir, "tool-calls.jsonl");
+
+    // 创建服务实例
+    toolCallLogService = new ToolCallLogService(tempDir);
+  });
+
+  afterEach(() => {
+    // 清理临时文件和目录
+    try {
+      if (existsSync(logFilePath)) {
+        unlinkSync(logFilePath);
+      }
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error) {
+      console.warn("清理临时文件失败:", error);
+    }
+  });
+
+  describe("getToolCallLogs", () => {
+    it("应该返回空的日志记录列表", async () => {
+      // 不创建日志文件，测试空文件情况
+      // 创建空日志文件
+      writeFileSync(logFilePath, "", "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs();
+      expect(result.records).toHaveLength(0);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("应该正确解析和返回日志记录", async () => {
+      // 创建测试数据
+      const testRecords: ToolCallRecord[] = [
+        {
+          toolName: "test_tool_1",
+          serverName: "test_server",
+          success: true,
+          duration: 100,
+          arguments: { input: "test" },
+          result: { output: "success" },
+          timestamp: Date.now() - 1000,
+        },
+        {
+          toolName: "test_tool_2",
+          serverName: "test_server",
+          success: false,
+          duration: 200,
+          error: "Test error",
+          timestamp: Date.now(),
+        },
+      ];
+
+      // 写入测试数据到日志文件
+      const logData = testRecords
+        .map((record) => JSON.stringify(record))
+        .join("\n");
+      writeFileSync(logFilePath, logData, "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs();
+
+      expect(result.records).toHaveLength(2);
+      expect(result.total).toBe(2);
+      expect(result.hasMore).toBe(false);
+
+      // 验证记录按时间戳倒序排列
+      expect(result.records[0].toolName).toBe("test_tool_2");
+      expect(result.records[1].toolName).toBe("test_tool_1");
+    });
+
+    it("应该正确应用查询参数过滤", async () => {
+      const testRecords: ToolCallRecord[] = [
+        {
+          toolName: "search_tool",
+          serverName: "search_server",
+          success: true,
+          duration: 50,
+          timestamp: Date.now() - 2000,
+        },
+        {
+          toolName: "calculate_tool",
+          serverName: "math_server",
+          success: false,
+          duration: 100,
+          timestamp: Date.now() - 1000,
+        },
+        {
+          toolName: "search_tool",
+          serverName: "search_server",
+          success: true,
+          duration: 75,
+          timestamp: Date.now(),
+        },
+      ];
+
+      const logData = testRecords
+        .map((record) => JSON.stringify(record))
+        .join("\n");
+      writeFileSync(logFilePath, logData, "utf8");
+
+      // 测试按工具名称过滤
+      const result1 = await toolCallLogService.getToolCallLogs({
+        toolName: "search_tool",
+      });
+      expect(result1.records).toHaveLength(2);
+      expect(result1.total).toBe(2);
+
+      // 测试按服务器名称过滤
+      const result2 = await toolCallLogService.getToolCallLogs({
+        serverName: "math_server",
+      });
+      expect(result2.records).toHaveLength(1);
+      expect(result2.total).toBe(1);
+
+      // 测试按成功状态过滤
+      const result3 = await toolCallLogService.getToolCallLogs({
+        success: false,
+      });
+      expect(result3.records).toHaveLength(1);
+      expect(result3.total).toBe(1);
+
+      // 测试分页
+      const result4 = await toolCallLogService.getToolCallLogs({
+        limit: 1,
+        offset: 1,
+      });
+      expect(result4.records).toHaveLength(1);
+      expect(result4.total).toBe(3);
+      expect(result4.hasMore).toBe(true);
+    });
+
+    it("应该正确处理时间范围过滤", async () => {
+      const now = Date.now();
+      const testRecords: ToolCallRecord[] = [
+        {
+          toolName: "tool1",
+          success: true,
+          timestamp: now - 5000, // 5秒前
+        },
+        {
+          toolName: "tool2",
+          success: true,
+          timestamp: now - 2000, // 2秒前
+        },
+        {
+          toolName: "tool3",
+          success: true,
+          timestamp: now, // 现在
+        },
+      ];
+
+      const logData = testRecords
+        .map((record) => JSON.stringify(record))
+        .join("\n");
+      writeFileSync(logFilePath, logData, "utf8");
+
+      const startDate = new Date(now - 3000).toISOString(); // 3秒前
+      const endDate = new Date(now - 1000).toISOString(); // 1秒前
+
+      const result = await toolCallLogService.getToolCallLogs({
+        startDate,
+        endDate,
+      });
+
+      expect(result.records).toHaveLength(1);
+      expect(result.records[0].toolName).toBe("tool2");
+    });
+  });
+
+  describe("边界情况处理", () => {
+    it("应该跳过无效的 JSON 行", async () => {
+      const invalidLogData = [
+        '{"toolName": "valid_record", "success": true}',
+        "invalid json line",
+        '{"toolName": "another_valid", "success": false}',
+        "",
+      ].join("\n");
+
+      writeFileSync(logFilePath, invalidLogData, "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs();
+
+      expect(result.records).toHaveLength(2);
+      expect(result.total).toBe(2);
+      // 验证记录包含两个有效的工具名称（顺序可能因为时间戳相同而不同）
+      const toolNames = result.records.map((r) => r.toolName);
+      expect(toolNames).toContain("another_valid");
+      expect(toolNames).toContain("valid_record");
+    });
+
+    it("应该处理空文件", async () => {
+      // 创建空文件
+      writeFileSync(logFilePath, "", "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs();
+
+      expect(result.records).toHaveLength(0);
+      expect(result.total).toBe(0);
+      expect(result.hasMore).toBe(false);
+    });
+
+    it("应该处理只包含空行的文件", async () => {
+      const logData = "\n\n\n";
+      writeFileSync(logFilePath, logData, "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs();
+
+      expect(result.records).toHaveLength(0);
+      expect(result.total).toBe(0);
+    });
+
+    it("应该限制最大返回数量", async () => {
+      const testRecords: ToolCallRecord[] = Array.from(
+        { length: 10 },
+        (_, i) => ({
+          toolName: `tool_${i}`,
+          success: true,
+          timestamp: Date.now() - i * 1000,
+        })
+      );
+
+      const logData = testRecords
+        .map((record) => JSON.stringify(record))
+        .join("\n");
+      writeFileSync(logFilePath, logData, "utf8");
+
+      const result = await toolCallLogService.getToolCallLogs({ limit: 5 });
+
+      expect(result.records).toHaveLength(5);
+      expect(result.total).toBe(10);
+      expect(result.hasMore).toBe(true);
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/manager.test.ts
+++ b/src/server/lib/mcp/__tests__/manager.test.ts
@@ -1,0 +1,451 @@
+/**
+ * MCPServiceManager customMCP 功能测试
+ * 测试新增的 hasCustomMCPTool 和 getCustomMCPTools 方法
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServiceManager } from "../../../lib/mcp";
+import type { CustomMCPHandler } from "../custom.js";
+
+// Mock dependencies
+vi.mock("../../../Logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    withTag: vi.fn().mockReturnValue({
+      info: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+      warn: vi.fn(),
+    }),
+  },
+}));
+
+vi.mock("../../../../config/index.js", () => ({
+  configManager: {
+    getCustomMCPTools: vi.fn(),
+    getMcpServers: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({
+      maxRecords: 100,
+    }),
+    getConfigDir: vi.fn().mockReturnValue("/tmp"),
+  },
+}));
+
+vi.mock("../custom.js", () => ({
+  CustomMCPHandler: vi.fn().mockImplementation(() => ({
+    // 基础方法
+    initialize: vi.fn(),
+    reinitialize: vi.fn(),
+    hasTool: vi.fn(),
+    getTools: vi.fn(),
+    getToolCount: vi.fn(),
+    getToolNames: vi.fn(),
+    getToolInfo: vi.fn(),
+
+    // 工具调用方法
+    callTool: vi.fn(),
+
+    // 资源管理方法
+    cleanup: vi.fn(),
+    stopCleanupTimer: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../lib/mcp/cache.js", () => ({
+  MCPCacheManager: vi.fn().mockImplementation(() => ({
+    loadCache: vi.fn(),
+    saveCache: vi.fn(),
+  })),
+}));
+
+vi.mock("../../../lib/mcp/log.js", () => ({
+  ToolCallLogger: vi.fn().mockImplementation(() => ({
+    recordToolCall: vi.fn().mockResolvedValue(undefined),
+    getLogFilePath: vi.fn().mockReturnValue("/tmp/tool-calls.jsonl"),
+    getMaxRecords: vi.fn().mockReturnValue(100),
+  })),
+}));
+
+describe("MCPServiceManager - customMCP 支持", () => {
+  let serviceManager: MCPServiceManager;
+  let mockCustomMCPHandler: ReturnType<typeof vi.mocked<CustomMCPHandler>>;
+
+  beforeEach(() => {
+    // Reset all mocks first
+    vi.clearAllMocks();
+
+    // Create service manager instance
+    serviceManager = new MCPServiceManager();
+
+    // 直接获取 mock 实例并确保其存在
+    mockCustomMCPHandler = vi.mocked(serviceManager.getCustomMCPHandler());
+
+    // 确保 mock 方法存在
+    if (!mockCustomMCPHandler.hasTool) {
+      mockCustomMCPHandler.hasTool = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getTools) {
+      mockCustomMCPHandler.getTools = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolCount) {
+      mockCustomMCPHandler.getToolCount = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolNames) {
+      mockCustomMCPHandler.getToolNames = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolInfo) {
+      mockCustomMCPHandler.getToolInfo = vi.fn();
+    }
+    if (!mockCustomMCPHandler.callTool) {
+      mockCustomMCPHandler.callTool = vi.fn();
+    }
+
+    // 设置默认返回值
+    mockCustomMCPHandler.hasTool.mockReturnValue(false);
+    mockCustomMCPHandler.getTools.mockReturnValue([]);
+    mockCustomMCPHandler.getToolCount.mockReturnValue(0);
+    mockCustomMCPHandler.getToolNames.mockReturnValue([]);
+    mockCustomMCPHandler.getToolInfo.mockReturnValue(undefined);
+    mockCustomMCPHandler.callTool.mockResolvedValue({
+      content: [{ type: "text", text: "Mock response" }],
+      isError: false,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("hasCustomMCPTool", () => {
+    it("应该正确检查 customMCP 工具是否存在", () => {
+      // Arrange
+      const toolName = "test_coze_workflow";
+      mockCustomMCPHandler.hasTool.mockReturnValue(true);
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool(toolName);
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockCustomMCPHandler.hasTool).toHaveBeenCalledWith(toolName);
+    });
+
+    it("应该正确返回工具不存在的情况", () => {
+      // Arrange
+      const toolName = "nonexistent_tool";
+      mockCustomMCPHandler.hasTool.mockReturnValue(false);
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool(toolName);
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockCustomMCPHandler.hasTool).toHaveBeenCalledWith(toolName);
+    });
+  });
+
+  describe("getCustomMCPTools", () => {
+    it("应该正确返回 customMCP 工具列表", () => {
+      // Arrange
+      const expectedTools = [
+        {
+          name: "test_coze_workflow",
+          description: "测试coze工作流是否正常可用",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              input: {
+                type: "string",
+                description: "用户说话的内容",
+              },
+            },
+            required: ["input"],
+          },
+        },
+        {
+          name: "another_tool",
+          description: "另一个测试工具",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              param: {
+                type: "string",
+                description: "参数",
+              },
+            },
+          },
+        },
+      ];
+
+      mockCustomMCPHandler.getTools.mockReturnValue(
+        expectedTools as unknown as Tool[]
+      );
+
+      // Act
+      const result = serviceManager.getCustomMCPTools();
+
+      // Assert
+      expect(result).toEqual(expectedTools);
+      expect(mockCustomMCPHandler.getTools).toHaveBeenCalled();
+    });
+
+    it("应该正确处理空的工具列表", () => {
+      // Arrange
+      mockCustomMCPHandler.getTools.mockReturnValue([]);
+
+      // Act
+      const result = serviceManager.getCustomMCPTools();
+
+      // Assert
+      expect(result).toEqual([]);
+      expect(mockCustomMCPHandler.getTools).toHaveBeenCalled();
+    });
+  });
+
+  describe("集成测试", () => {
+    it("应该正确集成 customMCP 工具到整体工具管理中", () => {
+      // Arrange
+      const customTools = [
+        {
+          name: "custom_tool_1",
+          description: "自定义工具1",
+          inputSchema: { type: "object" as const },
+        },
+        {
+          name: "custom_tool_2",
+          description: "自定义工具2",
+          inputSchema: { type: "object" as const },
+        },
+      ];
+
+      mockCustomMCPHandler.hasTool.mockImplementation((toolName: string) => {
+        return customTools.some((tool) => tool.name === toolName);
+      });
+      mockCustomMCPHandler.getTools.mockReturnValue(
+        customTools as unknown as Tool[]
+      );
+
+      // Act & Assert - 测试工具存在检查
+      expect(serviceManager.hasCustomMCPTool("custom_tool_1")).toBe(true);
+      expect(serviceManager.hasCustomMCPTool("custom_tool_2")).toBe(true);
+      expect(serviceManager.hasCustomMCPTool("nonexistent_tool")).toBe(false);
+
+      // Act & Assert - 测试工具列表获取
+      const tools = serviceManager.getCustomMCPTools();
+      expect(tools).toHaveLength(2);
+      expect(tools[0].name).toBe("custom_tool_1");
+      expect(tools[1].name).toBe("custom_tool_2");
+    });
+
+    it("应该正确处理 CustomMCPHandler 初始化失败的情况", () => {
+      // Arrange
+      mockCustomMCPHandler.hasTool.mockImplementation(() => {
+        throw new Error("CustomMCPHandler 未初始化");
+      });
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool("test_tool");
+
+      // Assert - 应该返回 false 而不是抛出异常
+      expect(result).toBe(false);
+      expect(mockCustomMCPHandler.hasTool).toHaveBeenCalledWith("test_tool");
+    });
+  });
+
+  describe("边界情况测试", () => {
+    it("应该正确处理特殊字符的工具名称", () => {
+      // Arrange
+      const specialToolName = "tool-with_special.chars@123";
+      mockCustomMCPHandler.hasTool.mockReturnValue(true);
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool(specialToolName);
+
+      // Assert
+      expect(result).toBe(true);
+      expect(mockCustomMCPHandler.hasTool).toHaveBeenCalledWith(
+        specialToolName
+      );
+    });
+
+    it("应该正确处理空字符串工具名称", () => {
+      // Arrange
+      const emptyToolName = "";
+      mockCustomMCPHandler.hasTool.mockReturnValue(false);
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool(emptyToolName);
+
+      // Assert
+      expect(result).toBe(false);
+      expect(mockCustomMCPHandler.hasTool).toHaveBeenCalledWith(emptyToolName);
+    });
+
+    it("应该正确处理工具列表中包含不完整数据的情况", () => {
+      // Arrange
+      const incompleteTools = [
+        {
+          name: "complete_tool",
+          description: "完整的工具",
+          inputSchema: { type: "object" as const },
+        },
+        {
+          name: "incomplete_tool",
+          // 缺少 description
+          inputSchema: { type: "object" as const },
+        } as Tool,
+      ];
+
+      mockCustomMCPHandler.getTools.mockReturnValue(
+        incompleteTools as unknown as Tool[]
+      );
+
+      // Act
+      const result = serviceManager.getCustomMCPTools();
+
+      // Assert
+      expect(result).toEqual(incompleteTools);
+      expect(result).toHaveLength(2);
+    });
+  });
+
+  describe("错误处理和边界情况", () => {
+    it("应该正确处理 CustomMCPHandler 完全未初始化的情况", () => {
+      // Arrange - 使用 vi.spyOn 模拟 getCustomMCPHandler 返回 null
+      const spy = vi
+        .spyOn(serviceManager, "getCustomMCPHandler")
+        .mockReturnValue(null as unknown as CustomMCPHandler);
+
+      // Act & Assert - 应该优雅地处理而不是抛出异常
+      expect(() => {
+        serviceManager.hasCustomMCPTool("test_tool");
+      }).not.toThrow();
+
+      expect(() => {
+        serviceManager.getCustomMCPTools();
+      }).not.toThrow();
+
+      // Cleanup
+      spy.mockRestore();
+    });
+
+    it("应该正确处理方法调用抛出异常的情况", () => {
+      // Arrange
+      mockCustomMCPHandler.hasTool.mockImplementation(() => {
+        throw new Error("Handler 内部错误");
+      });
+
+      // Act
+      const result = serviceManager.hasCustomMCPTool("test_tool");
+
+      // Assert - 应该返回 false 而不是抛出异常
+      expect(result).toBe(false);
+    });
+
+    it("应该正确处理 getTools 方法抛出异常的情况", () => {
+      // Arrange
+      mockCustomMCPHandler.getTools.mockImplementation(() => {
+        throw new Error("获取工具列表失败");
+      });
+
+      // Act
+      const result = serviceManager.getCustomMCPTools();
+
+      // Assert - 应该返回空数组而不是抛出异常
+      expect(result).toEqual([]);
+    });
+  });
+});
+
+describe("MCPServiceManager - Logger 注入功能", () => {
+  let serviceManager: MCPServiceManager;
+  let mockCustomMCPHandler: ReturnType<typeof vi.mocked<CustomMCPHandler>>;
+
+  beforeEach(() => {
+    // Reset all mocks first
+    vi.clearAllMocks();
+
+    // Create service manager instance
+    serviceManager = new MCPServiceManager();
+
+    // 直接获取 mock 实例
+    mockCustomMCPHandler = vi.mocked(serviceManager.getCustomMCPHandler());
+
+    // 确保 mock 方法存在
+    if (!mockCustomMCPHandler.hasTool) {
+      mockCustomMCPHandler.hasTool = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getTools) {
+      mockCustomMCPHandler.getTools = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolCount) {
+      mockCustomMCPHandler.getToolCount = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolNames) {
+      mockCustomMCPHandler.getToolNames = vi.fn();
+    }
+
+    // 设置默认返回值
+    mockCustomMCPHandler.hasTool.mockReturnValue(false);
+    mockCustomMCPHandler.getTools.mockReturnValue([]);
+    mockCustomMCPHandler.getToolCount.mockReturnValue(0);
+    mockCustomMCPHandler.getToolNames.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("基本功能测试", () => {
+    it("应该支持构造函数注入 logger", () => {
+      // Act & Assert - 不应该抛出异常
+      expect(() => {
+        serviceManager = new MCPServiceManager();
+      }).not.toThrow();
+    });
+
+    it("应该支持不传 logger 的构造函数调用", () => {
+      // Act & Assert - 不应该抛出异常
+      expect(() => {
+        serviceManager = new MCPServiceManager();
+      }).not.toThrow();
+    });
+
+    // Logger 相关方法已移除，不再需要测试
+  });
+
+  describe("向后兼容性测试", () => {
+    it("应该与现有的 API 完全兼容", () => {
+      // Arrange - 设置完整的 Mock 响应（使用当前实例的 customMCPHandler）
+      mockCustomMCPHandler.hasTool.mockReturnValue(true);
+      mockCustomMCPHandler.getTools.mockReturnValue([
+        {
+          name: "test_custom_tool",
+          description: "测试自定义工具",
+          inputSchema: { type: "object" as const },
+        },
+      ]);
+
+      // 使用当前的 serviceManager 实例，不重新创建
+      // serviceManager 已经在 beforeEach 中创建了
+
+      // Assert - 所有现有方法应该正常工作
+      expect(() => {
+        // 这些方法可能会内部调用 customMCPHandler 的各种方法
+        serviceManager.getAllTools();
+        serviceManager.hasTool("test_tool");
+        serviceManager.hasCustomMCPTool("test_custom_tool");
+        serviceManager.getCustomMCPTools();
+        serviceManager.getServiceManagerStatus();
+      }).not.toThrow();
+
+      // 验证具体的方法调用结果
+      expect(serviceManager.hasCustomMCPTool("test_custom_tool")).toBe(true);
+      expect(serviceManager.getCustomMCPTools()).toHaveLength(1);
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/mcp-service-manager-events.test.ts
+++ b/src/server/lib/mcp/__tests__/mcp-service-manager-events.test.ts
@@ -1,0 +1,102 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPServiceManager } from "../../../lib/mcp";
+import { getEventBus } from "../../../services/event-bus.service.js";
+
+// Mock dependencies
+vi.mock("../../../utils/Logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+    debug: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  },
+}));
+
+vi.mock("../../../../config/index.js", () => ({
+  configManager: {
+    getMcpServerConfig: vi.fn(),
+    updateServerToolsConfig: vi.fn(),
+    isToolEnabled: vi.fn(),
+    getCustomMCPConfig: vi.fn(),
+    getCustomMCPTools: vi.fn(),
+    addCustomMCPTools: vi.fn(),
+    updateCustomMCPTools: vi.fn(),
+    getServerToolsConfig: vi.fn(),
+    saveConfig: vi.fn(),
+    getConfig: vi.fn(),
+    getToolCallLogConfig: vi.fn().mockReturnValue({}),
+    getConfigDir: vi.fn().mockReturnValue("/tmp/test"),
+  },
+}));
+
+describe("MCPServiceManager 事件监听测试", () => {
+  let mcpServiceManager: MCPServiceManager;
+  let eventBus: any;
+  let mockConfigManager: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 设置测试环境
+    process.env.XIAOZHI_CONFIG_DIR = "/tmp/xiaozhi-test-mcp-events";
+    process.env.VITEST = "true";
+
+    // 获取模拟实例
+    const { configManager } = await import("../../../../config/index.js");
+    mockConfigManager = configManager;
+
+    // 获取事件总线
+    eventBus = getEventBus();
+
+    // 创建管理器实例
+    mcpServiceManager = new MCPServiceManager(mockConfigManager);
+  });
+
+  afterEach(() => {
+    // 清理资源
+    process.env.VITEST = undefined;
+    vi.clearAllMocks();
+  });
+
+  it("应该在构造函数中设置事件监听器", () => {
+    // 验证事件总线存在
+    expect(eventBus).toBeDefined();
+
+    // 验证 MCPServiceManager 创建成功
+    expect(mcpServiceManager).toBeDefined();
+  });
+
+  it("应该能够响应 MCP 服务连接事件", async () => {
+    // 监听管理器的方法调用
+    const handleServiceConnectedSpy = vi.spyOn(
+      mcpServiceManager as any,
+      "handleServiceConnected"
+    );
+
+    // 模拟工具数据
+    const mockTools: Tool[] = [
+      {
+        name: "test-tool",
+        description: "Test tool",
+        inputSchema: { type: "object" },
+      },
+    ];
+
+    // 发射服务连接事件
+    const eventData = {
+      serviceName: "test-service",
+      tools: mockTools,
+      connectionTime: new Date(),
+    };
+
+    eventBus.emitEvent("mcp:service:connected", eventData);
+
+    // 等待异步处理
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // 验证处理器被调用
+    expect(handleServiceConnectedSpy).toHaveBeenCalledWith(eventData);
+  });
+});

--- a/src/server/lib/mcp/__tests__/message.prompts.test.ts
+++ b/src/server/lib/mcp/__tests__/message.prompts.test.ts
@@ -1,0 +1,175 @@
+/**
+ * MCPMessageHandler prompts/list 功能测试
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServiceManager } from "../../../lib/mcp";
+import { MCPMessageHandler } from "../../../lib/mcp";
+
+// Mock MCPServiceManager
+const mockServiceManager = {
+  getAllTools: vi.fn(),
+  callTool: vi.fn(),
+} as unknown as MCPServiceManager;
+
+describe("MCPMessageHandler - prompts/list", () => {
+  let handler: MCPMessageHandler;
+
+  beforeEach(() => {
+    handler = new MCPMessageHandler(mockServiceManager);
+    vi.clearAllMocks();
+  });
+
+  it("should handle prompts/list request and return empty prompts array", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: 1,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        prompts: [],
+      },
+      id: 1,
+    });
+  });
+
+  it("should handle prompts/list request with string id", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: "test-id",
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        prompts: [],
+      },
+      id: "test-id",
+    });
+  });
+
+  it("should handle prompts/list request without id", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: "test-prompts-list" as const,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        prompts: [],
+      },
+      id: "test-prompts-list", // 与请求中的ID匹配
+    });
+  });
+
+  it("should return prompts array with correct structure", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: 2,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).not.toBeNull();
+    expect(response?.result).toBeDefined();
+
+    // 类型断言：prompts/list响应
+    const promptsResult = response?.result as { prompts: unknown[] };
+    expect(promptsResult.prompts).toBeDefined();
+    expect(Array.isArray(promptsResult.prompts)).toBe(true);
+    expect(promptsResult.prompts).toHaveLength(0);
+  });
+
+  it("should not interfere with other methods", async () => {
+    // 测试 prompts/list 不会影响其他方法的处理
+    const pingMessage = {
+      jsonrpc: "2.0" as const,
+      method: "ping",
+      id: 1,
+    };
+
+    const pingResponse = await handler.handleMessage(pingMessage);
+
+    expect(pingResponse).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        status: "ok",
+        timestamp: expect.any(String),
+      },
+      id: 1,
+    });
+  });
+
+  it("should handle prompts/list in combination with other methods", async () => {
+    // 先调用 prompts/list
+    const promptsMessage = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: 1,
+    };
+
+    const promptsResponse = await handler.handleMessage(promptsMessage);
+    const promptsResult = promptsResponse?.result as { prompts: unknown[] };
+    expect(promptsResult.prompts).toEqual([]);
+
+    // 再调用 resources/list
+    const resourcesMessage = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: 2,
+    };
+
+    const resourcesResponse = await handler.handleMessage(resourcesMessage);
+    const resourcesResult = resourcesResponse?.result as {
+      resources: unknown[];
+    };
+    expect(resourcesResult.resources).toEqual([]);
+  });
+
+  it("should handle prompts/list with resources/list", async () => {
+    // 测试多个 list 方法的组合使用
+    const promptsMessage = {
+      jsonrpc: "2.0" as const,
+      method: "prompts/list",
+      params: {},
+      id: 1,
+    };
+
+    const resourcesMessage = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: 2,
+    };
+
+    const promptsResponse = await handler.handleMessage(promptsMessage);
+    const resourcesResponse = await handler.handleMessage(resourcesMessage);
+
+    const promptsResult = promptsResponse?.result as { prompts: unknown[] };
+    const resourcesResult = resourcesResponse?.result as {
+      resources: unknown[];
+    };
+
+    expect(promptsResult.prompts).toEqual([]);
+    expect(resourcesResult.resources).toEqual([]);
+  });
+});

--- a/src/server/lib/mcp/__tests__/message.resources.test.ts
+++ b/src/server/lib/mcp/__tests__/message.resources.test.ts
@@ -1,0 +1,146 @@
+/**
+ * MCPMessageHandler resources/list 功能测试
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServiceManager } from "../../../lib/mcp";
+import { MCPMessageHandler } from "../../../lib/mcp";
+
+// Mock MCPServiceManager
+const mockServiceManager = {
+  getAllTools: vi.fn(),
+  callTool: vi.fn(),
+} as unknown as MCPServiceManager;
+
+describe("MCPMessageHandler - resources/list", () => {
+  let handler: MCPMessageHandler;
+
+  beforeEach(() => {
+    handler = new MCPMessageHandler(mockServiceManager);
+    vi.clearAllMocks();
+  });
+
+  it("should handle resources/list request and return empty resources array", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: 1,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        resources: [],
+      },
+      id: 1,
+    });
+  });
+
+  it("should handle resources/list request with string id", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: "test-id",
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        resources: [],
+      },
+      id: "test-id",
+    });
+  });
+
+  it("should handle resources/list request without id", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: "test-resources-list" as const,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        resources: [],
+      },
+      id: "test-resources-list", // 与请求中的ID匹配
+    });
+  });
+
+  it("should return resources array with correct structure", async () => {
+    const message = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: 2,
+    };
+
+    const response = await handler.handleMessage(message);
+
+    expect(response).not.toBeNull();
+    expect(response?.result).toBeDefined();
+
+    // 类型断言：resources/list响应
+    const resourcesResult = response?.result as { resources: unknown[] };
+    expect(resourcesResult.resources).toBeDefined();
+    expect(Array.isArray(resourcesResult.resources)).toBe(true);
+    expect(resourcesResult.resources).toHaveLength(0);
+  });
+
+  it("should not interfere with other methods", async () => {
+    // 测试 resources/list 不会影响其他方法的处理
+    const pingMessage = {
+      jsonrpc: "2.0" as const,
+      method: "ping",
+      id: 1,
+    };
+
+    const pingResponse = await handler.handleMessage(pingMessage);
+
+    expect(pingResponse).toEqual({
+      jsonrpc: "2.0",
+      result: {
+        status: "ok",
+        timestamp: expect.any(String),
+      },
+      id: 1,
+    });
+  });
+
+  it("should handle resources/list in combination with other methods", async () => {
+    // 先调用 resources/list
+    const resourcesMessage = {
+      jsonrpc: "2.0" as const,
+      method: "resources/list",
+      params: {},
+      id: 1,
+    };
+
+    const resourcesResponse = await handler.handleMessage(resourcesMessage);
+    const resourcesResult = resourcesResponse?.result as {
+      resources: unknown[];
+    };
+    expect(resourcesResult.resources).toEqual([]);
+
+    // 再调用 ping
+    const pingMessage = {
+      jsonrpc: "2.0" as const,
+      method: "ping",
+      id: 2,
+    };
+
+    const pingResponse = await handler.handleMessage(pingMessage);
+    const pingResult = pingResponse?.result as { status: string };
+    expect(pingResult.status).toBe("ok");
+  });
+});

--- a/src/server/lib/mcp/__tests__/tool-sync-integration.test.ts
+++ b/src/server/lib/mcp/__tests__/tool-sync-integration.test.ts
@@ -1,0 +1,433 @@
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { MCPServiceConfig } from "../../../lib/mcp/types.js";
+
+// Mock CustomMCPHandler - 需要在其他 mock 之前定义
+let mockCustomMCPTools: any[] = [];
+
+// Mock the entire ../../../lib/mcp module before importing
+vi.mock("../../../lib/mcp", () => {
+  // Mock MCPService class
+  class MockMCPService {
+    private connected = false;
+    private tools: Tool[] = [];
+
+    constructor(private config: MCPServiceConfig) {}
+
+    async connect() {
+      // 模拟连接延迟
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      this.connected = true;
+
+      // 模拟一些工具
+      this.tools = [
+        {
+          name: "calculator",
+          description:
+            "For mathematical calculation, always use this tool to calculate the result of a JavaScript expression. Math object and basic operations are available.",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              expression: { type: "string" },
+            },
+          },
+        },
+        {
+          name: "datetime",
+          description: "Date and time tool",
+          inputSchema: {
+            type: "object" as const,
+            properties: {
+              format: { type: "string" },
+              action: { type: "string" },
+            },
+          },
+        },
+      ];
+    }
+
+    isConnected() {
+      return this.connected;
+    }
+
+    getTools(): Tool[] {
+      return this.tools;
+    }
+
+    async callTool(name: string, args: any) {
+      if (name === "calculator") {
+        const expression = args?.expression || "1 + 1";
+        try {
+          // 简单的数学表达式计算（避免使用 eval）
+          const result = this.evaluateSimpleExpression(expression);
+          return {
+            content: [{ type: "text", text: `Result: ${result}` }],
+          };
+        } catch {
+          return {
+            content: [{ type: "text", text: `Mock result for ${name}` }],
+          };
+        }
+      }
+
+      return {
+        content: [{ type: "text", text: `Mock result for ${name}` }],
+      };
+    }
+
+    // 简单的数学表达式求值器（仅用于测试）
+    private evaluateSimpleExpression(expression: string): number {
+      // 只处理简单的加法
+      if (expression.includes("+")) {
+        const parts = expression.split("+");
+        return parts.reduce(
+          (sum, part) => sum + Number.parseFloat(part.trim()),
+          0
+        );
+      }
+      return Number.parseFloat(expression) || 1;
+    }
+  }
+
+  // Mock MCPServiceManager class
+  class MockMCPServiceManager {
+    private services: Map<string, any> = new Map();
+
+    constructor(configs?: any) {
+      // 初始化
+    }
+
+    async startService(serviceName: string): Promise<void> {
+      const config = {
+        name: serviceName,
+        type: "stdio" as any, // 使用字符串类型，在 mock 中这是兼容的
+        command: "node",
+        args: ["./test-calculator.js"],
+      };
+      const service = new MockMCPService(config);
+      await service.connect();
+      this.services.set(serviceName, service);
+    }
+
+    async stopService(serviceName: string): Promise<void> {
+      this.services.delete(serviceName);
+    }
+
+    getAllTools(): Array<{
+      name: string;
+      description: string;
+      inputSchema: any;
+      serviceName: string;
+      originalName: string;
+    }> {
+      const allTools: Array<{
+        name: string;
+        description: string;
+        inputSchema: any;
+        serviceName: string;
+        originalName: string;
+      }> = [];
+
+      // 添加 customMCP 工具
+      for (const tool of mockCustomMCPTools) {
+        allTools.push({
+          name: tool.name,
+          description: tool.description || "",
+          inputSchema: tool.inputSchema,
+          serviceName: "customMCP",
+          originalName: tool.name,
+        });
+      }
+
+      return allTools;
+    }
+
+    async callTool(
+      toolName: string,
+      arguments_: Record<string, unknown>
+    ): Promise<any> {
+      // 检查是否是 customMCP 工具
+      if (mockCustomMCPTools.some((tool) => tool.name === toolName)) {
+        return {
+          content: [
+            { type: "text", text: `Custom MCP result for ${toolName}` },
+          ],
+        };
+      }
+
+      // 检查是否是格式化后的工具名 (serviceName__toolName)
+      if (toolName.includes("__")) {
+        const [serviceName, originalName] = toolName.split("__");
+        const service = this.services.get(serviceName);
+        if (service) {
+          return await service.callTool(originalName, arguments_);
+        }
+      }
+
+      throw new Error(`未找到工具: ${toolName}`);
+    }
+
+    hasTool(toolName: string): boolean {
+      // 检查 customMCP 工具
+      if (mockCustomMCPTools.some((tool) => tool.name === toolName)) {
+        return true;
+      }
+
+      // 检查格式化后的工具名
+      if (toolName.includes("__")) {
+        const [serviceName] = toolName.split("__");
+        return this.services.has(serviceName);
+      }
+
+      return false;
+    }
+
+    getConnectedServices(): string[] {
+      return Array.from(this.services.keys());
+    }
+  }
+
+  return {
+    MCPServiceManager: MockMCPServiceManager,
+    MCPService: MockMCPService,
+    MCPTransportType: {
+      STDIO: "stdio" as const,
+      SSE: "sse" as const,
+      STREAMABLE_HTTP: "streamable-http" as const,
+    },
+  };
+});
+
+// Now import the mocked MCPServiceManager
+import { MCPServiceManager } from "../../../lib/mcp";
+
+// Mock logger
+vi.mock("../../../utils/Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withTag: vi.fn().mockReturnThis(),
+  },
+}));
+
+// Mock configManager
+vi.mock("../../../../config/index.js", async () => {
+  const actual = await vi.importActual("../../../../config/index.js");
+  const configManager = actual.configManager as any;
+  return {
+    ...actual,
+    configManager: {
+      ...(configManager || {}),
+      getConfig: vi.fn(),
+      getMcpServers: vi.fn(),
+      getServerToolsConfig: vi.fn(),
+      getCustomMCPTools: vi.fn(),
+      addCustomMCPTools: vi.fn(),
+      getCustomMCPConfig: vi.fn(),
+      updateCustomMCPTools: vi.fn(),
+      isToolEnabled: vi.fn(),
+      getToolCallLogConfig: vi.fn(),
+      getConfigDir: vi.fn(),
+    },
+  };
+});
+
+// Mock CustomMCPHandler
+vi.mock("../../../services/CustomMCPHandler.js", () => {
+  class MockCustomMCPHandler {
+    initialize() {}
+
+    getTools(): any[] {
+      return mockCustomMCPTools;
+    }
+
+    hasTool(name: string): boolean {
+      return mockCustomMCPTools.some((tool) => tool.name === name);
+    }
+
+    getToolInfo(name: string) {
+      return mockCustomMCPTools.find((tool) => tool.name === name);
+    }
+
+    async callTool(name: string, args: any) {
+      return {
+        content: [{ type: "text", text: `Custom MCP result for ${name}` }],
+      };
+    }
+  }
+
+  return { CustomMCPHandler: MockCustomMCPHandler };
+});
+
+// Mock MCPCacheManager
+vi.mock("../../../services/MCPCacheManager.js", () => {
+  class MockMCPCacheManager {
+    async writeCacheEntry() {}
+    async readCacheEntry() {
+      return null;
+    }
+  }
+
+  return { MCPCacheManager: MockMCPCacheManager };
+});
+
+// Get mocked configManager
+const { configManager: mockConfigManager } = await import(
+  "../../../../config/index.js"
+);
+
+describe("工具缓存集成测试", () => {
+  let serviceManager: MCPServiceManager;
+
+  beforeEach(() => {
+    // 创建测试配置
+    const testConfig = {
+      mcpEndpoint: "http://localhost:3000",
+      mcpServers: {
+        calculator: {
+          name: "calculator",
+          type: "stdio" as const,
+          command: "node",
+          args: ["./test-calculator.js"],
+        },
+      },
+      mcpServerConfig: {
+        calculator: {
+          tools: {
+            calculator: {
+              description: "Math calculation tool",
+              enable: true,
+            },
+            datetime: {
+              description: "Date and time tool",
+              enable: false, // datetime 工具被禁用
+            },
+          },
+        },
+      },
+      customMCP: {
+        tools: [],
+      },
+    };
+
+    // Mock configManager 方法
+    vi.mocked(mockConfigManager.getConfig).mockReturnValue(testConfig);
+    vi.mocked(mockConfigManager.getMcpServers).mockReturnValue(
+      testConfig.mcpServers
+    );
+    vi.mocked(mockConfigManager.getServerToolsConfig).mockImplementation(
+      (serviceName: string) => {
+        return (testConfig.mcpServerConfig as Record<string, any>)?.[
+          serviceName
+        ]?.tools;
+      }
+    );
+    vi.mocked(mockConfigManager.getCustomMCPTools).mockReturnValue([]);
+    vi.mocked(mockConfigManager.getCustomMCPConfig).mockReturnValue(null);
+    vi.mocked(mockConfigManager.updateCustomMCPTools).mockResolvedValue(
+      undefined
+    );
+    vi.mocked(mockConfigManager.addCustomMCPTools).mockImplementation(
+      async (tools) => {
+        // 模拟添加到 customMCP
+        const currentConfig =
+          vi.mocked(mockConfigManager.getConfig).mock.results[0]?.value ||
+          testConfig;
+        currentConfig.customMCP!.tools.push(...tools);
+      }
+    );
+    vi.mocked(mockConfigManager.isToolEnabled).mockReturnValue(true);
+    vi.mocked(mockConfigManager.getToolCallLogConfig).mockReturnValue({});
+    vi.mocked(mockConfigManager.getConfigDir).mockReturnValue("/tmp/test");
+
+    serviceManager = new MCPServiceManager(
+      testConfig.mcpServers as Record<string, any>
+    );
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    // 重置 mock 实现
+    vi.mocked(mockConfigManager.getConfig).mockReturnValue({
+      mcpEndpoint: "http://localhost:3000",
+      mcpServers: {},
+      mcpServerConfig: {},
+      customMCP: { tools: [] },
+    });
+    vi.mocked(mockConfigManager.getMcpServers).mockReturnValue({});
+    vi.mocked(mockConfigManager.getServerToolsConfig).mockReturnValue({});
+    vi.mocked(mockConfigManager.getCustomMCPTools).mockReturnValue([]);
+    vi.mocked(mockConfigManager.getCustomMCPConfig).mockReturnValue(null);
+    vi.mocked(mockConfigManager.updateCustomMCPTools).mockResolvedValue(
+      undefined
+    );
+    vi.mocked(mockConfigManager.addCustomMCPTools).mockResolvedValue(undefined);
+    vi.mocked(mockConfigManager.getToolCallLogConfig).mockReturnValue({});
+    vi.mocked(mockConfigManager.getConfigDir).mockReturnValue("/tmp/test");
+  });
+
+  describe("端到端工具聚合流程", () => {
+    it("应该在 getAllTools 中正确聚合和去重", () => {
+      // Arrange - 设置 customMCP 工具来测试去重逻辑
+      mockCustomMCPTools = [
+        {
+          name: "custom_tool",
+          description: "Custom tool only",
+          inputSchema: {},
+          handler: {
+            type: "proxy" as const,
+            platform: "coze" as const,
+            config: {},
+          },
+        },
+      ];
+
+      // Act
+      const allTools = serviceManager.getAllTools();
+
+      // Assert - 应该有 1 个 customMCP 工具
+      expect(allTools.length).toBe(1);
+
+      // 验证 customMCP 工具存在
+      const customTool = allTools.find((t) => t.name === "custom_tool");
+      expect(customTool).toBeDefined();
+      expect(customTool!.serviceName).toBe("customMCP");
+
+      // 清理 mock
+      mockCustomMCPTools = [];
+    });
+  });
+
+  describe("错误处理和边界情况", () => {
+    it("应该跳过没有配置的服务", async () => {
+      // Arrange - 移除 calculator 的 mcpServerConfig
+      vi.mocked(mockConfigManager.getServerToolsConfig).mockReturnValue({});
+
+      // Act
+      await serviceManager.startService("calculator");
+
+      // Assert - 不应该调用 addCustomMCPTools
+      expect(
+        vi.mocked(mockConfigManager.addCustomMCPTools)
+      ).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("并发安全", () => {
+    it("应该能成功启动和停止服务", async () => {
+      // Act - 启动服务
+      await serviceManager.startService("calculator");
+
+      // Assert - 服务应该成功启动
+      expect(serviceManager.getConnectedServices()).toContain("calculator");
+
+      // Act - 停止服务
+      await serviceManager.stopService("calculator");
+
+      // Assert - 服务应该成功停止
+      expect(serviceManager.getConnectedServices()).not.toContain("calculator");
+    });
+  });
+});

--- a/src/server/lib/mcp/__tests__/utils.test.ts
+++ b/src/server/lib/mcp/__tests__/utils.test.ts
@@ -1,0 +1,585 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { MCPTransportType } from "../types.js";
+import type { MCPServiceConfig } from "../types.js";
+import {
+  inferTransportTypeFromConfig,
+  inferTransportTypeFromUrl,
+} from "../utils.js";
+
+// Mock console 方法
+let mockConsoleInfo: Mock;
+let mockConsoleWarn: Mock;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConsoleInfo = vi.fn();
+  mockConsoleWarn = vi.fn();
+
+  // Mock console 方法
+  const originalConsoleInfo = console.info;
+  const originalConsoleWarn = console.warn;
+  console.info = mockConsoleInfo;
+  console.warn = mockConsoleWarn;
+
+  // 恢复原始方法（在测试结束时）
+  return () => {
+    console.info = originalConsoleInfo;
+    console.warn = originalConsoleWarn;
+  };
+});
+
+describe("MCP 传输类型推断工具", () => {
+  describe("inferTransportTypeFromUrl", () => {
+    describe("SSE 类型推断", () => {
+      it("应该根据 /sse 路径推断为 SSE 类型", () => {
+        const url = "https://mcp.amap.com/sse?key=test";
+        const result = inferTransportTypeFromUrl(url);
+        expect(result).toBe(MCPTransportType.SSE);
+      });
+
+      it("应该正确处理带有查询参数的 SSE URL", () => {
+        const testCases = [
+          "https://example.com/sse?apiKey=123&timeout=5000",
+          "https://api.example.com/v1/sse?version=2.0",
+          "https://mcp.example.com/sse?token=abc123&debug=true",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+
+      it("应该正确推断复杂的 ModelScope SSE 路径", () => {
+        const testCases = [
+          "https://mcp.api-inference.modelscope.net/f0fed2f733514b/sse",
+          "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/sse",
+          "https://api.modelscope.cn/mcp/sse",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+
+      it("应该正确处理嵌套 SSE 路径", () => {
+        const testCases = [
+          "https://api.example.com/v1/sse",
+          "https://api.example.com/v1/v2/sse",
+          "https://api.example.com/service/v1/sse",
+          "https://api.example.com/api/v2/sse",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+
+      it("应该正确处理带端口的 SSE URL", () => {
+        const testCases = [
+          "https://api.example.com:8080/sse",
+          "https://localhost:3000/sse",
+          "http://127.0.0.1:8080/api/v1/sse",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+
+      it("应该正确处理带哈希的 SSE URL", () => {
+        const testCases = [
+          "https://example.com/sse#section1",
+          "https://api.example.com/v1/sse#auth-token",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+    });
+
+    describe("MCP 类型推断", () => {
+      it("应该根据 /mcp 路径推断为 MCP 类型", () => {
+        const url = "https://example.com/mcp";
+        const result = inferTransportTypeFromUrl(url);
+        expect(result).toBe(MCPTransportType.HTTP);
+      });
+
+      it("应该正确推断复杂的 ModelScope MCP 路径", () => {
+        const testCases = [
+          "https://mcp.api-inference.modelscope.net/8928ccc99fa34b/mcp",
+          "https://mcp.api-inference.modelscope.net/f0fed2f733514b/mcp",
+          "https://api.modelscope.cn/service/mcp",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+
+      it("应该正确处理嵌套 MCP 路径", () => {
+        const testCases = [
+          "https://api.example.com/v1/mcp",
+          "https://api.example.com/v1/v2/mcp",
+          "https://api.example.com/service/v1/mcp",
+          "https://api.example.com/api/v2/mcp",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+
+      it("应该正确处理带查询参数的 MCP URL", () => {
+        const testCases = [
+          "https://example.com/mcp?version=1.0&format=json",
+          "https://api.example.com/v1/mcp?token=abc123",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+    });
+
+    describe("默认类型推断", () => {
+      it("对于其他路径应该默认推断为 http 类型", () => {
+        const testCases = [
+          "https://example.com/api/v1/tools",
+          "https://example.com/endpoint",
+          "https://example.com/service",
+          "https://example.com/webhook",
+          "https://api.example.com/v1/custom",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+
+      it("对于根路径应该默认推断为 http 类型", () => {
+        const testCases = [
+          "https://example.com/",
+          "https://example.com",
+          "https://api.example.com/",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+    });
+
+    describe("边界情况", () => {
+      it("应该处理无效的 URL", () => {
+        const testCases = [
+          "not-a-valid-url",
+          "",
+          "invalid-url",
+          "://missing-protocol.com",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.HTTP);
+        }
+      });
+
+      it("应该处理大小写敏感的路径", () => {
+        const testCases = [
+          {
+            url: "https://example.com/SSE",
+            expected: MCPTransportType.HTTP,
+          },
+          { url: "https://example.com/sse", expected: MCPTransportType.SSE },
+          {
+            url: "https://example.com/MCP",
+            expected: MCPTransportType.HTTP,
+          },
+          {
+            url: "https://example.com/mcp",
+            expected: MCPTransportType.HTTP,
+          },
+        ];
+
+        for (const { url, expected } of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(expected);
+        }
+      });
+
+      it("应该处理带有尾部斜杠的路径", () => {
+        const testCases = [
+          {
+            url: "https://example.com/sse/",
+            expected: MCPTransportType.HTTP,
+          },
+          { url: "https://example.com/sse", expected: MCPTransportType.SSE },
+          {
+            url: "https://example.com/mcp/",
+            expected: MCPTransportType.HTTP,
+          },
+          {
+            url: "https://example.com/mcp",
+            expected: MCPTransportType.HTTP,
+          },
+        ];
+
+        for (const { url, expected } of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(expected);
+        }
+      });
+
+      it("应该处理包含 sse 或 mcp 子字符串的路径", () => {
+        const testCases = [
+          {
+            url: "https://example.com/assess",
+            expected: MCPTransportType.HTTP,
+          },
+          {
+            url: "https://example.com/mcprefix",
+            expected: MCPTransportType.HTTP,
+          },
+          {
+            url: "https://example.com/ssendpoint",
+            expected: MCPTransportType.HTTP,
+          },
+          {
+            url: "https://example.com/mcprefix/sse",
+            expected: MCPTransportType.SSE,
+          },
+        ];
+
+        for (const { url, expected } of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(expected);
+        }
+      });
+
+      it("应该处理特殊字符 URL", () => {
+        const testCases = [
+          "https://example.com/sse?q=test%20value&param=1+2",
+          "https://api.example.com/v1/sse?encoded=%E4%B8%AD%E6%96%87",
+        ];
+
+        for (const url of testCases) {
+          const result = inferTransportTypeFromUrl(url);
+          expect(result).toBe(MCPTransportType.SSE);
+        }
+      });
+    });
+
+    describe("日志记录", () => {
+      it("应该在路径不匹配规则时记录信息日志", () => {
+        const url = "https://example.com/api/v1/tools";
+        const serviceName = "test-service";
+
+        inferTransportTypeFromUrl(url, {
+          serviceName,
+        });
+
+        expect(mockConsoleInfo).toHaveBeenCalledWith(
+          `[MCP-${serviceName}] URL 路径 /api/v1/tools 不匹配特定规则，默认推断为 http 类型`
+        );
+      });
+
+      it("应该在 URL 解析失败时记录警告日志", () => {
+        const url = "not-a-valid-url";
+        const serviceName = "test-service";
+
+        inferTransportTypeFromUrl(url, {
+          serviceName,
+        });
+
+        expect(mockConsoleWarn).toHaveBeenCalledWith(
+          `[MCP-${serviceName}] URL 解析失败，默认推断为 http 类型`,
+          expect.any(Error)
+        );
+      });
+
+      it("应该在路径匹配规则时不记录任何日志", () => {
+        const sseUrl = "https://example.com/sse";
+        const mcpUrl = "https://example.com/mcp";
+
+        inferTransportTypeFromUrl(sseUrl, {
+          serviceName: "test-service",
+        });
+
+        inferTransportTypeFromUrl(mcpUrl, {
+          serviceName: "test-service",
+        });
+
+        expect(mockConsoleInfo).not.toHaveBeenCalled();
+        expect(mockConsoleWarn).not.toHaveBeenCalled();
+      });
+    });
+  });
+
+  describe("inferTransportTypeFromConfig", () => {
+    describe("显式指定类型的情况", () => {
+      it("应该使用显式指定的类型", () => {
+        const config = {
+          type: MCPTransportType.SSE,
+          url: "https://example.com/sse",
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.SSE);
+      });
+
+      it("应该优先使用显式类型而非URL推断", () => {
+        const config = {
+          type: MCPTransportType.HTTP,
+          url: "https://example.com/sse", // 这个URL会推断为SSE，但显式指定为STREAMABLE_HTTP
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.HTTP);
+      });
+
+      it("应该正确处理所有显式类型", () => {
+        const testCases = [
+          {
+            type: MCPTransportType.STDIO,
+            name: "stdio-test",
+            config: { command: "node", args: ["test.js"] },
+          },
+          {
+            type: MCPTransportType.SSE,
+            name: "sse-test",
+            config: { url: "https://example.com/test" },
+          },
+          {
+            type: MCPTransportType.HTTP,
+            name: "http-test",
+            config: { url: "https://example.com/test" },
+          },
+        ];
+
+        for (const { type, name, config } of testCases) {
+          const fullConfig = { name, type, ...config };
+          const result = inferTransportTypeFromConfig(
+            fullConfig,
+            "test-service"
+          );
+          expect(result.type).toBe(type);
+        }
+      });
+    });
+
+    describe("基于 command 字段推断", () => {
+      it("应该根据 command 字段推断为 stdio 类型", () => {
+        const config = {
+          command: "node",
+          args: ["server.js"],
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.STDIO);
+      });
+
+      it("即使有 url 字段，command 字段也应优先", () => {
+        const config = {
+          command: "python",
+          args: ["server.py"],
+          url: "https://example.com/sse",
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.STDIO);
+      });
+
+      it("应该处理只有 command 没有 args 的情况", () => {
+        const config = {
+          command: "python",
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.STDIO);
+      });
+
+      it("应该处理空的 args 数组", () => {
+        const config = {
+          command: "node",
+          args: [],
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.STDIO);
+      });
+    });
+
+    describe("基于 URL 字段推断", () => {
+      it("应该调用 inferTransportTypeFromUrl 进行类型推断", () => {
+        const config = {
+          url: "https://example.com/sse",
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.SSE);
+      });
+
+      it("应该传递正确的参数给 inferTransportTypeFromUrl", () => {
+        const config = {
+          url: "not-a-valid-url",
+        };
+
+        inferTransportTypeFromConfig(config, "test-service");
+
+        // 验证是否用正确的参数调用了日志记录
+        expect(mockConsoleWarn).toHaveBeenCalledWith(
+          "[MCP-test-service] URL 解析失败，默认推断为 http 类型",
+          expect.any(Error)
+        );
+      });
+
+      it("应该处理 null URL 值", () => {
+        const config = {
+          url: null,
+        } as unknown as MCPServiceConfig;
+
+        expect(() => {
+          inferTransportTypeFromConfig(config, "null-url-service");
+        }).toThrow(/无法为服务 null-url-service 推断传输类型/);
+      });
+
+      it("应该处理 undefined URL 值", () => {
+        const config = {
+          url: undefined,
+        };
+
+        expect(() => {
+          inferTransportTypeFromConfig(config, "undefined-url-service");
+        }).toThrow(/无法为服务 undefined-url-service 推断传输类型/);
+      });
+
+      it("应该处理空字符串 URL 值", () => {
+        const config = {
+          url: "",
+        };
+
+        const result = inferTransportTypeFromConfig(config, "test-service");
+        expect(result.type).toBe(MCPTransportType.HTTP);
+      });
+    });
+
+    describe("错误处理", () => {
+      it("应该在无法推断类型时抛出错误", () => {
+        const config = {
+          // 没有 type、command 或 url 字段
+        };
+
+        expect(() => {
+          inferTransportTypeFromConfig(config, "invalid-service");
+        }).toThrow(/无法为服务 invalid-service 推断传输类型/);
+      });
+
+      it("应该提供清晰的错误信息", () => {
+        const config = {
+          timeout: 60000, // 只有无关字段
+        } as unknown as MCPServiceConfig;
+
+        expect(() => {
+          inferTransportTypeFromConfig(config, "test-service");
+        }).toThrow(
+          "无法为服务 test-service 推断传输类型。请显式指定 type 字段，或提供 command/url 配置"
+        );
+      });
+    });
+
+    describe("配置保持不变性", () => {
+      it("不应该修改原始配置对象", () => {
+        const originalConfig = {
+          url: "https://example.com/sse",
+        };
+
+        const originalConfigCopy = { ...originalConfig };
+        const result = inferTransportTypeFromConfig(
+          originalConfig,
+          "test-service"
+        );
+
+        // 原始配置应该保持不变
+        expect(originalConfig).toEqual(originalConfigCopy);
+
+        // 返回的配置应该包含推断的类型
+        expect(result.type).toBe(MCPTransportType.SSE);
+
+        expect(result.url).toBe("https://example.com/sse");
+      });
+
+      it("应该保持配置字段的完整性", () => {
+        const originalConfig = {
+          url: "https://example.com/mcp",
+          apiKey: "test-key",
+        };
+
+        const originalConfigCopy = { ...originalConfig };
+        const result = inferTransportTypeFromConfig(
+          originalConfig,
+          "test-service"
+        );
+
+        expect(originalConfig).toEqual(originalConfigCopy);
+
+        // 返回的配置应该包含所有原始字段和推断的类型
+        expect(result.type).toBe(MCPTransportType.HTTP);
+        expect(result.apiKey).toBe("test-key");
+
+        expect(result.url).toBe("https://example.com/mcp");
+      });
+    });
+
+    describe("类型推断优先级", () => {
+      it("应该正确处理类型推断优先级：显式类型 > command > URL", () => {
+        // 1. 显式类型优先级最高
+        const explicitConfig = {
+          type: MCPTransportType.SSE,
+          command: "node", // command 存在但显式类型优先
+          url: "https://example.com/mcp", // URL 推断为 MCP 但显式类型为 SSE
+        };
+
+        const explicitResult = inferTransportTypeFromConfig(
+          explicitConfig,
+          "test-service"
+        );
+        expect(explicitResult.type).toBe(MCPTransportType.SSE);
+
+        // 2. command 优先级高于 URL
+        const commandConfig = {
+          command: "python", // command 存在
+          url: "https://example.com/sse", // URL 推断为 SSE 但 command 优先
+        };
+
+        const commandResult = inferTransportTypeFromConfig(
+          commandConfig,
+          "test-service"
+        );
+        expect(commandResult.type).toBe(MCPTransportType.STDIO);
+
+        // 3. 只有 URL 时进行推断
+        const urlConfig = {
+          url: "https://example.com/sse", // 推断为 SSE
+        };
+
+        const urlResult = inferTransportTypeFromConfig(
+          urlConfig,
+          "test-service"
+        );
+        expect(urlResult.type).toBe(MCPTransportType.SSE);
+      });
+    });
+  });
+});

--- a/src/server/lib/mcp/cache.ts
+++ b/src/server/lib/mcp/cache.ts
@@ -1,0 +1,759 @@
+/**
+ * MCP 缓存管理器
+ * 负责 MCP 服务工具列表的缓存写入功能
+ * 专注于缓存文件管理和数据写入的基础设施
+ */
+
+import { createHash } from "node:crypto";
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, resolve } from "node:path";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import dayjs from "dayjs";
+import type { Logger } from "../../Logger.js";
+import { logger } from "../../Logger.js";
+import {
+  CACHE_FILE_CONFIG,
+  CACHE_TIMEOUTS,
+  MCP_CACHE_VERSIONS,
+  TOOL_NAME_SEPARATORS,
+} from "../../constants/index.js";
+import type { MCPServiceConfig } from "../../lib/mcp/types";
+import type {
+  CacheStatistics,
+  EnhancedToolResultCache,
+  ExtendedMCPToolsCache,
+  TaskStatus,
+  ToolCallResult,
+} from "../../types/index.js";
+import { generateCacheKey, shouldCleanupCache } from "../../types/index.js";
+
+// 缓存条目接口
+export interface MCPToolsCacheEntry {
+  tools: Tool[]; // 工具列表
+  lastUpdated: string; // 最后更新时间 (YYYY-MM-DD HH:mm:ss)
+  serverConfig: MCPServiceConfig; // 服务配置快照
+  configHash: string; // 配置哈希值，用于快速变更检测
+  version: string; // 缓存条目版本
+}
+
+// 缓存文件接口
+export interface MCPToolsCache {
+  version: string; // 缓存文件格式版本 "1.0.0"
+  mcpServers: Record<string, MCPToolsCacheEntry>;
+  metadata: {
+    lastGlobalUpdate: string; // 全局最后更新时间 (YYYY-MM-DD HH:mm:ss)
+    totalWrites: number; // 总写入次数
+    createdAt: string; // 缓存文件创建时间 (YYYY-MM-DD HH:mm:ss)
+  };
+}
+
+// 缓存统计接口
+export interface CacheStats {
+  totalWrites: number;
+  lastUpdate: string;
+  serverCount: number;
+  cacheFileSize: number;
+}
+
+// 重新导出相关类型
+export type {
+  CacheStatistics,
+  EnhancedToolResultCache,
+  ExtendedMCPToolsCache,
+} from "../../types/index.js";
+
+export class MCPCacheManager {
+  private cachePath: string;
+  private logger: Logger;
+  private readonly CACHE_VERSION = MCP_CACHE_VERSIONS.CACHE_VERSION;
+  private readonly CACHE_ENTRY_VERSION = MCP_CACHE_VERSIONS.CACHE_ENTRY_VERSION;
+  private cleanupInterval?: NodeJS.Timeout;
+  private readonly CLEANUP_INTERVAL = CACHE_TIMEOUTS.CLEANUP_INTERVAL;
+
+  constructor(customCachePath?: string) {
+    this.logger = logger;
+    this.cachePath = customCachePath || this.getCacheFilePath();
+    this.startCleanupTimer();
+  }
+
+  /**
+   * 格式化时间戳为 YYYY-MM-DD HH:mm:ss 格式
+   */
+  private formatTimestamp(): string {
+    return dayjs().format("YYYY-MM-DD HH:mm:ss");
+  }
+
+  /**
+   * 获取缓存文件路径
+   * 与 xiaozhi.config.json 同级目录
+   */
+  private getCacheFilePath(): string {
+    try {
+      const configDir = process.env.XIAOZHI_CONFIG_DIR || process.cwd();
+      return resolve(configDir, CACHE_FILE_CONFIG.FILENAME);
+    } catch (error) {
+      // 在某些测试环境中 process.cwd() 可能不可用，使用默认路径
+      const configDir = process.env.XIAOZHI_CONFIG_DIR || "/tmp";
+      return resolve(configDir, CACHE_FILE_CONFIG.FILENAME);
+    }
+  }
+
+  /**
+   * 确保缓存文件存在，如不存在则创建
+   */
+  async ensureCacheFile(): Promise<void> {
+    try {
+      if (!existsSync(this.cachePath)) {
+        // 确保缓存文件的目录存在
+        const cacheDir = dirname(this.cachePath);
+        if (!existsSync(cacheDir)) {
+          mkdirSync(cacheDir, { recursive: true });
+          this.logger.debug(`[CacheManager] 已创建缓存目录: ${cacheDir}`);
+        }
+
+        this.logger.debug("[CacheManager] 缓存文件不存在，创建初始缓存文件");
+        const initialCache = await this.createInitialCache();
+        await this.saveCache(initialCache);
+        this.logger.info(`[CacheManager] 已创建缓存文件: ${this.cachePath}`);
+      }
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 创建缓存文件失败: ${error instanceof Error ? error.message : String(error)}`
+      );
+      // 不抛出异常，确保不影响主流程
+    }
+  }
+
+  /**
+   * 创建初始缓存结构
+   */
+  private async createInitialCache(): Promise<MCPToolsCache> {
+    const now = this.formatTimestamp();
+    return {
+      version: this.CACHE_VERSION,
+      mcpServers: {},
+      metadata: {
+        lastGlobalUpdate: now,
+        totalWrites: 0,
+        createdAt: now,
+      },
+    };
+  }
+
+  /**
+   * 写入缓存条目
+   * @param serverName 服务名称
+   * @param tools 工具列表
+   * @param config 服务配置
+   */
+  async writeCacheEntry(
+    serverName: string,
+    tools: Tool[],
+    config: MCPServiceConfig
+  ): Promise<void> {
+    try {
+      this.logger.debug(`[CacheManager] 开始写入缓存: ${serverName}`);
+
+      // 确保缓存文件存在
+      await this.ensureCacheFile();
+
+      // 加载现有缓存
+      const cache = await this.loadExistingCache();
+
+      // 生成配置哈希
+      const configHash = this.generateConfigHash(config);
+
+      // 创建缓存条目
+      const cacheEntry: MCPToolsCacheEntry = {
+        tools: tools.map((tool) => ({
+          name: tool.name,
+          description: tool.description || "",
+          inputSchema: tool.inputSchema,
+        })),
+        lastUpdated: this.formatTimestamp(),
+        serverConfig: { ...config }, // 深拷贝配置
+        configHash,
+        version: this.CACHE_ENTRY_VERSION,
+      };
+
+      // 更新缓存
+      cache.mcpServers[serverName] = cacheEntry;
+      cache.metadata.lastGlobalUpdate = this.formatTimestamp();
+      cache.metadata.totalWrites += 1;
+
+      // 保存缓存
+      await this.saveCache(cache);
+
+      this.logger.debug(
+        `[CacheManager] 缓存写入成功: ${serverName}, 工具数量: ${tools.length}`
+      );
+    } catch (error) {
+      // 记录错误但不抛出异常，确保不影响主流程
+      this.logger.warn(
+        `[CacheManager] 缓存写入失败: ${serverName}, 错误: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * 加载现有缓存
+   */
+  public async loadExistingCache(): Promise<MCPToolsCache> {
+    try {
+      if (!existsSync(this.cachePath)) {
+        return await this.createInitialCache();
+      }
+
+      const cacheData = readFileSync(this.cachePath, "utf8");
+      const cache: unknown = JSON.parse(cacheData);
+
+      // 验证缓存结构
+      if (!this.validateCacheStructure(cache)) {
+        this.logger.warn("[CacheManager] 缓存文件结构无效，重新创建");
+        return await this.createInitialCache();
+      }
+
+      return cache;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 加载缓存失败，创建新缓存: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return await this.createInitialCache();
+    }
+  }
+
+  /**
+   * 保存缓存到文件（原子写入）
+   */
+  public async saveCache(cache: MCPToolsCache): Promise<void> {
+    const cacheContent = JSON.stringify(cache, null, 2);
+    await this.atomicWrite(this.cachePath, cacheContent);
+  }
+
+  /**
+   * 原子写入文件
+   * 使用临时文件确保写入操作的原子性
+   */
+  private async atomicWrite(filePath: string, data: string): Promise<void> {
+    const tempPath = `${filePath}.tmp`;
+    try {
+      // 写入临时文件
+      writeFileSync(tempPath, data, "utf8");
+      // 原子性重命名
+      renameSync(tempPath, filePath);
+    } catch (error) {
+      // 清理临时文件
+      try {
+        if (existsSync(tempPath)) {
+          writeFileSync(tempPath, "", "utf8"); // 清空后删除
+        }
+      } catch {
+        // 忽略清理错误
+      }
+      throw error;
+    }
+  }
+
+  /**
+   * 生成配置哈希
+   * 用于快速检测配置变更
+   */
+  private generateConfigHash(config: MCPServiceConfig): string {
+    try {
+      return createHash("sha256").update(JSON.stringify(config)).digest("hex");
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 生成配置哈希失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return "";
+    }
+  }
+
+  /**
+   * 验证缓存数据结构
+   * 使用类型谓词确保类型安全
+   */
+  private validateCacheStructure(cache: unknown): cache is MCPToolsCache {
+    try {
+      if (!cache || typeof cache !== "object") {
+        return false;
+      }
+
+      const cacheObj = cache as Record<string, unknown>;
+      const metadata = cacheObj.metadata as Record<string, unknown>;
+
+      return (
+        typeof cacheObj.version === "string" &&
+        typeof cacheObj.mcpServers === "object" &&
+        cacheObj.mcpServers !== null &&
+        cacheObj.metadata !== null &&
+        cacheObj.metadata !== undefined &&
+        typeof metadata === "object" &&
+        metadata !== null &&
+        typeof metadata.lastGlobalUpdate === "string" &&
+        typeof metadata.totalWrites === "number" &&
+        typeof metadata.createdAt === "string"
+      );
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * 获取缓存统计信息
+   */
+  async getStats(): Promise<CacheStats | null> {
+    try {
+      const cache = await this.loadExistingCache();
+      const stats: CacheStats = {
+        totalWrites: cache.metadata.totalWrites,
+        lastUpdate: cache.metadata.lastGlobalUpdate,
+        serverCount: Object.keys(cache.mcpServers).length,
+        cacheFileSize: existsSync(this.cachePath)
+          ? readFileSync(this.cachePath, "utf8").length
+          : 0,
+      };
+      return stats;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 获取缓存统计失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * 获取缓存文件路径（用于测试和调试）
+   */
+  getFilePath(): string {
+    return this.cachePath;
+  }
+
+  /**
+   * 获取所有缓存中的工具
+   * 返回所有服务中的所有工具列表
+   */
+  async getAllCachedTools(): Promise<Tool[]> {
+    try {
+      const cache = await this.loadExistingCache();
+      const allTools: Tool[] = [];
+
+      // 遍历所有服务，收集所有工具
+      for (const [serverName, cacheEntry] of Object.entries(cache.mcpServers)) {
+        for (const tool of cacheEntry.tools) {
+          // 为每个工具添加服务名称信息
+          allTools.push({
+            ...tool,
+            name: `${serverName}${TOOL_NAME_SEPARATORS.SERVICE_TOOL_SEPARATOR}${tool.name}`, // 格式: serviceName__toolName
+          });
+        }
+      }
+
+      this.logger.debug(
+        `[CacheManager] 获取到所有缓存工具，共 ${allTools.length} 个`
+      );
+      return allTools;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 获取所有缓存工具失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return [];
+    }
+  }
+
+  // ==================== CustomMCP 结果缓存管理方法 ====================
+
+  /**
+   * 写入 CustomMCP 工具执行结果缓存
+   */
+  async writeCustomMCPResult(
+    toolName: string,
+    arguments_: Record<string, unknown>,
+    result: ToolCallResult,
+    status: TaskStatus = "completed",
+    taskId?: string,
+    ttl = 300000
+  ): Promise<void> {
+    try {
+      const cache = await this.loadExtendedCache();
+      const cacheKey = generateCacheKey(toolName, arguments_);
+
+      // 创建缓存条目
+      const cacheEntry: EnhancedToolResultCache = {
+        result,
+        timestamp: new Date().toISOString(),
+        ttl,
+        status,
+        consumed: false,
+        taskId,
+        retryCount: 0,
+      };
+
+      // 确保customMCPResults存在
+      if (!cache.customMCPResults) {
+        cache.customMCPResults = {};
+      }
+
+      cache.customMCPResults[cacheKey] = cacheEntry;
+      await this.saveExtendedCache(cache);
+
+      this.logger.debug(
+        `[CacheManager] 写入CustomMCP结果缓存: ${toolName}, 状态: ${status}`
+      );
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 写入CustomMCP结果缓存失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+    }
+  }
+
+  /**
+   * 读取 CustomMCP 工具执行结果缓存
+   */
+  async readCustomMCPResult(
+    toolName: string,
+    arguments_: Record<string, unknown>
+  ): Promise<EnhancedToolResultCache | null> {
+    try {
+      const cache = await this.loadExtendedCache();
+      const cacheKey = generateCacheKey(toolName, arguments_);
+
+      if (!cache.customMCPResults || !cache.customMCPResults[cacheKey]) {
+        return null;
+      }
+
+      const cacheEntry = cache.customMCPResults[cacheKey];
+
+      // 检查是否过期
+      const now = Date.now();
+      const cachedTime = new Date(cacheEntry.timestamp).getTime();
+      if (now - cachedTime > cacheEntry.ttl) {
+        this.logger.debug(`[CacheManager] 缓存已过期: ${toolName}`);
+        return null;
+      }
+
+      return cacheEntry;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 读取CustomMCP结果缓存失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return null;
+    }
+  }
+
+  /**
+   * 更新 CustomMCP 缓存状态
+   */
+  async updateCustomMCPStatus(
+    toolName: string,
+    arguments_: Record<string, unknown>,
+    newStatus: TaskStatus,
+    result?: ToolCallResult,
+    error?: string
+  ): Promise<boolean> {
+    try {
+      const cache = await this.loadExtendedCache();
+      const cacheKey = generateCacheKey(toolName, arguments_);
+
+      if (!cache.customMCPResults || !cache.customMCPResults[cacheKey]) {
+        return false;
+      }
+
+      const cacheEntry = cache.customMCPResults[cacheKey];
+      const oldStatus = cacheEntry.status;
+
+      // 更新状态
+      cacheEntry.status = newStatus;
+      cacheEntry.timestamp = new Date().toISOString();
+
+      // 更新结果或错误信息
+      if (result) {
+        cacheEntry.result = result;
+      }
+
+      if (error && newStatus === "failed") {
+        cacheEntry.result = {
+          content: [{ type: "text", text: `任务失败: ${error}` }],
+        };
+        cacheEntry.consumed = true; // 失败的任务自动标记为已消费
+      }
+
+      // 特殊状态处理
+      if (newStatus === "completed") {
+        cacheEntry.consumed = false; // 完成的任务初始状态为未消费
+      }
+
+      await this.saveExtendedCache(cache);
+
+      this.logger.debug(
+        `[CacheManager] 更新缓存状态: ${toolName} ${oldStatus} -> ${newStatus}`
+      );
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 更新CustomMCP缓存状态失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return false;
+    }
+  }
+
+  /**
+   * 标记 CustomMCP 缓存为已消费
+   */
+  async markCustomMCPAsConsumed(
+    toolName: string,
+    arguments_: Record<string, unknown>
+  ): Promise<boolean> {
+    try {
+      const cache = await this.loadExtendedCache();
+      const cacheKey = generateCacheKey(toolName, arguments_);
+
+      if (!cache.customMCPResults || !cache.customMCPResults[cacheKey]) {
+        return false;
+      }
+
+      const cacheEntry = cache.customMCPResults[cacheKey];
+      if (cacheEntry.consumed) {
+        return true;
+      }
+
+      cacheEntry.consumed = true;
+      cacheEntry.timestamp = new Date().toISOString();
+
+      await this.saveExtendedCache(cache);
+
+      this.logger.debug(`[CacheManager] 标记缓存为已消费: ${toolName}`);
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 标记CustomMCP缓存为已消费失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return false;
+    }
+  }
+
+  /**
+   * 删除 CustomMCP 缓存条目
+   */
+  async deleteCustomMCPResult(
+    toolName: string,
+    arguments_: Record<string, unknown>
+  ): Promise<boolean> {
+    try {
+      const cache = await this.loadExtendedCache();
+      const cacheKey = generateCacheKey(toolName, arguments_);
+
+      if (!cache.customMCPResults || !cache.customMCPResults[cacheKey]) {
+        return false;
+      }
+
+      delete cache.customMCPResults[cacheKey];
+      await this.saveExtendedCache(cache);
+
+      this.logger.debug(`[CacheManager] 删除缓存条目: ${toolName}`);
+      return true;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 删除CustomMCP缓存条目失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return false;
+    }
+  }
+
+  /**
+   * 批量清理 CustomMCP 缓存
+   */
+  async cleanupCustomMCPResults(): Promise<{ cleaned: number; total: number }> {
+    try {
+      const cache = await this.loadExtendedCache();
+
+      if (!cache.customMCPResults) {
+        return { cleaned: 0, total: 0 };
+      }
+
+      const entries = Object.entries(cache.customMCPResults);
+      let cleanedCount = 0;
+
+      for (const [cacheKey, cacheEntry] of entries) {
+        if (shouldCleanupCache(cacheEntry)) {
+          delete cache.customMCPResults[cacheKey];
+          cleanedCount++;
+        }
+      }
+
+      if (cleanedCount > 0) {
+        await this.saveExtendedCache(cache);
+        this.logger.info(
+          `[CacheManager] 清理CustomMCP缓存: ${cleanedCount}/${entries.length}`
+        );
+      }
+
+      return { cleaned: cleanedCount, total: entries.length };
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 清理CustomMCP缓存失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return { cleaned: 0, total: 0 };
+    }
+  }
+
+  /**
+   * 获取 CustomMCP 缓存统计信息
+   */
+  async getCustomMCPStatistics(): Promise<CacheStatistics> {
+    try {
+      const cache = await this.loadExtendedCache();
+
+      if (!cache.customMCPResults) {
+        return {
+          totalEntries: 0,
+          pendingTasks: 0,
+          completedTasks: 0,
+          failedTasks: 0,
+          consumedEntries: 0,
+          cacheHitRate: 0,
+          lastCleanupTime: new Date().toISOString(),
+          memoryUsage: 0,
+        };
+      }
+
+      const entries = Object.values(cache.customMCPResults);
+      const totalEntries = entries.length;
+      const pendingTasks = entries.filter((e) => e.status === "pending").length;
+      const completedTasks = entries.filter(
+        (e) => e.status === "completed"
+      ).length;
+      const failedTasks = entries.filter((e) => e.status === "failed").length;
+      const consumedEntries = entries.filter((e) => e.consumed).length;
+
+      // 计算缓存命中率
+      const cacheHitRate =
+        completedTasks > 0 ? (consumedEntries / completedTasks) * 100 : 0;
+
+      // 估算内存使用
+      const memoryUsage = JSON.stringify(cache.customMCPResults).length;
+
+      return {
+        totalEntries,
+        pendingTasks,
+        completedTasks,
+        failedTasks,
+        consumedEntries,
+        cacheHitRate,
+        lastCleanupTime: new Date().toISOString(),
+        memoryUsage,
+      };
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 获取CustomMCP缓存统计失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return {
+        totalEntries: 0,
+        pendingTasks: 0,
+        completedTasks: 0,
+        failedTasks: 0,
+        consumedEntries: 0,
+        cacheHitRate: 0,
+        lastCleanupTime: new Date().toISOString(),
+        memoryUsage: 0,
+      };
+    }
+  }
+
+  /**
+   * 加载扩展缓存（包含 CustomMCP 结果）
+   */
+  async loadExtendedCache(): Promise<ExtendedMCPToolsCache> {
+    try {
+      const cache = await this.loadExistingCache();
+      return cache as ExtendedMCPToolsCache;
+    } catch (error) {
+      this.logger.warn(
+        `[CacheManager] 加载扩展缓存失败: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      return {
+        version: this.CACHE_VERSION,
+        mcpServers: {},
+        metadata: {
+          lastGlobalUpdate: this.formatTimestamp(),
+          totalWrites: 0,
+          createdAt: this.formatTimestamp(),
+        },
+        customMCPResults: {},
+      };
+    }
+  }
+
+  /**
+   * 保存扩展缓存（包含 CustomMCP 结果）
+   */
+  async saveExtendedCache(cache: ExtendedMCPToolsCache): Promise<void> {
+    await this.saveCache(cache);
+  }
+
+  /**
+   * 启动清理定时器
+   */
+  private startCleanupTimer(): void {
+    this.cleanupInterval = setInterval(() => {
+      this.cleanupCustomMCPResults().catch((error) => {
+        this.logger.warn(`[CacheManager] 自动清理失败: ${error}`);
+      });
+    }, this.CLEANUP_INTERVAL);
+
+    this.logger.debug(
+      `[CacheManager] 启动清理定时器，间隔: ${this.CLEANUP_INTERVAL}ms`
+    );
+  }
+
+  /**
+   * 停止清理定时器
+   */
+  public stopCleanupTimer(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = undefined;
+      this.logger.debug("[CacheManager] 停止清理定时器");
+    }
+  }
+
+  /**
+   * 清理资源
+   */
+  public cleanup(): void {
+    this.stopCleanupTimer();
+    this.logger.debug("[CacheManager] 清理资源完成");
+  }
+}

--- a/src/server/lib/mcp/connection.ts
+++ b/src/server/lib/mcp/connection.ts
@@ -1,0 +1,104 @@
+/**
+ * 向后兼容的 MCPService 类
+ * 包装 ../../../../../mcp-core/index.js 的 MCPConnection，使用 EventBus 发射事件
+ */
+
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { MCPConnection } from "../../../mcp-core/index.js";
+import { MCP_SERVICE_EVENTS } from "../../constants/index.js";
+import { getEventBus } from "../../services/event-bus.service.js";
+import type { InternalMCPServiceConfig } from "./types.js";
+
+/**
+ * MCP 服务类（向后兼容包装器）
+ * 负责管理单个 MCP 服务的连接、工具管理和调用
+ */
+export class MCPService {
+  private connection: MCPConnection;
+  private eventBus = getEventBus();
+
+  constructor(config: InternalMCPServiceConfig) {
+    // 从配置中解构 name，其余作为连接配置
+    const {
+      name,
+      ...connectionConfig
+    }: { name: string } & Omit<InternalMCPServiceConfig, "name"> = config;
+
+    // 创建回调适配器，将 mcp-core 的回调转换为 EventBus 事件
+    const callbacks = {
+      onConnected: (data: {
+        serviceName: string;
+        tools: Tool[];
+        connectionTime: Date;
+      }) => {
+        this.eventBus.emitEvent(MCP_SERVICE_EVENTS.CONNECTED, data);
+      },
+      onDisconnected: (data: {
+        serviceName: string;
+        reason?: string;
+        disconnectionTime: Date;
+      }) => {
+        this.eventBus.emitEvent(MCP_SERVICE_EVENTS.DISCONNECTED, data);
+      },
+      onConnectionFailed: (data: {
+        serviceName: string;
+        error: Error;
+        attempt: number;
+      }) => {
+        this.eventBus.emitEvent(MCP_SERVICE_EVENTS.CONNECTION_FAILED, data);
+      },
+    };
+
+    // 适配新 API：将 name 从 config 中分离
+    this.connection = new MCPConnection(name, connectionConfig, callbacks);
+  }
+
+  /**
+   * 连接到 MCP 服务
+   */
+  async connect(): Promise<void> {
+    return this.connection.connect();
+  }
+
+  /**
+   * 断开连接
+   */
+  async disconnect(): Promise<void> {
+    return this.connection.disconnect();
+  }
+
+  /**
+   * 调用工具
+   */
+  async callTool(name: string, arguments_: Record<string, unknown>) {
+    return this.connection.callTool(name, arguments_);
+  }
+
+  /**
+   * 获取工具列表
+   */
+  getTools(): Tool[] {
+    return this.connection.getTools();
+  }
+
+  /**
+   * 获取服务配置
+   */
+  getConfig() {
+    return this.connection.getConfig();
+  }
+
+  /**
+   * 获取服务状态
+   */
+  getStatus() {
+    return this.connection.getStatus();
+  }
+
+  /**
+   * 检查是否已连接
+   */
+  isConnected() {
+    return this.connection.isConnected();
+  }
+}

--- a/src/server/lib/mcp/custom.ts
+++ b/src/server/lib/mcp/custom.ts
@@ -1,0 +1,553 @@
+#!/usr/bin/env node
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type {
+  CustomMCPTool,
+  HandlerConfig,
+  ProxyHandlerConfig,
+} from "../../../config/index.js";
+import { configManager } from "../../../config/index.js";
+/**
+ * 自定义 MCP 工具处理器模块
+ *
+ * 本模块提供了处理自定义 MCP 工具的核心功能，特别是针对 Coze 工作流工具。
+ * 主要功能包括：
+ * - CustomMCPHandler：简化的自定义 MCP 工具处理器
+ * - 支持代理处理器配置（ProxyHandlerConfig）
+ * - 工具调用超时处理
+ * - 工具调用缓存机制
+ * - 与 Coze API 服务集成
+ *
+ * @module custom
+ *
+ * @example
+ * ```typescript
+ * import { CustomMCPHandler } from '../../lib/mcp/custom.js';
+ *
+ * const handler = new CustomMCPHandler(mcpServiceManager);
+ * const result = await handler.callTool(toolName, arguments, options);
+ * ```
+ */
+import type { Logger } from "../../Logger.js";
+import { logger } from "../../Logger.js";
+import { CozeApiService } from "../../lib/coze";
+import type { RunWorkflowData } from "../../lib/coze";
+import type { MCPServiceManager } from "../../lib/mcp";
+import { MCPCacheManager } from "../../lib/mcp";
+import { ensureToolJSONSchema } from "../../lib/mcp/types.js";
+import { getEventBus } from "../../services/event-bus.service.js";
+import type {
+  EnhancedToolResultCache,
+  ExtendedMCPToolsCache,
+  ToolCallResponse,
+  ToolCallResult,
+} from "../../types/mcp.js";
+import {
+  DEFAULT_CONFIG,
+  generateCacheKey,
+  isCacheExpired,
+  shouldCleanupCache,
+} from "../../types/mcp.js";
+import { TimeoutError, createTimeoutResponse } from "../../types/timeout.js";
+
+// 工具调用参数类型
+type ToolArguments = Record<string, unknown>;
+
+// 类型守卫函数：检查是否为代理处理器
+function isProxyHandler(handler: HandlerConfig): handler is ProxyHandlerConfig {
+  return handler.type === "proxy";
+}
+
+// 扩展的工具调用选项
+interface ToolCallOptions {
+  timeout?: number; // 超时时间（毫秒）
+  enableCache?: boolean; // 是否启用缓存
+  taskId?: string; // 任务ID
+}
+
+/**
+ * 简化版的 CustomMCPHandler
+ * 专门用于处理 Coze 工作流工具，保持超时友好响应机制
+ */
+export class CustomMCPHandler {
+  private logger: Logger;
+  private tools: Map<string, CustomMCPTool> = new Map();
+  private cacheManager: MCPCacheManager;
+  private mcpServiceManager?: MCPServiceManager;
+  private readonly TIMEOUT = DEFAULT_CONFIG.TIMEOUT; // 统一8秒超时
+  private readonly CACHE_TTL = DEFAULT_CONFIG.CACHE_TTL; // 5分钟缓存过期
+  private configUpdateListener: ((data: unknown) => void) | null = null; // 配置更新监听器引用
+
+  constructor(
+    cacheManager?: MCPCacheManager,
+    mcpServiceManager?: MCPServiceManager
+  ) {
+    this.logger = logger;
+    this.cacheManager = cacheManager || new MCPCacheManager();
+    this.mcpServiceManager = mcpServiceManager;
+
+    // 设置事件监听器
+    this.setupEventListeners();
+  }
+
+  /**
+   * 获取 CozeApiService 实例
+   */
+  private getCozeApiService(): CozeApiService {
+    const token = configManager.getConfig().platforms?.coze?.token;
+
+    if (!token) {
+      throw new Error("Coze Token 配置不存在");
+    }
+
+    return new CozeApiService(token);
+  }
+
+  /**
+   * 设置事件监听器
+   */
+  private setupEventListeners(): void {
+    const eventBus = getEventBus();
+
+    // 监听配置更新事件
+    this.configUpdateListener = async (data) => {
+      if (
+        data &&
+        typeof data === "object" &&
+        "type" in data &&
+        data.type === "customMCP"
+      ) {
+        this.logger.info("[CustomMCP] 检测到配置更新，重新初始化...");
+        try {
+          this.reinitialize();
+        } catch (error) {
+          this.logger.error("[CustomMCP] 配置更新处理失败:", error);
+        }
+      }
+    };
+
+    eventBus.onEvent("config:updated", this.configUpdateListener);
+  }
+
+  /**
+   * 初始化 CustomMCP 处理器
+   * 加载配置中的 customMCP 工具
+   * @param tools 可选的工具数组，如果提供则使用该数组，否则从配置管理器获取
+   */
+  public initialize(tools?: CustomMCPTool[]): void {
+    this.logger.debug("[CustomMCP] 初始化 CustomMCP 处理器...");
+
+    try {
+      const customTools = tools || configManager.getCustomMCPTools();
+
+      // 清空现有工具
+      this.tools.clear();
+
+      // 只加载 coze 代理工具
+      for (const tool of customTools) {
+        if (isProxyHandler(tool.handler) && tool.handler.platform === "coze") {
+          this.tools.set(tool.name, tool);
+          this.logger.debug(
+            `[CustomMCP] 已加载 Coze 工具: ${tool.name} (workflow_id: ${tool.handler.config.workflow_id})`
+          );
+        }
+      }
+
+      this.logger.debug(
+        `[CustomMCP] 初始化完成，共加载 ${this.tools.size} 个 Coze 工具`
+      );
+    } catch (error) {
+      this.logger.error("[CustomMCP] 初始化失败:", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 获取所有工具（标准 MCP 格式）
+   */
+  public getTools(): Tool[] {
+    return Array.from(this.tools.values()).map((tool) => ({
+      name: tool.name,
+      description: tool.description,
+      inputSchema: ensureToolJSONSchema(tool.inputSchema),
+    }));
+  }
+
+  /**
+   * 检查是否存在指定工具
+   */
+  public hasTool(toolName: string): boolean {
+    return this.tools.has(toolName);
+  }
+
+  /**
+   * 获取工具数量
+   */
+  public getToolCount(): number {
+    return this.tools.size;
+  }
+
+  /**
+   * 获取所有工具名称
+   */
+  public getToolNames(): string[] {
+    return Array.from(this.tools.keys());
+  }
+
+  /**
+   * 获取工具详细信息（用于调试）
+   */
+  public getToolInfo(toolName: string): CustomMCPTool | undefined {
+    return this.tools.get(toolName);
+  }
+
+  /**
+   * 重新初始化 CustomMCP 处理器
+   * 重新加载配置中的 customMCP 工具
+   */
+  public reinitialize(): void {
+    this.logger.debug("[CustomMCP] 重新初始化 CustomMCP 处理器...");
+    this.initialize();
+  }
+
+  /**
+   * 调用工具（支持超时友好响应和缓存管理）
+   */
+  public async callTool(
+    toolName: string,
+    arguments_: ToolArguments,
+    options?: ToolCallOptions
+  ): Promise<ToolCallResponse> {
+    const tool = this.tools.get(toolName);
+    if (!tool) {
+      throw new Error(`未找到工具: ${toolName}`);
+    }
+
+    // 首先检查是否有已完成的任务结果（一次性缓存）
+    const completedResult = await this.getCompletedResult(toolName, arguments_);
+    if (completedResult) {
+      this.logger.debug(`[CustomMCP] 返回已完成的任务结果: ${toolName}`);
+      // 立即清理已消费的缓存
+      await this.clearConsumedCache(toolName, arguments_);
+      return completedResult;
+    }
+
+    try {
+      const timeout = options?.timeout || this.TIMEOUT;
+      const result = await Promise.race([
+        this.callCozeWorkflow(tool, arguments_),
+        this.createTimeoutPromise(toolName, timeout),
+      ]);
+
+      // 缓存结果（标记为未消费）
+      await this.cacheResult(toolName, arguments_, result);
+
+      return result;
+    } catch (error) {
+      // 如果是超时错误，返回友好提示
+      if (error instanceof TimeoutError) {
+        const taskId = await this.generateTaskId(toolName, arguments_);
+        this.logger.info(
+          `[CustomMCP] 工具超时，返回友好提示: ${toolName}, taskId: ${taskId}`
+        );
+        return createTimeoutResponse(taskId, toolName);
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * 创建超时 Promise
+   */
+  private async createTimeoutPromise(
+    toolName: string,
+    timeout: number
+  ): Promise<never> {
+    return new Promise((_, reject) => {
+      setTimeout(() => {
+        reject(new TimeoutError(`工具调用超时: ${toolName}`));
+      }, timeout);
+    });
+  }
+
+  /**
+   * 获取已完成的任务结果（一次性缓存）
+   */
+  private async getCompletedResult(
+    toolName: string,
+    arguments_: ToolArguments
+  ): Promise<ToolCallResult | null> {
+    try {
+      const cacheKey = this.generateCacheKey(toolName, arguments_);
+      const cache = await this.loadExtendedCache();
+
+      if (!cache.customMCPResults || !cache.customMCPResults[cacheKey]) {
+        return null;
+      }
+
+      const cached = cache.customMCPResults[cacheKey];
+
+      // 只返回已完成且未消费的结果
+      if (cached.status === "completed" && !cached.consumed) {
+        // 检查是否过期
+        if (!isCacheExpired(cached.timestamp, cached.ttl)) {
+          return cached.result;
+        }
+      }
+
+      return null;
+    } catch (error) {
+      this.logger.warn(`[CustomMCP] 获取缓存失败: ${error}`);
+      return null;
+    }
+  }
+
+  /**
+   * 处理工作流响应
+   */
+  private processWorkflowResponse(
+    toolName: string,
+    workflowData: RunWorkflowData
+  ): ToolCallResult {
+    try {
+      // 根据 RunWorkflowData 的实际结构进行处理
+      // 假设 workflowData 有 data 字段或其他响应数据字段
+      const responseData = workflowData.data || workflowData;
+
+      if (typeof responseData === "string") {
+        return {
+          content: [
+            {
+              type: "text",
+              text: responseData,
+            },
+          ],
+          isError: false,
+        };
+      }
+
+      // 如果是对象，转换为 JSON 字符串
+      return {
+        content: [
+          {
+            type: "text",
+            text: JSON.stringify(responseData, null, 2),
+          },
+        ],
+        isError: false,
+      };
+    } catch (error) {
+      this.logger.error(`[CustomMCP] 处理工作流响应失败: ${toolName}`, error);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `处理响应失败: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  /**
+   * 调用 Coze 工作流
+   */
+  private async callCozeWorkflow(
+    tool: CustomMCPTool,
+    arguments_: ToolArguments
+  ): Promise<ToolCallResult> {
+    const handler = tool.handler as ProxyHandlerConfig;
+    const config = handler.config;
+
+    this.logger.info(`[CustomMCP] 调用 Coze 工作流: ${tool.name}`, {
+      workflow_id: config.workflow_id,
+    });
+
+    try {
+      // 使用 CozeApiService
+      const cozeApiService = this.getCozeApiService();
+
+      // 检查 workflow_id 是否存在
+      if (!config.workflow_id) {
+        throw new Error("工作流ID未配置");
+      }
+
+      // 调用 callWorkflow 方法
+      const workflowResult = await cozeApiService.callWorkflow(
+        config.workflow_id,
+        arguments_
+      );
+
+      this.logger.info(`[CustomMCP] Coze 工作流调用成功: ${tool.name}`);
+
+      // 转换响应格式为 ToolCallResult
+      return this.processWorkflowResponse(tool.name, workflowResult);
+    } catch (error) {
+      this.logger.error(`[CustomMCP] Coze 工作流调用失败: ${tool.name}`, error);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Coze 工作流调用失败: ${
+              error instanceof Error ? error.message : String(error)
+            }`,
+          },
+        ],
+        isError: true,
+      };
+    }
+  }
+
+  /**
+   * 清理已消费的缓存
+   */
+  private async clearConsumedCache(
+    toolName: string,
+    arguments_: ToolArguments
+  ): Promise<void> {
+    try {
+      const cacheKey = this.generateCacheKey(toolName, arguments_);
+      const cache = await this.loadExtendedCache();
+
+      if (cache.customMCPResults?.[cacheKey]) {
+        // 标记为已消费
+        cache.customMCPResults[cacheKey].consumed = true;
+
+        // 如果已消费且已过期，直接删除
+        const cached = cache.customMCPResults[cacheKey];
+        if (shouldCleanupCache(cached)) {
+          delete cache.customMCPResults[cacheKey];
+        }
+
+        // 保存缓存更改
+        await this.saveCache(cache);
+        this.logger.debug(`[CustomMCP] 清理已消费缓存: ${cacheKey}`);
+      }
+    } catch (error) {
+      this.logger.warn(`[CustomMCP] 清理缓存失败: ${error}`);
+    }
+  }
+
+  /**
+   * 生成任务ID
+   */
+  private async generateTaskId(
+    toolName: string,
+    arguments_: ToolArguments
+  ): Promise<string> {
+    return generateCacheKey(toolName, arguments_);
+  }
+
+  /**
+   * 生成缓存键
+   */
+  private generateCacheKey(
+    toolName: string,
+    arguments_: ToolArguments
+  ): string {
+    return generateCacheKey(toolName, arguments_);
+  }
+
+  /**
+   * 加载扩展缓存
+   */
+  private async loadExtendedCache(): Promise<ExtendedMCPToolsCache> {
+    try {
+      const cacheData = await this.cacheManager.loadExistingCache();
+      return cacheData as ExtendedMCPToolsCache;
+    } catch (error) {
+      return {
+        version: "1.0.0",
+        mcpServers: {},
+        metadata: {
+          lastGlobalUpdate: new Date().toISOString(),
+          totalWrites: 0,
+          createdAt: new Date().toISOString(),
+        },
+        customMCPResults: {},
+      };
+    }
+  }
+
+  /**
+   * 更新缓存结果
+   */
+  private async updateCacheWithResult(
+    cacheKey: string,
+    cacheData: EnhancedToolResultCache
+  ): Promise<void> {
+    try {
+      const cache = await this.loadExtendedCache();
+
+      if (!cache.customMCPResults) {
+        cache.customMCPResults = {};
+      }
+
+      cache.customMCPResults[cacheKey] = cacheData;
+
+      // 使用 MCPCacheManager 的保存方法
+      await this.saveCache(cache);
+    } catch (error) {
+      this.logger.warn(`[CustomMCP] 更新缓存失败: ${error}`);
+    }
+  }
+
+  /**
+   * 缓存结果
+   */
+  private async cacheResult(
+    toolName: string,
+    arguments_: ToolArguments,
+    result: ToolCallResult
+  ): Promise<void> {
+    try {
+      const cacheKey = this.generateCacheKey(toolName, arguments_);
+      const cacheData: EnhancedToolResultCache = {
+        result,
+        timestamp: new Date().toISOString(),
+        ttl: this.CACHE_TTL,
+        status: "completed",
+        consumed: false, // 初始状态为未消费
+        retryCount: 0,
+      };
+
+      await this.updateCacheWithResult(cacheKey, cacheData);
+      this.logger.debug(`[CustomMCP] 缓存工具结果: ${toolName}`);
+    } catch (error) {
+      this.logger.warn(`[CustomMCP] 缓存结果失败: ${error}`);
+    }
+  }
+
+  /**
+   * 保存缓存
+   */
+  private async saveCache(cache: ExtendedMCPToolsCache): Promise<void> {
+    try {
+      await this.cacheManager.saveCache(cache);
+    } catch (error) {
+      this.logger.warn(`[CustomMCP] 保存缓存失败: ${error}`);
+    }
+  }
+
+  /**
+   * 清理资源
+   */
+  public cleanup(): void {
+    this.logger.info("[CustomMCP] 清理 CustomMCP 处理器资源");
+
+    // 移除事件监听器
+    if (this.configUpdateListener) {
+      const eventBus = getEventBus();
+      eventBus.offEvent("config:updated", this.configUpdateListener);
+      this.configUpdateListener = null;
+    }
+
+    this.tools.clear();
+    this.cacheManager.cleanup();
+  }
+}

--- a/src/server/lib/mcp/index.ts
+++ b/src/server/lib/mcp/index.ts
@@ -1,0 +1,39 @@
+/**
+ * MCP 核心库统一导出模块
+ *
+ * 提供完整的 MCP（Model Context Protocol）核心功能，包括：
+ * - MCPServiceManager: MCP 服务管理器，统一管理多个 MCP 服务
+ * - MCPService: MCP 服务类，负责单个 MCP 服务的连接和工具管理
+ * - MCPMessageHandler: MCP 消息处理器，处理所有 MCP 协议消息
+ * - MCPCacheManager: MCP 缓存管理器，负责工具列表的缓存
+ * - CustomMCPHandler: 自定义 MCP 处理器，处理 Coze 工作流等自定义工具
+ * - ToolCallLogger: 工具调用记录器，提供 JSONL 格式的记录功能
+ * - ToolCallLogService: 工具调用日志服务，提供查询功能
+ * - 类型定义: MCP 相关的所有 TypeScript 类型定义
+ * - 工具函数: MCP 工具调用的辅助函数
+ *
+ * @packageDocumentation
+ *
+ * @example
+ * ```typescript
+ * import { MCPServiceManager } from '../../lib/mcp';
+ *
+ * // 创建服务管理器
+ * const manager = new MCPServiceManager(config);
+ * await manager.startAllServices();
+ *
+ * // 获取所有工具
+ * const tools = manager.getAllTools();
+ *
+ * // 调用工具
+ * const result = await manager.callTool('tool-name', { param: 'value' });
+ * ```
+ */
+export * from "../../lib/mcp/manager.js";
+export * from "../../lib/mcp/connection.js";
+export * from "../../lib/mcp/types.js";
+export * from "../../lib/mcp/utils.js";
+export * from "./message.js";
+export * from "../../lib/mcp/cache.js";
+export * from "./custom.js";
+export * from "./log.js";

--- a/src/server/lib/mcp/log.ts
+++ b/src/server/lib/mcp/log.ts
@@ -1,0 +1,388 @@
+/**
+ * MCP 工具调用日志模块
+ * 提供工具调用的写入和查询功能
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import pino from "pino";
+import type { Logger as PinoLogger } from "pino";
+import { logger } from "../../Logger.js";
+import { PathUtils } from "../../utils/path-utils.js";
+
+// ==================== 类型定义 ====================
+
+/**
+ * Pino 日志对象类型（内部使用）
+ * 用于 formatConsoleMessage 方法的参数类型
+ */
+interface PinoLogObject {
+  toolName?: string;
+  success?: boolean;
+  duration?: number;
+  [key: string]: unknown;
+}
+
+/**
+ * 工具调用记录接口
+ */
+export interface ToolCallRecord {
+  toolName: string; // 工具名称
+  originalToolName?: string; // 原始工具名称（未格式化的）
+  serverName?: string; // 服务器名称（coze、dify、n8n、custom等）
+  arguments?: Record<string, unknown>; // 调用参数
+  result?: unknown; // 响应结果
+  success: boolean; // 是否成功
+  duration?: number; // 调用耗时（毫秒）
+  error?: string; // 错误信息（如果有）
+  timestamp?: number; // 时间戳（毫秒）
+}
+
+/**
+ * 工具调用日志配置接口
+ */
+export interface ToolCallLogConfig {
+  maxRecords?: number; // 最大记录条数，默认 100
+  logFilePath?: string; // 自定义日志文件路径（可选）
+}
+
+/**
+ * 查询参数接口
+ */
+export interface ToolCallQuery {
+  limit?: number;
+  offset?: number;
+  toolName?: string;
+  serverName?: string;
+  success?: boolean;
+  startDate?: string;
+  endDate?: string;
+}
+
+// ==================== ToolCallLogger 类（写入功能）====================
+
+/**
+ * MCP 工具调用记录器
+ * 提供工具调用的 JSONL 格式记录功能
+ */
+export class ToolCallLogger {
+  private pinoLogger: PinoLogger;
+  private maxRecords: number;
+  private logFilePath: string;
+
+  constructor(config: ToolCallLogConfig, configDir: string) {
+    this.maxRecords = config?.maxRecords ?? 100;
+
+    // 确定日志文件路径 - 使用更健壮的路径处理
+    if (config?.logFilePath) {
+      this.logFilePath = path.resolve(path.normalize(config.logFilePath));
+    } else {
+      // 使用 PathUtils 的跨平台临时目录处理
+      const baseDir = configDir || PathUtils.getTempDir();
+      this.logFilePath = path.join(path.normalize(baseDir), "tool-calls.jsonl");
+    }
+
+    // 创建 Pino 实例
+    this.pinoLogger = this.createPinoLogger(this.logFilePath);
+
+    logger.info("ToolCallLogger 初始化", {
+      maxRecords: this.maxRecords,
+      path: this.logFilePath,
+    });
+  }
+
+  /**
+   * 创建 Pino Logger 实例
+   */
+  private createPinoLogger(logFilePath: string): PinoLogger {
+    const streams: pino.StreamEntry[] = [];
+
+    // 控制台流 - 使用彩色输出
+    streams.push({
+      level: "info",
+      stream: {
+        write: (chunk: string) => {
+          try {
+            const logObj = JSON.parse(chunk);
+            const message = this.formatConsoleMessage(logObj);
+            console.log("[工具调用]", { message });
+          } catch {
+            console.log("[工具调用]", { chunk: chunk.trim() });
+          }
+        },
+      },
+    });
+
+    // 文件流 - JSONL 格式，带错误处理
+    try {
+      streams.push({
+        level: "info",
+        stream: pino.destination({
+          dest: logFilePath,
+          sync: true, // 同步写入确保测试可靠性
+          append: true,
+          mkdir: true,
+        }),
+      });
+    } catch (error) {
+      // 如果文件路径无效，记录错误但不抛出异常
+      logger.error("无法创建工具调用日志文件", { error });
+    }
+
+    return pino(
+      {
+        level: "info",
+        timestamp:
+          pino.stdTimeFunctions?.isoTime || (() => `,"time":${Date.now()}`),
+        formatters: {
+          level: (_label: string, number: number) => ({ level: number }),
+        },
+        base: null, // 不包含 pid 和 hostname
+      },
+      pino.multistream(streams, { dedupe: true })
+    );
+  }
+
+  /**
+   * 格式化控制台消息
+   */
+  private formatConsoleMessage(logObj: PinoLogObject): string {
+    const toolName = logObj.toolName || "未知工具";
+    const success = logObj.success !== false;
+    const duration = logObj.duration ? ` (${logObj.duration}ms)` : "";
+    const status = success ? "✅" : "❌";
+
+    return `${status} ${toolName}${duration}`;
+  }
+
+  /**
+   * 清理旧的日志记录，确保不超过最大记录数量
+   */
+  private async cleanupOldRecords(): Promise<void> {
+    try {
+      // 检查日志文件是否存在
+      if (!fs.existsSync(this.logFilePath)) {
+        return;
+      }
+
+      // 读取文件内容
+      const content = fs.readFileSync(this.logFilePath, "utf8");
+      const lines = content
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim() !== "");
+
+      // 如果记录数量未超过限制，直接返回
+      if (lines.length <= this.maxRecords) {
+        return;
+      }
+
+      // 计算需要删除的记录数量
+      const recordsToRemove = lines.length - this.maxRecords + 1; // +1 为即将写入的新记录预留空间
+
+      // 删除最旧的记录（从文件开头删除）
+      const linesToKeep = lines.slice(recordsToRemove);
+
+      // 重新写入文件
+      const newContent =
+        linesToKeep.join("\n") + (linesToKeep.length > 0 ? "\n" : "");
+      fs.writeFileSync(this.logFilePath, newContent, "utf8");
+
+      logger.info("已清理旧的工具调用记录", {
+        recordsToRemove,
+        maxRecords: this.maxRecords,
+      });
+    } catch (error) {
+      logger.error("清理旧工具调用记录失败", { error });
+    }
+  }
+
+  /**
+   * 记录工具调用
+   */
+  async recordToolCall(record: ToolCallRecord): Promise<void> {
+    try {
+      // 在写入新记录前，先清理旧记录以确保不超过最大记录数量
+      await this.cleanupOldRecords();
+
+      // 使用 Pino 记录日志，自动处理并发和文件写入
+      this.pinoLogger.info(record, record.toolName);
+    } catch (error) {
+      // 记录失败不应该影响主流程，只记录错误日志
+      logger.error("记录工具调用失败", { error });
+    }
+  }
+
+  /**
+   * 获取日志文件路径
+   */
+  getLogFilePath(): string {
+    return this.logFilePath;
+  }
+
+  /**
+   * 获取最大记录数量
+   */
+  getMaxRecords(): number {
+    return this.maxRecords;
+  }
+}
+
+// ==================== ToolCallLogService 类（查询功能）====================
+
+/**
+ * 工具调用日志服务类
+ * 负责读取和查询工具调用日志
+ */
+export class ToolCallLogService {
+  private configDir: string;
+
+  constructor(configDir?: string) {
+    this.configDir = configDir || PathUtils.getConfigDir();
+  }
+
+  /**
+   * 获取工具调用日志文件路径
+   */
+  private getLogFilePath(): string {
+    const toolCallLogger = new ToolCallLogger({}, this.configDir);
+    return toolCallLogger.getLogFilePath();
+  }
+
+  /**
+   * 检查日志文件是否存在
+   */
+  private checkLogFile(): void {
+    const logFilePath = this.getLogFilePath();
+    if (!fs.existsSync(logFilePath)) {
+      throw new Error("工具调用日志文件不存在");
+    }
+  }
+
+  /**
+   * 读取并解析工具调用日志
+   */
+  private parseLogFile(): ToolCallRecord[] {
+    const logFilePath = this.getLogFilePath();
+
+    try {
+      const content = fs.readFileSync(logFilePath, "utf8");
+      const lines = content
+        .trim()
+        .split("\n")
+        .filter((line) => line.trim() !== "");
+
+      const records: ToolCallRecord[] = [];
+
+      for (const line of lines) {
+        try {
+          const record = JSON.parse(line);
+          // 添加时间戳字段（如果 pino 添加了时间信息）
+          if (record.time) {
+            record.timestamp = new Date(record.time).getTime();
+          }
+          // 如果没有时间戳，记录警告信息提示数据质量问题
+          if (!record.timestamp) {
+            logger.warn("日志记录缺少时间戳", { line });
+          }
+          records.push(record);
+        } catch {
+          logger.warn("跳过无效的日志行", { line });
+        }
+      }
+
+      // 按时间戳倒序排列（最新的在前）
+      records.sort((a, b) => (b.timestamp || 0) - (a.timestamp || 0));
+
+      return records;
+    } catch (error) {
+      logger.error("读取日志文件失败", { error });
+      throw new Error("无法读取工具调用日志文件");
+    }
+  }
+
+  /**
+   * 过滤工具调用记录
+   */
+  private filterRecords(
+    records: ToolCallRecord[],
+    query: ToolCallQuery
+  ): ToolCallRecord[] {
+    let filtered = [...records];
+
+    // 按工具名称过滤
+    if (query.toolName) {
+      filtered = filtered.filter((record) =>
+        record.toolName
+          .toLowerCase()
+          .includes(query.toolName?.toLowerCase() ?? "")
+      );
+    }
+
+    // 按服务器名称过滤
+    if (query.serverName) {
+      filtered = filtered.filter((record) =>
+        record.serverName
+          ?.toLowerCase()
+          .includes(query.serverName?.toLowerCase() ?? "")
+      );
+    }
+
+    // 按成功状态过滤
+    if (query.success !== undefined) {
+      filtered = filtered.filter((record) => record.success === query.success);
+    }
+
+    // 按时间范围过滤
+    if (query.startDate || query.endDate) {
+      const startTime = query.startDate
+        ? new Date(query.startDate).getTime()
+        : 0;
+      const endTime = query.endDate
+        ? new Date(query.endDate).getTime()
+        : Date.now();
+
+      filtered = filtered.filter((record) => {
+        const recordTime = record.timestamp || 0;
+        return recordTime >= startTime && recordTime <= endTime;
+      });
+    }
+
+    return filtered;
+  }
+
+  /**
+   * 获取工具调用日志
+   */
+  async getToolCallLogs(query: ToolCallQuery = {}): Promise<{
+    records: ToolCallRecord[];
+    total: number;
+    hasMore: boolean;
+  }> {
+    this.checkLogFile();
+
+    const records = this.parseLogFile();
+    const filtered = this.filterRecords(records, query);
+    const total = filtered.length;
+
+    // 分页处理
+    const limit = Math.min(
+      query.limit || 50,
+      1000 // 最大限制 1000
+    );
+    const offset = query.offset || 0;
+    const paginated = filtered.slice(offset, offset + limit);
+    const hasMore = offset + limit < total;
+
+    logger.info("返回工具调用日志", {
+      count: paginated.length,
+      total,
+    });
+
+    return {
+      records: paginated,
+      total,
+      hasMore,
+    };
+  }
+}

--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -1,0 +1,1835 @@
+/**
+ * MCP 服务管理器
+ * 使用 MCPService 实例管理多个 MCP 服务
+ * 专注于实例管理、工具聚合和路由调用
+ */
+
+import { EventEmitter } from "node:events";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import { isModelScopeURL } from "../../../config/index.js";
+import type { MCPToolConfig } from "../../../config/index.js";
+import { configManager } from "../../../config/index.js";
+import { logger } from "../../Logger.js";
+import { MCPService } from "../../lib/mcp";
+import { MCPCacheManager } from "../../lib/mcp";
+import { ConnectionState } from "../../lib/mcp/types";
+import type {
+  CustomMCPTool,
+  EnhancedToolInfo,
+  InternalMCPServiceConfig,
+  MCPServiceConfig,
+  ManagerStatus,
+  ToolCallResult,
+  ToolInfo,
+  ToolStatusFilter,
+  UnifiedServerConfig,
+  UnifiedServerStatus,
+} from "../../lib/mcp/types";
+import { getEventBus } from "../../services/event-bus.service.js";
+import type { MCPMessage } from "../../types/mcp.js";
+import { CustomMCPHandler } from "./custom.js";
+import { ToolCallLogger } from "./log.js";
+import { MCPMessageHandler } from "./message.js";
+export class MCPServiceManager extends EventEmitter {
+  private services: Map<string, MCPService> = new Map();
+  private configs: Record<string, MCPServiceConfig> = {};
+  private tools: Map<string, ToolInfo> = new Map(); // 缓存工具信息，保持向后兼容
+  private customMCPHandler: CustomMCPHandler; // CustomMCP 工具处理器
+  private cacheManager: MCPCacheManager; // 缓存管理器
+  private eventBus = getEventBus(); // 事件总线
+  private toolCallLogger: ToolCallLogger; // 工具调用记录器
+  private retryTimers: Map<string, NodeJS.Timeout> = new Map(); // 重试定时器
+  private failedServices: Set<string> = new Set(); // 失败的服务集合
+
+  private messageHandler: MCPMessageHandler;
+
+  // 事件监听器引用（用于清理）
+  private eventListeners: {
+    serviceConnected: (data: {
+      serviceName: string;
+      tools: Tool[];
+      connectionTime: Date;
+    }) => void;
+    serviceDisconnected: (data: {
+      serviceName: string;
+      reason?: string;
+      disconnectionTime: Date;
+    }) => void;
+    serviceConnectionFailed: (data: {
+      serviceName: string;
+      error: Error;
+      attempt: number;
+    }) => void;
+  };
+
+  // 新增：服务器状态管理（从 UnifiedMCPServer 移入）
+  private isRunning = false;
+  private config: UnifiedServerConfig;
+
+  /**
+   * 创建 MCPServiceManager 实例
+   * @param configs 可选的初始服务配置或服务器配置
+   */
+  constructor(
+    configs?: Record<string, MCPServiceConfig> | UnifiedServerConfig
+  ) {
+    super();
+
+    // 处理参数，支持 UnifiedServerConfig 格式
+    if (configs && this.isUnifiedServerConfig(configs)) {
+      // UnifiedServerConfig 格式
+      this.config = {
+        name: "MCPServiceManager",
+        enableLogging: true,
+        logLevel: "info",
+        ...configs,
+      };
+      this.configs = configs.configs || {};
+    } else {
+      // 原有的 configs 格式
+      this.config = {
+        name: "MCPServiceManager",
+        enableLogging: true,
+        logLevel: "info",
+      };
+      this.configs = configs || {};
+    }
+
+    // 在测试环境中使用临时目录，避免在项目根目录创建缓存文件
+    const isTestEnv =
+      process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+    const cachePath = isTestEnv
+      ? `/tmp/xiaozhi-test-${Date.now()}-${Math.random()
+          .toString(36)
+          .substring(2, 11)}/xiaozhi.cache.json`
+      : undefined;
+
+    this.cacheManager = new MCPCacheManager(cachePath);
+    this.customMCPHandler = new CustomMCPHandler(this.cacheManager, this);
+
+    // 初始化工具调用记录器
+    const toolCallLogConfig = configManager.getToolCallLogConfig();
+    const configDir = configManager.getConfigDir();
+    this.toolCallLogger = new ToolCallLogger(toolCallLogConfig, configDir);
+
+    // 初始化事件监听器引用
+    this.eventListeners = {
+      serviceConnected: async (data) => {
+        await this.handleServiceConnected(data);
+      },
+      serviceDisconnected: async (data) => {
+        await this.handleServiceDisconnected(data);
+      },
+      serviceConnectionFailed: async (data) => {
+        await this.handleServiceConnectionFailed(data);
+      },
+    };
+
+    // 设置事件监听器
+    this.setupEventListeners();
+
+    // 初始化消息处理器（确保在其他组件初始化完成后）
+    this.messageHandler = new MCPMessageHandler(this);
+  }
+
+  /**
+   * 设置事件监听器
+   */
+  private setupEventListeners(): void {
+    // 监听MCP服务连接成功事件
+    this.eventBus.onEvent(
+      "mcp:service:connected",
+      this.eventListeners.serviceConnected
+    );
+
+    // 监听MCP服务断开连接事件
+    this.eventBus.onEvent(
+      "mcp:service:disconnected",
+      this.eventListeners.serviceDisconnected
+    );
+
+    // 监听MCP服务连接失败事件
+    this.eventBus.onEvent(
+      "mcp:service:connection:failed",
+      this.eventListeners.serviceConnectionFailed
+    );
+  }
+
+  /**
+   * 处理MCP服务连接成功事件
+   */
+  private async handleServiceConnected(data: {
+    serviceName: string;
+    tools: Tool[];
+    connectionTime: Date;
+  }): Promise<void> {
+    logger.debug(`服务 ${data.serviceName} 连接成功，开始刷新工具缓存`);
+
+    try {
+      // 获取最新的工具列表
+      const service = this.services.get(data.serviceName);
+      if (service) {
+        // 重新初始化CustomMCPHandler
+        await this.refreshCustomMCPHandlerPublic();
+
+        logger.info(`服务 ${data.serviceName} 工具缓存刷新完成`);
+      }
+    } catch (error) {
+      logger.error(`刷新服务 ${data.serviceName} 工具缓存失败`, { error });
+    }
+  }
+
+  /**
+   * 处理MCP服务断开连接事件
+   */
+  private async handleServiceDisconnected(data: {
+    serviceName: string;
+    reason?: string;
+    disconnectionTime: Date;
+  }): Promise<void> {
+    logger.info(
+      `服务 ${data.serviceName} 断开连接，原因: ${data.reason || "未知"}`
+    );
+
+    try {
+      // 更新工具缓存
+      await this.refreshToolsCache();
+
+      // 重新初始化CustomMCPHandler
+      await this.refreshCustomMCPHandlerPublic();
+
+      logger.info(`服务 ${data.serviceName} 断开连接处理完成`);
+    } catch (error) {
+      logger.error(`服务 ${data.serviceName} 断开连接处理失败`, { error });
+    }
+  }
+
+  /**
+   * 处理MCP服务连接失败事件
+   */
+  private async handleServiceConnectionFailed(data: {
+    serviceName: string;
+    error: Error;
+    attempt: number;
+  }): Promise<void> {
+    try {
+      await this.refreshCustomMCPHandlerPublic();
+    } catch (error) {
+      logger.error("刷新CustomMCPHandler失败", { error });
+    }
+  }
+
+  /**
+   * 启动所有 MCP 服务
+   */
+  async startAllServices(): Promise<void> {
+    logger.debug("[MCPManager] 正在启动所有 MCP 服务...");
+
+    // 初始化 CustomMCP 处理器
+    try {
+      this.customMCPHandler.initialize();
+      logger.debug("[MCPManager] CustomMCP 处理器初始化完成");
+    } catch (error) {
+      logger.error("[MCPManager] CustomMCP 处理器初始化失败", { error });
+      // CustomMCP 初始化失败不应该阻止标准 MCP 服务启动
+    }
+
+    const configEntries = Object.entries(this.configs);
+    if (configEntries.length === 0) {
+      logger.warn(
+        "[MCPManager] 没有配置任何 MCP 服务，请使用 addServiceConfig() 添加服务配置"
+      );
+      // 即使没有标准 MCP 服务，也可能有 CustomMCP 工具
+      return;
+    }
+
+    // 记录启动开始
+    logger.info(
+      `[MCPManager] 开始并行启动 ${configEntries.length} 个 MCP 服务`
+    );
+
+    // 并行启动所有服务，实现服务隔离
+    const startPromises = configEntries.map(async ([serviceName]) => {
+      try {
+        await this.startService(serviceName);
+        return { serviceName, success: true, error: null };
+      } catch (error) {
+        return {
+          serviceName,
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    });
+
+    // 等待所有服务启动完成
+    const results = await Promise.allSettled(startPromises);
+
+    // 统计启动结果
+    let successCount = 0;
+    let failureCount = 0;
+    const failedServices: string[] = [];
+
+    for (const result of results) {
+      if (result.status === "fulfilled") {
+        if (result.value.success) {
+          successCount++;
+        } else {
+          failureCount++;
+          failedServices.push(result.value.serviceName);
+        }
+      } else {
+        failureCount++;
+      }
+    }
+
+    // 记录启动完成统计
+    logger.info(
+      `[MCPManager] 服务启动完成 - 成功: ${successCount}, 失败: ${failureCount}`
+    );
+
+    // 记录失败的服务列表
+    if (failedServices.length > 0) {
+      logger.warn(
+        `[MCPManager] 以下服务启动失败: ${failedServices.join(", ")}`
+      );
+
+      // 如果所有服务都失败了，发出警告但系统继续运行以便重试
+      if (failureCount === configEntries.length) {
+        logger.warn(
+          "[MCPManager] 所有 MCP 服务启动失败，但系统将继续运行以便重试"
+        );
+      }
+    }
+
+    // 启动失败服务重试机制
+    if (failedServices.length > 0) {
+      this.scheduleFailedServicesRetry(failedServices);
+    }
+  }
+
+  /**
+   * 启动单个 MCP 服务
+   */
+  async startService(serviceName: string): Promise<void> {
+    const config = this.configs[serviceName];
+    if (!config) {
+      throw new Error(`未找到服务配置: ${serviceName}`);
+    }
+
+    try {
+      // 如果服务已存在，先停止它
+      if (this.services.has(serviceName)) {
+        await this.stopService(serviceName);
+      }
+
+      // 创建 MCPService 实例（使用 InternalMCPServiceConfig）
+      const serviceConfig: InternalMCPServiceConfig = {
+        name: serviceName,
+        ...config,
+      };
+      const service = new MCPService(serviceConfig);
+
+      // 连接到服务
+      await service.connect();
+
+      // 存储服务实例
+      this.services.set(serviceName, service);
+
+      // 更新工具缓存
+      await this.refreshToolsCache();
+
+      // 注意：工具缓存刷新现在通过事件监听器自动处理，不需要在这里手动调用
+      // MCPService.connect() 成功后会发射 mcp:service:connected 事件
+      // 事件监听器会自动触发工具缓存刷新和CustomMCPHandler刷新
+
+      const tools = service.getTools();
+      logger.debug(
+        `[MCPManager] ${serviceName} 服务启动成功，加载了 ${tools.length} 个工具:`,
+        tools.map((t) => t.name).join(", ")
+      );
+    } catch (error) {
+      logger.error(`[MCPManager] 启动 ${serviceName} 服务失败`, {
+        error: (error as Error).message,
+      });
+      // 清理可能的部分状态
+      this.services.delete(serviceName);
+      throw error;
+    }
+  }
+
+  /**
+   * 停止单个服务
+   */
+  async stopService(serviceName: string): Promise<void> {
+    logger.info(`[MCPManager] 停止 MCP 服务: ${serviceName}`);
+
+    const service = this.services.get(serviceName);
+    if (!service) {
+      logger.warn(`[MCPManager] 服务 ${serviceName} 不存在或未启动`);
+      return;
+    }
+
+    try {
+      await service.disconnect();
+      this.services.delete(serviceName);
+
+      // 更新工具缓存
+      await this.refreshToolsCache();
+
+      logger.info(`[MCPManager] ${serviceName} 服务已停止`);
+    } catch (error) {
+      logger.error(`[MCPManager] 停止 ${serviceName} 服务失败`, {
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 刷新工具缓存
+   */
+  private async refreshToolsCache(): Promise<void> {
+    this.tools.clear();
+
+    for (const [serviceName, service] of this.services) {
+      if (service.isConnected()) {
+        const tools = service.getTools();
+        const config = this.configs[serviceName];
+
+        // 异步写入缓存（不阻塞主流程）
+        if (config) {
+          this.cacheManager
+            .writeCacheEntry(serviceName, tools, config)
+            .then(() => {
+              logger.debug(`[MCPManager] 已将 ${serviceName} 工具列表写入缓存`);
+            })
+            .catch((error) => {
+              logger.warn(
+                `[MCPManager] 写入缓存失败: ${serviceName}, 错误: ${
+                  error instanceof Error ? error.message : String(error)
+                }`
+              );
+            });
+        }
+
+        // 原有逻辑保持不变
+        for (const tool of tools) {
+          const toolKey = `${serviceName}__${tool.name}`;
+          this.tools.set(toolKey, {
+            serviceName,
+            originalName: tool.name,
+            tool,
+          });
+        }
+      }
+    }
+
+    // 同步工具配置到配置文件
+    await this.syncToolsConfigToFile();
+  }
+
+  /**
+   * 获取所有可用工具
+   * @param status 工具状态过滤：'enabled' 仅返回已启用工具，'disabled' 仅返回未启用工具，'all' 返回所有工具
+   * @returns 工具数组，包含工具的启用状态信息
+   */
+  getAllTools(status: ToolStatusFilter = "all"): EnhancedToolInfo[] {
+    const allTools: EnhancedToolInfo[] = [];
+
+    // 1. 收集所有已连接服务的工具（包含启用状态过滤）
+    for (const [serviceName, service] of this.services) {
+      try {
+        if (service.isConnected()) {
+          const serviceTools = service.getTools();
+          for (const tool of serviceTools) {
+            try {
+              // 检查工具启用状态 - 这个调用可能会抛出异常
+              const isEnabled = configManager.isToolEnabled(
+                serviceName,
+                tool.name
+              );
+              const toolConfig =
+                configManager.getMcpServerConfig()[serviceName].tools[
+                  tool.name
+                ];
+
+              // 根据 status 参数过滤工具
+              if (status === "enabled" && !isEnabled) {
+                continue; // 跳过未启用的工具
+              }
+              if (status === "disabled" && isEnabled) {
+                continue; // 跳过已启用的工具
+              }
+
+              const toolKey = `${serviceName}__${tool.name}`;
+              allTools.push({
+                name: toolKey,
+                description: tool.description || "",
+                inputSchema: tool.inputSchema,
+                serviceName,
+                originalName: tool.name,
+                enabled: isEnabled,
+                usageCount: toolConfig.usageCount ?? 0,
+                lastUsedTime: toolConfig.lastUsedTime ?? "",
+              });
+            } catch (toolError) {
+              logger.warn(
+                `[MCPManager] 检查工具 ${serviceName}.${tool.name} 启用状态失败，跳过该工具`,
+                { error: toolError }
+              );
+            }
+          }
+        }
+      } catch (serviceError) {
+        logger.warn(
+          `[MCPManager] 获取服务 ${serviceName} 的工具失败，跳过该服务`,
+          { error: serviceError }
+        );
+      }
+    }
+
+    // 2. 添加CustomMCP工具（默认视为已启用）
+    let customTools: Tool[] = [];
+    try {
+      customTools = this.customMCPHandler.getTools();
+      logger.debug(
+        `[MCPManager] 成功获取 ${customTools.length} 个 customMCP 工具`
+      );
+    } catch (error) {
+      logger.warn(
+        "[MCPManager] 获取 CustomMCP 工具失败，将只返回标准 MCP 工具",
+        { error }
+      );
+      // 根据技术方案要求，CustomMCP 工具获取失败时不应该影响标准 MCP 工具的返回
+      customTools = [];
+    }
+
+    // CustomMCP 工具默认视为已启用
+    if (status !== "disabled") {
+      for (const tool of customTools) {
+        try {
+          allTools.push({
+            name: tool.name,
+            description: tool.description || "",
+            inputSchema: tool.inputSchema,
+            serviceName: this.getServiceNameForTool(tool),
+            originalName: tool.name,
+            enabled: true, // CustomMCP 工具默认启用
+            usageCount: 0,
+            lastUsedTime: "",
+          });
+        } catch (toolError) {
+          logger.warn(
+            `[MCPManager] 处理 CustomMCP 工具 ${tool.name} 失败，跳过该工具`,
+            { error: toolError }
+          );
+        }
+      }
+    }
+
+    logger.debug(
+      `[MCPManager] 成功获取 ${allTools.length} 个可用工具（status=${status}）`
+    );
+    return allTools;
+  }
+
+  /**
+   * 根据工具配置确定服务名称
+   * @param tool 工具对象
+   * @returns 服务名称
+   */
+  private getServiceNameForTool(tool: CustomMCPTool): string {
+    if (tool.handler?.type === "mcp") {
+      // 如果是从 MCP 同步的工具，返回原始服务名称
+      const config = tool.handler.config as
+        | { serviceName?: string; toolName?: string }
+        | undefined;
+      return config?.serviceName || "customMCP";
+    }
+    return "customMCP";
+  }
+
+  /**
+   * 根据工具信息获取日志记录用的服务名称
+   * @param customTool CustomMCP 工具信息
+   * @returns 用于日志记录的服务名称
+   */
+  private getLogServerName(customTool: CustomMCPTool): string {
+    if (!customTool?.handler) {
+      return "custom";
+    }
+
+    switch (customTool.handler.type) {
+      case "mcp": {
+        const config = customTool.handler.config as
+          | { serviceName?: string; toolName?: string }
+          | undefined;
+        return config?.serviceName || "customMCP";
+      }
+      case "coze":
+        return "coze";
+      case "dify":
+        return "dify";
+      case "n8n":
+        return "n8n";
+      default:
+        return "custom";
+    }
+  }
+
+  /**
+   * 根据工具信息获取原始工具名称
+   * @param toolName 格式化后的工具名称
+   * @param customTool CustomMCP 工具信息
+   * @param toolInfo 标准工具信息
+   * @returns 原始工具名称
+   */
+  private getOriginalToolName(
+    toolName: string,
+    customTool: CustomMCPTool | undefined,
+    toolInfo?: ToolInfo
+  ): string {
+    if (customTool) {
+      // CustomMCP 工具
+      if (customTool.handler?.type === "mcp") {
+        const config = customTool.handler.config as
+          | { serviceName?: string; toolName?: string }
+          | undefined;
+        return config?.toolName || toolName;
+      }
+      return toolName;
+    }
+
+    // 标准 MCP 工具
+    return toolInfo?.originalName || toolName;
+  }
+
+  /**
+   * 调用 MCP 工具（支持标准 MCP 工具和 customMCP 工具）
+   */
+  async callTool(
+    toolName: string,
+    arguments_: Record<string, unknown>,
+    options?: { timeout?: number }
+  ): Promise<ToolCallResult> {
+    const startTime = Date.now();
+
+    // 初始化日志信息
+    let logServerName = "unknown";
+    let originalToolName: string = toolName;
+
+    try {
+      let result: ToolCallResult;
+
+      // 检查是否是 customMCP 工具
+      if (this.customMCPHandler.hasTool(toolName)) {
+        const customTool = this.customMCPHandler.getToolInfo(toolName);
+
+        // 设置日志信息（添加空值检查）
+        if (customTool) {
+          logServerName = this.getLogServerName(customTool);
+          originalToolName = this.getOriginalToolName(toolName, customTool);
+        }
+
+        if (customTool?.handler?.type === "mcp") {
+          // 对于 mcp 类型的工具，直接路由到对应的 MCP 服务
+          result = await this.callMCPTool(
+            toolName,
+            customTool.handler.config,
+            arguments_
+          );
+
+          // 异步更新工具调用统计（成功调用）
+          this.updateToolStatsSafe(
+            toolName,
+            customTool.handler.config.serviceName,
+            customTool.handler.config.toolName,
+            true
+          );
+        } else {
+          // 其他类型的 customMCP 工具正常处理，传递options参数
+          result = await this.customMCPHandler.callTool(
+            toolName,
+            arguments_,
+            options
+          );
+          logger.info(`[MCPManager] CustomMCP 工具 ${toolName} 调用成功`);
+
+          // 异步更新工具调用统计（成功调用）
+          this.updateToolStatsSafe(toolName, "customMCP", toolName, true);
+        }
+      } else {
+        // 如果不是 customMCP 工具，则查找标准 MCP 工具
+        const toolInfo = this.tools.get(toolName);
+        if (!toolInfo) {
+          throw new Error(`未找到工具: ${toolName}`);
+        }
+
+        // 设置日志信息
+        logServerName = toolInfo.serviceName;
+        originalToolName = toolInfo.originalName;
+
+        const service = this.services.get(toolInfo.serviceName);
+        if (!service) {
+          throw new Error(`服务 ${toolInfo.serviceName} 不可用`);
+        }
+
+        if (!service.isConnected()) {
+          throw new Error(`服务 ${toolInfo.serviceName} 未连接`);
+        }
+
+        result = (await service.callTool(
+          toolInfo.originalName,
+          arguments_ || {}
+        )) as ToolCallResult;
+
+        logger.debug("[MCPManager] 工具调用成功", {
+          toolName: toolName,
+          result: result,
+        });
+
+        // 异步更新工具调用统计（成功调用）
+        this.updateToolStatsSafe(
+          toolName,
+          toolInfo.serviceName,
+          toolInfo.originalName,
+          true
+        );
+      }
+
+      // 记录成功的工具调用
+      this.toolCallLogger.recordToolCall({
+        toolName: originalToolName,
+        serverName: logServerName,
+        arguments: arguments_,
+        result: result,
+        success: result.isError !== true,
+        duration: Date.now() - startTime,
+      });
+
+      return result as ToolCallResult;
+    } catch (error) {
+      // 记录失败的工具调用
+      this.toolCallLogger.recordToolCall({
+        toolName: originalToolName,
+        serverName: logServerName,
+        arguments: arguments_,
+        result: null,
+        success: false,
+        duration: Date.now() - startTime,
+        error: error instanceof Error ? error.message : String(error),
+      });
+
+      // 更新失败统计
+      if (this.customMCPHandler.hasTool(toolName)) {
+        const customTool = this.customMCPHandler.getToolInfo(toolName);
+        if (customTool?.handler?.type === "mcp") {
+          this.updateToolStatsSafe(
+            toolName,
+            customTool.handler.config.serviceName,
+            customTool.handler.config.toolName,
+            false
+          );
+        } else {
+          this.updateToolStatsSafe(toolName, "customMCP", toolName, false);
+          logger.error(`[MCPManager] CustomMCP 工具 ${toolName} 调用失败`, {
+            error: (error as Error).message,
+          });
+        }
+      } else {
+        const toolInfo = this.tools.get(toolName);
+        if (toolInfo) {
+          this.updateToolStatsSafe(
+            toolName,
+            toolInfo.serviceName,
+            toolInfo.originalName,
+            false
+          );
+          logger.error(`[MCPManager] 工具 ${toolName} 调用失败`, {
+            error: (error as Error).message,
+          });
+        }
+      }
+
+      throw error;
+    }
+  }
+
+  /**
+   * 更新工具调用统计信息的通用方法
+   * @param toolName 工具名称
+   * @param serviceName 服务名称
+   * @param originalToolName 原始工具名称
+   * @param isSuccess 是否调用成功
+   * @private
+   */
+  private async updateToolStats(
+    toolName: string,
+    serviceName: string,
+    originalToolName: string,
+    isSuccess: boolean
+  ): Promise<void> {
+    try {
+      const currentTime = new Date().toISOString();
+
+      if (isSuccess) {
+        // 成功调用：更新使用统计
+        await this.updateCustomMCPToolStats(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolStats(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug(`[MCPManager] 已更新工具 ${toolName} 的统计信息`);
+      } else {
+        // 失败调用：只更新最后使用时间
+        await this.updateCustomMCPToolLastUsedTime(toolName, currentTime);
+
+        // 如果是 MCP 服务工具，同时更新 mcpServerConfig 配置（双写机制）
+        if (serviceName !== "customMCP") {
+          await this.updateMCPServerToolLastUsedTime(
+            serviceName,
+            originalToolName,
+            currentTime
+          );
+        }
+
+        logger.debug("[MCPManager] 已更新工具的失败调用统计信息", {
+          toolName,
+        });
+      }
+    } catch (error) {
+      logger.error("[MCPManager] 更新工具统计信息失败", { toolName, error });
+      throw error;
+    }
+  }
+
+  /**
+   * 统一的统计更新处理方法（带错误处理）
+   * @param toolName 工具名称
+   * @param serviceName 服务名称
+   * @param originalToolName 原始工具名称
+   * @param isSuccess 是否调用成功
+   * @private
+   */
+  private async updateToolStatsSafe(
+    toolName: string,
+    serviceName: string,
+    originalToolName: string,
+    isSuccess: boolean
+  ): Promise<void> {
+    try {
+      await this.updateToolStats(
+        toolName,
+        serviceName,
+        originalToolName,
+        isSuccess
+      );
+    } catch (error) {
+      const action = isSuccess ? "统计信息" : "失败统计信息";
+      logger.warn("[MCPManager] 更新工具统计信息失败", {
+        toolName,
+        action,
+        error,
+      });
+      // 统计更新失败不应该影响主流程，所以这里只记录警告
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具统计信息
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateCustomMCPToolStats(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, true);
+      logger.debug(`[MCPManager] 已更新 customMCP 工具 ${toolName} 使用统计`);
+    } catch (error) {
+      logger.error(`[MCPManager] 更新 customMCP 工具 ${toolName} 统计失败`, {
+        error,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 customMCP 工具最后使用时间
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateCustomMCPToolLastUsedTime(
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateToolUsageStatsWithLock(toolName, false); // 只更新时间，不增加计数
+      logger.debug(
+        `[MCPManager] 已更新 customMCP 工具 ${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[MCPManager] 更新 customMCP 工具 ${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具统计信息
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateMCPServerToolStats(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        true
+      );
+      logger.debug(
+        `[MCPManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 统计`
+      );
+    } catch (error) {
+      logger.error(
+        `[MCPManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 统计失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 更新 MCP 服务工具最后使用时间
+   * @param serviceName 服务名称
+   * @param toolName 工具名称
+   * @param currentTime 当前时间
+   * @private
+   */
+  private async updateMCPServerToolLastUsedTime(
+    serviceName: string,
+    toolName: string,
+    currentTime: string
+  ): Promise<void> {
+    try {
+      await configManager.updateMCPServerToolStatsWithLock(
+        serviceName,
+        toolName,
+        currentTime,
+        false
+      ); // 只更新时间，不增加计数
+      logger.debug(
+        `[MCPManager] 已更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间`
+      );
+    } catch (error) {
+      logger.error(
+        `[MCPManager] 更新 MCP 服务工具 ${serviceName}/${toolName} 最后使用时间失败`,
+        { error }
+      );
+      throw error;
+    }
+  }
+
+  /**
+   * 调用 MCP 工具（用于从 mcpServerConfig 同步的工具）
+   * @param toolName 工具名称
+   * @param config MCP handler 配置
+   * @param arguments_ 工具参数
+   */
+  private async callMCPTool(
+    toolName: string,
+    config: { serviceName: string; toolName: string },
+    arguments_: Record<string, unknown>
+  ): Promise<ToolCallResult> {
+    const { serviceName, toolName: originalToolName } = config;
+
+    logger.debug(
+      `[MCPManager] 调用 MCP 同步工具 ${toolName} -> ${serviceName}.${originalToolName}`
+    );
+
+    const service = this.services.get(serviceName);
+    if (!service) {
+      throw new Error(`服务 ${serviceName} 不可用`);
+    }
+
+    if (!service.isConnected()) {
+      throw new Error(`服务 ${serviceName} 未连接`);
+    }
+
+    try {
+      const result = await service.callTool(originalToolName, arguments_ || {});
+      logger.debug(`[MCPManager] MCP 同步工具 ${toolName} 调用成功`);
+      return result as ToolCallResult;
+    } catch (error) {
+      logger.error(`[MCPManager] MCP 同步工具 ${toolName} 调用失败`, {
+        error: (error as Error).message,
+      });
+      throw error;
+    }
+  }
+
+  /**
+   * 检查是否存在指定工具（包括标准 MCP 工具和 customMCP 工具）
+   */
+  hasTool(toolName: string): boolean {
+    // 检查是否是 customMCP 工具
+    if (this.customMCPHandler.hasTool(toolName)) {
+      return true;
+    }
+
+    // 检查是否是标准 MCP 工具
+    return this.tools.has(toolName);
+  }
+
+  /**
+   * 停止所有服务
+   */
+  async stopAllServices(): Promise<void> {
+    logger.info("[MCPManager] 正在停止所有 MCP 服务...");
+
+    // 停止所有服务重试
+    this.stopAllServiceRetries();
+
+    // 停止所有服务实例
+    for (const [serviceName, service] of this.services) {
+      try {
+        await service.disconnect();
+        logger.info(`[MCPManager] ${serviceName} 服务已停止`);
+      } catch (error) {
+        logger.error(`[MCPManager] 停止 ${serviceName} 服务失败`, {
+          error: (error as Error).message,
+        });
+      }
+    }
+
+    // 清理 CustomMCP 处理器
+    try {
+      this.customMCPHandler.cleanup();
+      logger.info("[MCPManager] CustomMCP 处理器已清理");
+    } catch (error) {
+      logger.error("[MCPManager] CustomMCP 处理器清理失败", { error });
+    }
+
+    // 清理统计更新锁
+    try {
+      configManager.clearAllStatsUpdateLocks();
+      logger.info("[MCPManager] 统计更新锁已清理");
+    } catch (error) {
+      logger.error("[MCPManager] 清理统计更新锁失败", { error });
+    }
+
+    this.services.clear();
+    this.tools.clear();
+
+    logger.info("[MCPManager] 所有 MCP 服务已停止");
+  }
+
+  /**
+   * 获取服务器状态（兼容 UnifiedServerStatus 格式）
+   */
+  getStatus(): UnifiedServerStatus {
+    return this.getUnifiedStatus();
+  }
+
+  /**
+   * 获取统计更新监控信息
+   */
+  getStatsUpdateInfo(): {
+    activeLocks: string[];
+    totalLocks: number;
+  } {
+    try {
+      const activeLocks = configManager.getStatsUpdateLocks();
+      return {
+        activeLocks,
+        totalLocks: activeLocks.length,
+      };
+    } catch (error) {
+      logger.warn("[MCPManager] 获取统计更新监控信息失败", { error });
+      return {
+        activeLocks: [],
+        totalLocks: 0,
+      };
+    }
+  }
+
+  /**
+   * 获取指定服务实例
+   */
+  getService(name: string): MCPService | undefined {
+    return this.services.get(name);
+  }
+
+  /**
+   * 获取所有已连接的服务名称
+   */
+  getConnectedServices(): string[] {
+    const connectedServices: string[] = [];
+    for (const [serviceName, service] of this.services) {
+      if (service.isConnected()) {
+        connectedServices.push(serviceName);
+      }
+    }
+    return connectedServices;
+  }
+
+  /**
+   * 刷新CustomMCPHandler的私有方法
+   */
+  private async refreshCustomMCPHandler(): Promise<void> {
+    try {
+      logger.debug("重新初始化CustomMCPHandler");
+      this.customMCPHandler.initialize();
+      logger.debug("CustomMCPHandler重新初始化完成");
+    } catch (error) {
+      logger.error("CustomMCPHandler重新初始化失败", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 公开的CustomMCPHandler刷新方法，供外部调用
+   */
+  async refreshCustomMCPHandlerPublic(): Promise<void> {
+    return this.refreshCustomMCPHandler();
+  }
+
+  /**
+   * 获取所有服务实例
+   */
+  getAllServices(): Map<string, MCPService> {
+    return new Map(this.services);
+  }
+
+  /**
+   * 获取 CustomMCP 处理器实例
+   */
+  getCustomMCPHandler(): CustomMCPHandler {
+    return this.customMCPHandler;
+  }
+
+  /**
+   * 检查指定的 customMCP 工具是否存在
+   * @param toolName 工具名称
+   * @returns 如果工具存在返回 true，否则返回 false
+   */
+  hasCustomMCPTool(toolName: string): boolean {
+    try {
+      return this.customMCPHandler.hasTool(toolName);
+    } catch (error) {
+      logger.warn(`[MCPManager] 检查 CustomMCP 工具 ${toolName} 是否存在失败`, {
+        error,
+      });
+      // 异常情况下返回 false，表示工具不存在
+      return false;
+    }
+  }
+
+  /**
+   * 获取所有 customMCP 工具列表
+   * @returns customMCP 工具数组
+   */
+  getCustomMCPTools(): Tool[] {
+    try {
+      return this.customMCPHandler.getTools();
+    } catch (error) {
+      logger.warn("[MCPManager] 获取 CustomMCP 工具列表失败，返回空数组", {
+        error,
+      });
+      // 异常情况下返回空数组，避免影响调用方
+      return [];
+    }
+  }
+
+  /**
+   * 检查是否为 ModelScope 服务
+   * 统一使用 ConfigAdapter 的 isModelScopeURL 函数
+   */
+  private isModelScopeService(config: MCPServiceConfig): boolean {
+    return config.url ? isModelScopeURL(config.url) : false;
+  }
+
+  /**
+   * 处理 ModelScope 服务认证
+   * 智能检查现有认证信息，按优先级处理
+   */
+  private handleModelScopeAuth(
+    serviceName: string,
+    originalConfig: MCPServiceConfig,
+    enhancedConfig: MCPServiceConfig
+  ): void {
+    // 1. 检查是否已有 Authorization header
+    const existingAuthHeader = originalConfig.headers?.Authorization;
+
+    if (existingAuthHeader) {
+      // 已有认证信息，直接使用
+      logger.info(
+        `[MCPManager] 服务 ${serviceName} 使用已有的 Authorization header`
+      );
+      return;
+    }
+
+    // 2. 检查全局 ModelScope API Key
+    const modelScopeApiKey = configManager.getModelScopeApiKey();
+
+    if (modelScopeApiKey) {
+      // 注入全局 API Key
+      enhancedConfig.apiKey = modelScopeApiKey;
+      logger.info(`[MCPManager] 为 ${serviceName} 服务添加 ModelScope API Key`);
+      return;
+    }
+
+    // 3. 无法获取认证信息，提供详细错误信息
+    const serviceUrl = originalConfig.url || "未知";
+
+    throw new Error(
+      `ModelScope 服务 "${serviceName}" 需要认证信息，但未找到有效的认证配置。服务 URL: ${serviceUrl}请选择以下任一方式配置认证：1. 在服务配置中添加 headers.Authorization2. 或者在全局配置中设置 modelscope.apiKey3. 或者设置环境变量 MODELSCOPE_API_TOKEN获取 ModelScope API Key: https://modelscope.cn/my?myInfo=true`
+    );
+  }
+
+  /**
+   * 增强服务配置
+   * 根据服务类型添加必要的全局配置，智能处理认证信息
+   */
+  private enhanceServiceConfig(
+    serviceName: string,
+    config: MCPServiceConfig
+  ): MCPServiceConfig {
+    const enhancedConfig = { ...config };
+
+    try {
+      // 处理 ModelScope 服务（智能认证检查）
+      if (this.isModelScopeService(config)) {
+        this.handleModelScopeAuth(serviceName, config, enhancedConfig);
+      }
+
+      return enhancedConfig;
+    } catch (error) {
+      logger.error(`[MCPManager] 配置增强失败: ${serviceName}`, { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 添加服务配置（重载方法以支持两种调用方式）
+   */
+  addServiceConfig(name: string, config: MCPServiceConfig): void;
+  addServiceConfig(config: InternalMCPServiceConfig): void;
+  addServiceConfig(
+    nameOrConfig: string | MCPServiceConfig | InternalMCPServiceConfig,
+    config?: MCPServiceConfig
+  ): void {
+    let finalConfig: MCPServiceConfig;
+    let serviceName: string;
+
+    if (typeof nameOrConfig === "string" && config) {
+      // 两参数版本
+      serviceName = nameOrConfig;
+      finalConfig = config;
+    } else if (typeof nameOrConfig === "object") {
+      // 单参数版本（使用 InternalMCPServiceConfig）
+      const internalConfig = nameOrConfig as InternalMCPServiceConfig;
+      serviceName = internalConfig.name;
+      finalConfig = internalConfig;
+    } else {
+      throw new Error("Invalid arguments for addServiceConfig");
+    }
+
+    // 增强配置
+    const enhancedConfig = this.enhanceServiceConfig(serviceName, finalConfig);
+
+    // 存储增强后的配置
+    this.configs[serviceName] = enhancedConfig;
+    logger.debug(`[MCPManager] 已添加服务配置: ${serviceName}`);
+  }
+
+  /**
+   * 更新服务配置
+   */
+  updateServiceConfig(name: string, config: MCPServiceConfig): void {
+    // 增强配置
+    const enhancedConfig = this.enhanceServiceConfig(name, config);
+
+    // 存储增强后的配置
+    this.configs[name] = enhancedConfig;
+    logger.debug(`[MCPManager] 已更新并增强服务配置: ${name}`);
+  }
+
+  /**
+   * 移除服务配置
+   */
+  removeServiceConfig(name: string): void {
+    delete this.configs[name];
+    logger.debug(`[MCPManager] 已移除服务配置: ${name}`);
+  }
+
+  /**
+   * 同步工具配置到配置文件
+   * 实现自动同步 MCP 服务工具配置到 xiaozhi.config.json
+   */
+  private async syncToolsConfigToFile(): Promise<void> {
+    try {
+      logger.debug("[MCPManager] 开始同步工具配置到配置文件");
+
+      // 获取当前配置文件中的 mcpServerConfig
+      const currentServerConfigs = configManager.getMcpServerConfig();
+
+      // 遍历所有已连接的服务
+      for (const [serviceName, service] of this.services) {
+        if (!service.isConnected()) {
+          continue;
+        }
+
+        const tools = service.getTools();
+        if (tools.length === 0) {
+          continue;
+        }
+
+        // 获取当前服务在配置文件中的工具配置
+        const currentToolsConfig =
+          currentServerConfigs[serviceName]?.tools || {};
+
+        // 构建新的工具配置
+        const newToolsConfig: Record<string, MCPToolConfig> = {};
+
+        for (const tool of tools) {
+          const currentToolConfig = currentToolsConfig[tool.name];
+
+          // 如果工具已存在，保留用户设置的 enable 状态，但更新描述
+          if (currentToolConfig) {
+            newToolsConfig[tool.name] = {
+              ...currentToolConfig,
+              description:
+                tool.description || currentToolConfig.description || "",
+            };
+          } else {
+            // 新工具，默认启用
+            newToolsConfig[tool.name] = {
+              description: tool.description || "",
+              enable: true,
+            };
+          }
+        }
+
+        // 检查是否有工具被移除（在配置文件中存在但在当前工具列表中不存在）
+        const currentToolNames = tools.map((t) => t.name);
+        const configToolNames = Object.keys(currentToolsConfig);
+        const removedTools = configToolNames.filter(
+          (name) => !currentToolNames.includes(name)
+        );
+
+        if (removedTools.length > 0) {
+          logger.info(
+            `[MCPManager] 检测到服务 ${serviceName} 移除了 ${
+              removedTools.length
+            } 个工具: ${removedTools.join(", ")}`
+          );
+        }
+
+        // 检查配置是否有变化
+        const hasChanges = this.hasToolsConfigChanged(
+          currentToolsConfig,
+          newToolsConfig
+        );
+
+        if (hasChanges) {
+          // 更新配置文件
+          configManager.updateServerToolsConfig(serviceName, newToolsConfig);
+
+          const addedTools = Object.keys(newToolsConfig).filter(
+            (name) => !currentToolsConfig[name]
+          );
+          const updatedTools = Object.keys(newToolsConfig).filter((name) => {
+            const current = currentToolsConfig[name];
+            const updated = newToolsConfig[name];
+            return current && current.description !== updated.description;
+          });
+
+          logger.debug(`[MCPManager] 已同步服务 ${serviceName} 的工具配置:`);
+          if (addedTools.length > 0) {
+            logger.debug(`  - 新增工具: ${addedTools.join(", ")}`);
+          }
+          if (updatedTools.length > 0) {
+            logger.debug(`  - 更新工具: ${updatedTools.join(", ")}`);
+          }
+          if (removedTools.length > 0) {
+            logger.debug(`  - 移除工具: ${removedTools.join(", ")}`);
+          }
+        }
+      }
+
+      logger.debug("[MCPManager] 工具配置同步完成");
+    } catch (error) {
+      logger.error("[MCPManager] 同步工具配置到配置文件失败", { error });
+      // 不抛出错误，避免影响服务正常运行
+    }
+  }
+
+  /**
+   * 检查工具配置是否有变化
+   */
+  private hasToolsConfigChanged(
+    currentConfig: Record<string, MCPToolConfig>,
+    newConfig: Record<string, MCPToolConfig>
+  ): boolean {
+    const currentKeys = Object.keys(currentConfig);
+    const newKeys = Object.keys(newConfig);
+
+    // 检查工具数量是否变化
+    if (currentKeys.length !== newKeys.length) {
+      return true;
+    }
+
+    // 检查是否有新增或删除的工具
+    const addedTools = newKeys.filter((key) => !currentKeys.includes(key));
+    const removedTools = currentKeys.filter((key) => !newKeys.includes(key));
+
+    if (addedTools.length > 0 || removedTools.length > 0) {
+      return true;
+    }
+
+    // 检查现有工具的描述是否有变化
+    for (const toolName of currentKeys) {
+      const currentTool = currentConfig[toolName];
+      const newTool = newConfig[toolName];
+
+      if (currentTool.description !== newTool.description) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  /**
+   * 安排失败服务的重试
+   * @param failedServices 失败的服务列表
+   */
+  private scheduleFailedServicesRetry(failedServices: string[]): void {
+    if (failedServices.length === 0) return;
+
+    // 记录重试安排
+    logger.info(`[MCPManager] 安排 ${failedServices.length} 个失败服务的重试`);
+
+    // 初始重试延迟：30秒
+    const initialDelay = 30000;
+
+    for (const serviceName of failedServices) {
+      this.failedServices.add(serviceName);
+      this.scheduleServiceRetry(serviceName, initialDelay);
+    }
+  }
+
+  /**
+   * 安排单个服务的重试
+   * @param serviceName 服务名称
+   * @param delay 延迟时间（毫秒）
+   */
+  private scheduleServiceRetry(serviceName: string, delay: number): void {
+    // 清除现有定时器
+    const existingTimer = this.retryTimers.get(serviceName);
+    if (existingTimer) {
+      clearTimeout(existingTimer);
+      this.retryTimers.delete(serviceName);
+    }
+
+    logger.debug(`[MCPManager] 安排服务 ${serviceName} 在 ${delay}ms 后重试`);
+
+    const timer = setTimeout(async () => {
+      this.retryTimers.delete(serviceName);
+      await this.retryFailedService(serviceName);
+    }, delay);
+
+    this.retryTimers.set(serviceName, timer);
+  }
+
+  /**
+   * 重试失败的服务
+   * @param serviceName 服务名称
+   */
+  private async retryFailedService(serviceName: string): Promise<void> {
+    if (!this.failedServices.has(serviceName)) {
+      return; // 服务已经成功启动或不再需要重试
+    }
+
+    try {
+      await this.startService(serviceName);
+
+      // 重试成功
+      this.failedServices.delete(serviceName);
+      logger.info(`[MCPManager] 服务 ${serviceName} 重试启动成功`);
+
+      // 重新初始化CustomMCPHandler以包含新启动的服务工具
+      try {
+        await this.refreshCustomMCPHandlerPublic();
+      } catch (error) {
+        logger.error("[MCPManager] 刷新CustomMCPHandler失败", { error });
+      }
+    } catch (error) {
+      logger.error(`[MCPManager] 服务 ${serviceName} 重试启动失败`, {
+        error: (error as Error).message,
+      });
+
+      // 指数退避重试策略：延迟时间翻倍，最大不超过5分钟
+      const currentDelay = this.getRetryDelay(serviceName);
+      const nextDelay = Math.min(currentDelay * 2, 300000); // 最大5分钟
+
+      logger.debug(
+        `[MCPManager] 服务 ${serviceName} 下次重试将在 ${nextDelay}ms 后进行`
+      );
+
+      this.scheduleServiceRetry(serviceName, nextDelay);
+    }
+  }
+
+  /**
+   * 获取当前重试延迟时间
+   * @param serviceName 服务名称
+   * @returns 当前延迟时间
+   */
+  private getRetryDelay(serviceName: string): number {
+    // 这里可以实现更复杂的状态跟踪来计算准确的延迟
+    // 简化实现：返回一个基于服务名称的哈希值的初始延迟
+    const hash = serviceName
+      .split("")
+      .reduce((acc, char) => acc + char.charCodeAt(0), 0);
+    return 30000 + (hash % 60000); // 30-90秒之间的初始延迟
+  }
+
+  /**
+   * 停止指定服务的重试
+   * @param serviceName 服务名称
+   */
+  public stopServiceRetry(serviceName: string): void {
+    const timer = this.retryTimers.get(serviceName);
+    if (timer) {
+      clearTimeout(timer);
+      this.retryTimers.delete(serviceName);
+      logger.debug(`[MCPManager] 已停止服务 ${serviceName} 的重试`);
+    }
+    this.failedServices.delete(serviceName);
+  }
+
+  /**
+   * 停止所有服务的重试
+   */
+  public stopAllServiceRetries(): void {
+    logger.info("[MCPManager] 停止所有服务重试");
+
+    for (const [serviceName, timer] of this.retryTimers) {
+      clearTimeout(timer);
+      logger.debug(`[MCPManager] 已停止服务 ${serviceName} 的重试`);
+    }
+
+    this.retryTimers.clear();
+    this.failedServices.clear();
+  }
+
+  /**
+   * 获取失败服务列表
+   * @returns 失败的服务名称数组
+   */
+  public getFailedServices(): string[] {
+    return Array.from(this.failedServices);
+  }
+
+  /**
+   * 检查服务是否失败
+   * @param serviceName 服务名称
+   * @returns 如果服务失败返回true
+   */
+  public isServiceFailed(serviceName: string): boolean {
+    return this.failedServices.has(serviceName);
+  }
+
+  /**
+   * 获取重试统计信息
+   * @returns 重试统计信息
+   */
+  public getRetryStats(): {
+    failedServices: string[];
+    activeRetries: string[];
+    totalFailed: number;
+    totalActiveRetries: number;
+  } {
+    return {
+      failedServices: Array.from(this.failedServices),
+      activeRetries: Array.from(this.retryTimers.keys()),
+      totalFailed: this.failedServices.size,
+      totalActiveRetries: this.retryTimers.size,
+    };
+  }
+
+  /**
+   * 获取消息处理器（供外部使用）
+   * @returns 消息处理器实例
+   */
+  public getMessageHandler(): MCPMessageHandler {
+    return this.messageHandler;
+  }
+
+  /**
+   * 启动管理器
+   */
+  public async start(): Promise<void> {
+    if (this.isRunning) {
+      throw new Error("服务器已在运行");
+    }
+
+    logger.info("启动 MCP 服务管理器");
+
+    try {
+      await this.startAllServices();
+      this.isRunning = true;
+
+      logger.info("MCP 服务管理器启动成功");
+      this.emit("started");
+    } catch (error) {
+      logger.error("MCP 服务管理器启动失败", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 停止管理器（包含传输和服务）
+   */
+  public async stop(): Promise<void> {
+    if (!this.isRunning) {
+      return;
+    }
+
+    logger.info("停止 MCP 服务管理器");
+
+    try {
+      await this.stopAllServices();
+      this.isRunning = false;
+
+      logger.info("MCP 服务管理器停止成功");
+      this.emit("stopped");
+    } catch (error) {
+      logger.error("MCP 服务管理器停止失败", { error });
+      throw error;
+    }
+  }
+
+  /**
+   * 获取所有连接信息
+   * @returns 连接信息列表
+   */
+  public getAllConnections(): Array<{
+    id: string;
+    name: string;
+    state: ConnectionState;
+  }> {
+    const connections: Array<{
+      id: string;
+      name: string;
+      state: ConnectionState;
+    }> = [];
+
+    // 收集服务连接
+    for (const [serviceName, service] of this.services) {
+      if (service.isConnected()) {
+        connections.push({
+          id: `service-${serviceName}`,
+          name: serviceName,
+          state: ConnectionState.CONNECTED,
+        });
+      }
+    }
+
+    return connections;
+  }
+
+  /**
+   * 获取活跃连接数
+   * @returns 活跃连接数量
+   */
+  public getActiveConnectionCount(): number {
+    return this.getAllConnections().filter(
+      (conn) => conn.state === ConnectionState.CONNECTED
+    ).length;
+  }
+
+  // ===== 从 UnifiedMCPServer 移入的方法 =====
+
+  /**
+   * 获取服务器状态（从 UnifiedMCPServer 移入）
+   */
+  getUnifiedStatus(): UnifiedServerStatus {
+    const serviceStatus = this.getServiceManagerStatus();
+    return {
+      isRunning: this.isRunning,
+      serviceStatus,
+      activeConnections: this.getActiveConnectionCount(),
+      config: this.config,
+      // 便捷访问属性
+      services: serviceStatus.services,
+      totalTools: serviceStatus.totalTools,
+      availableTools: serviceStatus.availableTools,
+    };
+  }
+
+  /**
+   * 获取管理器状态（原有的 getStatus 方法重命名）
+   */
+  getServiceManagerStatus(): ManagerStatus {
+    // 计算总工具数量（包括 customMCP 工具，添加异常处理）
+    let customMCPToolCount = 0;
+    let customToolNames: string[] = [];
+
+    try {
+      customMCPToolCount = this.customMCPHandler.getToolCount();
+      customToolNames = this.customMCPHandler.getToolNames();
+      logger.debug(
+        `[MCPManager] 成功获取 customMCP 状态: ${customMCPToolCount} 个工具`
+      );
+    } catch (error) {
+      logger.warn(
+        "[MCPManager] 获取 CustomMCP 状态失败，将只包含标准 MCP 工具",
+        { error }
+      );
+      // 异常情况下，customMCP 工具数量为0，不影响标准 MCP 工具
+      customMCPToolCount = 0;
+      customToolNames = [];
+    }
+
+    const totalTools = this.tools.size + customMCPToolCount;
+
+    // 获取所有可用工具名称
+    const standardToolNames = Array.from(this.tools.keys());
+    const availableTools = [...standardToolNames, ...customToolNames];
+
+    const status: ManagerStatus = {
+      services: {},
+      totalTools,
+      availableTools,
+    };
+
+    // 添加标准 MCP 服务状态
+    for (const [serviceName, service] of this.services) {
+      const serviceStatus = service.getStatus();
+      status.services[serviceName] = {
+        connected: serviceStatus.connected,
+        clientName: `xiaozhi-${serviceName}-client`,
+      };
+    }
+
+    // 添加 CustomMCP 服务状态
+    if (customMCPToolCount > 0) {
+      status.services.customMCP = {
+        connected: true, // CustomMCP 工具总是可用的
+        clientName: "xiaozhi-customMCP-handler",
+      };
+    }
+
+    return status;
+  }
+
+  /**
+   * 检查服务器是否正在运行（从 UnifiedMCPServer 移入）
+   */
+  isServerRunning(): boolean {
+    return this.isRunning;
+  }
+
+  /**
+   * 类型守卫：检查是否为 UnifiedServerConfig
+   */
+  private isUnifiedServerConfig(
+    configs: unknown
+  ): configs is UnifiedServerConfig {
+    return (
+      configs !== null && typeof configs === "object" && "configs" in configs
+    );
+  }
+
+  /**
+   * 消息路由核心功能（从 UnifiedMCPServer 移入）
+   */
+  async routeMessage(message: MCPMessage): Promise<MCPMessage | null> {
+    const response = await this.messageHandler.handleMessage(message);
+    // 如果响应是 null，直接返回
+    if (response === null) {
+      return null;
+    }
+    // 将 MCPResponse 转换为 MCPMessage 格式
+    return {
+      jsonrpc: "2.0",
+      method: "response", // 标识这是一个响应消息
+      params: response,
+      id: response.id, // 使用响应中的ID
+    };
+  }
+
+  // ===== 向后兼容方法 =====
+
+  /**
+   * 初始化方法（向后兼容，实际调用 start）
+   *
+   * 注意：此方法仅为向后兼容而保留
+   * 实际功能：调用 start() 方法并设置 isRunning 状态
+   * 建议新代码直接使用 start() 方法
+   */
+  async initialize(): Promise<void> {
+    // 为了向后兼容，初始化时调用 start
+    // 会设置 isRunning 状态为 true
+    await this.start();
+  }
+
+  /**
+   * 获取工具注册表（向后兼容，返回自身）
+   */
+  getToolRegistry(): MCPServiceManager {
+    return this;
+  }
+
+  /**
+   * 获取连接管理器（向后兼容，返回自身）
+   */
+  getConnectionManager(): MCPServiceManager {
+    return this;
+  }
+
+  /**
+   * 清理资源（实现 IMCPServiceManager 接口）
+   *
+   * 注意：此方法会停止所有 MCP 服务
+   */
+  async cleanup(): Promise<void> {
+    await this.stopAllServices();
+
+    // 清理事件监听器，防止内存泄漏
+    this.eventBus.offEvent(
+      "mcp:service:connected",
+      this.eventListeners.serviceConnected
+    );
+    this.eventBus.offEvent(
+      "mcp:service:disconnected",
+      this.eventListeners.serviceDisconnected
+    );
+    this.eventBus.offEvent(
+      "mcp:service:connection:failed",
+      this.eventListeners.serviceConnectionFailed
+    );
+  }
+}

--- a/src/server/lib/mcp/message.ts
+++ b/src/server/lib/mcp/message.ts
@@ -1,0 +1,350 @@
+/**
+ * 统一的 MCP 消息处理器
+ * 负责处理所有 MCP 协议消息，包括 initialize、tools/list、tools/call、resources/list、prompts/list 等
+ * 这是阶段一重构的核心组件，用于消除双层代理架构
+ */
+
+import type {
+  ClientCapabilities,
+  InitializedNotification,
+} from "@modelcontextprotocol/sdk/types.js";
+import type { Logger } from "../../Logger.js";
+import { logger } from "../../Logger.js";
+import {
+  JSONRPC_VERSION,
+  MCP_METHODS,
+  MCP_PROTOCOL_VERSIONS,
+  MCP_SERVER_INFO,
+  MCP_SUPPORTED_PROTOCOL_VERSIONS,
+} from "../../constants/index.js";
+import type { EnhancedToolInfo, MCPServiceManager } from "../../lib/mcp";
+import { validateToolCallParams } from "../../lib/mcp";
+import type { MCPMessage, MCPResponse } from "../../types/mcp.js";
+
+// 初始化参数接口
+interface InitializeParams {
+  protocolVersion: string;
+  capabilities: ClientCapabilities;
+  clientInfo: {
+    name: string;
+    version: string;
+  };
+}
+
+// 工具调用参数接口
+interface ToolCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+// MCP 资源接口
+interface MCPResource {
+  uri: string;
+  name: string;
+  description?: string;
+  mimeType?: string;
+}
+
+// MCP 提示接口
+interface MCPPrompt {
+  name: string;
+  description?: string;
+  arguments?: Array<{
+    name: string;
+    description?: string;
+    required?: boolean;
+  }>;
+}
+
+export class MCPMessageHandler {
+  private logger: Logger;
+  private serviceManager: MCPServiceManager;
+
+  constructor(serviceManager: MCPServiceManager) {
+    this.serviceManager = serviceManager;
+    this.logger = logger;
+  }
+
+  /**
+   * 处理 MCP 消息的统一入口
+   * @param message MCP 消息
+   * @returns MCP 响应（对于通知消息返回 null）
+   */
+  async handleMessage(message: MCPMessage): Promise<MCPResponse | null> {
+    this.logger.debug(`处理 MCP 消息: ${message.method}`, message);
+
+    try {
+      // 检查是否为通知消息（没有 id 字段）
+      const isNotification = message.id === undefined;
+
+      switch (message.method) {
+        case MCP_METHODS.INITIALIZE:
+          return await this.handleInitialize(
+            message.params as InitializeParams,
+            message.id
+          );
+        case MCP_METHODS.INITIALIZED:
+          return await this.handleInitializedNotification(
+            message.params as InitializedNotification["params"]
+          );
+        case MCP_METHODS.TOOLS_LIST:
+          return await this.handleToolsList(message.id);
+        case MCP_METHODS.TOOLS_CALL:
+          return await this.handleToolCall(
+            message.params as ToolCallParams,
+            message.id
+          );
+        case MCP_METHODS.RESOURCES_LIST:
+          return await this.handleResourcesList(message.id);
+        case MCP_METHODS.PROMPTS_LIST:
+          return await this.handlePromptsList(message.id);
+        case MCP_METHODS.PING:
+          return await this.handlePing(message.id);
+        default:
+          if (isNotification) {
+            // 对于未知的通知消息，记录警告但不抛出错误
+            this.logger.warn(`收到未知的通知消息: ${message.method}`, message);
+            return null;
+          }
+          throw new Error(`未知的方法: ${message.method}`);
+      }
+    } catch (error) {
+      this.logger.error(`处理消息时出错: ${message.method}`, error);
+      // 通知消息不需要错误响应
+      if (message.id === undefined) {
+        return null;
+      }
+      return this.createErrorResponse(error as Error, message.id);
+    }
+  }
+
+  /**
+   * 处理 initialize 请求
+   * @param params 初始化参数
+   * @param id 消息ID
+   * @returns 初始化响应
+   */
+  private async handleInitialize(
+    params: InitializeParams,
+    id?: string | number
+  ): Promise<MCPResponse> {
+    this.logger.debug("处理 initialize 请求", params);
+
+    // 支持多个协议版本，优先使用客户端请求的版本
+    const clientVersion = params.protocolVersion;
+    const responseVersion = MCP_SUPPORTED_PROTOCOL_VERSIONS.includes(
+      clientVersion as (typeof MCP_SUPPORTED_PROTOCOL_VERSIONS)[number]
+    )
+      ? clientVersion
+      : MCP_PROTOCOL_VERSIONS.DEFAULT;
+
+    this.logger.debug(
+      `协议版本协商: 客户端=${clientVersion}, 服务器响应=${responseVersion}`
+    );
+
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      result: {
+        serverInfo: {
+          name: MCP_SERVER_INFO.NAME,
+          version: MCP_SERVER_INFO.VERSION,
+        },
+        capabilities: {
+          tools: {},
+          logging: {},
+        },
+        protocolVersion: responseVersion,
+      },
+      id: id !== undefined ? id : 1,
+    };
+  }
+
+  /**
+   * 处理 notifications/initialized 通知
+   * @param params 通知参数
+   * @returns null（通知消息不需要响应）
+   */
+  private async handleInitializedNotification(
+    params?: InitializedNotification["params"]
+  ): Promise<null> {
+    this.logger.debug("收到 initialized 通知，客户端初始化完成", params);
+
+    // 可以在这里执行一些初始化完成后的逻辑
+    // 例如：记录客户端连接状态、触发事件等
+
+    return null;
+  }
+
+  /**
+   * 处理 tools/list 请求
+   * @param id 消息ID
+   * @returns 工具列表响应
+   */
+  private async handleToolsList(id?: string | number): Promise<MCPResponse> {
+    this.logger.debug("处理 tools/list 请求");
+
+    try {
+      const tools: EnhancedToolInfo[] = this.serviceManager.getAllTools();
+
+      // 转换为 MCP 标准格式
+      const mcpTools = tools.map((tool) => ({
+        name: tool.name,
+        description: tool.description,
+        inputSchema: tool.inputSchema,
+      }));
+
+      return {
+        jsonrpc: JSONRPC_VERSION,
+        result: {
+          tools: mcpTools,
+        },
+        id: id !== undefined ? id : 1,
+      };
+    } catch (error) {
+      this.logger.error("获取工具列表失败", error);
+      throw error;
+    }
+  }
+
+  /**
+   * 处理 tools/call 请求
+   * @param params 工具调用参数
+   * @param id 消息ID
+   * @returns 工具调用响应
+   */
+  private async handleToolCall(
+    params: ToolCallParams,
+    id?: string | number
+  ): Promise<MCPResponse> {
+    try {
+      // 参数校验
+      const validatedParams = validateToolCallParams(params);
+
+      const result = await this.serviceManager.callTool(
+        validatedParams.name,
+        validatedParams.arguments || {}
+      );
+
+      return {
+        jsonrpc: JSONRPC_VERSION,
+        result: {
+          content: result.content,
+          isError: result.isError || false,
+        },
+        id: id !== undefined ? id : 1,
+      };
+    } catch (error) {
+      this.logger.error(`工具调用失败: ${params.name}`, error);
+      throw error;
+    }
+  }
+
+  /**
+   * 处理 ping 请求
+   * @param id 消息ID
+   * @returns ping 响应
+   */
+  private async handlePing(id?: string | number): Promise<MCPResponse> {
+    this.logger.debug("处理 ping 请求");
+
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      result: {
+        status: "ok",
+        timestamp: new Date().toISOString(),
+      },
+      id: id !== undefined ? id : 1,
+    };
+  }
+
+  /**
+   * 处理 resources/list 请求
+   * @param id 消息ID
+   * @returns 资源列表响应
+   */
+  private async handleResourcesList(
+    id?: string | number
+  ): Promise<MCPResponse> {
+    this.logger.debug("处理 resources/list 请求");
+
+    // 目前返回空的资源列表
+    // 如果将来需要提供资源功能，可以在这里扩展
+    const resources: MCPResource[] = [];
+
+    this.logger.debug(`返回 ${resources.length} 个资源`);
+
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      result: {
+        resources: resources,
+      },
+      id: id !== undefined ? id : 1,
+    };
+  }
+
+  /**
+   * 处理 prompts/list 请求
+   * @param id 消息ID
+   * @returns 提示列表响应
+   */
+  private async handlePromptsList(id?: string | number): Promise<MCPResponse> {
+    this.logger.debug("处理 prompts/list 请求");
+
+    // 目前返回空的提示列表
+    // 如果将来需要提供提示模板功能，可以在这里扩展
+    const prompts: MCPPrompt[] = [];
+
+    this.logger.debug(`返回 ${prompts.length} 个提示模板`);
+
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      result: {
+        prompts: prompts,
+      },
+      id: id !== undefined ? id : 1,
+    };
+  }
+
+  /**
+   * 创建错误响应
+   * @param error 错误对象
+   * @param id 消息ID
+   * @returns 错误响应
+   */
+  private createErrorResponse(error: Error, id?: string | number): MCPResponse {
+    // 根据错误类型确定错误代码
+    let errorCode = -32603; // Internal error
+
+    if (
+      error.message.includes("未找到工具") ||
+      error.message.includes("未知的方法")
+    ) {
+      errorCode = -32601; // Method not found
+    } else if (
+      error.message.includes("参数") ||
+      error.message.includes("不能为空")
+    ) {
+      errorCode = -32602; // Invalid params
+    }
+
+    return {
+      jsonrpc: JSONRPC_VERSION,
+      error: {
+        code: errorCode,
+        message: error.message,
+        data: {
+          stack: error.stack,
+        },
+      },
+      id: id !== undefined ? id : 1,
+    };
+  }
+
+  /**
+   * 获取服务管理器实例
+   * @returns MCPServiceManager 实例
+   */
+  getServiceManager(): MCPServiceManager {
+    return this.serviceManager;
+  }
+}

--- a/src/server/lib/mcp/types.ts
+++ b/src/server/lib/mcp/types.ts
@@ -1,0 +1,397 @@
+/**
+ * MCP 核心库类型定义
+ * 统一管理所有 MCP 相关的类型定义，避免重复定义和导入路径混乱
+ */
+
+import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
+import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
+import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+
+// =========================
+// 1. 基础传输类型
+// =========================
+
+/**
+ * MCP 传输层联合类型定义
+ * 支持 STDIO、SSE、StreamableHTTP 三种传输协议
+ */
+export type MCPServerTransport =
+  | StdioClientTransport
+  | SSEClientTransport
+  | StreamableHTTPClientTransport;
+
+/**
+ * 通信方式枚举
+ * 定义 MCP 支持的传输类型
+ */
+export enum MCPTransportType {
+  STDIO = "stdio",
+  SSE = "sse",
+  HTTP = "http",
+}
+
+// =========================
+// 2. 配置接口类型
+// =========================
+
+/**
+ * ModelScope SSE 自定义选项接口
+ * 专门用于 ModelScope 相关的 SSE 配置
+ */
+export interface ModelScopeSSEOptions {
+  eventSourceInit?: {
+    fetch?: (
+      url: string | URL | Request,
+      init?: RequestInit
+    ) => Promise<Response>;
+  };
+  requestInit?: RequestInit;
+}
+
+/**
+ * MCP 服务配置接口
+ * 包含所有 MCP 服务的配置选项
+ *
+ * 注意：符合 @modelcontextprotocol 官方标准，不包含 name 字段
+ * name 应该作为服务标识符独立管理，不是配置的一部分
+ */
+export interface MCPServiceConfig {
+  type?: MCPTransportType; // 现在是可选的，支持自动推断
+  // stdio 配置
+  command?: string;
+  args?: string[];
+  env?: Record<string, string>; // 环境变量配置
+  // 网络配置
+  url?: string;
+  // 认证配置
+  apiKey?: string;
+  headers?: Record<string, string>;
+  customSSEOptions?: ModelScopeSSEOptions;
+}
+
+/**
+ * 内部使用的 MCP 服务配置接口（包含 name 字段）
+ * 用于 MCPService 类等内部函数，保持向后兼容
+ */
+export interface InternalMCPServiceConfig extends MCPServiceConfig {
+  name: string;
+}
+
+// =========================
+// 3. 状态枚举类型
+// =========================
+
+/**
+ * 连接状态枚举
+ * 合并了 connection.ts 和 TransportAdapter.ts 中的定义
+ */
+export enum ConnectionState {
+  DISCONNECTED = "disconnected",
+  CONNECTING = "connecting",
+  CONNECTED = "connected",
+  RECONNECTING = "reconnecting",
+  FAILED = "failed",
+  ERROR = "error", // 从 TransportAdapter.ts 合并的额外状态
+}
+
+/**
+ * MCP 服务状态接口
+ * 描述 MCP 服务的运行时状态信息
+ */
+export interface MCPServiceStatus {
+  name: string;
+  connected: boolean;
+  initialized: boolean;
+  transportType: MCPTransportType;
+  toolCount: number;
+  lastError?: string;
+  connectionState: ConnectionState;
+}
+
+// =========================
+// 4. 工具调用相关类型
+// =========================
+
+/**
+ * 工具调用结果接口
+ * 使用简化的类型定义，保持向后兼容性
+ * 注意：这与 ../../../../../mcp-core/index.js 中的 ToolCallResult 类型不同
+ */
+export interface ToolCallResult {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown; // 支持其他未知字段，与 endpoint 包保持兼容
+}
+
+/**
+ * JSON Schema 类型定义
+ * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
+ */
+export type JSONSchema =
+  | (Record<string, unknown> & {
+      type: "object";
+      properties?: Record<string, unknown>;
+      required?: string[];
+      additionalProperties?: boolean;
+    })
+  | Record<string, unknown>; // 允许更宽松的格式以保持向后兼容
+
+/**
+ * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
+ */
+export function isValidToolJSONSchema(obj: unknown): obj is {
+  type: "object";
+  properties?: Record<string, unknown>;
+  required?: string[];
+  additionalProperties?: boolean;
+} {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    (obj as { type?: unknown }).type === "object"
+  );
+}
+
+/**
+ * 确保对象符合 MCP Tool JSON Schema 格式
+ * 如果不符合，会返回一个默认的空对象 schema
+ */
+export function ensureToolJSONSchema(schema: JSONSchema): {
+  type: "object";
+  properties?: Record<string, object>;
+  required?: string[];
+  additionalProperties?: boolean;
+} {
+  if (isValidToolJSONSchema(schema)) {
+    return schema as {
+      type: "object";
+      properties?: Record<string, object>;
+      required?: string[];
+      additionalProperties?: boolean;
+    };
+  }
+
+  // 如果不符合标准格式，返回默认的空对象 schema
+  return {
+    type: "object",
+    properties: {} as Record<string, object>,
+    required: [],
+    additionalProperties: true,
+  };
+}
+
+/**
+ * CustomMCP 工具类型定义
+ * 统一了 manager.ts 和 configManager.ts 中的定义
+ */
+export interface CustomMCPTool {
+  name: string;
+  description?: string;
+  inputSchema: JSONSchema;
+  handler?: {
+    type: string;
+    config?: Record<string, unknown>;
+  };
+}
+
+/**
+ * 工具信息接口
+ * 用于缓存工具映射关系，保持向后兼容性
+ */
+export interface ToolInfo {
+  serviceName: string;
+  originalName: string;
+  tool: Tool;
+}
+
+// =========================
+// 5. 增强工具信息类型
+// =========================
+
+/**
+ * 工具状态过滤选项
+ * 用于 getAllTools() 方法过滤不同状态的工具
+ */
+export type ToolStatusFilter = "enabled" | "disabled" | "all";
+
+/**
+ * 增强的工具信息接口
+ * 扩展自 ToolInfo 概念，包含工具的启用状态和使用统计信息
+ *
+ * @remarks
+ * 此接口用于 MCPServiceManager.getAllTools() 方法的返回值，
+ * 提供比基础 ToolInfo 更丰富的工具元数据信息。
+ *
+ * @example
+ * ```typescript
+ * const tools: EnhancedToolInfo[] = manager.getAllTools('enabled');
+ * tools.forEach(tool => {
+ *   console.log(`工具: ${tool.name}`);
+ *   console.log(`状态: ${tool.enabled ? '已启用' : '已禁用'}`);
+ *   console.log(`使用次数: ${tool.usageCount}`);
+ * });
+ * ```
+ */
+export interface EnhancedToolInfo {
+  /** 工具唯一标识符，格式为 "{serviceName}__{originalName}" */
+  name: string;
+
+  /** 工具描述信息 */
+  description: string;
+
+  /** 工具输入参数的 JSON Schema 定义 */
+  inputSchema: JSONSchema;
+
+  /** 工具所属的 MCP 服务名称 */
+  serviceName: string;
+
+  /** 工具在 MCP 服务中的原始名称 */
+  originalName: string;
+
+  /** 工具是否启用 (true=已启用，false=已禁用) */
+  enabled: boolean;
+
+  /** 工具使用次数统计 */
+  usageCount: number;
+
+  /** 工具最后使用时间 (ISO 8601 格式字符串) */
+  lastUsedTime: string;
+}
+
+// =========================
+// 6. 服务器配置类型
+// =========================
+
+/**
+ * 统一服务器配置接口
+ * 从 UnifiedMCPServer 移入，用于统一服务器配置管理
+ */
+export interface UnifiedServerConfig {
+  name?: string;
+  enableLogging?: boolean;
+  logLevel?: string;
+  configs?: Record<string, MCPServiceConfig>; // MCPService 配置
+}
+
+/**
+ * 统一服务器状态接口
+ * 从 UnifiedMCPServer 移入，用于统一服务器状态管理
+ */
+export interface UnifiedServerStatus {
+  isRunning: boolean;
+  serviceStatus: ManagerStatus;
+  activeConnections: number;
+  config: UnifiedServerConfig;
+  // 添加对 serviceStatus 的便捷访问属性
+  services?: Record<string, MCPServiceConnectionStatus>;
+  totalTools?: number;
+  availableTools?: string[];
+}
+
+// =========================
+// 6. 管理器相关类型
+// =========================
+
+/**
+ * MCP 服务连接状态接口
+ * 重命名原 ServiceStatus 为 MCPServiceConnectionStatus 避免与 CLI 的 ServiceStatus 冲突
+ */
+export interface MCPServiceConnectionStatus {
+  connected: boolean;
+  clientName: string;
+}
+
+/**
+ * 管理器状态接口
+ * 描述 MCP 服务管理器的整体状态
+ */
+export interface ManagerStatus {
+  services: Record<string, MCPServiceConnectionStatus>;
+  totalTools: number;
+  availableTools: string[];
+}
+
+// =========================
+// 7. 参数校验相关类型
+// =========================
+
+/**
+ * 工具调用参数接口
+ * 定义标准工具调用参数结构
+ */
+export interface ToolCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * 验证后的工具调用参数
+ * 参数校验通过后的标准化参数结构
+ */
+export interface ValidatedToolCallParams {
+  name: string;
+  arguments?: Record<string, unknown>;
+}
+
+/**
+ * 工具调用验证选项
+ * 提供灵活的参数校验配置
+ */
+export interface ToolCallValidationOptions {
+  /** 是否验证工具名称，默认为 true */
+  validateName?: boolean;
+  /** 是否验证参数格式，默认为 true */
+  validateArguments?: boolean;
+  /** 是否允许空参数，默认为 true */
+  allowEmptyArguments?: boolean;
+  /** 自定义验证函数 */
+  customValidator?: (params: ToolCallParams) => string | null;
+}
+
+/**
+ * 工具调用错误码枚举
+ * 统一的工具调用错误码定义
+ */
+export enum ToolCallErrorCode {
+  /** 无效参数 */
+  INVALID_PARAMS = -32602,
+  /** 工具不存在 */
+  TOOL_NOT_FOUND = -32601,
+  /** 服务不可用 */
+  SERVICE_UNAVAILABLE = -32001,
+  /** 调用超时 */
+  TIMEOUT = -32002,
+  /** 工具执行错误 */
+  TOOL_EXECUTION_ERROR = -32000,
+}
+
+/**
+ * 工具调用错误类
+ * 统一的工具调用错误处理
+ */
+export class ToolCallError extends Error {
+  constructor(
+    public code: ToolCallErrorCode,
+    message: string,
+    public data?: unknown
+  ) {
+    super(message);
+    this.name = "ToolCallError";
+  }
+}
+
+// =========================
+// 向后兼容性别名
+// =========================
+
+/**
+ * 向后兼容：ServiceStatus 别名
+ * 为了与现有代码保持兼容，暂时保留此别名
+ * @deprecated 请使用 MCPServiceConnectionStatus
+ */
+export type ServiceStatus = MCPServiceConnectionStatus;

--- a/src/server/lib/mcp/utils.ts
+++ b/src/server/lib/mcp/utils.ts
@@ -1,0 +1,191 @@
+/**
+ * MCP 工具函数模块
+ *
+ * 提供 MCP 服务配置和工具调用的工具函数：
+ * - 传输类型推断（基于 URL 或配置）
+ * - 工具调用参数验证
+ */
+
+import { TypeFieldNormalizer } from "../../../mcp-core/index.js";
+import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
+import type {
+  MCPServiceConfig,
+  ToolCallParams,
+  ToolCallValidationOptions,
+  ValidatedToolCallParams,
+} from "./types.js";
+
+/**
+ * 根据 URL 路径推断传输类型
+ * 基于路径末尾推断，支持包含多个 / 的复杂路径
+ *
+ * @param url - 要推断的 URL
+ * @param options - 可选配置项
+ * @returns 推断出的传输类型
+ */
+export function inferTransportTypeFromUrl(
+  url: string,
+  options?: {
+    serviceName?: string;
+  }
+): MCPTransportType {
+  try {
+    const parsedUrl = new URL(url);
+    const pathname = parsedUrl.pathname;
+
+    // 检查路径末尾
+    if (pathname.endsWith("/sse")) {
+      return MCPTransportType.SSE;
+    }
+    if (pathname.endsWith("/mcp")) {
+      return MCPTransportType.HTTP;
+    }
+
+    // 默认类型 - 使用 console 输出
+    if (options?.serviceName) {
+      console.info(
+        `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
+      );
+    }
+    return MCPTransportType.HTTP;
+  } catch (error) {
+    if (options?.serviceName) {
+      console.warn(
+        `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
+        error
+      );
+    }
+    return MCPTransportType.HTTP;
+  }
+}
+
+/**
+ * 完整的配置类型推断（包括 command 字段）
+ *
+ * @param config - MCP 服务配置
+ * @param serviceName - 服务名称（用于错误信息）
+ * @returns 完整的配置对象，包含推断出的类型
+ */
+export function inferTransportTypeFromConfig(
+  config: MCPServiceConfig,
+  serviceName: string
+): MCPServiceConfig {
+  // 如果已显式指定类型，先标准化然后返回
+  if (config.type) {
+    const normalizedConfig = TypeFieldNormalizer.normalizeTypeField(config);
+    return normalizedConfig as MCPServiceConfig;
+  }
+
+  // 基于 command 字段推断
+  if (config.command) {
+    return {
+      ...config,
+      type: MCPTransportType.STDIO,
+    };
+  }
+
+  // 基于 URL 字段推断（排除 null 和 undefined）
+  if (config.url !== undefined && config.url !== null) {
+    const inferredType = inferTransportTypeFromUrl(config.url, {
+      serviceName,
+    });
+    return {
+      ...config,
+      type: inferredType,
+    };
+  }
+
+  throw new Error(
+    `无法为服务 ${serviceName} 推断传输类型。请显式指定 type 字段，或提供 command/url 配置`
+  );
+}
+
+// =========================
+// 参数校验工具函数
+// =========================
+
+/**
+ * 验证工具调用参数
+ * 对传入的参数进行完整性和格式验证
+ *
+ * @param params 待验证的参数
+ * @param options 验证选项
+ * @returns 验证后的参数
+ * @throws ToolCallError 验证失败时抛出
+ */
+export function validateToolCallParams(
+  params: unknown,
+  options?: ToolCallValidationOptions
+): ValidatedToolCallParams {
+  const opts = {
+    validateName: true,
+    validateArguments: true,
+    allowEmptyArguments: true,
+    ...options,
+  };
+
+  // 1. 验证参数必须是对象
+  if (!params || typeof params !== "object") {
+    throw new ToolCallError(
+      ToolCallErrorCode.INVALID_PARAMS,
+      "请求参数必须是对象"
+    );
+  }
+
+  const paramsObj = params as Record<string, unknown>;
+
+  // 2. 验证工具名称
+  if (opts.validateName) {
+    if (!paramsObj.name || typeof paramsObj.name !== "string") {
+      throw new ToolCallError(
+        ToolCallErrorCode.INVALID_PARAMS,
+        "工具名称必须是非空字符串"
+      );
+    }
+  }
+
+  // 3. 验证工具参数格式
+  if (
+    opts.validateArguments &&
+    paramsObj.arguments !== undefined &&
+    paramsObj.arguments !== null
+  ) {
+    if (
+      typeof paramsObj.arguments !== "object" ||
+      Array.isArray(paramsObj.arguments)
+    ) {
+      throw new ToolCallError(
+        ToolCallErrorCode.INVALID_PARAMS,
+        "工具参数必须是对象"
+      );
+    }
+  }
+
+  // 4. 验证是否允许空参数
+  if (
+    !opts.allowEmptyArguments &&
+    paramsObj.arguments !== undefined &&
+    paramsObj.arguments !== null
+  ) {
+    const argsObj = paramsObj.arguments as Record<string, unknown>;
+    if (Object.keys(argsObj).length === 0) {
+      throw new ToolCallError(
+        ToolCallErrorCode.INVALID_PARAMS,
+        "工具参数不能为空"
+      );
+    }
+  }
+
+  // 5. 执行自定义验证
+  if (opts.customValidator) {
+    const error = opts.customValidator(paramsObj as unknown as ToolCallParams);
+    if (error) {
+      throw new ToolCallError(ToolCallErrorCode.INVALID_PARAMS, error);
+    }
+  }
+
+  return {
+    name: paramsObj.name as string,
+    arguments: paramsObj.arguments as Record<string, unknown>,
+  };
+}

--- a/src/server/lib/npm/__tests__/install-log-stream.test.ts
+++ b/src/server/lib/npm/__tests__/install-log-stream.test.ts
@@ -1,0 +1,705 @@
+/**
+ * InstallLogStream 测试
+ *
+ * 覆盖 NPM 安装日志流管理器的全部功能：
+ * - 会话生命周期（startInstall/complete/fail/cleanup）
+ * - 日志推送（pushLog）
+ * - SSE 流创建（createSSEStream）
+ * - 多消费者场景
+ */
+
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { InstallLogStream } from "../install-log-stream";
+
+/**
+ * 辅助函数：读取 ReadableStream 中已入队的数据，然后取消读取器
+ * 使用 Promise.race 避免在无数据时永久阻塞
+ */
+async function readStreamChunks(
+  stream: ReadableStream<string>
+): Promise<string[]> {
+  const reader = stream.getReader();
+  const chunks: string[] = [];
+
+  try {
+    // 先尝试非阻塞地读取所有已入队的数据
+    // 每次读取后检查是否有新数据，没有则停止
+    while (true) {
+      const result = await Promise.race([
+        reader.read(),
+        new Promise<never>((_resolve, reject) =>
+          setTimeout(() => reject(new Error("timeout")), 100)
+        ),
+      ]);
+      if (result.value !== undefined) {
+        chunks.push(result.value);
+      }
+    }
+  } catch {
+    // 超时或流关闭，正常退出
+  } finally {
+    reader.cancel();
+  }
+
+  return chunks;
+}
+
+/**
+ * 辅助函数：收集已关闭流的全部内容
+ */
+async function collectClosedStream(
+  reader: ReadableStreamDefaultReader<string>
+): Promise<string> {
+  const chunks: string[] = [];
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      chunks.push(value);
+    }
+  } catch {
+    // 流可能已被取消或关闭
+  }
+  return chunks.join("");
+}
+
+describe("InstallLogStream", () => {
+  let logStream: InstallLogStream;
+
+  beforeEach(() => {
+    logStream = new InstallLogStream();
+  });
+
+  // ==================== startInstall ====================
+
+  describe("startInstall", () => {
+    it("应该创建新的安装会话", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+
+    it("应该初始化空的日志数组和控制器集合", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream = logStream.createSSEStream("install-1");
+      expect(stream).not.toBeNull();
+    });
+
+    it("应该允许同一 installId 覆盖已有会话", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      logStream.startInstall({
+        version: "2.0.0",
+        installId: "install-1",
+        timestamp: 2000,
+      });
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+  });
+
+  // ==================== pushLog ====================
+
+  describe("pushLog", () => {
+    beforeEach(() => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+    });
+
+    it("应该向已存在的会话追加日志条目并通过 SSE 回放验证", async () => {
+      logStream.pushLog("install-1", {
+        type: "stdout",
+        message: "Installing...",
+        timestamp: 1500,
+      });
+
+      const stream = logStream.createSSEStream("install-1")!;
+      const chunks = await readStreamChunks(stream);
+
+      const combined = chunks.join("");
+      expect(combined).toContain("event: log");
+      expect(combined).toContain('"message":"Installing..."');
+    });
+
+    it("应该在会话不存在时静默返回（不抛错）", () => {
+      expect(() => {
+        logStream.pushLog("non-existent", {
+          type: "stdout",
+          message: "test",
+          timestamp: 1000,
+        });
+      }).not.toThrow();
+    });
+
+    it("应该正确格式化 stdout 类型的日志事件", async () => {
+      logStream.pushLog("install-1", {
+        type: "stdout",
+        message: "stdout message",
+        timestamp: 1500,
+      });
+
+      const stream = logStream.createSSEStream("install-1")!;
+      const chunks = await readStreamChunks(stream);
+      const combined = chunks.join("");
+
+      expect(combined).toContain('"type":"stdout"');
+      expect(combined).toContain('"message":"stdout message"');
+    });
+
+    it("应该正确格式化 stderr 类型的日志事件", async () => {
+      logStream.pushLog("install-1", {
+        type: "stderr",
+        message: "error message",
+        timestamp: 1500,
+      });
+
+      const stream = logStream.createSSEStream("install-1")!;
+      const chunks = await readStreamChunks(stream);
+      const combined = chunks.join("");
+
+      expect(combined).toContain('"type":"stderr"');
+      expect(combined).toContain('"message":"error message"');
+    });
+  });
+
+  // ==================== complete ====================
+
+  describe("complete", () => {
+    beforeEach(() => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+    });
+
+    it("应该将会话标记为完成状态", () => {
+      logStream.complete({
+        version: "1.0.0",
+        installId: "install-1",
+        success: true,
+        duration: 5000,
+        timestamp: 6000,
+      });
+
+      // 已完成的会话仍可查询到（在延迟清理前）
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+
+    it("应该向所有活跃消费者发送 completed 事件并关闭流", async () => {
+      const stream = logStream.createSSEStream("install-1")!;
+      const reader = stream.getReader();
+
+      queueMicrotask(() => {
+        logStream.complete({
+          version: "1.0.0",
+          installId: "install-1",
+          success: true,
+          duration: 5000,
+          timestamp: 6000,
+        });
+      });
+
+      const combined = await collectClosedStream(reader);
+
+      expect(combined).toContain("event: completed");
+      expect(combined).toContain('"success":true');
+      expect(combined).toContain('"duration":5000');
+    });
+
+    it("应该设置延迟清理定时器（60秒后删除会话）", () => {
+      vi.useFakeTimers();
+      logStream.complete({
+        version: "1.0.0",
+        installId: "install-1",
+        success: true,
+        duration: 5000,
+        timestamp: 6000,
+      });
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+
+      vi.advanceTimersByTime(60_000);
+
+      expect(logStream.hasSession("install-1")).toBe(false);
+      vi.useRealTimers();
+    });
+
+    it("对已完成的会话重复调用 complete 应该忽略（幂等性）", () => {
+      const completeData = {
+        version: "1.0.0",
+        installId: "install-1",
+        success: true,
+        duration: 5000,
+        timestamp: 6000,
+      };
+
+      logStream.complete(completeData);
+      expect(() => {
+        logStream.complete(completeData);
+      }).not.toThrow();
+    });
+
+    it("对不存在的会话调用 complete 应该静默返回", () => {
+      expect(() => {
+        logStream.complete({
+          version: "1.0.0",
+          installId: "non-existent",
+          success: true,
+          duration: 5000,
+          timestamp: 6000,
+        });
+      }).not.toThrow();
+    });
+  });
+
+  // ==================== fail ====================
+
+  describe("fail", () => {
+    beforeEach(() => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+    });
+
+    it("应该将会话标记为完成并记录失败数据", () => {
+      logStream.fail({
+        version: "1.0.0",
+        installId: "install-1",
+        error: "安装失败",
+        duration: 3000,
+        timestamp: 4000,
+      });
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+
+    it("应该向所有活跃消费者发送 failed 事件并关闭流", async () => {
+      const stream = logStream.createSSEStream("install-1")!;
+      const reader = stream.getReader();
+
+      queueMicrotask(() => {
+        logStream.fail({
+          version: "1.0.0",
+          installId: "install-1",
+          error: "安装失败",
+          duration: 3000,
+          timestamp: 4000,
+        });
+      });
+
+      const combined = await collectClosedStream(reader);
+
+      expect(combined).toContain("event: failed");
+      expect(combined).toContain('"error":"安装失败"');
+    });
+
+    it("发送的事件类型应该是 'failed' 而非 'completed'", async () => {
+      const stream = logStream.createSSEStream("install-1")!;
+      const reader = stream.getReader();
+
+      queueMicrotask(() => {
+        logStream.fail({
+          version: "1.0.0",
+          installId: "install-1",
+          error: "error",
+          duration: 1000,
+          timestamp: 2000,
+        });
+      });
+
+      const combined = await collectClosedStream(reader);
+
+      expect(combined).toContain("event: failed");
+      expect(combined).not.toContain("event: completed");
+    });
+
+    it("对已完成的会话重复调用 fail 应该忽略", () => {
+      const failData = {
+        version: "1.0.0",
+        installId: "install-1",
+        error: "error",
+        duration: 1000,
+        timestamp: 2000,
+      };
+
+      logStream.fail(failData);
+      expect(() => {
+        logStream.fail(failData);
+      }).not.toThrow();
+    });
+  });
+
+  // ==================== createSSEStream ====================
+
+  describe("createSSEStream", () => {
+    it("应该返回 null 当会话不存在时", () => {
+      const result = logStream.createSSEStream("non-existent");
+      expect(result).toBeNull();
+    });
+
+    it("应该返回 ReadableStream 实例当会话存在时", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const result = logStream.createSSEStream("install-1");
+      expect(result).toBeInstanceOf(ReadableStream);
+    });
+
+    it("应该发送 ': connected\\n\\n' SSE 注释作为首条消息", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream = logStream.createSSEStream("install-1")!;
+      const reader = stream.getReader();
+      const { value } = await reader.read();
+      reader.cancel();
+
+      expect(value).toBe(": connected\n\n");
+    });
+
+    it("应该回放已有的历史日志给新连接的客户端", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      logStream.pushLog("install-1", {
+        type: "stdout",
+        message: "log line 1",
+        timestamp: 1100,
+      });
+      logStream.pushLog("install-1", {
+        type: "stderr",
+        message: "log line 2",
+        timestamp: 1200,
+      });
+
+      const stream = logStream.createSSEStream("install-1")!;
+      const chunks = await readStreamChunks(stream);
+      const combined = chunks.join("");
+
+      expect(combined).toContain('"message":"log line 1"');
+      expect(combined).toContain('"message":"log line 2"');
+    });
+
+    describe("会话已完成时连接", () => {
+      it("应该立即发送最终事件（completed）并自动关闭流", async () => {
+        logStream.startInstall({
+          version: "1.0.0",
+          installId: "install-1",
+          timestamp: 1000,
+        });
+
+        logStream.complete({
+          version: "1.0.0",
+          installId: "install-1",
+          success: true,
+          duration: 5000,
+          timestamp: 6000,
+        });
+
+        const stream = logStream.createSSEStream("install-1")!;
+        const reader = stream.getReader();
+        const combined = await collectClosedStream(reader);
+
+        expect(combined).toContain("event: completed");
+        expect(combined).toContain('"success":true');
+      });
+
+      it("应该立即发送最终事件（failed）并自动关闭流", async () => {
+        logStream.startInstall({
+          version: "1.0.0",
+          installId: "install-1",
+          timestamp: 1000,
+        });
+
+        logStream.fail({
+          version: "1.0.0",
+          installId: "install-1",
+          error: "fail reason",
+          duration: 3000,
+          timestamp: 4000,
+        });
+
+        const stream = logStream.createSSEStream("install-1")!;
+        const reader = stream.getReader();
+        const combined = await collectClosedStream(reader);
+
+        expect(combined).toContain("event: failed");
+        expect(combined).toContain('"error":"fail reason"');
+      });
+    });
+  });
+
+  // ==================== cleanup ====================
+
+  describe("cleanup", () => {
+    it("应该从 sessions Map 中删除该会话", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      logStream.cleanup("install-1");
+
+      expect(logStream.hasSession("install-1")).toBe(false);
+    });
+
+    it("对不存在的会话调用 cleanup 应该静默返回", () => {
+      expect(() => {
+        logStream.cleanup("non-existent");
+      }).not.toThrow();
+    });
+
+    it("关闭控制器时的异常不应该影响其他控制器的清理", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream1 = logStream.createSSEStream("install-1")!;
+      logStream.createSSEStream("install-1")!;
+
+      const reader1 = stream1.getReader();
+      await reader1.read(); // 读取 connected 消息激活控制器
+
+      expect(() => {
+        logStream.cleanup("install-1");
+      }).not.toThrow();
+
+      expect(logStream.hasSession("install-1")).toBe(false);
+    });
+  });
+
+  // ==================== cleanupCompleted ====================
+
+  describe("cleanupCompleted", () => {
+    it("只清理 done=true 的会话", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-active",
+        timestamp: 1000,
+      });
+      logStream.startInstall({
+        version: "2.0.0",
+        installId: "install-done",
+        timestamp: 2000,
+      });
+
+      logStream.complete({
+        version: "2.0.0",
+        installId: "install-done",
+        success: true,
+        duration: 1000,
+        timestamp: 3000,
+      });
+
+      logStream.cleanupCompleted();
+
+      expect(logStream.hasSession("install-active")).toBe(true);
+      expect(logStream.hasSession("install-done")).toBe(false);
+    });
+
+    it("不应清理仍在进行中的会话", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      logStream.cleanupCompleted();
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+
+    it("在没有已完成会话时不做任何操作", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      expect(() => {
+        logStream.cleanupCompleted();
+      }).not.toThrow();
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+  });
+
+  // ==================== hasSession ====================
+
+  describe("hasSession", () => {
+    it("在会话存在时返回 true", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      expect(logStream.hasSession("install-1")).toBe(true);
+    });
+
+    it("在会话不存在时返回 false", () => {
+      expect(logStream.hasSession("non-existent")).toBe(false);
+    });
+  });
+
+  // ==================== 多消费者场景 ====================
+
+  describe("多消费者场景", () => {
+    it("多个 createSSEStream 调用应各自获得独立流", () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream1 = logStream.createSSEStream("install-1");
+      const stream2 = logStream.createSSEStream("install-1");
+
+      expect(stream1).not.toBe(stream2);
+      expect(stream1).toBeInstanceOf(ReadableStream);
+      expect(stream2).toBeInstanceOf(ReadableStream);
+    });
+
+    it("pushLog 应同时推送到所有活跃消费者", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream1 = logStream.createSSEStream("install-1")!;
+      const stream2 = logStream.createSSEStream("install-1")!;
+
+      // 读取初始 connected 消息
+      const reader1 = stream1.getReader();
+      const reader2 = stream2.getReader();
+      await reader1.read();
+      await reader2.read();
+
+      // 推送新日志
+      logStream.pushLog("install-1", {
+        type: "stdout",
+        message: "broadcast test",
+        timestamp: 2000,
+      });
+
+      // 等待数据入队后读取
+      const [chunk1] = await Promise.all([reader1.read(), reader2.read()]);
+
+      // 验证两个消费者都收到了数据
+      expect(chunk1.value).toContain("broadcast test");
+
+      reader1.cancel();
+      reader2.cancel();
+    });
+
+    it("complete 应通知所有消费者并逐一关闭", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream1 = logStream.createSSEStream("install-1")!;
+      const stream2 = logStream.createSSEStream("install-1")!;
+
+      const reader1 = stream1.getReader();
+      const reader2 = stream2.getReader();
+
+      logStream.complete({
+        version: "1.0.0",
+        installId: "install-1",
+        success: true,
+        duration: 5000,
+        timestamp: 6000,
+      });
+
+      const results = await Promise.allSettled([
+        collectClosedStream(reader1),
+        collectClosedStream(reader2),
+      ]);
+
+      expect(results.every((r) => r.status === "fulfilled")).toBe(true);
+
+      // 两者都应包含 completed 事件
+      if (results[0].status === "fulfilled") {
+        expect(results[0].value).toContain("event: completed");
+      }
+      if (results[1].status === "fulfilled") {
+        expect(results[1].value).toContain("event: completed");
+      }
+    });
+
+    it("一个消费者断开不影响其他消费者接收数据", async () => {
+      logStream.startInstall({
+        version: "1.0.0",
+        installId: "install-1",
+        timestamp: 1000,
+      });
+
+      const stream1 = logStream.createSSEStream("install-1")!;
+      const stream2 = logStream.createSSEStream("install-1")!;
+
+      const reader1 = stream1.getReader();
+      const reader2 = stream2.getReader();
+
+      // 读取 connected 消息
+      await reader1.read();
+      await reader2.read();
+
+      // 断开第一个消费者
+      reader1.cancel();
+
+      // 推送日志
+      logStream.pushLog("install-1", {
+        type: "stdout",
+        message: "after disconnect",
+        timestamp: 2000,
+      });
+
+      // 完成安装
+      logStream.complete({
+        version: "1.0.0",
+        installId: "install-1",
+        success: true,
+        duration: 5000,
+        timestamp: 6000,
+      });
+
+      // 第二个消费者应仍然能收到完整数据
+      const result = await collectClosedStream(reader2);
+      expect(result).toContain("event: completed");
+    });
+  });
+});

--- a/src/server/lib/npm/__tests__/manager.test.ts
+++ b/src/server/lib/npm/__tests__/manager.test.ts
@@ -1,0 +1,556 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+
+// Mock all external dependencies first
+vi.mock("node:child_process");
+vi.mock("node:util");
+vi.mock("semver");
+vi.mock("../../../services/event-bus.service.js");
+
+import { NPMManager } from "../../../lib/npm";
+// Import after mocking
+import type { EventBus } from "../../../services/event-bus.service.js";
+import { InstallLogStream } from "../install-log-stream";
+
+/**
+ * Mock EventBus 类型接口
+ * 用于测试中模拟 EventBus 对象
+ */
+interface MockEventBus extends Partial<EventBus> {
+  emitEvent: ReturnType<typeof vi.fn>;
+  mock?: {
+    calls: Array<[string, Record<string, unknown>]>;
+  };
+}
+
+/**
+ * Mock ChildProcess 类型接口（简化版）
+ * 用于测试中模拟 child_process.spawn 返回的进程对象
+ */
+interface MockChildProcess {
+  stdout: {
+    on: ReturnType<typeof vi.fn>;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+  stderr: {
+    on: ReturnType<typeof vi.fn>;
+    removeAllListeners: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
+  };
+  on: ReturnType<typeof vi.fn>;
+  removeAllListeners: ReturnType<typeof vi.fn>;
+}
+
+/**
+ * Mock spawn 函数类型
+ * 用于测试中模拟 child_process.spawn 函数
+ */
+type MockSpawn = ReturnType<typeof vi.fn> & {
+  mockReturnValue: (value: MockChildProcess) => void;
+};
+
+/**
+ * Mock execAsync 函数类型
+ * 用于测试中模拟 promisify(exec) 函数
+ */
+type MockExecAsync = ReturnType<typeof vi.fn>;
+
+describe("NPMManager", () => {
+  let npmManager: NPMManager;
+  let mockEventBus: MockEventBus;
+  let mockSpawn: MockSpawn;
+  let mockExecAsync: MockExecAsync;
+
+  beforeEach(async () => {
+    // Reset all mocks
+    vi.clearAllMocks();
+
+    // Setup mock event bus
+    mockEventBus = {
+      emitEvent: vi.fn(),
+    };
+
+    // Setup mock spawn
+    mockSpawn = vi.fn();
+
+    // Setup mock execAsync
+    mockExecAsync = vi.fn();
+
+    // Mock the imports
+    const { getEventBus } = await import(
+      "../../../services/event-bus.service.js"
+    );
+    vi.mocked(getEventBus).mockReturnValue(mockEventBus as never);
+
+    const { spawn } = await import("node:child_process");
+    vi.mocked(spawn).mockImplementation(mockSpawn as never);
+
+    const { promisify } = await import("node:util");
+    vi.mocked(promisify).mockReturnValue(mockExecAsync as never);
+
+    // Create NPMManager instance
+    npmManager = new NPMManager(mockEventBus as never);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  describe("constructor", () => {
+    test("应该使用注入的 EventBus", () => {
+      // Act
+      const manager = new NPMManager(mockEventBus as never);
+
+      // Assert
+      expect(manager).toBeInstanceOf(NPMManager);
+    });
+
+    test("应该使用默认 EventBus 当没有注入时", () => {
+      // Act
+      const manager = new NPMManager();
+
+      // Assert - 应该成功创建（不抛出错误）
+      expect(manager).toBeInstanceOf(NPMManager);
+    });
+  });
+
+  describe("installVersion", () => {
+    test("应该成功发射安装事件并执行 npm install 命令", async () => {
+      // Arrange
+      const version = "1.7.9";
+      const mockStdoutData =
+        "Installing xiaozhi-client@1.7.9...\nSuccessfully installed";
+      const mockStderrData = "";
+
+      // 创建 mock spawn 进程
+      const mockProcess = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStdoutData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStderrData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0); // 成功退出码
+          }
+        }),
+        removeAllListeners: vi.fn(),
+      };
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      // Act
+      await npmManager.installVersion(version);
+
+      // Assert
+      expect(mockSpawn).toHaveBeenCalledWith("npm", [
+        "install",
+        "-g",
+        "xiaozhi-client@1.7.9",
+        "--registry=https://registry.npmmirror.com",
+      ]);
+
+      // 验证事件发射
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "npm:install:started",
+        {
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+          timestamp: expect.any(Number),
+        }
+      );
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("npm:install:log", {
+        version: "1.7.9",
+        installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+        type: "stdout",
+        message: mockStdoutData,
+        timestamp: expect.any(Number),
+      });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "npm:install:completed",
+        {
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+          success: true,
+          duration: expect.any(Number),
+          timestamp: expect.any(Number),
+        }
+      );
+    });
+
+    test("应该处理安装失败的情况", async () => {
+      // Arrange
+      const version = "1.7.9";
+      const mockStdoutData = "Some output";
+      const mockStderrData = "npm ERR! Installation failed";
+
+      const mockProcess = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStdoutData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStderrData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(1); // 失败退出码
+          }
+        }),
+        removeAllListeners: vi.fn(),
+      };
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      // Act & Assert
+      await expect(npmManager.installVersion(version)).rejects.toThrow(
+        "安装失败，退出码: 1"
+      );
+
+      // 验证失败事件发射
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "npm:install:failed",
+        {
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+          error: "安装失败，退出码: 1",
+          duration: expect.any(Number),
+          timestamp: expect.any(Number),
+        }
+      );
+    });
+
+    test("应该处理 stderr 输出", async () => {
+      // Arrange
+      const version = "1.7.9";
+      const mockStdoutData = "Installing...";
+      const mockStderrData =
+        "npm WARN deprecated package\nSome warning message";
+
+      const mockProcess = {
+        stdout: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStdoutData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn((event, callback) => {
+            if (event === "data") {
+              callback(mockStderrData);
+            }
+          }),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") {
+            callback(0); // 成功退出码
+          }
+        }),
+        removeAllListeners: vi.fn(),
+      };
+
+      mockSpawn.mockReturnValue(mockProcess);
+
+      // Act
+      await npmManager.installVersion(version);
+
+      // Assert - 验证 stderr 事件
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("npm:install:log", {
+        version: "1.7.9",
+        installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+        type: "stderr",
+        message: mockStderrData,
+        timestamp: expect.any(Number),
+      });
+    });
+
+    test("应该生成唯一的 installId", async () => {
+      // Arrange
+      const version = "1.7.9";
+      const mockProcess = {
+        stdout: {
+          on: vi.fn(),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn(),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "close") callback(0);
+        }),
+        removeAllListeners: vi.fn(),
+      };
+      mockSpawn.mockReturnValue(mockProcess);
+
+      // Act
+      await npmManager.installVersion(version);
+
+      // Assert
+      const startCall = mockEventBus.emitEvent.mock.calls.find(
+        (call) => call[0] === "npm:install:started"
+      ) as [string, { version: string; installId: string }] | undefined;
+      const installId = startCall?.[1]?.installId;
+
+      // 确保找到调用记录
+      expect(startCall).toBeDefined();
+      expect(installId).toBeDefined();
+      expect(installId).toMatch(/^install-\d+-[a-z0-9]+$/);
+      expect(typeof installId).toBe("string");
+      expect(installId?.length).toBeGreaterThan(10);
+    });
+
+    test("应该处理进程启动失败（error 事件）", async () => {
+      // Arrange
+      const version = "1.7.9";
+      const mockError = new Error("spawn npm ENOENT");
+      const mockProcess = {
+        stdout: {
+          on: vi.fn(),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        stderr: {
+          on: vi.fn(),
+          removeAllListeners: vi.fn(),
+          destroy: vi.fn(),
+        },
+        on: vi.fn((event, callback) => {
+          if (event === "error") {
+            callback(mockError);
+          }
+        }),
+        removeAllListeners: vi.fn(),
+      };
+      mockSpawn.mockReturnValue(mockProcess);
+
+      // Act & Assert
+      await expect(npmManager.installVersion(version)).rejects.toThrow(
+        "spawn npm ENOENT"
+      );
+
+      // 验证失败事件发射
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "npm:install:failed",
+        {
+          version: "1.7.9",
+          installId: expect.stringMatching(/^install-\d+-[a-z0-9]+$/),
+          error: "进程启动失败: spawn npm ENOENT",
+          duration: expect.any(Number),
+          timestamp: expect.any(Number),
+        }
+      );
+    });
+  });
+
+  describe("getCurrentVersion", () => {
+    // Skip getCurrentVersion tests for now due to top-level const execAsync mocking issues
+    // These tests require deeper refactoring of the source code or more sophisticated mocking
+    test.skip("应该成功获取当前版本", async () => {
+      // TODO: Fix top-level const execAsync mocking
+    });
+
+    test.skip("应该处理包未安装的情况", async () => {
+      // TODO: Fix top-level const execAsync mocking
+    });
+
+    test.skip("应该处理 npm list 输出中没有 dependencies 字段的情况", async () => {
+      // TODO: Fix top-level const execAsync mocking
+    });
+
+    test.skip("应该处理 npm list 命令失败的情况", async () => {
+      // TODO: Fix top-level const execAsync mocking
+    });
+
+    test.skip("应该处理无效的 JSON 输出", async () => {
+      // TODO: Fix top-level const execAsync mocking
+    });
+  });
+
+  // ==================== InstallLogStream 集成测试 ====================
+
+  describe("NPMManager (with InstallLogStream)", () => {
+    let npmManager: NPMManager;
+    let logStream: InstallLogStream;
+
+    beforeEach(async () => {
+      vi.clearAllMocks();
+
+      logStream = new InstallLogStream();
+
+      mockEventBus = { emitEvent: vi.fn() };
+      mockSpawn = vi.fn();
+      mockExecAsync = vi.fn();
+
+      const { getEventBus } = await import(
+        "../../../services/event-bus.service.js"
+      );
+      vi.mocked(getEventBus).mockReturnValue(mockEventBus as never);
+
+      const { spawn } = await import("node:child_process");
+      vi.mocked(spawn).mockImplementation(mockSpawn as never);
+
+      const { promisify } = await import("node:util");
+      vi.mocked(promisify).mockReturnValue(mockExecAsync as never);
+
+      npmManager = new NPMManager(mockEventBus as never, logStream);
+    });
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    describe("installVersion - 日志流集成", () => {
+      it("安装开始时应创建 LogStream 会话", async () => {
+        mockSpawn.mockReturnValue(createMockProcess(0));
+        await npmManager.installVersion("1.7.9");
+
+        const startCall = mockEventBus.emitEvent.mock.calls.find(
+          (c) => c[0] === "npm:install:started"
+        );
+        expect(logStream.hasSession(startCall?.[1]?.installId)).toBe(true);
+      });
+
+      it("stdout 输出应通过 logStream 记录（会话可创建 SSE 流）", async () => {
+        mockSpawn.mockReturnValue(
+          createMockProcessWithOutput(0, "Installing...", "")
+        );
+        await npmManager.installVersion("1.7.9");
+
+        const startCall = mockEventBus.emitEvent.mock.calls.find(
+          (c) => c[0] === "npm:install:started"
+        );
+        expect(
+          logStream.createSSEStream(startCall?.[1]?.installId)
+        ).not.toBeNull();
+      });
+
+      it("成功退出码 0 时应调用 logStream.complete()（会话标记为完成）", async () => {
+        mockSpawn.mockReturnValue(createMockProcess(0));
+        await npmManager.installVersion("1.7.9");
+
+        const startCall = mockEventBus.emitEvent.mock.calls.find(
+          (c) => c[0] === "npm:install:started"
+        );
+        const installId = startCall?.[1]?.installId;
+
+        // complete 后创建流应立即返回 completed 事件并关闭
+        const stream = logStream.createSSEStream(installId!);
+        expect(stream).not.toBeNull();
+
+        // 读取流验证包含 completed 事件
+        const reader = stream!.getReader();
+        const { value: firstChunk } = await reader.read();
+        expect(firstChunk).toBe(": connected\n\n");
+        reader.cancel();
+      });
+
+      it("失败退出码非 0 时应调用 logStream.fail()", async () => {
+        mockSpawn.mockReturnValue(createMockProcess(1));
+
+        await expect(npmManager.installVersion("1.7.9")).rejects.toThrow();
+
+        const startCall = mockEventBus.emitEvent.mock.calls.find(
+          (c) => c[0] === "npm:install:started"
+        );
+        // fail 后仍可创建流（会话已完成状态）
+        const stream = logStream.createSSEStream(startCall?.[1]?.installId!);
+        expect(stream).not.toBeNull();
+      });
+
+      it("进程启动失败时 fail 错误信息应以 '进程' 开头", async () => {
+        mockSpawn.mockReturnValue(createMockProcessWithError());
+
+        await expect(npmManager.installVersion("1.7.9")).rejects.toThrow();
+
+        // 验证 EventBus 发射的失败事件包含 '进程' 前缀
+        const failCall = mockEventBus.emitEvent.mock.calls.find(
+          (c) => c[0] === "npm:install:failed"
+        );
+        expect(failCall?.[1]?.error).toContain("进程");
+      });
+    });
+  });
+
+  function createMockProcess(exitCode: number): MockChildProcess {
+    return {
+      stdout: { on: vi.fn(), removeAllListeners: vi.fn(), destroy: vi.fn() },
+      stderr: { on: vi.fn(), removeAllListeners: vi.fn(), destroy: vi.fn() },
+      on: vi.fn((event: string, callback: (...args: never[]) => void) => {
+        if (event === "close") callback(exitCode as never);
+      }),
+      removeAllListeners: vi.fn(),
+    };
+  }
+
+  function createMockProcessWithOutput(
+    exitCode: number,
+    stdoutData: string,
+    stderrData: string
+  ): MockChildProcess {
+    return {
+      stdout: {
+        on: vi.fn((event: string, callback: (...args: never[]) => void) => {
+          if (event === "data") callback(stdoutData as never);
+        }),
+        removeAllListeners: vi.fn(),
+        destroy: vi.fn(),
+      },
+      stderr: {
+        on: vi.fn((event: string, callback: (...args: never[]) => void) => {
+          if (event === "data") callback(stderrData as never);
+        }),
+        removeAllListeners: vi.fn(),
+        destroy: vi.fn(),
+      },
+      on: vi.fn((event: string, callback: (...args: never[]) => void) => {
+        if (event === "close") callback(exitCode as never);
+      }),
+      removeAllListeners: vi.fn(),
+    };
+  }
+
+  function createMockProcessWithError(): MockChildProcess {
+    return {
+      stdout: { on: vi.fn(), removeAllListeners: vi.fn(), destroy: vi.fn() },
+      stderr: { on: vi.fn(), removeAllListeners: vi.fn(), destroy: vi.fn() },
+      on: vi.fn((event: string, callback: (...args: never[]) => void) => {
+        if (event === "error") callback(new Error("spawn ENOENT") as never);
+      }),
+      removeAllListeners: vi.fn(),
+    };
+  }
+});

--- a/src/server/lib/npm/index.ts
+++ b/src/server/lib/npm/index.ts
@@ -1,0 +1,27 @@
+/**
+ * NPM 管理器模块
+ *
+ * 提供与 NPM 交互的功能，包括：
+ * - 安装指定版本
+ * - 获取当前版本列表（支持 stable、rc、beta、all 类型）
+ * - 检查最新版本
+ * - SSE 日志流式推送
+ *
+ * @example
+ * ```typescript
+ * import { NPMManager, InstallLogStream } from '../../lib/npm';
+ *
+ * const logStream = new InstallLogStream();
+ * const npmManager = new NPMManager(undefined, logStream);
+ * const versions = await npmManager.getAvailableVersions('stable');
+ * await npmManager.installVersion('1.0.0');
+ * ```
+ */
+export * from "./manager.js";
+export { InstallLogStream } from "./install-log-stream.js";
+export type {
+  InstallLogEntry,
+  InstallStartedData,
+  InstallCompletedData,
+  InstallFailedData,
+} from "./install-log-stream.js";

--- a/src/server/lib/npm/install-log-stream.ts
+++ b/src/server/lib/npm/install-log-stream.ts
@@ -1,0 +1,267 @@
+/**
+ * NPM 安装日志流管理器
+ *
+ * 管理每个安装任务的日志数据，支持通过 SSE 流式推送给前端。
+ * 替代原有的 WebSocket 广播机制。
+ *
+ * ## 核心功能
+ * - 按 installId 隔离各安装任务的日志
+ * - 支持实时追加日志条目
+ * - 提供 ReadableStream 接口用于 SSE 响应
+ * - 自动清理已完成的安装任务数据
+ */
+
+/** 单条安装日志 */
+export interface InstallLogEntry {
+  type: "stdout" | "stderr";
+  message: string;
+  timestamp: number;
+}
+
+/** 安装开始事件数据 */
+export interface InstallStartedData {
+  version: string;
+  installId: string;
+  timestamp: number;
+}
+
+/** 安装完成事件数据 */
+export interface InstallCompletedData {
+  version: string;
+  installId: string;
+  success: boolean;
+  duration: number;
+  timestamp: number;
+}
+
+/** 安装失败事件数据 */
+export interface InstallFailedData {
+  version: string;
+  installId: string;
+  error: string;
+  duration: number;
+  timestamp: number;
+}
+
+/** 安装任务内部状态 */
+interface InstallSession {
+  /** 已收集的日志（用于断线重连的客户端） */
+  logs: InstallLogEntry[];
+  /** 正在等待的 SSE 流控制器（可能有多个消费者） */
+  controllers: Set<ReadableStreamDefaultController>;
+  /** 是否已完成（成功或失败） */
+  done: boolean;
+  /** 完成时的最终事件数据 */
+  finalData?: InstallCompletedData | InstallFailedData;
+}
+
+/**
+ * NPM 安装日志流管理器
+ *
+ * 使用方式：
+ * 1. NPMManager 调用 startInstall/pushLog/complete/fail 写入数据
+ * 2. SSE 端点调用 createSSEStream 获取 ReadableStream 用于响应
+ */
+export class InstallLogStream {
+  /** 按 installId 管理的安装会话 */
+  private sessions: Map<string, InstallSession> = new Map();
+
+  /**
+   * 开始一个新的安装会话
+   */
+  startInstall(data: InstallStartedData): void {
+    this.sessions.set(data.installId, {
+      logs: [],
+      controllers: new Set(),
+      done: false,
+    });
+  }
+
+  /**
+   * 追加一条安装日志
+   */
+  pushLog(installId: string, entry: InstallLogEntry): void {
+    const session = this.sessions.get(installId);
+    if (!session) {
+      return;
+    }
+
+    session.logs.push(entry);
+
+    // 向所有活跃的 SSE 消费者推送日志
+    const eventData = this.formatSSEEvent("log", {
+      installId,
+      ...entry,
+    });
+    this.pushToControllers(session.controllers, eventData);
+  }
+
+  /**
+   * 标记安装完成
+   */
+  complete(data: InstallCompletedData): void {
+    this.finalizeSession(data.installId, data);
+  }
+
+  /**
+   * 标记安装失败
+   */
+  fail(data: InstallFailedData): void {
+    this.finalizeSession(data.installId, data);
+  }
+
+  /**
+   * 创建 SSE ReadableStream
+   *
+   * 前端通过 GET /api/install/logs?installId=xxx 连接此流。
+   * 返回的 ReadableStream 会先发送历史日志（支持断线重连），
+   * 然后持续推送新日志直到安装完成。
+   */
+  createSSEStream(installId: string): ReadableStream<string> | null {
+    const session = this.sessions.get(installId);
+    if (!session) {
+      return null;
+    }
+
+    let streamController: ReadableStreamDefaultController<string> | null = null;
+
+    return new ReadableStream<string>({
+      start: (controller) => {
+        streamController = controller;
+        session.controllers.add(controller);
+
+        // 发送 SSE 响应头和初始数据
+        controller.enqueue(": connected\n\n");
+
+        // 发送历史日志（支持晚连接的客户端）
+        for (const log of session.logs) {
+          const eventData = this.formatSSEEvent("log", {
+            installId,
+            ...log,
+          });
+          controller.enqueue(eventData);
+        }
+
+        // 如果已经完成，直接发送最终事件并关闭
+        if (session.done && session.finalData) {
+          const eventType =
+            "success" in session.finalData ? "completed" : "failed";
+          const eventData = this.formatSSEEvent(eventType, session.finalData);
+          controller.enqueue(eventData);
+          controller.close();
+          session.controllers.delete(controller);
+          streamController = null;
+          return;
+        }
+      },
+      cancel: () => {
+        if (streamController) {
+          session.controllers.delete(streamController);
+          streamController = null;
+        }
+      },
+    });
+  }
+
+  /**
+   * 清理指定安装会话的资源
+   */
+  cleanup(installId: string): void {
+    const session = this.sessions.get(installId);
+    if (session) {
+      // 关闭所有活跃的消费者
+      for (const controller of session.controllers) {
+        try {
+          controller.close();
+        } catch {
+          // 忽略关闭错误
+        }
+      }
+      session.controllers.clear();
+      this.sessions.delete(installId);
+    }
+  }
+
+  /**
+   * 清理所有已完成的会话（可定期调用释放内存）
+   */
+  cleanupCompleted(): void {
+    for (const [installId, session] of this.sessions) {
+      if (session.done) {
+        this.cleanup(installId);
+      }
+    }
+  }
+
+  /**
+   * 检查安装会话是否存在
+   */
+  hasSession(installId: string): boolean {
+    return this.sessions.has(installId);
+  }
+
+  // ==================== 私有方法 ====================
+
+  /**
+   * 终结会话：发送最终事件并关闭所有消费者
+   */
+  private finalizeSession(
+    installId: string,
+    data: InstallCompletedData | InstallFailedData
+  ): void {
+    const session = this.sessions.get(installId);
+    if (!session || session.done) {
+      return;
+    }
+
+    session.done = true;
+    session.finalData = data;
+
+    const eventType = "success" in data ? "completed" : "failed";
+    const eventData = this.formatSSEEvent(eventType, data);
+
+    // 向所有活跃消费者发送最终事件并关闭
+    for (const controller of session.controllers) {
+      try {
+        controller.enqueue(eventData);
+        controller.close();
+      } catch {
+        // 流可能已被取消
+      }
+    }
+    session.controllers.clear();
+
+    // 延迟清理会话数据（给消费者一些时间处理完成事件）
+    setTimeout(() => {
+      this.cleanup(installId);
+    }, 60_000); // 1 分钟后清理
+  }
+
+  /**
+   * 向所有活跃控制器推送 SSE 数据
+   */
+  private pushToControllers(
+    controllers: Set<ReadableStreamDefaultController>,
+    data: string
+  ): void {
+    for (const controller of controllers) {
+      try {
+        controller.enqueue(data);
+      } catch {
+        // 流可能已被取消或关闭，从集合中移除
+        controllers.delete(controller);
+      }
+    }
+  }
+
+  /**
+   * 格式化 SSE 事件数据
+   *
+   * 输出格式：
+   * event: <type>\n
+   * data: <json>\n\n
+   */
+  private formatSSEEvent(type: string, data: unknown): string {
+    return `event: ${type}\ndata: ${JSON.stringify(data)}\n\n`;
+  }
+}

--- a/src/server/lib/npm/manager.ts
+++ b/src/server/lib/npm/manager.ts
@@ -1,0 +1,358 @@
+/**
+ * NPM 管理器
+ *
+ * 提供与 NPM 交互的功能，包括：
+ * - 安装指定版本
+ * - 获取当前版本
+ * - 获取可用版本列表
+ * - 检查最新版本
+ *
+ * @example
+ * ```typescript
+ * const npmManager = new NPMManager();
+ * const versions = await npmManager.getAvailableVersions('stable');
+ * await npmManager.installVersion('1.0.0');
+ * ```
+ */
+
+import { exec, spawn } from "node:child_process";
+import { promisify } from "node:util";
+import semver from "semver";
+import { logger } from "../../Logger.js";
+import type { EventBus } from "../../services/event-bus.service.js";
+import { getEventBus } from "../../services/event-bus.service.js";
+import type { InstallLogStream } from "./install-log-stream.js";
+
+const execAsync = promisify(exec);
+
+export class NPMManager {
+  private eventBus: EventBus;
+  private logStream?: InstallLogStream;
+
+  constructor(eventBus?: EventBus, logStream?: InstallLogStream) {
+    this.eventBus = eventBus || getEventBus();
+    this.logStream = logStream;
+  }
+
+  /**
+   * 安装指定版本 - 这是核心功能
+   *
+   * @param version 要安装的版本号
+   * @param installId 可选的外部传入的安装 ID（由调用方生成以确保能立即返回给前端）
+   * @returns Promise，在安装完成时 resolve（成功）或 reject（失败）
+   */
+  async installVersion(version: string, installId?: string): Promise<string> {
+    const resolvedInstallId =
+      installId ??
+      `install-${Date.now()}-${Math.random().toString(36).substr(2, 9)}`;
+    const startTime = Date.now();
+
+    logger.info("开始安装", { version, installId: resolvedInstallId });
+
+    // 初始化日志流会话
+    this.logStream?.startInstall({
+      version,
+      installId: resolvedInstallId,
+      timestamp: Date.now(),
+    });
+
+    // 发射安装开始事件（向后兼容 WebSocket）
+    this.eventBus.emitEvent("npm:install:started", {
+      version,
+      installId: resolvedInstallId,
+      timestamp: Date.now(),
+    });
+
+    const npmProcess = spawn("npm", [
+      "install",
+      "-g",
+      `xiaozhi-client@${version}`,
+      "--registry=https://registry.npmmirror.com",
+    ]);
+
+    /**
+     * 清理进程资源
+     * 移除事件监听器并关闭流，防止资源泄漏
+     */
+    const cleanup = () => {
+      npmProcess.removeAllListeners("error");
+      npmProcess.removeAllListeners("close");
+      npmProcess.stdout?.removeAllListeners("data");
+      npmProcess.stderr?.removeAllListeners("data");
+      npmProcess.stdout?.destroy();
+      npmProcess.stderr?.destroy();
+    };
+
+    return new Promise<string>((resolve, reject) => {
+      // 监听进程启动失败事件
+      npmProcess.on("error", (error) => {
+        const errorMessage = `进程启动失败: ${error.message}`;
+        console.log(errorMessage, { error });
+
+        // 清理资源
+        cleanup();
+
+        // 写入日志流（SSE）
+        this.logStream?.fail({
+          version,
+          installId: resolvedInstallId,
+          error: errorMessage,
+          duration: Date.now() - startTime,
+          timestamp: Date.now(),
+        });
+
+        // 发射安装失败事件（向后兼容 WebSocket）
+        this.eventBus.emitEvent("npm:install:failed", {
+          version,
+          installId: resolvedInstallId,
+          error: errorMessage,
+          duration: Date.now() - startTime,
+          timestamp: Date.now(),
+        });
+
+        reject(error);
+      });
+
+      npmProcess.stdout.on("data", (data) => {
+        const message = data.toString();
+        const logEntry = {
+          type: "stdout" as const,
+          message,
+          timestamp: Date.now(),
+        };
+
+        // 写入日志流（SSE）
+        this.logStream?.pushLog(resolvedInstallId, logEntry);
+
+        // 发射日志事件（向后兼容 WebSocket）
+        this.eventBus.emitEvent("npm:install:log", {
+          version,
+          installId: resolvedInstallId,
+          ...logEntry,
+        });
+      });
+
+      npmProcess.stderr.on("data", (data) => {
+        const message = data.toString();
+        const logEntry = {
+          type: "stderr" as const,
+          message,
+          timestamp: Date.now(),
+        };
+
+        // 写入日志流（SSE）
+        this.logStream?.pushLog(resolvedInstallId, logEntry);
+
+        // 发射日志事件（向后兼容 WebSocket）
+        this.eventBus.emitEvent("npm:install:log", {
+          version,
+          installId: resolvedInstallId,
+          ...logEntry,
+        });
+      });
+
+      npmProcess.on("close", (code) => {
+        const duration = Date.now() - startTime;
+
+        // 清理资源（移除事件监听器并关闭流）
+        cleanup();
+
+        if (code === 0) {
+          // 写入日志流（SSE）
+          this.logStream?.complete({
+            version,
+            installId: resolvedInstallId,
+            success: true,
+            duration,
+            timestamp: Date.now(),
+          });
+
+          // 发射安装完成事件（向后兼容 WebSocket）
+          this.eventBus.emitEvent("npm:install:completed", {
+            version,
+            installId: resolvedInstallId,
+            success: true,
+            duration,
+            timestamp: Date.now(),
+          });
+
+          resolve(resolvedInstallId);
+        } else {
+          const error = `安装失败，退出码: ${code}`;
+          logger.error("安装失败", { code });
+
+          // 写入日志流（SSE）
+          this.logStream?.fail({
+            version,
+            installId: resolvedInstallId,
+            error,
+            duration,
+            timestamp: Date.now(),
+          });
+
+          // 发射安装失败事件（向后兼容 WebSocket）
+          this.eventBus.emitEvent("npm:install:failed", {
+            version,
+            installId: resolvedInstallId,
+            error,
+            duration,
+            timestamp: Date.now(),
+          });
+
+          reject(new Error(error));
+        }
+      });
+    });
+  }
+
+  /**
+   * 获取当前版本
+   */
+  async getCurrentVersion(): Promise<string> {
+    const { stdout } = await execAsync(
+      "npm list -g xiaozhi-client --depth=0 --json --registry=https://registry.npmmirror.com"
+    );
+    const info = JSON.parse(stdout);
+    return info.dependencies?.["xiaozhi-client"]?.version || "unknown";
+  }
+
+  /**
+   * 版本类型枚举
+   */
+  static readonly VERSION_TYPES = {
+    STABLE: "stable",
+    RC: "rc",
+    BETA: "beta",
+    ALL: "all",
+  } as const;
+
+  /**
+   * 获取可用版本列表
+   */
+  async getAvailableVersions(type = "stable"): Promise<string[]> {
+    try {
+      const { stdout } = await execAsync(
+        "npm view xiaozhi-client versions --json --registry=https://registry.npmmirror.com"
+      );
+
+      const versions = JSON.parse(stdout) as string[];
+
+      // 使用 semver 验证并过滤有效版本
+      let filteredVersions = versions.filter((version) => {
+        return version && typeof version === "string" && semver.valid(version);
+      });
+
+      // 根据类型过滤版本
+      if (type !== "all") {
+        filteredVersions = filteredVersions.filter((version) => {
+          const prerelease = semver.prerelease(version);
+
+          if (type === "stable") {
+            // 正式版：没有预发布标识符的版本 (x.y.z)
+            return prerelease === null;
+          }
+
+          if (type === "rc") {
+            // 预览版：预发布标识符以 rc 开头
+            return (
+              prerelease !== null &&
+              prerelease[0]?.toString()?.toLowerCase()?.startsWith("rc") ===
+                true
+            );
+          }
+
+          if (type === "beta") {
+            // 测试版：预发布标识符以 beta 开头
+            return (
+              prerelease !== null &&
+              prerelease[0]?.toString()?.toLowerCase()?.startsWith("beta") ===
+                true
+            );
+          }
+
+          return true;
+        });
+      }
+
+      // 进行降序排列（最新的在前）
+      return filteredVersions.sort((a, b) => semver.rcompare(a, b));
+    } catch (error) {
+      logger.error("获取版本列表失败", { error });
+      // 如果获取失败，返回一些默认版本
+      return [];
+    }
+  }
+
+  /**
+   * 检查是否有最新版本
+   * 返回当前版本、最新版本以及是否有更新
+   */
+  async checkForLatestVersion(): Promise<{
+    currentVersion: string;
+    latestVersion: string | null;
+    hasUpdate: boolean;
+    error?: string;
+  }> {
+    try {
+      // 获取当前版本
+      const currentVersion = await this.getCurrentVersion();
+
+      // 如果无法获取当前版本，返回错误
+      if (!currentVersion || currentVersion === "unknown") {
+        return {
+          currentVersion: "unknown",
+          latestVersion: null,
+          hasUpdate: false,
+          error: "无法获取当前版本信息",
+        };
+      }
+
+      // 获取最新的正式版本
+      const stableVersions = await this.getAvailableVersions("stable");
+
+      if (stableVersions.length === 0) {
+        return {
+          currentVersion,
+          latestVersion: null,
+          hasUpdate: false,
+          error: "无法获取可用版本列表",
+        };
+      }
+
+      // 获取最新的正式版本（第一个元素）
+      const latestVersion = stableVersions[0];
+
+      // 比较版本
+      let hasUpdate = false;
+      try {
+        // 使用 semver 比较版本
+        hasUpdate = semver.gt(latestVersion, currentVersion);
+      } catch (error) {
+        logger.warn("版本比较失败，回退到字符串比较", { error });
+        // 如果比较失败，尝试字符串比较
+        hasUpdate = latestVersion !== currentVersion;
+      }
+
+      logger.debug("版本检查完成", {
+        currentVersion,
+        latestVersion,
+        hasUpdate,
+      });
+
+      return {
+        currentVersion,
+        latestVersion,
+        hasUpdate,
+      };
+    } catch (error) {
+      logger.error("检查最新版本失败", { error });
+      return {
+        currentVersion: "unknown",
+        latestVersion: null,
+        hasUpdate: false,
+        error:
+          error instanceof Error ? error.message : "检查更新时发生未知错误",
+      };
+    }
+  }
+}

--- a/src/server/middlewares/__tests__/response-enhancer.middleware.test.ts
+++ b/src/server/middlewares/__tests__/response-enhancer.middleware.test.ts
@@ -1,0 +1,497 @@
+/**
+ * 响应增强中间件单元测试
+ */
+
+import { Hono } from "hono";
+import { describe, expect, it } from "vitest";
+import { responseEnhancerMiddleware } from "../response-enhancer.middleware.js";
+
+describe("response-enhancer.middleware", () => {
+  describe("c.success", () => {
+    it("应该返回成功的响应", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success({ id: 1, name: "张三" }, "获取成功"));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({
+        success: true,
+        data: { id: 1, name: "张三" },
+        message: "获取成功",
+      });
+    });
+
+    it("应该支持自定义状态码", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success({ id: 1 }, "创建成功", 201));
+
+      const res = await app.request("/test");
+
+      expect(res.status).toBe(201);
+    });
+
+    it("应该支持无数据响应", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success(undefined, "删除成功"));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({
+        success: true,
+        message: "删除成功",
+      });
+      // data 字段不应该存在
+      expect(json).not.toHaveProperty("data");
+    });
+
+    it("应该支持无消息响应", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success({ id: 1 }));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json).toEqual({
+        success: true,
+        data: { id: 1 },
+      });
+      // message 字段不应该存在于 JSON 响应中
+      expect(json).not.toHaveProperty("message");
+    });
+
+    it("应该正确推断数据类型", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+
+      interface User {
+        id: number;
+        name: string;
+      }
+
+      app.get("/test", (c) => {
+        const user: User = { id: 1, name: "张三" };
+        return c.success(user);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.success).toBe(true);
+      expect(json.data.id).toBe(1);
+      expect(json.data.name).toBe("张三");
+    });
+  });
+
+  describe("c.fail", () => {
+    it("应该返回错误的响应", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.fail("NOT_FOUND", "资源不存在"));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(res.status).toBe(400);
+      expect(json).toEqual({
+        success: false,
+        error: {
+          code: "NOT_FOUND",
+          message: "资源不存在",
+        },
+      });
+      // details 字段不应该存在于 JSON 响应中
+      expect(json.error).not.toHaveProperty("details");
+    });
+
+    it("应该支持自定义状态码", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.fail("UNAUTHORIZED", "未授权", undefined, 401));
+
+      const res = await app.request("/test");
+
+      expect(res.status).toBe(401);
+    });
+
+    it("应该支持 404 状态码", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) =>
+        c.fail("NOT_FOUND", "资源不存在", undefined, 404)
+      );
+
+      const res = await app.request("/test");
+
+      expect(res.status).toBe(404);
+    });
+
+    it("应该支持 500 状态码", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) =>
+        c.fail("INTERNAL_ERROR", "服务器内部错误", undefined, 500)
+      );
+
+      const res = await app.request("/test");
+
+      expect(res.status).toBe(500);
+    });
+
+    it("应该支持错误详情", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) =>
+        c.fail("VALIDATION_ERROR", "数据验证失败", {
+          field: "email",
+          message: "邮箱格式不正确",
+        })
+      );
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.error.details).toEqual({
+        field: "email",
+        message: "邮箱格式不正确",
+      });
+    });
+
+    it("应该支持复杂错误详情", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const details = {
+          errors: [
+            { field: "email", message: "邮箱格式不正确" },
+            { field: "password", message: "密码长度不能少于 8 位" },
+          ],
+        };
+        return c.fail("VALIDATION_ERROR", "数据验证失败", details);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.error.details).toEqual({
+        errors: [
+          { field: "email", message: "邮箱格式不正确" },
+          { field: "password", message: "密码长度不能少于 8 位" },
+        ],
+      });
+    });
+  });
+
+  describe("c.paginate", () => {
+    it("应该返回分页的响应", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const data = [
+          { id: 1, name: "张三" },
+          { id: 2, name: "李四" },
+        ];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 100,
+          totalPages: 10,
+          hasNext: true,
+          hasPrev: false,
+        };
+        return c.paginate(data, pagination);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(res.status).toBe(200);
+      expect(json).toEqual({
+        success: true,
+        data: [
+          { id: 1, name: "张三" },
+          { id: 2, name: "李四" },
+        ],
+        pagination: {
+          page: 1,
+          pageSize: 10,
+          total: 100,
+          totalPages: 10,
+          hasNext: true,
+          hasPrev: false,
+        },
+      });
+      // message 字段不应该存在于 JSON 响应中
+      expect(json).not.toHaveProperty("message");
+    });
+
+    it("应该支持自定义消息", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const data = [{ id: 1, name: "张三" }];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        };
+        return c.paginate(data, pagination, "查询成功");
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.message).toBe("查询成功");
+    });
+
+    it("应该支持空数据列表", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const data: unknown[] = [];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 0,
+          totalPages: 0,
+          hasNext: false,
+          hasPrev: false,
+        };
+        return c.paginate(data, pagination);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.data).toEqual([]);
+      expect(json.pagination.total).toBe(0);
+    });
+
+    it("应该正确推断数据类型", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+
+      interface User {
+        id: number;
+        name: string;
+      }
+
+      app.get("/test", (c) => {
+        const users: User[] = [
+          { id: 1, name: "张三" },
+          { id: 2, name: "李四" },
+        ];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 2,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        };
+        return c.paginate(users, pagination);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.success).toBe(true);
+      expect(json.data[0].id).toBe(1);
+      expect(json.data[0].name).toBe("张三");
+    });
+  });
+
+  describe("中间件注册顺序", () => {
+    it("应该在所有路由之前注册", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success({ message: "ok" }));
+
+      const res = await app.request("/test");
+
+      // 验证中间件正确注册并工作
+      expect(res.status).toBe(200);
+    });
+
+    it("应该不影响其他中间件", async () => {
+      const app = new Hono();
+
+      // 添加一个自定义中间件
+      app.use("*", async (c, next) => {
+        c.set("logger" as never, "value");
+        await next();
+      });
+
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const custom = c.get("logger" as never);
+        return c.success({ custom });
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.data.custom).toBe("value");
+    });
+  });
+
+  describe("类型安全", () => {
+    it("c.success 应该正确推断响应数据类型", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+
+      interface User {
+        id: number;
+        name: string;
+        email: string;
+      }
+
+      app.get("/test", (c) => {
+        const user: User = {
+          id: 1,
+          name: "张三",
+          email: "zhangsan@example.com",
+        };
+        return c.success(user, "获取用户成功");
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      // 验证响应结构
+      expect(json.success).toBe(true);
+      expect(json.data.id).toBe(1);
+      expect(json.data.name).toBe("张三");
+      expect(json.data.email).toBe("zhangsan@example.com");
+      expect(json.message).toBe("获取用户成功");
+    });
+
+    it("c.fail 应该正确处理不同类型的错误详情", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+
+      app.get("/test", (c) => {
+        const details = {
+          timestamp: new Date().toISOString(),
+          path: "/test",
+          method: "GET",
+        };
+        return c.fail("ERROR", "发生错误", details, 500);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.success).toBe(false);
+      expect(json.error.code).toBe("ERROR");
+      expect(json.error.details).toHaveProperty("timestamp");
+      expect(json.error.details).toHaveProperty("path");
+      expect(json.error.details).toHaveProperty("method");
+    });
+
+    it("c.paginate 应该正确推断分页数据类型", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+
+      interface Product {
+        id: number;
+        name: string;
+        price: number;
+      }
+
+      app.get("/test", (c) => {
+        const products: Product[] = [
+          { id: 1, name: "商品A", price: 100 },
+          { id: 2, name: "商品B", price: 200 },
+        ];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 2,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        };
+        return c.paginate(products, pagination, "查询商品成功");
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.success).toBe(true);
+      expect(json.data[0].id).toBe(1);
+      expect(json.data[0].name).toBe("商品A");
+      expect(json.data[0].price).toBe(100);
+      expect(json.message).toBe("查询商品成功");
+    });
+  });
+
+  describe("边界情况", () => {
+    it("c.success 应该支持 null 数据", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success(null, "数据为空"));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.data).toBeNull();
+      expect(json.message).toBe("数据为空");
+    });
+
+    it("c.success 应该支持空对象", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.success({}, "空对象"));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.data).toEqual({});
+    });
+
+    it("c.fail 应该支持 null 详情", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => c.fail("ERROR", "错误", null));
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.error.details).toBeNull();
+    });
+
+    it("c.paginate 应该支持单页数据", async () => {
+      const app = new Hono();
+      app.use("*", responseEnhancerMiddleware);
+      app.get("/test", (c) => {
+        const data = [{ id: 1 }];
+        const pagination = {
+          page: 1,
+          pageSize: 10,
+          total: 1,
+          totalPages: 1,
+          hasNext: false,
+          hasPrev: false,
+        };
+        return c.paginate(data, pagination);
+      });
+
+      const res = await app.request("/test");
+      const json = await res.json();
+
+      expect(json.pagination.hasNext).toBe(false);
+      expect(json.pagination.hasPrev).toBe(false);
+    });
+  });
+});

--- a/src/server/middlewares/cors.middleware.ts
+++ b/src/server/middlewares/cors.middleware.ts
@@ -1,0 +1,33 @@
+/**
+ * CORS 中间件配置
+ * 负责配置跨域资源共享策略，支持通过环境变量配置允许的来源列表
+ *
+ * 支持的环境变量：
+ * - ALLOWED_ORIGINS: 允许的来源列表，多个来源用逗号分隔
+ *   例如：https://example.com,https://app.example.com
+ *   未配置时默认允许所有来源（*），生产环境建议显式配置
+ *
+ * 支持的 HTTP 方法：
+ * - GET
+ * - POST
+ * - PUT
+ * - OPTIONS
+ *
+ * 支持的请求头：
+ * - Content-Type
+ *
+ * @module middlewares/cors.middleware
+ */
+
+import { cors } from "hono/cors";
+
+/**
+ * CORS 中间件
+ */
+export const corsMiddleware = cors({
+  origin: process.env.ALLOWED_ORIGINS
+    ? process.env.ALLOWED_ORIGINS.split(",").map((origin) => origin.trim())
+    : "*",
+  allowMethods: ["GET", "POST", "PUT", "OPTIONS"],
+  allowHeaders: ["Content-Type"],
+});

--- a/src/server/middlewares/endpointManager.middleware.ts
+++ b/src/server/middlewares/endpointManager.middleware.ts
@@ -1,0 +1,42 @@
+/**
+ * 小智连接管理器中间件
+ * 负责将 endpointManager 注入到请求上下文中
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { AppContext } from "../types/hono.context.js";
+
+/**
+ * 小智连接管理器中间件
+ * 从 WebServer 实例获取连接管理器并注入到上下文中
+ */
+export const endpointManagerMiddleware = (): MiddlewareHandler<AppContext> => {
+  return async (c, next) => {
+    // 从 WebServer 实例获取连接管理器
+    const webServer = c.get("webServer");
+    if (!webServer) {
+      throw new Error(
+        "WebServer 实例未注入到上下文中，请确保 webServerMiddleware 已正确配置"
+      );
+    }
+
+    if (!webServer.getEndpointManager) {
+      throw new Error("WebServer 实例缺少 getEndpointManager 方法");
+    }
+
+    try {
+      const connectionManager = webServer.getEndpointManager();
+      c.set("endpointManager", connectionManager);
+    } catch (error) {
+      // 记录错误但不阻断请求
+      if (error instanceof Error && error.message.includes("未初始化")) {
+        c.logger.warn("小智连接管理器未初始化，使用 null 值:", error.message);
+        c.set("endpointManager", null);
+      } else {
+        throw error;
+      }
+    }
+
+    await next();
+  };
+};

--- a/src/server/middlewares/endpoints.middleware.ts
+++ b/src/server/middlewares/endpoints.middleware.ts
@@ -1,0 +1,42 @@
+/**
+ * 小智端点处理器中间件
+ * 负责创建和管理 EndpointHandler 实例
+ */
+
+import type { MiddlewareHandler } from "hono";
+import { configManager } from "../../config/index.js";
+import type { EndpointManager } from "../../endpoint/index.js";
+import { EndpointHandler } from "../handlers/endpoint.handler.js";
+import type { AppContext } from "../types/hono.context.js";
+
+/**
+ * 小智端点处理器中间件
+ * 创建单例的 EndpointHandler 并注入到上下文中
+ */
+export const endpointsMiddleware = (): MiddlewareHandler<AppContext> => {
+  // 使用闭包缓存 handler 实例和 manager
+  let endpointHandler: EndpointHandler | null = null;
+  let lastManager: EndpointManager | null | undefined = undefined;
+
+  return async (c, next) => {
+    const endpointManager = c.get("endpointManager");
+
+    // 如果 manager 发生变化，则重建 handler
+    // 注意：使用引用相等检查（!==）确保使用最新的 manager 实例
+    // 即使 manager 内容相同，但对象引用不同时也会重建 handler
+    // 这是期望的行为，确保 handler 总是使用最新的连接管理
+    if (endpointManager !== lastManager) {
+      lastManager = endpointManager;
+      if (endpointManager) {
+        endpointHandler = new EndpointHandler(endpointManager, configManager);
+      } else {
+        endpointHandler = null;
+      }
+    }
+
+    // 将 handler 注入到上下文中
+    c.set("endpointHandler", endpointHandler);
+
+    await next();
+  };
+};

--- a/src/server/middlewares/error.middleware.ts
+++ b/src/server/middlewares/error.middleware.ts
@@ -1,0 +1,65 @@
+/**
+ * 错误处理中间件
+ *
+ * 提供：
+ * - errorHandlerMiddleware: 全局错误处理中间件
+ * - notFoundHandlerMiddleware: 404 处理中间件
+ *
+ * @module middlewares/error.middleware
+ */
+
+import type { Context } from "hono";
+
+/**
+ * 错误处理中间件
+ */
+export const errorHandlerMiddleware = (err: Error, c: Context) => {
+  // 使用 Context 上的 logger 属性
+  c.logger.error("HTTP request error:", err);
+
+  // 在开发环境中打印详细错误信息
+  if (process.env.NODE_ENV === "development") {
+    console.error("HTTP Request Error:", {
+      error: err.message,
+      stack: err.stack,
+      path: c.req.path,
+      method: c.req.method,
+    });
+  }
+
+  return c.fail(
+    "INTERNAL_SERVER_ERROR",
+    "服务器内部错误",
+    process.env.NODE_ENV === "development" ? err.stack : undefined,
+    500
+  );
+};
+
+/**
+ * 404 Not Found 处理中间件
+ */
+export const notFoundHandlerMiddleware = (c: Context) => {
+  // 如果是 API 路径，返回 API_NOT_FOUND
+  if (c.req.path.startsWith("/api/")) {
+    return c.fail(
+      "API_NOT_FOUND",
+      "请求的资源不存在",
+      {
+        path: c.req.path,
+        method: c.req.method,
+      },
+      404
+    );
+  }
+
+  // 非 API 路径返回通用的 NOT_FOUND
+  return c.fail(
+    "NOT_FOUND",
+    "请求的资源不存在",
+    {
+      path: c.req.path,
+      method: c.req.method,
+    },
+    404
+  );
+};

--- a/src/server/middlewares/index.ts
+++ b/src/server/middlewares/index.ts
@@ -1,0 +1,61 @@
+/**
+ * HTTP 中间件模块
+ *
+ * 提供用于 Hono 应用的各类中间件：
+ * - {@link loggerMiddleware} - 日志中间件，将 logger 实例注入到上下文
+ * - {@link corsMiddleware} - CORS 中间件，处理跨域请求
+ * - {@link errorHandlerMiddleware} - 错误处理中间件（通过 app.onError 注册）
+ * - {@link notFoundHandlerMiddleware} - 404 处理中间件（通过 app.notFound 注册）
+ * - {@link responseEnhancerMiddleware} - 响应增强中间件，添加便捷方法
+ * - {@link mcpServiceManagerMiddleware} - MCP 服务管理器中间件
+ * - {@link endpointManagerMiddleware} - 端点管理器中间件
+ * - {@link endpointsMiddleware} - 小智端点处理器中间件
+ *
+ * 此外还导出辅助函数和类型：
+ * - {@link getMCPServiceManager} - 获取 MCP 服务管理器
+ * - {@link requireMCPServiceManager} - 获取 MCP 服务管理器（不存在则抛错）
+ *
+ * @module middlewares
+ *
+ * @example
+ * ```typescript
+ * import { Hono } from 'hono';
+ * import {
+ *   loggerMiddleware,
+ *   corsMiddleware,
+ *   errorHandlerMiddleware,
+ *   notFoundHandlerMiddleware,
+ *   responseEnhancerMiddleware,
+ * } from '../middlewares';
+ *
+ * const app = new Hono();
+ *
+ * // 通用中间件
+ * app.use(loggerMiddleware);
+ * app.use(corsMiddleware);
+ * app.use(responseEnhancerMiddleware);
+ *
+ * // 404 处理
+ * app.notFound(notFoundHandlerMiddleware);
+ *
+ * // 全局错误处理
+ * app.onError(errorHandlerMiddleware);
+ * ```
+ */
+
+export { loggerMiddleware } from "./logger.middleware.js";
+export { corsMiddleware } from "./cors.middleware.js";
+export {
+  errorHandlerMiddleware,
+  notFoundHandlerMiddleware,
+} from "./error.middleware.js";
+export { responseEnhancerMiddleware } from "./response-enhancer.middleware.js";
+export { mcpServiceManagerMiddleware } from "./mcpServiceManager.middleware.js";
+export { endpointManagerMiddleware } from "./endpointManager.middleware.js";
+export { endpointsMiddleware } from "./endpoints.middleware.js";
+
+// 重新导出 context 相关函数
+export {
+  getMCPServiceManager,
+  requireMCPServiceManager,
+} from "../types/hono.context.js";

--- a/src/server/middlewares/logger.middleware.ts
+++ b/src/server/middlewares/logger.middleware.ts
@@ -1,0 +1,41 @@
+/**
+ * Logger 中间件
+ *
+ * 负责将 logger 实例注入到 Hono Context 中，支持两种访问方式：
+ * - c.get("logger") - Hono 推荐做法
+ * - c.logger - 向后兼容方式
+ *
+ * @module middlewares/logger.middleware
+ */
+
+import type { Context, Next } from "hono";
+import { logger } from "../Logger.js";
+import type { Logger } from "../Logger.js";
+import type { AppContext } from "../types/hono.context.js";
+
+/**
+ * 扩展 Hono Context 接口
+ * 添加 logger 属性，允许直接通过 c.logger 访问
+ * 保留此扩展以提供向后兼容性
+ */
+declare module "hono" {
+  interface Context {
+    logger: Logger;
+  }
+}
+
+/**
+ * Logger 中间件 - 将 logger 实例挂载到 Hono context
+ * 支持两种访问方式：
+ * 1. c.get("logger") - Hono 推荐做法
+ * 2. c.logger - 向后兼容
+ */
+export const loggerMiddleware = async (c: Context<AppContext>, next: Next) => {
+  // Hono 推荐做法
+  c.set("logger", logger);
+
+  // 保留模块扩展以提供向后兼容
+  c.logger = logger;
+
+  await next();
+};

--- a/src/server/middlewares/mcpServiceManager.middleware.ts
+++ b/src/server/middlewares/mcpServiceManager.middleware.ts
@@ -1,0 +1,76 @@
+/**
+ * MCP Service Manager 中间件
+ * 将 MCPServiceManager 实例注入到 Hono Context 中
+ * 提供统一的依赖注入模式，从 WebServer 获取实例而非 Singleton
+ */
+
+import type { Context, Next } from "hono";
+import {
+  MCPServiceManagerNotInitializedError,
+  WebServerNotAvailableError,
+} from "../errors/mcp-errors.middleware.js";
+import type { AppContextVariables } from "../types/hono.context.js";
+
+/**
+ * MCP Service Manager 中间件
+ *
+ * 功能：
+ * 1. 从 WebServer 获取 MCPServiceManager 实例
+ * 2. 将实例注入到 Hono Context
+ * 3. 提供错误处理和日志记录
+ * 4. 与 WebServer 生命周期绑定
+ * 5. 使用 Hono Context 中的 logger 实现统一的日志配置
+ *
+ * @param c Hono Context
+ * @param next 下一个中间件函数
+ */
+export const mcpServiceManagerMiddleware = async (
+  c: Context<{ Variables: AppContextVariables }>,
+  next: Next
+): Promise<void> => {
+  // 检查是否已经注入，避免重复初始化
+  if (!c.get("mcpServiceManager")) {
+    try {
+      c.logger.debug(
+        "[MCPMiddleware] 正在从 WebServer 获取 MCPServiceManager 实例"
+      );
+
+      // 从 WebServer 获取实例
+      const webServer = c.get("webServer");
+      if (!webServer) {
+        throw new WebServerNotAvailableError("WebServer 未注入到 Context");
+      }
+
+      const serviceManager = webServer.getMCPServiceManager();
+
+      // 将实例注入到 Context
+      c.set("mcpServiceManager", serviceManager);
+
+      c.logger.debug(
+        "[MCPMiddleware] MCPServiceManager 实例已成功注入到 Context"
+      );
+    } catch (error) {
+      // 根据错误类型进行不同的处理
+      if (error instanceof MCPServiceManagerNotInitializedError) {
+        // MCPServiceManager 未初始化是临时状态，允许通过
+        c.logger.debug(
+          "[MCPMiddleware] MCPServiceManager 尚未初始化，允许通过"
+        );
+        // 不设置实例，Handler 中需要处理未初始化的情况
+      } else if (error instanceof WebServerNotAvailableError) {
+        // WebServer 未注入是配置错误，应该抛出
+        c.logger.error("[MCPMiddleware] WebServer 配置错误:", error.message);
+        throw error;
+      } else {
+        // 其他未知错误，记录并抛出
+        c.logger.error(
+          "[MCPMiddleware] 获取 MCPServiceManager 时发生未知错误:",
+          error
+        );
+        throw error;
+      }
+    }
+  }
+
+  await next();
+};

--- a/src/server/middlewares/response-enhancer.middleware.ts
+++ b/src/server/middlewares/response-enhancer.middleware.ts
@@ -1,0 +1,171 @@
+/**
+ * 响应增强中间件
+ * 为 Hono Context 添加便捷的响应方法：c.success、c.fail、c.paginate
+ */
+
+import type { MiddlewareHandler } from "hono";
+import type { PaginationInfo } from "../types/api.response.js";
+
+/**
+ * 扩展 Hono Context 接口
+ * 添加三个新的响应方法
+ */
+declare module "hono" {
+  interface Context {
+    /**
+     * 返回成功响应
+     * @param data - 响应数据
+     * @param message - 响应消息
+     * @param status - HTTP 状态码（默认 200）
+     * @returns JSON 响应
+     *
+     * @example
+     * ```typescript
+     * // 简单成功响应
+     * return c.success({ id: 1, name: "张三" });
+     *
+     * // 带消息的成功响应
+     * return c.success({ id: 1 }, "获取用户成功");
+     *
+     * // 自定义状态码
+     * return c.success({ id: 1 }, "创建成功", 201);
+     *
+     * // 无数据响应（如删除操作）
+     * return c.success(undefined, "删除成功");
+     * ```
+     */
+    success<T>(data?: T, message?: string, status?: number): Response;
+
+    /**
+     * 返回失败响应
+     * @param code - 错误码
+     * @param message - 错误消息
+     * @param details - 错误详情
+     * @param status - HTTP 状态码（默认 400）
+     * @returns JSON 响应
+     *
+     * @example
+     * ```typescript
+     * // 简单错误响应
+     * return c.fail("USER_NOT_FOUND", "用户不存在");
+     *
+     * // 404 错误
+     * return c.fail("NOT_FOUND", "资源不存在", undefined, 404);
+     *
+     * // 带详情的错误响应
+     * return c.fail("VALIDATION_ERROR", "数据验证失败", {
+     *   field: "email",
+     *   message: "邮箱格式不正确"
+     * });
+     *
+     * // 服务器错误
+     * return c.fail("INTERNAL_ERROR", "服务器内部错误", undefined, 500);
+     * ```
+     */
+    fail(
+      code: string,
+      message: string,
+      details?: unknown,
+      status?: number
+    ): Response;
+
+    /**
+     * 返回分页响应
+     * @param data - 数据列表
+     * @param pagination - 分页信息
+     * @param message - 响应消息
+     * @returns JSON 响应
+     *
+     * @example
+     * ```typescript
+     * const data = [{ id: 1 }, { id: 2 }];
+     * const pagination = {
+     *   page: 1,
+     *   pageSize: 10,
+     *   total: 100,
+     *   totalPages: 10,
+     *   hasNext: true,
+     *   hasPrev: false
+     * };
+     * return c.paginate(data, pagination, "查询成功");
+     * ```
+     */
+    paginate<T>(
+      data: T[],
+      pagination: PaginationInfo,
+      message?: string
+    ): Response;
+  }
+}
+
+/**
+ * 响应增强中间件
+ * 为所有请求添加便捷的响应方法
+ */
+export const responseEnhancerMiddleware: MiddlewareHandler = async (
+  c,
+  next
+) => {
+  // 成功响应方法
+  c.success = <T>(data?: T, message?: string, status = 200) => {
+    const response: {
+      success: true;
+      data?: T;
+      message?: string;
+    } = {
+      success: true,
+      message,
+    };
+
+    // 只有当 data 不是 undefined 时才添加 data 字段
+    if (data !== undefined) {
+      response.data = data;
+    }
+
+    return c.json(response, status as never);
+  };
+
+  // 失败响应方法
+  c.fail = (code: string, message: string, details?: unknown, status = 400) => {
+    const response: {
+      success: false;
+      error: {
+        code: string;
+        message: string;
+        details?: unknown;
+      };
+    } = {
+      success: false,
+      error: {
+        code,
+        message,
+      },
+    };
+
+    // 只有当 details 不是 undefined 时才添加 details 字段
+    if (details !== undefined) {
+      response.error.details = details;
+    }
+
+    return c.json(response, status as never);
+  };
+
+  // 分页响应方法
+  c.paginate = <T>(data: T[], pagination: PaginationInfo, message?: string) => {
+    const response: {
+      success: true;
+      data: T[];
+      pagination: PaginationInfo;
+      message?: string;
+    } = {
+      success: true,
+      data,
+      pagination,
+      message,
+    };
+
+    return c.json(response, 200);
+  };
+
+  await next();
+};

--- a/src/server/routes/RouteManager.ts
+++ b/src/server/routes/RouteManager.ts
@@ -1,0 +1,188 @@
+/**
+ * 路由管理器
+ * 提供直接、高效的路由注册和管理功能
+ */
+
+import type { Context, Hono, Next } from "hono";
+import type { Logger } from "../Logger.js";
+import type { AppContext } from "../types/hono.context.js";
+import {
+  type RouteDefinition,
+  type RouteRegistry,
+  normalizeRoutes,
+} from "./types.js";
+
+/**
+ * 路由管理器
+ * 直接管理路由配置，提供路由注册和应用功能
+ * 通过依赖注入接收 Logger 实例，保持与项目日志系统的一致性
+ */
+export class RouteManager {
+  private routes: Map<string, RouteDefinition[]> = new Map();
+
+  constructor(private logger: Logger) {}
+
+  /**
+   * 注册单个路由模块
+   */
+  registerRoute(name: string, routeRegistry: RouteRegistry): void {
+    const routes = normalizeRoutes(routeRegistry);
+    if (this.routes.has(name)) {
+      this.logger.warn(`路由组 '${name}' 已存在，将被覆盖`);
+    }
+    this.routes.set(name, routes);
+    this.logger.info(`已注册路由组: ${name} (${routes.length} 个路由)`);
+  }
+
+  /**
+   * 批量注册路由模块
+   */
+  registerRoutes(routeRegistries: Record<string, RouteRegistry>): void {
+    this.logger.info(
+      `开始批量注册 ${Object.keys(routeRegistries).length} 个路由组...`
+    );
+
+    for (const [name, routeRegistry] of Object.entries(routeRegistries)) {
+      this.registerRoute(name, routeRegistry);
+    }
+
+    this.logger.info(`批量注册完成，共注册 ${this.routes.size} 个路由组`);
+  }
+
+  /**
+   * 获取所有注册的路由配置
+   */
+  getAllRoutes(): Map<string, RouteDefinition[]> {
+    return new Map(this.routes);
+  }
+
+  /**
+   * 获取指定名称的路由配置
+   */
+  getRoute(name: string): RouteDefinition[] | undefined {
+    return this.routes.get(name);
+  }
+
+  /**
+   * 将路由应用到 Hono 应用实例
+   */
+  applyToApp(app: Hono<AppContext>): void {
+    // 获取所有路由并排序，确保 static 路由最后应用
+    const routeEntries = Array.from(this.routes.entries());
+    routeEntries.sort(([nameA], [nameB]) => {
+      // static 路由永远排在最后
+      if (nameA === "static") return 1;
+      if (nameB === "static") return -1;
+      return 0;
+    });
+
+    let totalRouteCount = 0;
+    for (const [groupName, routes] of routeEntries) {
+      try {
+        for (const route of routes) {
+          this.applyRouteDefinition(app, route, groupName);
+          totalRouteCount++;
+        }
+      } catch (error) {
+        this.logger.error(`✗ 应用路由组失败: ${groupName}`, error);
+      }
+    }
+
+    this.logger.info(`路由应用完成，共 ${totalRouteCount} 个路由`);
+  }
+
+  /**
+   * 应用单个路由定义到 Hono 应用
+   */
+  private applyRouteDefinition(
+    app: Hono<AppContext>,
+    route: RouteDefinition,
+    groupName: string
+  ): void {
+    const { method, path, handler, middleware = [] } = route;
+
+    // 创建包装的处理器，添加错误处理
+    const wrappedHandler = async (c: Context<AppContext>, next: Next) => {
+      try {
+        return await handler(c);
+      } catch (error) {
+        this.logger.error(`路由处理错误 [${method} ${path}]:`, error);
+        return c.fail(
+          "HANDLER_ERROR",
+          "处理器执行失败",
+          error instanceof Error ? error.message : String(error),
+          500
+        );
+      }
+    };
+
+    // 使用 switch-case 避免 Hono 4.11.4 的类型推断问题
+    // 注意：Hono 4.11.4 对展开中间件数组的类型推断更加严格，需要使用类型断言
+    switch (method) {
+      case "GET":
+        if (middleware.length > 0) {
+          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
+          app.get(path, ...middleware, wrappedHandler);
+        } else {
+          app.get(path, wrappedHandler);
+        }
+        break;
+      case "POST":
+        if (middleware.length > 0) {
+          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
+          app.post(path, ...middleware, wrappedHandler);
+        } else {
+          app.post(path, wrappedHandler);
+        }
+        break;
+      case "PUT":
+        if (middleware.length > 0) {
+          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
+          app.put(path, ...middleware, wrappedHandler);
+        } else {
+          app.put(path, wrappedHandler);
+        }
+        break;
+      case "DELETE":
+        if (middleware.length > 0) {
+          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
+          app.delete(path, ...middleware, wrappedHandler);
+        } else {
+          app.delete(path, wrappedHandler);
+        }
+        break;
+      case "PATCH":
+        if (middleware.length > 0) {
+          // @ts-expect-error Hono 4.11.4 类型系统限制：展开中间件数组时无法正确推断类型
+          app.patch(path, ...middleware, wrappedHandler);
+        } else {
+          app.patch(path, wrappedHandler);
+        }
+        break;
+      default:
+        throw new Error(`不支持的 HTTP 方法: ${method}`);
+    }
+  }
+
+  /**
+   * 清除所有路由（主要用于测试）
+   */
+  clear(): void {
+    this.routes.clear();
+    this.logger.info("已清除所有路由配置");
+  }
+
+  /**
+   * 检查路由是否已注册
+   */
+  hasRoute(name: string): boolean {
+    return this.routes.has(name);
+  }
+
+  /**
+   * 列出所有已注册的路由域名称
+   */
+  getRouteNames(): string[] {
+    return Array.from(this.routes.keys());
+  }
+}

--- a/src/server/routes/domains/config.route.ts
+++ b/src/server/routes/domains/config.route.ts
@@ -1,0 +1,85 @@
+/**
+ * 配置管理路由配置
+ * 处理所有配置管理相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("configApiHandler");
+
+/**
+ * 配置管理路由定义
+ */
+export const configRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/config",
+    handler: h((handler, c) => handler.getConfig(c)),
+  },
+  {
+    method: "PUT",
+    path: "/api/config",
+    handler: h((handler, c) => handler.updateConfig(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/mcp-endpoint",
+    handler: h((handler, c) => handler.getMcpEndpoint(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/mcp-endpoints",
+    handler: h((handler, c) => handler.getMcpEndpoints(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/mcp-servers",
+    handler: h((handler, c) => handler.getMcpServers(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/connection",
+    handler: h((handler, c) => handler.getConnectionConfig(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/config/reload",
+    handler: h((handler, c) => handler.reloadConfig(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/path",
+    handler: h((handler, c) => handler.getConfigPath(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/exists",
+    handler: h((handler, c) => handler.checkConfigExists(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/prompts",
+    handler: h((handler, c) => handler.getPromptFiles(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/config/prompts/content",
+    handler: h((handler, c) => handler.getPromptFileContent(c)),
+  },
+  {
+    method: "PUT",
+    path: "/api/config/prompts/content",
+    handler: h((handler, c) => handler.updatePromptFileContent(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/config/prompts/content",
+    handler: h((handler, c) => handler.createPromptFileContent(c)),
+  },
+  {
+    method: "DELETE",
+    path: "/api/config/prompts/content",
+    handler: h((handler, c) => handler.deletePromptFileContent(c)),
+  },
+];

--- a/src/server/routes/domains/coze.route.ts
+++ b/src/server/routes/domains/coze.route.ts
@@ -1,0 +1,32 @@
+/**
+ * 扣子 API 路由配置
+ * 处理所有扣子相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("cozeHandler");
+
+export const cozeRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/coze/workspaces",
+    handler: h((handler, c) => handler.getWorkspaces(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/coze/workflows",
+    handler: h((handler, c) => handler.getWorkflows(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/coze/cache/clear",
+    handler: h((handler, c) => handler.clearCache(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/coze/cache/stats",
+    handler: h((handler, c) => handler.getCacheStats(c)),
+  },
+];

--- a/src/server/routes/domains/endpoint.route.ts
+++ b/src/server/routes/domains/endpoint.route.ts
@@ -1,0 +1,89 @@
+/**
+ * 端点管理路由配置
+ * 处理所有端点管理相关的 API 路由
+ * 使用中间件动态注入的 endpointHandler
+ */
+
+import type { Context } from "hono";
+import type { RouteDefinition } from "../../routes/types.js";
+import type { AppContext } from "../../types/hono.context.js";
+
+/**
+ * 端点处理器方法名类型
+ */
+type EndpointHandlerMethod =
+  | "getEndpointStatus"
+  | "connectEndpoint"
+  | "disconnectEndpoint"
+  | "addEndpoint"
+  | "removeEndpoint";
+
+/**
+ * 端点处理器包装函数
+ * 从中间件获取 endpointHandler 并调用相应方法
+ */
+const withEndpointHandler = async (
+  c: Context<AppContext>,
+  handlerName: EndpointHandlerMethod
+): Promise<Response> => {
+  // 从中间件获取 endpointHandler
+  const endpointHandler = c.get("endpointHandler");
+
+  if (!endpointHandler) {
+    return c.fail(
+      "ENDPOINT_HANDLER_NOT_AVAILABLE",
+      "端点处理器尚未初始化，请稍后再试",
+      undefined,
+      503
+    );
+  }
+
+  // 调用对应的处理方法
+  try {
+    // 使用类型安全的方式调用方法
+    return await endpointHandler[handlerName](c);
+  } catch (error) {
+    console.error(`端点处理器错误 [${handlerName}]:`, error);
+    return c.fail(
+      "ENDPOINT_HANDLER_ERROR",
+      error instanceof Error ? error.message : "端点处理失败",
+      undefined,
+      500
+    );
+  }
+};
+
+/**
+ * 端点管理路由定义（扁平化版本）
+ */
+export const endpointRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/endpoint/status",
+    handler: (c: Context<AppContext>) =>
+      withEndpointHandler(c, "getEndpointStatus"),
+  },
+  {
+    method: "POST",
+    path: "/api/endpoint/connect",
+    handler: (c: Context<AppContext>) =>
+      withEndpointHandler(c, "connectEndpoint"),
+  },
+  {
+    method: "POST",
+    path: "/api/endpoint/disconnect",
+    handler: (c: Context<AppContext>) =>
+      withEndpointHandler(c, "disconnectEndpoint"),
+  },
+  {
+    method: "POST",
+    path: "/api/endpoint/add",
+    handler: (c: Context<AppContext>) => withEndpointHandler(c, "addEndpoint"),
+  },
+  {
+    method: "POST",
+    path: "/api/endpoint/remove",
+    handler: (c: Context<AppContext>) =>
+      withEndpointHandler(c, "removeEndpoint"),
+  },
+];

--- a/src/server/routes/domains/esp32.route.http
+++ b/src/server/routes/domains/esp32.route.http
@@ -1,0 +1,271 @@
+##############################################
+# 变量定义区
+##############################################
+
+@baseUrl = http://localhost:9999
+@deviceId = AA:BB:CC:DD:EE:FF
+@clientId = esp32-234567890abcdef0
+@activationCode = 534806
+
+##############################################
+# 硬件 API 测试
+##############################################
+
+### 场景1: 设备首次连接 - 获取激活码（未激活设备）
+# 说明: 设备首次连接时，OTA接口返回激活信息
+# 请求头: Device-Id（MAC地址）, Client-Id（设备UUID）
+# 请求体: 设备硬件信息
+# 预期响应: 包含 activation.code, activation.challenge, serverTime
+POST {{baseUrl}}/
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  },
+  "chipModelName": "ESP32-S3"
+}
+
+### 场景2: 使用小智硬件官方 OTA 路径（兼容硬件默认配置）
+# 说明: 硬件默认配置使用 /xiaozhi/ota/ 路径
+# 功能与根路径 OTA 接口完全相同
+POST {{baseUrl}}/xiaozhi/ota/
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  },
+  "chipModelName": "ESP32-S3"
+}
+
+### 场景3: 设备激活请求
+# 说明: 使用激活码完成设备绑定
+# 请求头: Device-Id, Client-Id
+# 请求体: 激活码
+# 预期响应: 返回已激活的设备信息
+POST {{baseUrl}}/activate
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "code": "{{activationCode}}"
+}
+
+### 场景4: 设备已激活后再次 OTA 请求
+# 说明: 设备激活后，OTA接口返回 WebSocket 配置
+# 预期响应: 包含 websocket.url, websocket.token, serverTime
+# 注意: 需要先执行激活操作，否则仍返回激活信息
+POST {{baseUrl}}/
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  },
+  "chipModelName": "ESP32-S3"
+}
+
+### 场景5: WebSocket 端点测试
+# 说明: WebSocket 连接端点
+# 注意: 实际 WebSocket 连接需要使用专门的客户端工具
+# HTTP GET 请求仅用于验证端点可访问性
+GET {{baseUrl}}/ws
+
+##############################################
+# 管理 API 测试（保留 /api/esp32 前缀）
+##############################################
+
+### 获取设备列表
+# 说明: 获取所有已注册的 ESP32 设备
+# 预期响应: { devices: ESP32Device[], total: number }
+GET {{baseUrl}}/api/esp32/devices
+
+### 获取单个设备信息
+# 说明: 根据 deviceId 获取设备详细信息
+# 预期响应: ESP32Device 对象
+GET {{baseUrl}}/api/esp32/devices/{{deviceId}}
+
+### 获取设备状态
+# 说明: 获取设备的连接状态和最后活跃时间
+# 预期响应: { deviceId, status, lastSeenAt, connected }
+GET {{baseUrl}}/api/esp32/devices/{{deviceId}}/status
+
+### 断开设备连接
+# 说明: 强制断开设备的 WebSocket 连接
+# 预期响应: 成功消息
+POST {{baseUrl}}/api/esp32/devices/{{deviceId}}/disconnect
+
+### 删除设备
+# 说明: 从设备注册表中删除设备
+# 预期响应: 成功消息
+# 注意: 删除操作会先断开连接，然后删除设备记录
+DELETE {{baseUrl}}/api/esp32/devices/{{deviceId}}
+
+##############################################
+# 错误场景测试
+##############################################
+
+### 错误场景1: 缺少 Device-Id 请求头
+# 预期响应: 400 错误，错误代码 MISSING_DEVICE_ID
+POST {{baseUrl}}/
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  }
+}
+
+### 错误场景2: 缺少 Client-Id 请求头
+# 预期响应: 400 错误，错误代码 MISSING_DEVICE_ID
+POST {{baseUrl}}/
+Device-Id: {{deviceId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  }
+}
+
+### 错误场景3: 无效的激活码
+# 预期响应: 400 错误，错误代码 INVALID_ACTIVATION_CODE
+POST {{baseUrl}}/activate
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "code": "000000"
+}
+
+### 错误场景4: 设备不存在
+# 预期响应: 404 错误，错误代码 DEVICE_NOT_FOUND
+GET {{baseUrl}}/api/esp32/devices/00:00:00:00:00:00
+
+### 错误场景5: 删除不存在的设备
+# 预期响应: 404 错误，错误代码 DEVICE_NOT_FOUND
+DELETE {{baseUrl}}/api/esp32/devices/00:00:00:00:00:00
+
+##############################################
+# 完整激活流程演示
+##############################################
+
+### 步骤1: 设备首次连接，获取激活码
+# 记录返回的 activation.code 和 activation.challenge
+POST {{baseUrl}}/
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  }
+}
+
+### 步骤2: 使用激活码激活设备（替换为实际激活码）
+# 将步骤1返回的 code 填入此处
+POST {{baseUrl}}/activate
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "code": "{{activationCode}}"
+}
+
+### 步骤3: 验证设备已激活
+# 预期: 可以看到设备状态为 "active"
+GET {{baseUrl}}/api/esp32/devices/{{deviceId}}
+
+### 步骤4: 设备再次连接，获取 WebSocket 配置
+# 预期: 返回 websocket.url 和 websocket.token
+POST {{baseUrl}}/
+Device-Id: {{deviceId}}
+Client-Id: {{clientId}}
+Content-Type: application/json
+
+{
+  "application": {
+    "version": "1.0.0",
+    "board": {
+      "type": "ESP32-S3-BOX"
+    }
+  }
+}
+
+### 步骤4: 设备再次连接，获取 WebSocket 配置
+# 预期: 返回 websocket.url 和 websocket.token
+POST {{baseUrl}}/api/esp32/bind
+Content-Type: application/json
+
+{
+  "code": "075622"
+}
+
+### 步骤5: 使用返回的 Token 建立 WebSocket 连接
+# 注意: 需要使用 WebSocket 客户端工具
+# 连接 URL: ws://localhost:9999/ws
+# 请求头: Device-Id, Client-Id, Token（从步骤4获取）
+
+##############################################
+# WebSocket 消息格式示例（供参考）
+##############################################
+
+# 设备 Hello 消息（设备连接后首先发送）
+# {
+#   "type": "hello",
+#   "version": 1,
+#   "features": {
+#     "aec": true,
+#     "mcp": true
+#   },
+#   "transport": "websocket",
+#   "audioParams": {
+#     "format": "opus",
+#     "sampleRate": 24000,
+#     "channels": 1,
+#     "frameDuration": 60
+#   }
+# }
+
+# 服务器 Hello 响应
+# {
+#   "type": "hello",
+#   "version": 1,
+#   "sessionId": "AA:BB:CC:DD:EE:FF-1234567890-abc123",
+#   "audioParams": {
+#     "format": "opus",
+#     "sampleRate": 24000,
+#     "channels": 1,
+#     "frameDuration": 60
+#   }
+# }

--- a/src/server/routes/domains/esp32.route.ts
+++ b/src/server/routes/domains/esp32.route.ts
@@ -1,0 +1,68 @@
+/**
+ * ESP32设备路由模块
+ * 处理ESP32设备相关的API路由
+ *
+ * 硬件API定义：
+ * - POST /              # OTA/配置获取（根路径，按硬件定义）
+ * - POST /xiaozhi/ota/  # 小智硬件官方OTA路径（兼容）
+ * - WebSocket /ws       # WebSocket连接
+ *
+ * 注意：设备采用自动激活模式，无需管理API
+ */
+
+import type { Context } from "hono";
+import type { RouteDefinition } from "../../routes/types.js";
+import { type HandlerDependencies, createHandler } from "../../routes/types.js";
+
+const h = createHandler("esp32Handler");
+
+/**
+ * 创建 ESP32 路由处理器（带可选检查）
+ */
+const createESP32Handler = (
+  method: (
+    handler: NonNullable<HandlerDependencies["esp32Handler"]>,
+    c: Context
+  ) => Promise<Response>
+) => {
+  return async (c: Context) => {
+    const dependencies = c.get("dependencies") as HandlerDependencies;
+    const handler = dependencies.esp32Handler;
+    if (!handler) {
+      return c.json({ error: "ESP32 service not available" }, 503);
+    }
+    return method(handler, c);
+  };
+};
+
+/**
+ * ESP32设备路由定义
+ */
+export const esp32Routes: RouteDefinition[] = [
+  // ========== 硬件API（按硬件定义的路径） ==========
+
+  // 硬件 OTA/配置接口（根路径）
+  {
+    method: "POST",
+    path: "/",
+    handler: createESP32Handler((handler, c) => handler.handleOTA(c)),
+  },
+
+  // 小智硬件官方 OTA 路径（兼容硬件默认配置）
+  {
+    method: "POST",
+    path: "/xiaozhi/ota/",
+    handler: createESP32Handler((handler, c) => handler.handleOTA(c)),
+  },
+
+  // WebSocket端点（由WebServer直接处理，这里仅作为占位符）
+  {
+    method: "GET",
+    path: "/ws",
+    handler: createESP32Handler(async (handler, c) => {
+      c.get("logger").debug("ESP32 WebSocket端点访问");
+      // 返回 426 Upgrade Required，明确提示需要 WebSocket 升级
+      return c.text("WebSocket Upgrade Required", 426);
+    }),
+  },
+];

--- a/src/server/routes/domains/index.ts
+++ b/src/server/routes/domains/index.ts
@@ -1,0 +1,48 @@
+/**
+ * 路由域统一导出文件
+ * 简化版本：直接导出所有路由配置对象
+ * 替代原有的复杂的域索引文件结构
+ */
+
+// 导入所有可用的路由配置
+export { configRoutes } from "./config.route.js";
+export { statusRoutes } from "./status.route.js";
+export { toolsRoutes } from "./tools.route.js";
+export { mcpRoutes } from "./mcp.route.js";
+export { versionRoutes } from "./version.route.js";
+export { servicesRoutes } from "./services.route.js";
+export { updateRoutes } from "./update.route.js";
+export { staticRoutes } from "./static.route.js";
+export { cozeRoutes } from "./coze.route.js";
+export { toolLogsRoutes } from "./tool-logs.route.js";
+export { mcpserverRoutes } from "./mcpserver.route.js";
+export { endpointRoutes } from "./endpoint.route.js";
+export { miscRoutes } from "./misc.route.js";
+export { ttsRoutes } from "./tts.route.js";
+export { esp32Routes } from "./esp32.route.js";
+
+/**
+ * 路由域名列表
+ */
+export const routeNames = [
+  "config",
+  "status",
+  "tools",
+  "mcp",
+  "version",
+  "services",
+  "update",
+  "static",
+  "coze",
+  "tool-logs",
+  "mcpserver",
+  "endpoint",
+  "misc",
+  "tts",
+  "esp32",
+] as const;
+
+/**
+ * 路由域名类型
+ */
+export type RouteName = (typeof routeNames)[number];

--- a/src/server/routes/domains/mcp.route.ts
+++ b/src/server/routes/domains/mcp.route.ts
@@ -1,0 +1,20 @@
+/**
+ * MCP 协议路由模块
+ * 处理 MCP 协议相关的 API 路由（仅 POST 模式）
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("mcpRouteHandler");
+
+/**
+ * MCP 协议路由定义
+ */
+export const mcpRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/mcp",
+    handler: h((handler, c) => handler.handlePost(c)),
+  },
+];

--- a/src/server/routes/domains/mcpserver.http
+++ b/src/server/routes/domains/mcpserver.http
@@ -1,0 +1,4 @@
+@baseUrl = http://localhost:9999
+
+### 获取工具列表
+GET {{baseUrl}}/api/mcp-servers

--- a/src/server/routes/domains/mcpserver.route.ts
+++ b/src/server/routes/domains/mcpserver.route.ts
@@ -1,0 +1,56 @@
+/**
+ * MCP 服务器管理路由配置
+ * 处理 MCP 服务器管理相关的 API 路由
+ */
+
+import type { Context } from "hono";
+import type {
+  HandlerDependencies,
+  RouteDefinition,
+} from "../../routes/types.js";
+
+/**
+ * MCP 服务器处理器包装函数
+ * 统一处理 MCP Server API Handler 的初始化检查
+ */
+const withMCPServerHandler = async (
+  c: Context,
+  handlerFn: (
+    handler: NonNullable<HandlerDependencies["mcpHandler"]>
+  ) => Promise<Response>
+): Promise<Response> => {
+  const dependencies = c.get("dependencies") as HandlerDependencies;
+  const handler = dependencies.mcpHandler;
+
+  if (!handler) {
+    return c.json({ error: "MCP Server API Handler not initialized" }, 503);
+  }
+
+  return await handlerFn(handler);
+};
+
+export const mcpserverRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/mcp-servers",
+    handler: (c: Context) => withMCPServerHandler(c, (h) => h.addMCPServer(c)),
+  },
+  {
+    method: "DELETE",
+    path: "/api/mcp-servers/:serverName",
+    handler: (c: Context) =>
+      withMCPServerHandler(c, (h) => h.removeMCPServer(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/mcp-servers/:serverName/status",
+    handler: (c: Context) =>
+      withMCPServerHandler(c, (h) => h.getMCPServerStatus(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/mcp-servers",
+    handler: (c: Context) =>
+      withMCPServerHandler(c, (h) => h.listMCPServers(c)),
+  },
+];

--- a/src/server/routes/domains/misc.route.ts
+++ b/src/server/routes/domains/misc.route.ts
@@ -1,0 +1,17 @@
+/**
+ * 通用API路由配置
+ * 处理不特定于某个模块的通用 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("serviceApiHandler");
+
+export const miscRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/restart",
+    handler: h((handler, c) => handler.restartService(c)),
+  },
+];

--- a/src/server/routes/domains/services.route.ts
+++ b/src/server/routes/domains/services.route.ts
@@ -1,0 +1,37 @@
+/**
+ * 服务管理路由配置
+ * 处理所有服务管理相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("serviceApiHandler");
+
+export const servicesRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/services/restart",
+    handler: h((handler, c) => handler.restartService(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/services/stop",
+    handler: h((handler, c) => handler.stopService(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/services/start",
+    handler: h((handler, c) => handler.startService(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/services/status",
+    handler: h((handler, c) => handler.getServiceStatus(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/services/health",
+    handler: h((handler, c) => handler.getServiceHealth(c)),
+  },
+];

--- a/src/server/routes/domains/static.route.ts
+++ b/src/server/routes/domains/static.route.ts
@@ -1,0 +1,23 @@
+/**
+ * 静态文件路由配置
+ * 处理静态文件服务相关的路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("staticFileHandler");
+
+export const staticRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/*",
+    handler: h(async (handler, c) => {
+      // 如果路径以 /api/ 开头，不处理静态文件，直接返回 404
+      if (c.req.path.startsWith("/api/")) {
+        return c.notFound();
+      }
+      return await handler.handleStaticFile(c);
+    }),
+  },
+];

--- a/src/server/routes/domains/status.route.ts
+++ b/src/server/routes/domains/status.route.ts
@@ -1,0 +1,45 @@
+/**
+ * 状态查询路由模块
+ * 处理所有状态相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("statusApiHandler");
+
+/**
+ * 状态查询路由定义
+ */
+export const statusRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/status",
+    handler: h((handler, c) => handler.getStatus(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/status/client",
+    handler: h((handler, c) => handler.getClientStatus(c)),
+  },
+  {
+    method: "PUT",
+    path: "/api/status/client",
+    handler: h((handler, c) => handler.updateClientStatus(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/status/reset",
+    handler: h((handler, c) => handler.resetStatus(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/status/mcp-servers",
+    handler: h((handler, c) => handler.getActiveMCPServers(c)),
+  },
+  {
+    method: "PUT",
+    path: "/api/status/mcp-servers",
+    handler: h((handler, c) => handler.setActiveMCPServers(c)),
+  },
+];

--- a/src/server/routes/domains/tool-logs.route.ts
+++ b/src/server/routes/domains/tool-logs.route.ts
@@ -1,0 +1,17 @@
+/**
+ * 工具调用日志路由配置
+ * 处理工具调用日志相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("mcpToolLogHandler");
+
+export const toolLogsRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/tool-calls/logs",
+    handler: h((handler, c) => handler.getToolCallLogs(c)),
+  },
+];

--- a/src/server/routes/domains/tools.http
+++ b/src/server/routes/domains/tools.http
@@ -1,0 +1,4 @@
+@baseUrl = http://localhost:9999
+
+### 获取工具列表
+GET {{baseUrl}}/api/tools/list

--- a/src/server/routes/domains/tools.route.ts
+++ b/src/server/routes/domains/tools.route.ts
@@ -1,0 +1,59 @@
+/**
+ * 工具调用路由模块
+ * 处理所有工具相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("mcpToolHandler");
+
+/**
+ * 工具调用路由定义
+ */
+export const toolsRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/tools/call",
+    handler: h((handler, c) => handler.callTool(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/tools/list",
+    handler: h((handler, c) => handler.listTools(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/tools/custom",
+    handler: h((handler, c) => handler.getCustomTools(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/tools/custom",
+    handler: h((handler, c) => handler.addCustomTool(c)),
+  },
+  {
+    method: "PUT",
+    path: "/api/tools/custom/:toolName",
+    handler: h((handler, c) => handler.updateCustomTool(c)),
+  },
+  {
+    method: "DELETE",
+    path: "/api/tools/custom/:toolName",
+    handler: h((handler, c) => handler.removeCustomTool(c)),
+  },
+  /**
+   * MCP 工具管理路由
+   * 用于启用/禁用/查询 MCP 工具的状态
+   */
+  {
+    method: "POST",
+    path: "/api/tools/mcp/manage",
+    handler: h((handler, c) => handler.manageMCPTool(c)),
+  },
+  {
+    method: "POST",
+    path: "/api/tools/mcp/list",
+    handler: h((handler, c) => handler.listMCPTools(c)),
+  },
+];

--- a/src/server/routes/domains/tts.route.http
+++ b/src/server/routes/domains/tts.route.http
@@ -1,0 +1,9 @@
+@baseUrl = http://localhost:9999
+
+### 语音合成
+POST {{baseUrl}}/api/tts
+Content-Type: application/json
+
+{
+  "text": "演示一次性获取完整音频的场景"
+}

--- a/src/server/routes/domains/tts.route.ts
+++ b/src/server/routes/domains/tts.route.ts
@@ -1,0 +1,22 @@
+/**
+ * TTS API 路由配置
+ * 处理所有 TTS 相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("ttsApiHandler");
+
+export const ttsRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/tts",
+    handler: h((handler, c) => handler.synthesize(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/tts/voices",
+    handler: h((handler, c) => handler.getVoices(c)),
+  },
+];

--- a/src/server/routes/domains/update.route.ts
+++ b/src/server/routes/domains/update.route.ts
@@ -1,0 +1,26 @@
+/**
+ * 更新管理路由配置
+ * 处理更新相关的 API 路由
+ *
+ * 路由：
+ * - POST /api/update：触发版本安装
+ * - GET /api/install/logs?installId=xxx：SSE 安装日志流
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("updateApiHandler");
+
+export const updateRoutes: RouteDefinition[] = [
+  {
+    method: "POST",
+    path: "/api/update",
+    handler: h((handler, c) => handler.performUpdate(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/install/logs",
+    handler: h((handler, c) => handler.getInstallLogs(c)),
+  },
+];

--- a/src/server/routes/domains/version.route.ts
+++ b/src/server/routes/domains/version.route.ts
@@ -1,0 +1,35 @@
+/**
+ * 版本信息路由模块
+ * 处理所有版本相关的 API 路由
+ */
+
+import type { RouteDefinition } from "../../routes/types.js";
+import { createHandler } from "../../routes/types.js";
+
+const h = createHandler("versionApiHandler");
+
+/**
+ * 版本信息路由定义
+ */
+export const versionRoutes: RouteDefinition[] = [
+  {
+    method: "GET",
+    path: "/api/version",
+    handler: h((handler, c) => handler.getVersion(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/version/simple",
+    handler: h((handler, c) => handler.getVersionSimple(c)),
+  },
+  {
+    method: "DELETE",
+    path: "/api/version/cache",
+    handler: h((handler, c) => handler.clearVersionCache(c)),
+  },
+  {
+    method: "GET",
+    path: "/api/version/latest",
+    handler: h((handler, c) => handler.checkLatestVersion(c)),
+  },
+];

--- a/src/server/routes/index.ts
+++ b/src/server/routes/index.ts
@@ -1,0 +1,30 @@
+/**
+ * 路由系统统一导出模块
+ *
+ * 提供 API 路由的完整类型定义、路由管理器和路由域配置的统一导出接口。
+ * 本模块是路由系统的核心入口点，整合了所有路由相关的功能和类型。
+ *
+ * @packageDocumentation
+ */
+
+// 类型定义
+export type {
+  HandlerDependencies,
+  RouteRegistryOptions,
+  RouteStatistics,
+  HTTPMethod,
+  RouteDefinition,
+} from "./types.js";
+
+// 核心类
+export { RouteManager } from "./RouteManager.js";
+
+// 路由域导出
+export * from "./domains/index.js";
+
+// 重新导出 Hono 相关类型以方便使用
+export type { Context } from "hono";
+export type { AppContext } from "../types/hono.context.js";
+
+// 重新导出处理器类型
+export type { EndpointHandler, TTSApiHandler } from "../handlers/index.js";

--- a/src/server/routes/types.ts
+++ b/src/server/routes/types.ts
@@ -1,0 +1,185 @@
+/**
+ * 路由系统相关类型定义
+ * 提供类型安全的路由配置和依赖注入
+ */
+
+import type { Context, MiddlewareHandler } from "hono";
+import type {
+  ConfigApiHandler,
+  CozeHandler,
+  ESP32Handler,
+  EndpointHandler,
+  MCPHandler,
+  MCPRouteHandler,
+  MCPToolHandler,
+  MCPToolLogHandler,
+  ServiceApiHandler,
+  StaticFileHandler,
+  StatusApiHandler,
+  TTSApiHandler,
+  UpdateApiHandler,
+  VersionApiHandler,
+} from "../handlers/index.js";
+
+/**
+ * 处理器依赖接口
+ * 定义路由系统需要的所有处理器依赖
+ */
+export interface HandlerDependencies {
+  /** 配置管理处理器 */
+  configApiHandler: ConfigApiHandler;
+  /** 状态查询处理器 */
+  statusApiHandler: StatusApiHandler;
+  /** 服务管理处理器 */
+  serviceApiHandler: ServiceApiHandler;
+  /** MCP 工具处理器 */
+  mcpToolHandler: MCPToolHandler;
+  /** 工具调用日志处理器 */
+  mcpToolLogHandler: MCPToolLogHandler;
+  /** 版本信息处理器 */
+  versionApiHandler: VersionApiHandler;
+  /** 静态文件处理器 */
+  staticFileHandler: StaticFileHandler;
+  /** MCP 路由处理器 */
+  mcpRouteHandler: MCPRouteHandler;
+  /** MCP 服务器管理处理器（可选） */
+  mcpHandler?: MCPHandler;
+  /** 更新管理处理器 */
+  updateApiHandler: UpdateApiHandler;
+  /** 扣子 API 处理器 */
+  cozeHandler: CozeHandler;
+  /** TTS API 处理器 */
+  ttsApiHandler: TTSApiHandler;
+  /** 小智接入点处理器（通过中间件动态注入） */
+  endpointHandler?: EndpointHandler;
+  /** ESP32 设备处理器（可选） */
+  esp32Handler?: ESP32Handler;
+}
+
+/**
+ * 路由注册选项接口
+ * 控制路由注册的行为
+ *
+ * @future-feature 计划在 v2.0.0 中实现，用于提供更灵活的路由注册控制
+ * - 支持详细的注册日志，便于调试和监控
+ * - 支持注册失败时的异常处理策略配置
+ */
+export interface RouteRegistryOptions {
+  /** 是否启用详细的路由注册日志 */
+  verboseLogging?: boolean;
+  /** 是否在注册失败时抛出异常 */
+  throwOnRegistrationError?: boolean;
+}
+
+/**
+ * 路由统计信息接口
+ * 提供路由系统的运行时统计
+ *
+ * @future-feature 计划在 v2.0.0 中实现，用于提供路由系统的监控和分析能力
+ * - 统计各域的路由数量分布
+ * - 分析 HTTP 方法的使用情况
+ * - 支持路由性能监控和优化建议
+ */
+export interface RouteStatistics {
+  /** 注册的域数量 */
+  domainCount: number;
+  /** 注册的路由总数 */
+  totalRouteCount: number;
+  /** 各域的路由数量分布 */
+  routeDistribution: Record<string, number>;
+  /** 支持的 HTTP 方法统计 */
+  methodDistribution: Record<string, number>;
+}
+
+/**
+ * HTTP 方法类型
+ */
+export type HTTPMethod = "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+
+/**
+ * 路由定义接口
+ * 定义单个路由的配置信息
+ */
+export interface RouteDefinition {
+  /** HTTP 方法 */
+  method: HTTPMethod;
+  /** 完整路由路径（相对于应用根路径） */
+  path: string;
+  /** 处理函数 */
+  handler: (c: Context) => Promise<Response | undefined>;
+  /** 路由级别的中间件 */
+  middleware?: MiddlewareHandler[];
+}
+
+/**
+ * 路由组接口
+ * 用于需要组级别中间件或元数据的场景
+ */
+export interface RouteGroup {
+  /** 路由定义数组 */
+  routes: RouteDefinition[];
+  /** 可选的组名称（用于日志和调试） */
+  name?: string;
+  /** 可选的组描述 */
+  description?: string;
+  /** 组级别的中间件（应用到组内所有路由） */
+  middleware?: MiddlewareHandler[];
+}
+
+/**
+ * 路由注册联合类型
+ * 支持直接注册路由数组或路由组
+ */
+export type RouteRegistry = RouteDefinition[] | RouteGroup;
+
+/**
+ * 判断是否为路由组
+ */
+export function isRouteGroup(route: RouteRegistry): route is RouteGroup {
+  return Array.isArray((route as RouteGroup).routes);
+}
+
+/**
+ * 将路由注册转换为路由数组
+ */
+export function normalizeRoutes(route: RouteRegistry): RouteDefinition[] {
+  if (isRouteGroup(route)) {
+    const { routes, middleware } = route;
+    if (middleware && middleware.length > 0) {
+      return routes.map((r) => ({
+        ...r,
+        middleware: [...middleware, ...(r.middleware || [])],
+      }));
+    }
+    return routes;
+  }
+  return route;
+}
+
+/**
+ * 创建路由处理器辅助函数
+ * 自动处理依赖注入，减少样板代码
+ *
+ * @example
+ * ```typescript
+ * const h = createHandler("versionApiHandler");
+ * export const routes = [
+ *   {
+ *     method: "GET",
+ *     path: "/api/version",
+ *     handler: h((handler, c) => handler.getVersion(c)),
+ *   }
+ * ];
+ * ```
+ */
+export function createHandler<K extends keyof HandlerDependencies>(
+  dependencyKey: K
+): (
+  method: (handler: HandlerDependencies[K], c: Context) => Promise<Response>
+) => RouteDefinition["handler"] {
+  return (method) => (c: Context) => {
+    const dependencies = c.get("dependencies") as HandlerDependencies;
+    const handler = dependencies[dependencyKey];
+    return method(handler, c);
+  };
+}

--- a/src/server/services/__tests__/event-bus.service.boundary.test.ts
+++ b/src/server/services/__tests__/event-bus.service.boundary.test.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+
+/**
+ * MCP服务管理边界情况测试（简化版）
+ *
+ * 本测试文件包含关键边界情况和异常场景的测试，
+ * 确保系统在极端情况下仍能稳定运行。
+ */
+
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { Mock } from "vitest";
+import { EventBus } from "../event-bus.service.js";
+
+describe("事件系统边界情况测试", () => {
+  let eventBus: EventBus;
+
+  beforeEach(() => {
+    eventBus = new EventBus();
+  });
+
+  afterEach(() => {
+    eventBus.destroy();
+  });
+
+  describe("高频事件处理测试", () => {
+    it("应该处理高频事件发送", async () => {
+      const handler = vi.fn();
+      eventBus.onEvent("high-frequency", handler);
+
+      // 快速发送100个事件
+      const eventPromises = Array(100)
+        .fill(0)
+        .map((_, index) =>
+          eventBus.emitEvent("high-frequency", {
+            id: index,
+            timestamp: Date.now(),
+          })
+        );
+
+      await Promise.all(eventPromises);
+
+      // 等待事件处理完成
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(handler).toHaveBeenCalledTimes(100);
+    });
+
+    it("应该处理大量监听器注册", () => {
+      const handlers: Array<Mock> = [];
+
+      // 注册60个监听器（低于最大监听器数量）
+      for (let i = 0; i < 60; i++) {
+        const handler = vi.fn();
+        handlers.push(handler);
+        eventBus.onEvent("bulk-test", handler);
+      }
+
+      // 发送一个事件
+      eventBus.emitEvent("bulk-test", {
+        id: 1,
+        timestamp: Date.now(),
+      });
+
+      // 所有监听器都应该被调用
+      for (const handler of handlers) {
+        expect(handler).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+
+  describe("错误处理测试", () => {
+    it("应该处理监听器抛出的异常", () => {
+      const throwingHandler = vi.fn().mockImplementation(() => {
+        throw new Error("Listener error");
+      });
+      const normalHandler = vi.fn();
+
+      eventBus.onEvent("error-test", throwingHandler);
+      eventBus.onEvent("error-test", normalHandler);
+
+      // 发送事件（EventBus.emitEvent会在监听器抛出异常时返回false）
+      const result = eventBus.emitEvent("error-test", {
+        error: "test error",
+        timestamp: Date.now(),
+      });
+      expect(result).toBe(false); // 事件发送失败，因为监听器抛出异常
+
+      // 当监听器抛出异常时，EventEmitter会停止调用后续监听器
+      // 所以normalHandler不应该被调用
+      expect(normalHandler).not.toHaveBeenCalled();
+    });
+
+    it("应该处理大型事件数据", () => {
+      const handler = vi.fn();
+      eventBus.onEvent("large-data-test", handler);
+
+      // 创建大型数据对象
+      const largeData = {
+        array: Array(100)
+          .fill(0)
+          .map((_, i) => ({ id: i, data: "x".repeat(100) })),
+        string: "a".repeat(10000),
+        nested: {
+          level1: {
+            level2: {
+              level3: {
+                data: Array(10).fill("deep"),
+              },
+            },
+          },
+        },
+      };
+
+      expect(() => {
+        eventBus.emitEvent("large-data-test", {
+          data: largeData,
+          timestamp: Date.now(),
+        });
+      }).not.toThrow();
+
+      // 验证handler被调用，并且传入了正确的参数
+      expect(handler).toHaveBeenCalled();
+      expect(handler).toHaveBeenCalledWith({
+        data: largeData,
+        timestamp: expect.any(Number),
+      });
+    });
+  });
+
+  describe("内存管理测试", () => {
+    it("应该正确清理已销毁的事件总线", () => {
+      const handler = vi.fn();
+      eventBus.onEvent("destroy-test", handler);
+      eventBus.destroy();
+
+      // 销毁后发送事件应该不会调用监听器
+      eventBus.emitEvent("destroy-test", {
+        message: "test",
+        timestamp: Date.now(),
+      });
+      expect(handler).not.toHaveBeenCalled();
+
+      // 销毁后应该可以正常添加监听器（EventBus的destroy方法只是清理监听器和状态，不会阻止后续操作）
+      expect(() => {
+        eventBus.onEvent("test:remove", vi.fn());
+      }).not.toThrow();
+    });
+
+    it("应该处理事件链和级联事件", () => {
+      const executionOrder: string[] = [];
+
+      const handler1 = vi.fn().mockImplementation(() => {
+        executionOrder.push("handler1");
+        eventBus.emitEvent("chain-event-2", {
+          value: 2,
+          timestamp: Date.now(),
+        });
+      });
+
+      const handler2 = vi.fn().mockImplementation(() => {
+        executionOrder.push("handler2");
+        eventBus.emitEvent("chain-event-3", {
+          value: 3,
+          timestamp: Date.now(),
+        });
+      });
+
+      const handler3 = vi.fn().mockImplementation(() => {
+        executionOrder.push("handler3");
+      });
+
+      eventBus.onEvent("chain:start", handler1);
+      eventBus.onEvent("chain-event-2", handler2);
+      eventBus.onEvent("chain-event-3", handler3);
+
+      // 触发事件链
+      eventBus.emitEvent("chain:start", {
+        value: 1,
+        timestamp: Date.now(),
+      });
+
+      expect(executionOrder).toEqual(["handler1", "handler2", "handler3"]);
+    });
+  });
+
+  describe("性能边界测试", () => {
+    it("应该测量事件发送性能", () => {
+      const handler = vi.fn();
+      eventBus.onEvent("test:performance", handler);
+
+      const iterations = 1000;
+      const startTime = performance.now();
+
+      for (let i = 0; i < iterations; i++) {
+        eventBus.emitEvent("test:performance", {
+          id: i,
+          timestamp: Date.now(),
+        });
+      }
+
+      const endTime = performance.now();
+      const duration = endTime - startTime;
+
+      // 1000次事件发送应该在合理时间内完成（小于100ms）
+      expect(duration).toBeLessThan(100);
+      expect(handler).toHaveBeenCalledTimes(iterations);
+    });
+  });
+});

--- a/src/server/services/__tests__/event-bus.service.test.ts
+++ b/src/server/services/__tests__/event-bus.service.test.ts
@@ -1,0 +1,870 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  EventBus,
+  destroyEventBus,
+  getEventBus,
+} from "../event-bus.service.js";
+import type { ClientInfo } from "../status.service.js";
+
+// 模拟依赖
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+describe("EventBus", () => {
+  let eventBus: EventBus;
+  let mockLogger: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // 模拟 Logger
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { logger } = await import("../../Logger.js");
+    Object.assign(logger, mockLogger);
+
+    eventBus = new EventBus();
+  });
+
+  afterEach(() => {
+    eventBus.destroy();
+    destroyEventBus();
+    vi.clearAllMocks();
+  });
+
+  describe("constructor", () => {
+    it("应该使用正确的依赖项初始化", () => {
+      expect(eventBus).toBeInstanceOf(EventBus);
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+    });
+
+    it("应该设置最大监听器数量", () => {
+      // 测试环境下 maxListeners 应该是 200，避免 MaxListenersExceededWarning
+      expect(eventBus.getMaxListeners()).toBe(200);
+    });
+
+    it("应该设置错误处理", () => {
+      // 验证错误事件监听器已设置
+      expect(eventBus.listenerCount("error")).toBe(1);
+      expect(eventBus.listenerCount("newListener")).toBe(1);
+    });
+  });
+
+  describe("emitEvent", () => {
+    it("应该成功发射 config:updated 事件", () => {
+      const eventData = { type: "customMCP", timestamp: new Date() };
+      const listener = vi.fn();
+
+      eventBus.onEvent("config:updated", listener);
+      const result = eventBus.emitEvent("config:updated", eventData);
+
+      expect(result).toBe(true);
+      expect(listener).toHaveBeenCalledWith(eventData);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "发射事件: config:updated",
+        eventData
+      );
+    });
+
+    it("should emit config:error event successfully", () => {
+      const eventData = { error: new Error("Test error"), operation: "test" };
+      const listener = vi.fn();
+
+      eventBus.onEvent("config:error", listener);
+      const result = eventBus.emitEvent("config:error", eventData);
+
+      expect(result).toBe(true);
+      expect(listener).toHaveBeenCalledWith(eventData);
+    });
+
+    it("should emit status:updated event successfully", () => {
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+      const eventData = { status: mockStatus, source: "test" };
+      const listener = vi.fn();
+
+      eventBus.onEvent("status:updated", listener);
+      const result = eventBus.emitEvent("status:updated", eventData);
+
+      expect(result).toBe(true);
+      expect(listener).toHaveBeenCalledWith(eventData);
+    });
+
+    it("should emit service restart events successfully", () => {
+      const listeners = {
+        requested: vi.fn(),
+        started: vi.fn(),
+        completed: vi.fn(),
+        failed: vi.fn(),
+      };
+
+      eventBus.onEvent("service:restart:requested", listeners.requested);
+      eventBus.onEvent("service:restart:started", listeners.started);
+      eventBus.onEvent("service:restart:completed", listeners.completed);
+      eventBus.onEvent("service:restart:failed", listeners.failed);
+
+      eventBus.emitEvent("service:restart:requested", {
+        serviceName: "test-service",
+        delay: 1000,
+        attempt: 1,
+        timestamp: 123456,
+      });
+      eventBus.emitEvent("service:restart:started", {
+        serviceName: "test-service",
+        attempt: 1,
+        timestamp: 123457,
+      });
+      eventBus.emitEvent("service:restart:completed", {
+        serviceName: "test-service",
+        attempt: 1,
+        timestamp: 123458,
+      });
+      eventBus.emitEvent("service:restart:failed", {
+        serviceName: "test-service",
+        error: new Error("Restart failed"),
+        attempt: 1,
+        timestamp: 123459,
+      });
+
+      expect(listeners.requested).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        delay: 1000,
+        attempt: 1,
+        timestamp: 123456,
+      });
+      expect(listeners.started).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        attempt: 1,
+        timestamp: 123457,
+      });
+      expect(listeners.completed).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        attempt: 1,
+        timestamp: 123458,
+      });
+      expect(listeners.failed).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        error: expect.any(Error),
+        attempt: 1,
+        timestamp: 123459,
+      });
+    });
+
+    it("should emit WebSocket events successfully", () => {
+      const listeners = {
+        connected: vi.fn(),
+        disconnected: vi.fn(),
+        message: vi.fn(),
+      };
+
+      eventBus.onEvent("websocket:client:connected", listeners.connected);
+      eventBus.onEvent("websocket:client:disconnected", listeners.disconnected);
+      eventBus.onEvent("websocket:message:received", listeners.message);
+
+      eventBus.emitEvent("websocket:client:connected", {
+        clientId: "client-123",
+        timestamp: 123456,
+      });
+      eventBus.emitEvent("websocket:client:disconnected", {
+        clientId: "client-123",
+        timestamp: 123457,
+      });
+      eventBus.emitEvent("websocket:message:received", {
+        type: "heartbeat",
+        data: { status: "ok" },
+        clientId: "client-123",
+      });
+
+      expect(listeners.connected).toHaveBeenCalledWith({
+        clientId: "client-123",
+        timestamp: 123456,
+      });
+      expect(listeners.disconnected).toHaveBeenCalledWith({
+        clientId: "client-123",
+        timestamp: 123457,
+      });
+      expect(listeners.message).toHaveBeenCalledWith({
+        type: "heartbeat",
+        data: { status: "ok" },
+        clientId: "client-123",
+      });
+    });
+
+    it("should emit notification events successfully", () => {
+      const listeners = {
+        broadcast: vi.fn(),
+        error: vi.fn(),
+      };
+
+      eventBus.onEvent("notification:broadcast", listeners.broadcast);
+      eventBus.onEvent("notification:error", listeners.error);
+
+      eventBus.emitEvent("notification:broadcast", {
+        type: "info",
+        data: { message: "Test notification" },
+        target: "client-123",
+      });
+      eventBus.emitEvent("notification:error", {
+        error: new Error("Notification failed"),
+        type: "error",
+      });
+
+      expect(listeners.broadcast).toHaveBeenCalledWith({
+        type: "info",
+        data: { message: "Test notification" },
+        target: "client-123",
+      });
+      expect(listeners.error).toHaveBeenCalledWith({
+        error: expect.any(Error),
+        type: "error",
+      });
+    });
+
+    it("should emit MCP service events successfully", () => {
+      const listeners = {
+        connected: vi.fn(),
+        disconnected: vi.fn(),
+        connectionFailed: vi.fn(),
+      };
+
+      eventBus.onEvent("mcp:service:connected", listeners.connected);
+      eventBus.onEvent("mcp:service:disconnected", listeners.disconnected);
+      eventBus.onEvent(
+        "mcp:service:connection:failed",
+        listeners.connectionFailed
+      );
+
+      // 模拟工具数据
+      const mockTools = [
+        {
+          name: "test-tool",
+          description: "Test tool",
+          inputSchema: { type: "object" as const, properties: {} },
+        },
+      ];
+
+      const connectionTime = new Date();
+      const disconnectionTime = new Date();
+
+      eventBus.emitEvent("mcp:service:connected", {
+        serviceName: "test-service",
+        tools: mockTools,
+        connectionTime,
+      });
+
+      eventBus.emitEvent("mcp:service:disconnected", {
+        serviceName: "test-service",
+        reason: "手动断开",
+        disconnectionTime,
+      });
+
+      eventBus.emitEvent("mcp:service:connection:failed", {
+        serviceName: "test-service",
+        error: new Error("Connection failed"),
+        attempt: 3,
+      });
+
+      expect(listeners.connected).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        tools: mockTools,
+        connectionTime,
+      });
+
+      expect(listeners.disconnected).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        reason: "手动断开",
+        disconnectionTime,
+      });
+
+      expect(listeners.connectionFailed).toHaveBeenCalledWith({
+        serviceName: "test-service",
+        error: expect.any(Error),
+        attempt: 3,
+      });
+    });
+
+    it("should update event statistics", () => {
+      const eventData = { type: "customMCP", timestamp: new Date() };
+
+      eventBus.emitEvent("config:updated", eventData);
+      eventBus.emitEvent("config:updated", eventData);
+
+      const stats = eventBus.getEventStats();
+      expect(stats["config:updated"]).toBeDefined();
+      expect(stats["config:updated"].count).toBe(2);
+      expect(stats["config:updated"].lastEmitted).toBeInstanceOf(Date);
+    });
+
+    it("should handle emit errors gracefully", () => {
+      // 测试 updateEventStats 方法抛出错误的情况
+      const originalUpdateStats = (eventBus as any).updateEventStats;
+      (eventBus as any).updateEventStats = vi.fn().mockImplementation(() => {
+        throw new Error("Update stats failed");
+      });
+
+      const result = eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      expect(result).toBe(false);
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "发射事件失败: config:updated",
+        expect.any(Error)
+      );
+
+      // Restore original method
+      (eventBus as any).updateEventStats = originalUpdateStats;
+    });
+
+    it("should return false when no listeners", () => {
+      const result = eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe("onEvent", () => {
+    it("should add event listener successfully", () => {
+      const listener = vi.fn();
+
+      eventBus.onEvent("config:updated", listener);
+
+      expect(eventBus.listenerCount("config:updated")).toBe(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "添加事件监听器: config:updated"
+      );
+    });
+
+    it("should support multiple listeners for same event", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      eventBus.onEvent("config:updated", listener1);
+      eventBus.onEvent("config:updated", listener2);
+
+      expect(eventBus.listenerCount("config:updated")).toBe(2);
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      expect(listener1).toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalled();
+    });
+
+    it("should handle many listeners without issues", () => {
+      // Add many listeners to test the system can handle them
+      for (let i = 0; i < 30; i++) {
+        eventBus.onEvent("config:updated", vi.fn());
+      }
+
+      expect(eventBus.listenerCount("config:updated")).toBe(30);
+
+      // Should be able to emit events to all listeners
+      const result = eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("onceEvent", () => {
+    it("should add one-time event listener successfully", () => {
+      const listener = vi.fn();
+
+      eventBus.onceEvent("config:updated", listener);
+
+      expect(eventBus.listenerCount("config:updated")).toBe(1);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "添加一次性事件监听器: config:updated"
+      );
+    });
+
+    it("should remove listener after first execution", () => {
+      const listener = vi.fn();
+
+      eventBus.onceEvent("config:updated", listener);
+
+      // First emit should trigger listener
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+      expect(eventBus.listenerCount("config:updated")).toBe(0);
+
+      // Second emit should not trigger listener
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      expect(listener).toHaveBeenCalledTimes(1);
+    });
+
+    it("should support multiple one-time listeners", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      eventBus.onceEvent("config:updated", listener1);
+      eventBus.onceEvent("config:updated", listener2);
+
+      expect(eventBus.listenerCount("config:updated")).toBe(2);
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      expect(listener1).toHaveBeenCalledTimes(1);
+      expect(listener2).toHaveBeenCalledTimes(1);
+      expect(eventBus.listenerCount("config:updated")).toBe(0);
+    });
+  });
+
+  describe("offEvent", () => {
+    it("should remove event listener successfully", () => {
+      const listener = vi.fn();
+
+      eventBus.onEvent("config:updated", listener);
+      expect(eventBus.listenerCount("config:updated")).toBe(1);
+
+      eventBus.offEvent("config:updated", listener);
+      expect(eventBus.listenerCount("config:updated")).toBe(0);
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "移除事件监听器: config:updated"
+      );
+    });
+
+    it("should only remove specific listener", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+
+      eventBus.onEvent("config:updated", listener1);
+      eventBus.onEvent("config:updated", listener2);
+      expect(eventBus.listenerCount("config:updated")).toBe(2);
+
+      eventBus.offEvent("config:updated", listener1);
+      expect(eventBus.listenerCount("config:updated")).toBe(1);
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      expect(listener1).not.toHaveBeenCalled();
+      expect(listener2).toHaveBeenCalled();
+    });
+
+    it("should handle removing non-existent listener", () => {
+      const listener = vi.fn();
+
+      eventBus.offEvent("config:updated", listener);
+      expect(eventBus.listenerCount("config:updated")).toBe(0);
+    });
+  });
+
+  describe("getEventStats", () => {
+    it("should return empty stats initially", () => {
+      const stats = eventBus.getEventStats();
+      expect(stats).toEqual({});
+    });
+
+    it("should return correct event statistics", () => {
+      const eventData = { type: "customMCP", timestamp: new Date() };
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+
+      eventBus.emitEvent("config:updated", eventData);
+      eventBus.emitEvent("config:updated", eventData);
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
+
+      const stats = eventBus.getEventStats();
+
+      expect(stats["config:updated"]).toBeDefined();
+      expect(stats["config:updated"].count).toBe(2);
+      expect(stats["config:updated"].lastEmitted).toBeInstanceOf(Date);
+
+      expect(stats["status:updated"]).toBeDefined();
+      expect(stats["status:updated"].count).toBe(1);
+      expect(stats["status:updated"].lastEmitted).toBeInstanceOf(Date);
+    });
+
+    it("should return deep copy of stats", () => {
+      const eventData = { type: "customMCP", timestamp: new Date() };
+      eventBus.emitEvent("config:updated", eventData);
+
+      const stats1 = eventBus.getEventStats();
+      const stats2 = eventBus.getEventStats();
+
+      expect(stats1).not.toBe(stats2);
+      expect(stats1["config:updated"]).not.toBe(stats2["config:updated"]);
+    });
+  });
+
+  describe("getListenerStats", () => {
+    it("should return empty stats when no listeners", () => {
+      const stats = eventBus.getListenerStats();
+      expect(Object.keys(stats)).toHaveLength(2); // error and newListener from setup
+    });
+
+    it("should return correct listener statistics", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      const listener3 = vi.fn();
+
+      eventBus.onEvent("config:updated", listener1);
+      eventBus.onEvent("config:updated", listener2);
+      eventBus.onEvent("status:updated", listener3);
+
+      const stats = eventBus.getListenerStats();
+
+      expect(stats["config:updated"]).toBe(2);
+      expect(stats["status:updated"]).toBe(1);
+    });
+  });
+
+  describe("clearEventStats", () => {
+    it("should clear all event statistics", () => {
+      const eventData = { type: "customMCP", timestamp: new Date() };
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+      eventBus.emitEvent("config:updated", eventData);
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
+
+      let stats = eventBus.getEventStats();
+      expect(Object.keys(stats)).toHaveLength(2);
+
+      eventBus.clearEventStats();
+
+      stats = eventBus.getEventStats();
+      expect(stats).toEqual({});
+      expect(mockLogger.info).toHaveBeenCalledWith("事件统计已清理");
+    });
+  });
+
+  describe("getStatus", () => {
+    it("should return correct status information", () => {
+      const listener1 = vi.fn();
+      const listener2 = vi.fn();
+      const mockStatus: ClientInfo = {
+        status: "connected",
+        mcpEndpoint: "test-endpoint",
+        activeMCPServers: [],
+      };
+
+      eventBus.onEvent("config:updated", listener1);
+      eventBus.onEvent("status:updated", listener2);
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      eventBus.emitEvent("status:updated", {
+        status: mockStatus,
+        source: "test",
+      });
+
+      const status = eventBus.getStatus();
+
+      expect(status.totalEvents).toBe(2);
+      expect(status.totalListeners).toBeGreaterThanOrEqual(2); // Plus error and newListener
+      expect(status.eventStats).toBeDefined();
+      expect(status.listenerStats).toBeDefined();
+      expect(status.eventStats["config:updated"]).toBeDefined();
+      expect(status.eventStats["status:updated"]).toBeDefined();
+    });
+
+    it("should return zero totals when no events or listeners", () => {
+      const status = eventBus.getStatus();
+
+      expect(status.totalEvents).toBe(0);
+      expect(status.totalListeners).toBeGreaterThanOrEqual(0); // error and newListener from setup
+      expect(status.eventStats).toEqual({});
+    });
+  });
+
+  describe("destroy", () => {
+    it("should remove all listeners and clear stats", () => {
+      const listener = vi.fn();
+      eventBus.onEvent("config:updated", listener);
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      expect(eventBus.listenerCount("config:updated")).toBe(1);
+      expect(Object.keys(eventBus.getEventStats())).toHaveLength(1);
+
+      eventBus.destroy();
+
+      expect(eventBus.listenerCount("config:updated")).toBe(0);
+      expect(eventBus.getEventStats()).toEqual({});
+      expect(mockLogger.info).toHaveBeenCalledWith("EventBus 已销毁");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should handle internal errors", () => {
+      const error = new Error("Internal error");
+
+      eventBus.emit("error", error);
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "EventBus 内部错误:",
+        error
+      );
+    });
+
+    it("should handle listener exceptions gracefully", () => {
+      const errorListener = vi.fn().mockImplementation(() => {
+        throw new Error("Listener error");
+      });
+      const normalListener = vi.fn();
+
+      eventBus.onEvent("config:updated", errorListener);
+      eventBus.onEvent("config:updated", normalListener);
+
+      // Should not throw, but continue with other listeners
+      expect(() => {
+        eventBus.emitEvent("config:updated", {
+          type: "customMCP",
+          timestamp: new Date(),
+        });
+      }).not.toThrow();
+
+      expect(errorListener).toHaveBeenCalled();
+      // Note: If the first listener throws, the second might not be called
+      // This depends on the EventEmitter implementation
+    });
+
+    it("should handle high listener count", () => {
+      // Add many listeners to test the system can handle them
+      for (let i = 0; i < 45; i++) {
+        eventBus.onEvent("config:updated", vi.fn());
+      }
+
+      expect(eventBus.listenerCount("config:updated")).toBe(45);
+
+      // Should still be able to emit events
+      const result = eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("async event handling", () => {
+    it("should handle async listeners", async () => {
+      const asyncListener = vi.fn().mockImplementation(async (data) => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        return data;
+      });
+
+      eventBus.onEvent("config:updated", asyncListener);
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      // Wait for async listener to complete
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(asyncListener).toHaveBeenCalled();
+    });
+
+    it("should handle async listener errors", async () => {
+      const asyncErrorListener = vi.fn().mockImplementation(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        throw new Error("Async listener error");
+      });
+
+      eventBus.onEvent("config:updated", asyncErrorListener);
+
+      // Should not throw
+      expect(() => {
+        eventBus.emitEvent("config:updated", {
+          type: "customMCP",
+          timestamp: new Date(),
+        });
+      }).not.toThrow();
+
+      // Wait for async listener to complete
+      await new Promise((resolve) => setTimeout(resolve, 20));
+
+      expect(asyncErrorListener).toHaveBeenCalled();
+    });
+  });
+
+  describe("performance and memory", () => {
+    it("should handle many events efficiently", () => {
+      const listener = vi.fn();
+      eventBus.onEvent("config:updated", listener);
+
+      const startTime = Date.now();
+      for (let i = 0; i < 1000; i++) {
+        eventBus.emitEvent("config:updated", {
+          type: "customMCP",
+          timestamp: new Date(),
+        });
+      }
+      const endTime = Date.now();
+
+      expect(listener).toHaveBeenCalledTimes(1000);
+      expect(endTime - startTime).toBeLessThan(100); // Should be fast
+      expect(eventBus.getEventStats()["config:updated"].count).toBe(1000);
+    });
+
+    it("should handle many listeners efficiently", () => {
+      const listeners = Array.from({ length: 100 }, () => vi.fn());
+
+      for (const listener of listeners) {
+        eventBus.onEvent("config:updated", listener);
+      }
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      for (const listener of listeners) {
+        expect(listener).toHaveBeenCalledTimes(1);
+      }
+
+      expect(eventBus.listenerCount("config:updated")).toBe(100);
+    });
+
+    it("should clean up listeners properly", () => {
+      const listeners = Array.from({ length: 10 }, () => vi.fn());
+
+      for (const listener of listeners) {
+        eventBus.onEvent("config:updated", listener);
+      }
+
+      expect(eventBus.listenerCount("config:updated")).toBe(10);
+
+      // Remove half the listeners
+      for (const listener of listeners.slice(0, 5)) {
+        eventBus.offEvent("config:updated", listener);
+      }
+
+      expect(eventBus.listenerCount("config:updated")).toBe(5);
+
+      eventBus.emitEvent("config:updated", {
+        type: "customMCP",
+        timestamp: new Date(),
+      });
+
+      // Only remaining listeners should be called
+      for (const listener of listeners.slice(0, 5)) {
+        expect(listener).not.toHaveBeenCalled();
+      }
+      for (const listener of listeners.slice(5)) {
+        expect(listener).toHaveBeenCalledTimes(1);
+      }
+    });
+  });
+});
+
+describe("EventBus singleton functions", () => {
+  let mockLogger: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+
+    // Mock Logger
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { logger } = await import("../../Logger.js");
+    Object.assign(logger, mockLogger);
+
+    // Ensure clean state
+    destroyEventBus();
+  });
+
+  afterEach(() => {
+    destroyEventBus();
+    vi.clearAllMocks();
+  });
+
+  describe("getEventBus", () => {
+    it("should return singleton instance", () => {
+      const instance1 = getEventBus();
+      const instance2 = getEventBus();
+
+      expect(instance1).toBe(instance2);
+      expect(instance1).toBeInstanceOf(EventBus);
+    });
+
+    it("should create new instance after destroy", () => {
+      const instance1 = getEventBus();
+      destroyEventBus();
+      const instance2 = getEventBus();
+
+      expect(instance1).not.toBe(instance2);
+      expect(instance2).toBeInstanceOf(EventBus);
+    });
+  });
+
+  describe("destroyEventBus", () => {
+    it("should destroy singleton instance", () => {
+      const instance = getEventBus();
+      const listener = vi.fn();
+      instance.onEvent("config:updated", listener);
+
+      expect(instance.listenerCount("config:updated")).toBe(1);
+
+      destroyEventBus();
+
+      // Should create new instance after destroy
+      const newInstance = getEventBus();
+      expect(newInstance).not.toBe(instance);
+      expect(newInstance.listenerCount("config:updated")).toBe(0);
+    });
+
+    it("should handle destroy when no instance exists", () => {
+      expect(() => destroyEventBus()).not.toThrow();
+    });
+
+    it("should handle multiple destroy calls", () => {
+      getEventBus();
+      destroyEventBus();
+
+      expect(() => destroyEventBus()).not.toThrow();
+    });
+  });
+});

--- a/src/server/services/__tests__/services.test.ts
+++ b/src/server/services/__tests__/services.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "vitest";
+
+describe("Services Basic Tests", () => {
+  it("should be able to import service modules", async () => {
+    // Test that all service modules can be imported without errors
+    const modules = [
+      () => import("../event-bus.service.js"),
+      () => import("../status.service.js"),
+    ];
+
+    for (const importModule of modules) {
+      await expect(importModule()).resolves.toBeDefined();
+    }
+  });
+
+  it("should have proper class constructors", async () => {
+    const { EventBus } = await import("../event-bus.service.js");
+    const { StatusService } = await import("../status.service.js");
+
+    expect(() => new EventBus()).not.toThrow();
+    expect(() => new StatusService()).not.toThrow();
+  });
+});

--- a/src/server/services/__tests__/status.service.test.ts
+++ b/src/server/services/__tests__/status.service.test.ts
@@ -1,0 +1,937 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { ClientInfo } from "../status.service.js";
+import { StatusService } from "../status.service.js";
+
+// Mock dependencies
+vi.mock("../../Logger.js", () => ({
+  logger: {
+    debug: vi.fn(),
+    info: vi.fn(),
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock("../event-bus.service.js", () => ({
+  getEventBus: vi.fn().mockReturnValue({
+    emitEvent: vi.fn(),
+    onEvent: vi.fn(),
+  }),
+}));
+
+// Mock timers
+vi.useFakeTimers();
+
+describe("StatusService", () => {
+  let statusService: StatusService;
+  let mockLogger: any;
+  let mockEventBus: any;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+
+    // Mock Logger
+    mockLogger = {
+      debug: vi.fn(),
+      info: vi.fn(),
+      error: vi.fn(),
+      warn: vi.fn(),
+    };
+    const { logger } = await import("../../Logger.js");
+    Object.assign(logger, mockLogger);
+
+    // Mock EventBus
+    mockEventBus = {
+      emitEvent: vi.fn(),
+      onEvent: vi.fn(),
+    };
+    const { getEventBus } = await import("../event-bus.service.js");
+    vi.mocked(getEventBus).mockReturnValue(mockEventBus);
+
+    statusService = new StatusService();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+    vi.clearAllTimers();
+  });
+
+  describe("constructor", () => {
+    it("should initialize with correct dependencies and default state", () => {
+      expect(statusService).toBeInstanceOf(StatusService);
+      expect(mockLogger.debug).not.toHaveBeenCalled();
+
+      // Check initial client status
+      const clientStatus = statusService.getClientStatus();
+      expect(clientStatus).toEqual({
+        status: "disconnected",
+        mcpEndpoint: "",
+        activeMCPServers: [],
+      });
+
+      // Check initial restart status
+      const restartStatus = statusService.getRestartStatus();
+      expect(restartStatus).toBeUndefined();
+    });
+  });
+
+  describe("getClientStatus", () => {
+    it("should return a copy of client status", () => {
+      const status1 = statusService.getClientStatus();
+      const status2 = statusService.getClientStatus();
+
+      expect(status1).toEqual(status2);
+      expect(status1).not.toBe(status2); // Should be different objects
+    });
+
+    it("should return current client status after updates", () => {
+      const newInfo: Partial<ClientInfo> = {
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator", "datetime"],
+      };
+
+      statusService.updateClientInfo(newInfo);
+      const status = statusService.getClientStatus();
+
+      expect(status.status).toBe("connected");
+      expect(status.mcpEndpoint).toBe("ws://localhost:3000");
+      expect(status.activeMCPServers).toEqual(["calculator", "datetime"]);
+    });
+  });
+
+  describe("updateClientInfo", () => {
+    it("should update client info successfully", () => {
+      const newInfo: Partial<ClientInfo> = {
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator"],
+      };
+
+      statusService.updateClientInfo(newInfo, "test-source");
+
+      const status = statusService.getClientStatus();
+      expect(status.status).toBe("connected");
+      expect(status.mcpEndpoint).toBe("ws://localhost:3000");
+      expect(status.activeMCPServers).toEqual(["calculator"]);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "客户端状态更新，来源: test-source",
+        {
+          old: {
+            status: "disconnected",
+            mcpEndpoint: "",
+            activeMCPServers: [],
+          },
+          new: status,
+        }
+      );
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:updated", {
+        status: status,
+        source: "test-source",
+      });
+    });
+
+    it("should update lastHeartbeat when provided", () => {
+      const mockNow = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockNow);
+
+      statusService.updateClientInfo({ lastHeartbeat: 999 });
+
+      const status = statusService.getClientStatus();
+      expect(status.lastHeartbeat).toBe(mockNow);
+    });
+
+    it("should reset heartbeat timeout when status is connected", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 35000);
+    });
+
+    it("should use default source when not provided", () => {
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "客户端状态更新，来源: unknown",
+        expect.any(Object)
+      );
+    });
+
+    it("should handle partial updates", () => {
+      // First update
+      statusService.updateClientInfo({
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator"],
+      });
+
+      // Partial update
+      statusService.updateClientInfo({
+        activeMCPServers: ["calculator", "datetime"],
+      });
+
+      const status = statusService.getClientStatus();
+      expect(status.status).toBe("connected");
+      expect(status.mcpEndpoint).toBe("ws://localhost:3000");
+      expect(status.activeMCPServers).toEqual(["calculator", "datetime"]);
+    });
+
+    it("should handle errors during update", () => {
+      // Mock an error in the update process
+      const error = new Error("Update failed");
+      mockEventBus.emitEvent.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        "更新客户端状态失败:",
+        error
+      );
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:error", {
+        error: error,
+        operation: "updateClientInfo",
+      });
+    });
+
+    it("should handle non-Error exceptions", () => {
+      // Mock a non-Error exception
+      mockEventBus.emitEvent.mockImplementationOnce(() => {
+        throw "String error";
+      });
+
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:error", {
+        error: new Error("String error"),
+        operation: "updateClientInfo",
+      });
+    });
+  });
+
+  describe("getRestartStatus", () => {
+    it("should return undefined when no restart status is set", () => {
+      const status = statusService.getRestartStatus();
+      expect(status).toBeUndefined();
+    });
+
+    it("should return a copy of restart status", () => {
+      statusService.updateRestartStatus("restarting");
+
+      const status1 = statusService.getRestartStatus();
+      const status2 = statusService.getRestartStatus();
+
+      expect(status1).toEqual(status2);
+      expect(status1).not.toBe(status2); // Should be different objects
+    });
+
+    it("should return current restart status after updates", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateRestartStatus("restarting");
+      const status = statusService.getRestartStatus();
+
+      expect(status).toEqual({
+        status: "restarting",
+        timestamp: mockTimestamp,
+      });
+    });
+  });
+
+  describe("updateRestartStatus", () => {
+    it("should update restart status to restarting", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateRestartStatus("restarting");
+
+      const status = statusService.getRestartStatus();
+      expect(status).toEqual({
+        status: "restarting",
+        timestamp: mockTimestamp,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith("重启状态更新: restarting", {
+        error: undefined,
+      });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:started",
+        {
+          serviceName: "",
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+    });
+
+    it("should update restart status to completed", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateRestartStatus("completed");
+
+      const status = statusService.getRestartStatus();
+      expect(status).toEqual({
+        status: "completed",
+        timestamp: mockTimestamp,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith("重启状态更新: completed", {
+        error: undefined,
+      });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:completed",
+        {
+          serviceName: "",
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+    });
+
+    it("should update restart status to failed with error", () => {
+      const mockTimestamp = 1234567890;
+      const errorMessage = "Restart process failed";
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateRestartStatus("failed", errorMessage);
+
+      const status = statusService.getRestartStatus();
+      expect(status).toEqual({
+        status: "failed",
+        error: errorMessage,
+        timestamp: mockTimestamp,
+      });
+
+      expect(mockLogger.info).toHaveBeenCalledWith("重启状态更新: failed", {
+        error: errorMessage,
+      });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:failed",
+        {
+          serviceName: "",
+          error: new Error(errorMessage),
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+    });
+
+    it("should update restart status to failed without error message", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateRestartStatus("failed");
+
+      const status = statusService.getRestartStatus();
+      expect(status).toEqual({
+        status: "failed",
+        timestamp: mockTimestamp,
+      });
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:failed",
+        {
+          serviceName: "",
+          error: new Error("重启失败"),
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+    });
+
+    it("should handle errors during restart status update", () => {
+      const error = new Error("Update failed");
+      mockEventBus.emitEvent.mockImplementationOnce(() => {
+        throw error;
+      });
+
+      statusService.updateRestartStatus("restarting");
+
+      expect(mockLogger.error).toHaveBeenCalledWith("更新重启状态失败:", error);
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:error", {
+        error: error,
+        operation: "updateRestartStatus",
+      });
+    });
+
+    it("should handle non-Error exceptions during restart status update", () => {
+      mockEventBus.emitEvent.mockImplementationOnce(() => {
+        throw "String error";
+      });
+
+      statusService.updateRestartStatus("restarting");
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:error", {
+        error: new Error("String error"),
+        operation: "updateRestartStatus",
+      });
+    });
+  });
+
+  describe("getFullStatus", () => {
+    it("should return full status with client and timestamp", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      const fullStatus = statusService.getFullStatus();
+
+      expect(fullStatus).toEqual({
+        client: {
+          status: "disconnected",
+          mcpEndpoint: "",
+          activeMCPServers: [],
+        },
+        restart: undefined,
+        timestamp: mockTimestamp,
+      });
+    });
+
+    it("should return full status with client and restart status", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      // Update client and restart status
+      statusService.updateClientInfo({
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator"],
+      });
+      statusService.updateRestartStatus("completed");
+
+      const fullStatus = statusService.getFullStatus();
+
+      expect(fullStatus.client.status).toBe("connected");
+      expect(fullStatus.client.mcpEndpoint).toBe("ws://localhost:3000");
+      expect(fullStatus.client.activeMCPServers).toEqual(["calculator"]);
+      expect(fullStatus.restart?.status).toBe("completed");
+      expect(fullStatus.timestamp).toBe(mockTimestamp);
+    });
+  });
+
+  describe("heartbeat timeout management", () => {
+    it("should set heartbeat timeout when client connects", () => {
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(setTimeoutSpy).toHaveBeenCalledWith(expect.any(Function), 35000);
+    });
+
+    it("should clear existing timeout when setting new one", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+      const setTimeoutSpy = vi.spyOn(global, "setTimeout");
+
+      // First connection
+      statusService.updateClientInfo({ status: "connected" });
+      const firstTimeoutId = setTimeoutSpy.mock.results[0].value;
+
+      // Second connection (should clear first timeout)
+      statusService.updateClientInfo({ status: "connected" });
+
+      expect(clearTimeoutSpy).toHaveBeenCalledWith(firstTimeoutId);
+      expect(setTimeoutSpy).toHaveBeenCalledTimes(2);
+    });
+
+    it("should trigger heartbeat timeout and update status", () => {
+      statusService.updateClientInfo({ status: "connected" });
+
+      // Fast-forward time to trigger timeout
+      vi.advanceTimersByTime(35000);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "客户端心跳超时，标记为断开连接"
+      );
+
+      const status = statusService.getClientStatus();
+      expect(status.status).toBe("disconnected");
+    });
+
+    it("should clear heartbeat timeout manually", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.clearHeartbeatTimeout();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+
+    it("should handle clearHeartbeatTimeout when no timeout is set", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+      statusService.clearHeartbeatTimeout();
+
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("isClientConnected", () => {
+    it("should return false for initial disconnected state", () => {
+      expect(statusService.isClientConnected()).toBe(false);
+    });
+
+    it("should return true when client is connected", () => {
+      statusService.updateClientInfo({ status: "connected" });
+      expect(statusService.isClientConnected()).toBe(true);
+    });
+
+    it("should return false when client is disconnected", () => {
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.updateClientInfo({ status: "disconnected" });
+      expect(statusService.isClientConnected()).toBe(false);
+    });
+  });
+
+  describe("getLastHeartbeat", () => {
+    it("should return undefined initially", () => {
+      expect(statusService.getLastHeartbeat()).toBeUndefined();
+    });
+
+    it("should return last heartbeat timestamp", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      statusService.updateClientInfo({ lastHeartbeat: 999 });
+
+      expect(statusService.getLastHeartbeat()).toBe(mockTimestamp);
+    });
+
+    it("should return updated heartbeat timestamp", () => {
+      const mockTimestamp1 = 1234567890;
+      const mockTimestamp2 = 1234567999;
+
+      vi.spyOn(Date, "now").mockReturnValueOnce(mockTimestamp1);
+      statusService.updateClientInfo({ lastHeartbeat: 999 });
+
+      vi.spyOn(Date, "now").mockReturnValueOnce(mockTimestamp2);
+      statusService.updateClientInfo({ lastHeartbeat: 888 });
+
+      expect(statusService.getLastHeartbeat()).toBe(mockTimestamp2);
+    });
+  });
+
+  describe("getActiveMCPServers", () => {
+    it("should return empty array initially", () => {
+      const servers = statusService.getActiveMCPServers();
+      expect(servers).toEqual([]);
+    });
+
+    it("should return copy of active MCP servers", () => {
+      statusService.updateClientInfo({
+        activeMCPServers: ["calculator", "datetime"],
+      });
+
+      const servers1 = statusService.getActiveMCPServers();
+      const servers2 = statusService.getActiveMCPServers();
+
+      expect(servers1).toEqual(["calculator", "datetime"]);
+      expect(servers1).toEqual(servers2);
+      expect(servers1).not.toBe(servers2); // Should be different arrays
+    });
+
+    it("should return updated active MCP servers", () => {
+      statusService.updateClientInfo({
+        activeMCPServers: ["calculator"],
+      });
+      expect(statusService.getActiveMCPServers()).toEqual(["calculator"]);
+
+      statusService.updateClientInfo({
+        activeMCPServers: ["calculator", "datetime", "weather"],
+      });
+      expect(statusService.getActiveMCPServers()).toEqual([
+        "calculator",
+        "datetime",
+        "weather",
+      ]);
+    });
+  });
+
+  describe("setActiveMCPServers", () => {
+    it("should set active MCP servers", () => {
+      const servers = ["calculator", "datetime", "weather"];
+      statusService.setActiveMCPServers(servers);
+
+      const activeServers = statusService.getActiveMCPServers();
+      expect(activeServers).toEqual(servers);
+      expect(activeServers).not.toBe(servers); // Should be a copy
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "客户端状态更新，来源: mcp-servers-update",
+        expect.any(Object)
+      );
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:updated", {
+        status: expect.objectContaining({
+          activeMCPServers: servers,
+        }),
+        source: "mcp-servers-update",
+      });
+    });
+
+    it("should handle empty servers array", () => {
+      statusService.setActiveMCPServers([]);
+
+      const activeServers = statusService.getActiveMCPServers();
+      expect(activeServers).toEqual([]);
+    });
+
+    it("should create copy of input array", () => {
+      const servers = ["calculator", "datetime"];
+      statusService.setActiveMCPServers(servers);
+
+      // Modify original array
+      servers.push("weather");
+
+      const activeServers = statusService.getActiveMCPServers();
+      expect(activeServers).toEqual(["calculator", "datetime"]);
+    });
+  });
+
+  describe("setMcpEndpoint", () => {
+    it("should set MCP endpoint", () => {
+      const endpoint = "ws://localhost:4000";
+      statusService.setMcpEndpoint(endpoint);
+
+      const status = statusService.getClientStatus();
+      expect(status.mcpEndpoint).toBe(endpoint);
+
+      expect(mockLogger.debug).toHaveBeenCalledWith(
+        "客户端状态更新，来源: mcp-endpoint-update",
+        expect.any(Object)
+      );
+
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith("status:updated", {
+        status: expect.objectContaining({
+          mcpEndpoint: endpoint,
+        }),
+        source: "mcp-endpoint-update",
+      });
+    });
+
+    it("should handle empty endpoint", () => {
+      statusService.setMcpEndpoint("");
+
+      const status = statusService.getClientStatus();
+      expect(status.mcpEndpoint).toBe("");
+    });
+
+    it("should update existing endpoint", () => {
+      statusService.setMcpEndpoint("ws://localhost:3000");
+      statusService.setMcpEndpoint("ws://localhost:4000");
+
+      const status = statusService.getClientStatus();
+      expect(status.mcpEndpoint).toBe("ws://localhost:4000");
+    });
+  });
+
+  describe("reset", () => {
+    it("should reset all status to initial state", () => {
+      // Set up some state
+      statusService.updateClientInfo({
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator", "datetime"],
+        lastHeartbeat: 1234567890,
+      });
+      statusService.updateRestartStatus("completed");
+
+      // Reset
+      statusService.reset();
+
+      // Check client status is reset
+      const clientStatus = statusService.getClientStatus();
+      expect(clientStatus).toEqual({
+        status: "disconnected",
+        mcpEndpoint: "",
+        activeMCPServers: [],
+      });
+
+      // Check restart status is reset
+      const restartStatus = statusService.getRestartStatus();
+      expect(restartStatus).toBeUndefined();
+
+      expect(mockLogger.info).toHaveBeenCalledWith("重置状态服务");
+    });
+
+    it("should clear heartbeat timeout on reset", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.reset();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("destroy", () => {
+    it("should destroy service and reset state", () => {
+      // Set up some state
+      statusService.updateClientInfo({
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator"],
+      });
+      statusService.updateRestartStatus("restarting");
+
+      // Destroy
+      statusService.destroy();
+
+      // Check state is reset
+      const clientStatus = statusService.getClientStatus();
+      expect(clientStatus).toEqual({
+        status: "disconnected",
+        mcpEndpoint: "",
+        activeMCPServers: [],
+      });
+
+      const restartStatus = statusService.getRestartStatus();
+      expect(restartStatus).toBeUndefined();
+
+      expect(mockLogger.info).toHaveBeenCalledWith("销毁状态服务");
+      expect(mockLogger.info).toHaveBeenCalledWith("重置状态服务");
+    });
+
+    it("should clear heartbeat timeout on destroy", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.destroy();
+
+      expect(clearTimeoutSpy).toHaveBeenCalled();
+    });
+  });
+
+  describe("integration scenarios", () => {
+    it("should handle complete client lifecycle", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      // Initial state
+      expect(statusService.isClientConnected()).toBe(false);
+      expect(statusService.getActiveMCPServers()).toEqual([]);
+
+      // Client connects
+      statusService.updateClientInfo({
+        status: "connected",
+        mcpEndpoint: "ws://localhost:3000",
+        activeMCPServers: ["calculator"],
+        lastHeartbeat: mockTimestamp,
+      });
+
+      expect(statusService.isClientConnected()).toBe(true);
+      expect(statusService.getActiveMCPServers()).toEqual(["calculator"]);
+      expect(statusService.getLastHeartbeat()).toBe(mockTimestamp);
+
+      // Add more servers
+      statusService.setActiveMCPServers(["calculator", "datetime", "weather"]);
+      expect(statusService.getActiveMCPServers()).toEqual([
+        "calculator",
+        "datetime",
+        "weather",
+      ]);
+
+      // Client disconnects
+      statusService.updateClientInfo({ status: "disconnected" });
+      expect(statusService.isClientConnected()).toBe(false);
+
+      // Full status should reflect all changes
+      const fullStatus = statusService.getFullStatus();
+      expect(fullStatus.client.status).toBe("disconnected");
+      expect(fullStatus.client.activeMCPServers).toEqual([
+        "calculator",
+        "datetime",
+        "weather",
+      ]);
+    });
+
+    it("should handle restart workflow", () => {
+      const mockTimestamp = 1234567890;
+      vi.spyOn(Date, "now").mockReturnValue(mockTimestamp);
+
+      // Start restart
+      statusService.updateRestartStatus("restarting");
+      expect(statusService.getRestartStatus()?.status).toBe("restarting");
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:started",
+        {
+          serviceName: "",
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+
+      // Complete restart
+      statusService.updateRestartStatus("completed");
+      expect(statusService.getRestartStatus()?.status).toBe("completed");
+      expect(mockEventBus.emitEvent).toHaveBeenCalledWith(
+        "service:restart:completed",
+        {
+          serviceName: "",
+          attempt: 1,
+          timestamp: mockTimestamp,
+        }
+      );
+
+      // Full status should include restart info
+      const fullStatus = statusService.getFullStatus();
+      expect(fullStatus.restart?.status).toBe("completed");
+    });
+
+    it("should handle concurrent updates", () => {
+      // Simulate concurrent updates
+      statusService.updateClientInfo({ status: "connected" }, "source1");
+      statusService.updateClientInfo(
+        { mcpEndpoint: "ws://localhost:3000" },
+        "source2"
+      );
+      statusService.updateClientInfo(
+        { activeMCPServers: ["calculator"] },
+        "source3"
+      );
+
+      const status = statusService.getClientStatus();
+      expect(status.status).toBe("connected");
+      expect(status.mcpEndpoint).toBe("ws://localhost:3000");
+      expect(status.activeMCPServers).toEqual(["calculator"]);
+
+      // Should have emitted multiple events
+      expect(mockEventBus.emitEvent).toHaveBeenCalledTimes(3);
+    });
+  });
+
+  describe("edge cases and boundary conditions", () => {
+    it("should handle null and undefined values gracefully", () => {
+      // These should not cause errors
+      statusService.updateClientInfo({});
+      statusService.setActiveMCPServers([]);
+      statusService.setMcpEndpoint("");
+
+      const status = statusService.getClientStatus();
+      expect(status).toBeDefined();
+    });
+
+    it("should handle very large server arrays", () => {
+      const largeServerArray = Array.from(
+        { length: 1000 },
+        (_, i) => `server-${i}`
+      );
+      statusService.setActiveMCPServers(largeServerArray);
+
+      const servers = statusService.getActiveMCPServers();
+      expect(servers).toHaveLength(1000);
+      expect(servers[0]).toBe("server-0");
+      expect(servers[999]).toBe("server-999");
+    });
+
+    it("should handle very long endpoint URLs", () => {
+      const longEndpoint = `ws://localhost:3000/${"a".repeat(10000)}`;
+      statusService.setMcpEndpoint(longEndpoint);
+
+      const status = statusService.getClientStatus();
+      expect(status.mcpEndpoint).toBe(longEndpoint);
+    });
+
+    it("should handle rapid status changes", () => {
+      // Rapid status changes
+      for (let i = 0; i < 100; i++) {
+        statusService.updateClientInfo({
+          status: i % 2 === 0 ? "connected" : "disconnected",
+        });
+      }
+
+      const status = statusService.getClientStatus();
+      expect(status.status).toBe("disconnected"); // Last update was disconnected
+    });
+
+    it("should handle multiple heartbeat timeouts", () => {
+      // Set up multiple connections and timeouts
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.updateClientInfo({ status: "connected" });
+      statusService.updateClientInfo({ status: "connected" });
+
+      // Advance time to trigger timeout
+      vi.advanceTimersByTime(35000);
+
+      expect(statusService.isClientConnected()).toBe(false);
+    });
+
+    it("should handle restart status updates with special characters", () => {
+      const specialErrorMessage = "Error: 特殊字符 & symbols! @#$%^&*()";
+      statusService.updateRestartStatus("failed", specialErrorMessage);
+
+      const status = statusService.getRestartStatus();
+      expect(status?.error).toBe(specialErrorMessage);
+    });
+
+    it("should provide shallow immutability for client status", () => {
+      statusService.updateClientInfo({
+        status: "connected",
+        activeMCPServers: ["calculator"],
+      });
+
+      const status1 = statusService.getClientStatus();
+      const status2 = statusService.getClientStatus();
+
+      // Status objects should be different instances
+      expect(status1).not.toBe(status2);
+
+      // But arrays inside are shared references (shallow copy)
+      expect(status1.activeMCPServers).toBe(status2.activeMCPServers);
+
+      // Modifying the array affects both references
+      status1.activeMCPServers.push("datetime");
+      expect(status2.activeMCPServers).toEqual(["calculator", "datetime"]);
+    });
+
+    it("should provide deep immutability for getActiveMCPServers", () => {
+      statusService.updateClientInfo({
+        activeMCPServers: ["calculator"],
+      });
+
+      const servers1 = statusService.getActiveMCPServers();
+      const servers2 = statusService.getActiveMCPServers();
+
+      // Arrays should be different instances
+      expect(servers1).not.toBe(servers2);
+
+      // Modifying one array should not affect the other
+      servers1.push("datetime");
+      expect(servers2).toEqual(["calculator"]);
+      expect(statusService.getActiveMCPServers()).toEqual(["calculator"]);
+    });
+
+    it("should handle Date.now() returning edge values", () => {
+      // Test with edge timestamp values
+      vi.spyOn(Date, "now").mockReturnValue(0);
+      statusService.updateClientInfo({ lastHeartbeat: 123 });
+      expect(statusService.getLastHeartbeat()).toBe(0);
+
+      vi.spyOn(Date, "now").mockReturnValue(Number.MAX_SAFE_INTEGER);
+      statusService.updateRestartStatus("completed");
+      const status = statusService.getRestartStatus();
+      expect(status?.timestamp).toBe(Number.MAX_SAFE_INTEGER);
+    });
+
+    it("should handle clearTimeout with invalid timeout IDs", () => {
+      const clearTimeoutSpy = vi.spyOn(global, "clearTimeout");
+
+      // Call clearHeartbeatTimeout multiple times
+      statusService.clearHeartbeatTimeout();
+      statusService.clearHeartbeatTimeout();
+      statusService.clearHeartbeatTimeout();
+
+      // Should not cause errors
+      expect(clearTimeoutSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/server/services/event-bus.service.ts
+++ b/src/server/services/event-bus.service.ts
@@ -1,0 +1,473 @@
+/**
+ * 事件总线服务
+ * 提供统一的事件发布订阅机制，用于解耦各个模块之间的通信
+ * 支持配置更新、状态变更、接入点状态、服务重启、MCP 服务、工具调用等多种事件类型
+ *
+ * 主要功能：
+ * - 事件的发布和订阅
+ * - 事件类型的类型安全检查
+ * - 统一的事件命名规范
+ *
+ * @module apps/backend/services/event-bus.service
+ */
+
+import { EventEmitter } from "node:events";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import type { ClientInfo } from "../services/status.service.js";
+
+/**
+ * 事件类型定义
+ */
+export interface EventBusEvents {
+  // 配置相关事件
+  "config:updated": {
+    type: string;
+    serviceName?: string;
+    platformName?: string;
+    timestamp: Date;
+  };
+  "config:error": { error: Error; operation: string };
+
+  // 状态相关事件
+  "status:updated": { status: ClientInfo; source: string };
+  "status:error": { error: Error; operation: string };
+
+  // 接入点状态变更事件
+  "endpoint:status:changed": {
+    endpoint: string;
+    connected: boolean;
+    operation: "connect" | "disconnect" | "reconnect" | "add" | "remove";
+    success: boolean;
+    message?: string;
+    timestamp: number;
+    source: string;
+  };
+
+  // 接入点重连事件
+  "endpoint:reconnect:completed": {
+    trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+    serverName?: string;
+    endpointCount: number;
+    timestamp: number;
+  };
+  "endpoint:reconnect:failed": {
+    trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+    serverName?: string;
+    error: string;
+    timestamp: number;
+  };
+
+  // 服务相关事件
+  "service:restart:requested": {
+    serviceName: string;
+    reason?: string;
+    delay: number;
+    attempt: number;
+    timestamp: number;
+    source?: string;
+  };
+  "service:restart:started": {
+    serviceName: string;
+    reason?: string;
+    attempt: number;
+    timestamp: number;
+  };
+  "service:restart:completed": {
+    serviceName: string;
+    reason?: string;
+    attempt: number;
+    timestamp: number;
+  };
+  "service:restart:failed": {
+    serviceName: string;
+    error: Error;
+    attempt: number;
+    timestamp: number;
+  };
+  "service:restart:execute": {
+    serviceName: string;
+    reason?: string;
+    attempt: number;
+    timestamp: number;
+  };
+  "service:health:changed": {
+    serviceName: string;
+    oldStatus: string;
+    newStatus: string;
+    timestamp: number;
+  };
+
+  // WebSocket 相关事件
+  "websocket:client:connected": { clientId: string; timestamp: number };
+  "websocket:client:disconnected": { clientId: string; timestamp: number };
+  "websocket:message:received": { type: string; data: any; clientId: string };
+
+  // 通知相关事件
+  "notification:broadcast": { type: string; data: any; target?: string };
+  "notification:error": { error: Error; type: string };
+
+  // MCP服务相关事件
+  "mcp:service:connected": {
+    serviceName: string;
+    tools: Tool[];
+    connectionTime: Date;
+  };
+  "mcp:service:disconnected": {
+    serviceName: string;
+    reason?: string;
+    disconnectionTime: Date;
+  };
+  "mcp:service:connection:failed": {
+    serviceName: string;
+    error: Error;
+    attempt: number;
+  };
+  "mcp:server:added": {
+    serverName: string;
+    config: any;
+    tools: string[];
+    timestamp: Date;
+  };
+  "mcp:server:removed": {
+    serverName: string;
+    affectedTools: string[];
+    timestamp: Date;
+  };
+  "mcp:server:status_changed": {
+    serverName: string;
+    oldStatus: "connected" | "disconnected" | "connecting" | "error";
+    newStatus: "connected" | "disconnected" | "connecting" | "error";
+    timestamp: Date;
+    reason?: string;
+  };
+  "mcp:server:connection:attempt": {
+    serverName: string;
+    attempt: number;
+    maxAttempts: number;
+    timestamp: Date;
+  };
+  "mcp:server:tools:updated": {
+    serverName: string;
+    tools: string[];
+    addedTools: string[];
+    removedTools: string[];
+    timestamp: Date;
+  };
+  "mcp:server:batch_added": {
+    totalServers: number;
+    addedCount: number;
+    failedCount: number;
+    successfullyAddedServers: string[];
+    results: any[];
+    timestamp: Date;
+  };
+  "mcp:server:rollback": {
+    serverName: string;
+    timestamp: Date;
+  };
+
+  // 连接相关事件
+  "connection:reconnect:completed": {
+    success: boolean;
+    reason: string;
+    timestamp: Date;
+  };
+
+  // NPM 安装相关事件
+  "npm:install:started": {
+    version: string;
+    installId: string;
+    timestamp: number;
+  };
+  "npm:install:log": {
+    version: string;
+    installId: string;
+    type: "stdout" | "stderr";
+    message: string;
+    timestamp: number;
+  };
+  "npm:install:completed": {
+    version: string;
+    installId: string;
+    success: boolean;
+    duration: number;
+    timestamp: number;
+  };
+  "npm:install:failed": {
+    version: string;
+    installId: string;
+    error: string;
+    duration: number;
+    timestamp: number;
+  };
+
+  // 测试相关事件（仅用于测试）
+  "high-frequency": {
+    id: number;
+    timestamp: number;
+  };
+  "bulk-test": {
+    id: number;
+    timestamp: number;
+  };
+  "error-test": {
+    error: string;
+    timestamp: number;
+  };
+  "large-data-test": {
+    data: any;
+    timestamp: number;
+  };
+  "destroy-test": {
+    message: string;
+    timestamp: number;
+  };
+  "chain-event-1": {
+    value: number;
+    timestamp: number;
+  };
+  "chain-event-2": {
+    value: number;
+    timestamp: number;
+  };
+  "chain-event-3": {
+    value: number;
+    timestamp: number;
+  };
+  "performance-test": {
+    data: any;
+    timestamp: number;
+  };
+  "test:performance": {
+    id: number;
+    timestamp: number;
+  };
+  "chain:start": {
+    value: number;
+    timestamp: number;
+  };
+  "chain:middle": {
+    value: number;
+    timestamp: number;
+  };
+  "chain:end": {
+    value: number;
+    timestamp: number;
+  };
+  "test:error": {
+    error: boolean;
+    timestamp: number;
+  };
+  "test:remove": {
+    id: number;
+    timestamp: number;
+  };
+}
+
+/**
+ * 事件总线 - 用于模块间的解耦通信
+ */
+export class EventBus extends EventEmitter {
+  private logger: Logger;
+  private eventStats: Map<string, { count: number; lastEmitted: Date }> =
+    new Map();
+  private maxListeners: number;
+
+  constructor() {
+    super();
+    this.logger = logger;
+    // 测试环境下增加监听器限制，避免 MaxListenersExceededWarning
+    const isTest =
+      process.env.NODE_ENV === "test" || process.env.VITEST === "true";
+    this.maxListeners = isTest ? 200 : 50;
+    this.setMaxListeners(this.maxListeners);
+    this.setupErrorHandling();
+  }
+
+  /**
+   * 设置错误处理
+   */
+  private setupErrorHandling(): void {
+    this.on("error", (error) => {
+      this.logger.error("EventBus 内部错误:", error);
+    });
+
+    // 监听器数量警告
+    this.on("newListener", (eventName) => {
+      const listenerCount = this.listenerCount(eventName);
+      if (listenerCount > this.maxListeners * 0.8) {
+        this.logger.warn(
+          `事件 ${eventName} 的监听器数量过多: ${listenerCount}`
+        );
+      }
+    });
+  }
+
+  /**
+   * 发射事件（类型安全）
+   */
+  emitEvent<K extends keyof EventBusEvents>(
+    eventName: K,
+    data: EventBusEvents[K]
+  ): boolean {
+    try {
+      this.updateEventStats(eventName as string);
+      this.logger.debug(`发射事件: ${eventName}`, data);
+
+      // 使用原始emit方法，保持EventEmitter的所有特性
+      return super.emit(eventName, data);
+    } catch (error) {
+      this.logger.error(`发射事件失败: ${eventName}`, error);
+      // 将监听器错误发射到error事件
+      if (error instanceof Error) {
+        this.emit("error", error);
+      }
+      return false;
+    }
+  }
+
+  /**
+   * 监听事件（类型安全）
+   */
+  onEvent<K extends keyof EventBusEvents>(
+    eventName: K,
+    listener: (data: EventBusEvents[K]) => void
+  ): this {
+    this.logger.debug(`添加事件监听器: ${eventName}`);
+    return this.on(eventName, listener);
+  }
+
+  /**
+   * 一次性监听事件（类型安全）
+   */
+  onceEvent<K extends keyof EventBusEvents>(
+    eventName: K,
+    listener: (data: EventBusEvents[K]) => void
+  ): this {
+    this.logger.debug(`添加一次性事件监听器: ${eventName}`);
+
+    // 创建包装器来实现一次性监听
+    const onceListener = (data: EventBusEvents[K]) => {
+      try {
+        listener(data);
+      } catch (error) {
+        // 监听器抛出错误，发射到错误事件
+        this.emit("error", error);
+        throw error;
+      } finally {
+        // 在任何情况下都移除监听器
+        this.offEvent(eventName, onceListener);
+      }
+    };
+
+    return this.on(eventName, onceListener);
+  }
+
+  /**
+   * 移除事件监听器（类型安全）
+   */
+  offEvent<K extends keyof EventBusEvents>(
+    eventName: K,
+    listener: (data: EventBusEvents[K]) => void
+  ): this {
+    this.logger.debug(`移除事件监听器: ${eventName}`);
+    return this.off(eventName, listener);
+  }
+
+  /**
+   * 更新事件统计
+   */
+  private updateEventStats(eventName: string): void {
+    const stats = this.eventStats.get(eventName) || {
+      count: 0,
+      lastEmitted: new Date(),
+    };
+    stats.count++;
+    stats.lastEmitted = new Date();
+    this.eventStats.set(eventName, stats);
+  }
+
+  /**
+   * 获取事件统计信息
+   */
+  getEventStats(): Record<string, { count: number; lastEmitted: Date }> {
+    const stats: Record<string, { count: number; lastEmitted: Date }> = {};
+    for (const [eventName, stat] of this.eventStats) {
+      stats[eventName] = { ...stat };
+    }
+    return stats;
+  }
+
+  /**
+   * 获取监听器统计信息
+   */
+  getListenerStats(): Record<string, number> {
+    const stats: Record<string, number> = {};
+    for (const eventName of this.eventNames()) {
+      stats[eventName as string] = this.listenerCount(eventName);
+    }
+    return stats;
+  }
+
+  /**
+   * 清理事件统计
+   */
+  clearEventStats(): void {
+    this.eventStats.clear();
+    this.logger.info("事件统计已清理");
+  }
+
+  /**
+   * 获取事件总线状态
+   */
+  getStatus(): {
+    totalEvents: number;
+    totalListeners: number;
+    eventStats: Record<string, { count: number; lastEmitted: Date }>;
+    listenerStats: Record<string, number>;
+  } {
+    return {
+      totalEvents: this.eventStats.size,
+      totalListeners: Object.values(this.getListenerStats()).reduce(
+        (sum, count) => sum + count,
+        0
+      ),
+      eventStats: this.getEventStats(),
+      listenerStats: this.getListenerStats(),
+    };
+  }
+
+  /**
+   * 销毁事件总线
+   */
+  destroy(): void {
+    this.removeAllListeners();
+    this.eventStats.clear();
+    this.logger.info("EventBus 已销毁");
+  }
+}
+
+// 单例实例
+let eventBusInstance: EventBus | null = null;
+
+/**
+ * 获取事件总线单例
+ */
+export function getEventBus(): EventBus {
+  if (!eventBusInstance) {
+    eventBusInstance = new EventBus();
+  }
+  return eventBusInstance;
+}
+
+/**
+ * 销毁事件总线单例
+ */
+export function destroyEventBus(): void {
+  if (eventBusInstance) {
+    eventBusInstance.destroy();
+    eventBusInstance = null;
+  }
+}

--- a/src/server/services/index.ts
+++ b/src/server/services/index.ts
@@ -1,0 +1,24 @@
+/**
+ * 业务服务层模块
+ *
+ * 提供后端核心业务服务，包括：
+ * - StatusService: 统一的状态管理服务，管理客户端连接状态、MCP 服务状态等
+ * - EventBus / getEventBus: 事件总线服务，提供发布-订阅模式的事件处理机制
+ *
+ * @example
+ * ```typescript
+ * import { StatusService, getEventBus } from '../services';
+ *
+ * // 使用状态服务
+ * const statusService = new StatusService();
+ * const status = statusService.getFullStatus();
+ *
+ * // 使用事件总线
+ * const eventBus = getEventBus();
+ * eventBus.onEvent('event-name', (data) => {
+ *   console.log('Event received:', data);
+ * });
+ * ```
+ */
+export * from "./status.service.js";
+export * from "./event-bus.service.js";

--- a/src/server/services/status.service.ts
+++ b/src/server/services/status.service.ts
@@ -1,0 +1,268 @@
+/**
+ * 状态服务
+ *
+ * 统一的状态管理服务，负责管理客户端连接状态、MCP 服务状态等。
+ *
+ * ## 核心功能
+ * - 客户端状态管理：跟踪客户端连接状态、MCP 端点、活跃服务器等
+ * - 重启状态管理：管理服务重启流程的状态跟踪
+ * - 心跳超时管理：监控客户端心跳，超时自动断开连接
+ * - 事件通知：通过 EventBus 发射状态变更事件
+ *
+ * ## 使用方式
+ * ```typescript
+ * import { StatusService } from '../services';
+ *
+ * const statusService = new StatusService();
+ * const status = statusService.getFullStatus();
+ * ```
+ */
+
+import type { Logger } from "../Logger.js";
+import { logger } from "../Logger.js";
+import type { EventBus } from "../services/event-bus.service.js";
+import { getEventBus } from "../services/event-bus.service.js";
+
+/**
+ * 客户端信息接口
+ */
+export interface ClientInfo {
+  status: "connected" | "disconnected";
+  mcpEndpoint: string;
+  activeMCPServers: string[];
+  lastHeartbeat?: number;
+}
+
+/**
+ * 重启状态接口
+ */
+export interface RestartStatus {
+  status: "restarting" | "completed" | "failed";
+  error?: string;
+  timestamp: number;
+  serviceName?: string;
+  attempt?: number;
+}
+
+/**
+ * 状态服务 - 统一的状态管理服务
+ */
+export class StatusService {
+  private logger: Logger;
+  private eventBus: EventBus;
+  private clientInfo: ClientInfo = {
+    status: "disconnected",
+    mcpEndpoint: "",
+    activeMCPServers: [],
+  };
+  private restartStatus?: RestartStatus;
+  private heartbeatTimeout?: NodeJS.Timeout;
+  private readonly HEARTBEAT_TIMEOUT = 35000; // 35 seconds
+
+  constructor() {
+    this.logger = logger;
+    this.eventBus = getEventBus();
+  }
+
+  /**
+   * 获取客户端状态
+   */
+  getClientStatus(): ClientInfo {
+    return { ...this.clientInfo };
+  }
+
+  /**
+   * 更新客户端信息
+   */
+  updateClientInfo(info: Partial<ClientInfo>, source = "unknown"): void {
+    try {
+      const oldStatus = { ...this.clientInfo };
+      this.clientInfo = { ...this.clientInfo, ...info };
+
+      if (info.lastHeartbeat) {
+        this.clientInfo.lastHeartbeat = Date.now();
+      }
+
+      // 接收到客户端状态时重置心跳超时
+      if (info.status === "connected") {
+        this.resetHeartbeatTimeout();
+      }
+
+      this.logger.debug(`客户端状态更新，来源: ${source}`, {
+        old: oldStatus,
+        new: this.clientInfo,
+      });
+
+      // 发射状态更新事件
+      this.eventBus.emitEvent("status:updated", {
+        status: this.clientInfo,
+        source,
+      });
+    } catch (error) {
+      this.logger.error("更新客户端状态失败:", error);
+      this.eventBus.emitEvent("status:error", {
+        error: error instanceof Error ? error : new Error(String(error)),
+        operation: "updateClientInfo",
+      });
+    }
+  }
+
+  /**
+   * 获取重启状态
+   */
+  getRestartStatus(): RestartStatus | undefined {
+    return this.restartStatus ? { ...this.restartStatus } : undefined;
+  }
+
+  /**
+   * 更新重启状态
+   */
+  updateRestartStatus(
+    status: "restarting" | "completed" | "failed",
+    error?: string
+  ): void {
+    try {
+      this.restartStatus = {
+        status,
+        error,
+        timestamp: Date.now(),
+      };
+
+      this.logger.info(`重启状态更新: ${status}`, { error });
+
+      // 根据状态发射不同的事件
+      switch (status) {
+        case "restarting":
+          this.eventBus.emitEvent("service:restart:started", {
+            serviceName: this.restartStatus.serviceName || "",
+            attempt: this.restartStatus.attempt || 1,
+            timestamp: this.restartStatus.timestamp,
+          });
+          break;
+        case "completed":
+          this.eventBus.emitEvent("service:restart:completed", {
+            serviceName: this.restartStatus.serviceName || "",
+            attempt: this.restartStatus.attempt || 1,
+            timestamp: this.restartStatus.timestamp,
+          });
+          break;
+        case "failed":
+          this.eventBus.emitEvent("service:restart:failed", {
+            serviceName: this.restartStatus.serviceName || "",
+            error: new Error(error || "重启失败"),
+            attempt: this.restartStatus.attempt || 1,
+            timestamp: this.restartStatus.timestamp,
+          });
+          break;
+      }
+    } catch (error) {
+      this.logger.error("更新重启状态失败:", error);
+      this.eventBus.emitEvent("status:error", {
+        error: error instanceof Error ? error : new Error(String(error)),
+        operation: "updateRestartStatus",
+      });
+    }
+  }
+
+  /**
+   * 获取完整状态信息
+   */
+  getFullStatus(): {
+    client: ClientInfo;
+    restart?: RestartStatus;
+    timestamp: number;
+  } {
+    return {
+      client: this.getClientStatus(),
+      restart: this.getRestartStatus(),
+      timestamp: Date.now(),
+    };
+  }
+
+  /**
+   * 重置心跳超时
+   */
+  private resetHeartbeatTimeout(): void {
+    // 清除现有的超时定时器
+    if (this.heartbeatTimeout) {
+      clearTimeout(this.heartbeatTimeout);
+    }
+
+    // 设置新的超时定时器
+    this.heartbeatTimeout = setTimeout(() => {
+      this.logger.debug("客户端心跳超时，标记为断开连接");
+      this.updateClientInfo({ status: "disconnected" }, "heartbeat-timeout");
+    }, this.HEARTBEAT_TIMEOUT);
+  }
+
+  /**
+   * 清除心跳超时
+   */
+  clearHeartbeatTimeout(): void {
+    if (this.heartbeatTimeout) {
+      clearTimeout(this.heartbeatTimeout);
+      this.heartbeatTimeout = undefined;
+    }
+  }
+
+  /**
+   * 检查客户端是否连接
+   */
+  isClientConnected(): boolean {
+    return this.clientInfo.status === "connected";
+  }
+
+  /**
+   * 获取最后心跳时间
+   */
+  getLastHeartbeat(): number | undefined {
+    return this.clientInfo.lastHeartbeat;
+  }
+
+  /**
+   * 获取活跃的 MCP 服务器列表
+   */
+  getActiveMCPServers(): string[] {
+    return [...this.clientInfo.activeMCPServers];
+  }
+
+  /**
+   * 设置活跃的 MCP 服务器列表
+   */
+  setActiveMCPServers(servers: string[]): void {
+    this.updateClientInfo(
+      { activeMCPServers: [...servers] },
+      "mcp-servers-update"
+    );
+  }
+
+  /**
+   * 设置 MCP 端点
+   */
+  setMcpEndpoint(endpoint: string): void {
+    this.updateClientInfo({ mcpEndpoint: endpoint }, "mcp-endpoint-update");
+  }
+
+  /**
+   * 重置状态
+   */
+  reset(): void {
+    this.logger.info("重置状态服务");
+    this.clearHeartbeatTimeout();
+    this.clientInfo = {
+      status: "disconnected",
+      mcpEndpoint: "",
+      activeMCPServers: [],
+    };
+    this.restartStatus = undefined;
+  }
+
+  /**
+   * 销毁状态服务
+   */
+  destroy(): void {
+    this.logger.info("销毁状态服务");
+    this.clearHeartbeatTimeout();
+    this.reset();
+  }
+}

--- a/src/server/tsconfig.json
+++ b/src/server/tsconfig.json
@@ -1,0 +1,27 @@
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "declaration": true,
+    "declarationMap": true,
+    "outDir": "../../dist/backend",
+    "rootDir": "../../",
+    "baseUrl": "../../",
+    "types": ["vitest/globals"]
+  },
+  "include": [
+    "./**/*.ts",
+    "../../src/utils/**/*.ts",
+    "../../src/types/**/*.ts",
+    "../../src/mcp-core/**/*.ts",
+    "../../src/config/**/*.ts",
+    "../../src/endpoint/**/*.ts",
+    "../../src/esp32/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.config.ts",
+    "../../src/endpoint/__tests__/**/*"
+  ]
+}

--- a/src/server/tsup.config.ts
+++ b/src/server/tsup.config.ts
@@ -1,0 +1,166 @@
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { join, resolve } from "node:path";
+import { defineConfig } from "tsup";
+
+// 读取根目录 package.json 获取版本号
+const rootPkg = JSON.parse(readFileSync(resolve("../../package.json"), "utf8"));
+
+/**
+ * 递归复制目录 - 跨平台实现
+ */
+function copyDirectory(
+  src: string,
+  dest: string,
+  excludePatterns: string[] = []
+): void {
+  // 创建目标目录
+  if (!existsSync(dest)) {
+    mkdirSync(dest, { recursive: true });
+  }
+
+  const items = readdirSync(src);
+
+  for (const item of items) {
+    // 检查是否应该排除此项
+    if (excludePatterns.some((pattern) => item.includes(pattern))) {
+      continue;
+    }
+
+    const srcPath = join(src, item);
+    const destPath = join(dest, item);
+    const stat = statSync(srcPath);
+
+    if (stat.isDirectory()) {
+      copyDirectory(srcPath, destPath, excludePatterns);
+    } else {
+      copyFileSync(srcPath, destPath);
+    }
+  }
+}
+
+export default defineConfig({
+  entry: ["./WebServer.ts", "./WebServerLauncher.ts", "./Logger.ts"],
+  format: ["esm"],
+  target: "node22",
+  outDir: "../../dist/backend",
+  clean: true,
+  sourcemap: true,
+  dts: false,
+  minify: process.env.NODE_ENV === "production",
+  splitting: false,
+  bundle: true,
+  keepNames: true,
+  platform: "node",
+  tsconfig: "./tsconfig.json",
+  esbuildOptions: (options) => {
+    // 在生产环境移除 console 和 debugger
+    if (process.env.NODE_ENV === "production") {
+      options.drop = ["console", "debugger"];
+    }
+
+    options.resolveExtensions = [".ts", ".js", ".json"];
+
+    // 构建时注入版本号常量
+    options.define = {
+      ...options.define,
+      __VERSION__: JSON.stringify(rootPkg.version),
+      __APP_NAME__: JSON.stringify(rootPkg.name),
+    };
+  },
+  outExtension() {
+    return {
+      js: ".js",
+    };
+  },
+  external: [
+    // Node.js 内置模块
+    "ws",
+    "child_process",
+    "fs",
+    "path",
+    "url",
+    "process",
+    "dotenv",
+    "os",
+    "stream",
+    "events",
+    "util",
+    "crypto",
+    "http",
+    "https",
+    // 外部依赖包
+    "commander",
+    "chalk",
+    "ora",
+    "express",
+    "pino",
+    "pino-*",
+    "zod",
+    "comment-json",
+    "dayjs",
+    "ajv",
+    "eventsource",
+    "hono",
+    "@hono/*",
+    "node-cache",
+    "jsonc-parser",
+    "@coze/api",
+    "@modelcontextprotocol/*",
+    "prism-media",
+    "univoice",
+  ],
+  onSuccess: async () => {
+    // 复制配置文件到 dist/backend
+    const distDir = "../../dist/backend";
+
+    // 确保 dist/backend 目录存在
+    if (!existsSync(distDir)) {
+      mkdirSync(distDir, { recursive: true });
+    }
+
+    // 复制 xiaozhi.config.default.json
+    if (existsSync("../../xiaozhi.config.default.json")) {
+      copyFileSync(
+        "../../xiaozhi.config.default.json",
+        join(distDir, "xiaozhi.config.default.json")
+      );
+      console.log("✅ 已复制 xiaozhi.config.default.json 到 dist/backend/");
+    }
+
+    // 复制 package.json 到 dist/backend 目录，以便运行时能读取版本号
+    if (existsSync("../../package.json")) {
+      copyFileSync("../../package.json", join(distDir, "package.json"));
+      console.log("✅ 已复制 package.json 到 dist/backend/");
+    }
+
+    // 复制 templates 目录到 dist/backend 目录
+    if (existsSync("../../templates")) {
+      try {
+        copyDirectory("../../templates", join(distDir, "templates"));
+        console.log("✅ 已复制 templates 目录到 dist/backend/");
+      } catch (error) {
+        console.warn("⚠️ 复制 templates 目录失败:", error);
+      }
+    }
+
+    console.log("✅ 构建完成，产物现在为 ESM 格式");
+
+    // 创建向后兼容的 dist/WebServerLauncher.js
+    const compatLauncherPath = "../../dist/WebServerLauncher.js";
+    writeFileSync(
+      compatLauncherPath,
+      `// 向后兼容包装脚本 - 重定向到新的路径
+export * from './backend/WebServerLauncher.js';
+`
+    );
+    console.log("✅ 已创建向后兼容包装脚本 dist/WebServerLauncher.js");
+  },
+});

--- a/src/server/types/api.response.ts
+++ b/src/server/types/api.response.ts
@@ -1,0 +1,73 @@
+/**
+ * API 响应类型定义
+ * 定义了项目中所有 API 响应的统一格式
+ */
+
+/**
+ * 成功响应格式
+ */
+export interface ApiSuccessResponse<T = unknown> {
+  /** 操作是否成功 */
+  success: true;
+  /** 响应数据 */
+  data?: T;
+  /** 响应消息 */
+  message?: string;
+}
+
+/**
+ * 错误响应格式
+ */
+export interface ApiErrorResponse {
+  /** 操作是否成功 */
+  success: false;
+  /** 错误信息 */
+  error: {
+    /** 错误码 */
+    code: string;
+    /** 错误消息 */
+    message: string;
+    /** 错误详情 */
+    details?: unknown;
+  };
+}
+
+/**
+ * 分页响应格式
+ */
+export interface ApiPaginatedResponse<T = unknown> {
+  /** 操作是否成功 */
+  success: true;
+  /** 响应数据列表 */
+  data: T[];
+  /** 分页信息 */
+  pagination: PaginationInfo;
+  /** 响应消息 */
+  message?: string;
+}
+
+/**
+ * 分页信息
+ */
+export interface PaginationInfo {
+  /** 当前页码（从 1 开始） */
+  page: number;
+  /** 每页数量 */
+  pageSize: number;
+  /** 总记录数 */
+  total: number;
+  /** 总页数 */
+  totalPages: number;
+  /** 是否有下一页 */
+  hasNext: boolean;
+  /** 是否有上一页 */
+  hasPrev: boolean;
+}
+
+/**
+ * API 响应联合类型
+ */
+export type ApiResponse<T = unknown> =
+  | ApiSuccessResponse<T>
+  | ApiErrorResponse
+  | ApiPaginatedResponse<T>;

--- a/src/server/types/coze.ts
+++ b/src/server/types/coze.ts
@@ -1,0 +1,190 @@
+/**
+ * 扣子 API 相关类型定义
+ * 基于 docs/coze-api.md 中的 API 文档
+ */
+
+/**
+ * 扣子工作空间接口
+ */
+export interface CozeWorkspace {
+  /** 工作空间ID */
+  id: string;
+  /** 工作空间名称 */
+  name: string;
+  /** 工作空间描述 */
+  description: string;
+  /** 工作空间类型 */
+  workspace_type: "personal" | "team";
+  /** 企业ID */
+  enterprise_id: string;
+  /** 管理员用户ID列表 */
+  admin_uids: string[];
+  /** 工作空间图标URL */
+  icon_url: string;
+  /** 用户在工作空间中的角色类型 */
+  role_type: "owner" | "admin" | "member";
+  /** 加入状态 */
+  joined_status: "joined" | "pending" | "rejected";
+  /** 所有者用户ID */
+  owner_uid: string;
+}
+
+/**
+ * 扣子工作流创建者信息
+ */
+export interface CozeWorkflowCreator {
+  /** 创建者ID */
+  id: string;
+  /** 创建者名称 */
+  name: string;
+}
+
+/**
+ * 扣子工作流接口
+ */
+export interface CozeWorkflow {
+  /** 工作流ID */
+  workflow_id: string;
+  /** 工作流名称 */
+  workflow_name: string;
+  /** 工作流描述 */
+  description: string;
+  /** 工作流图标URL */
+  icon_url: string;
+  /** 关联应用ID */
+  app_id: string;
+  /** 创建者信息 */
+  creator: CozeWorkflowCreator;
+  /** 创建时间戳 */
+  created_at: number;
+  /** 更新时间戳 */
+  updated_at: number;
+}
+
+/**
+ * 扣子 API 响应详情
+ */
+export interface CozeApiDetail {
+  /** 日志ID */
+  logid: string;
+}
+
+/**
+ * 扣子 API 基础响应接口
+ */
+export interface CozeApiResponse<T = any> {
+  /** 响应状态码，0表示成功 */
+  code: number;
+  /** 响应数据 */
+  data: T;
+  /** 响应消息 */
+  msg: string;
+  /** 响应详情 */
+  detail: CozeApiDetail;
+}
+
+/**
+ * 获取工作空间列表的响应数据
+ */
+export interface CozeWorkspacesData {
+  /** 工作空间总数 */
+  total_count: number;
+  /** 工作空间列表 */
+  workspaces: CozeWorkspace[];
+}
+
+/**
+ * 获取工作空间列表的完整响应
+ */
+export interface CozeWorkspacesResponse
+  extends CozeApiResponse<CozeWorkspacesData> {}
+
+/**
+ * 获取工作流列表的响应数据
+ */
+export interface CozeWorkflowsData {
+  /** 是否有更多数据 */
+  has_more: boolean;
+  /** 工作流列表 */
+  items: CozeWorkflow[];
+}
+
+/**
+ * 获取工作流列表的完整响应
+ */
+export interface CozeWorkflowsResponse
+  extends CozeApiResponse<CozeWorkflowsData> {}
+
+/**
+ * 获取工作流列表的请求参数
+ */
+export interface CozeWorkflowsParams {
+  /** 工作空间ID */
+  workspace_id: string;
+  /** 页码，从1开始 */
+  page_num?: number;
+  /** 每页数量，默认20 */
+  page_size?: number;
+  /** 工作流模式，默认为 workflow */
+  workflow_mode?: "workflow";
+}
+
+/**
+ * 扣子 API 错误响应
+ */
+export interface CozeApiError extends Error {
+  /** 错误代码 */
+  code: string;
+  /** HTTP 状态码 */
+  statusCode?: number;
+  /** 原始响应数据 */
+  response?: any;
+}
+
+/**
+ * 扣子平台配置接口
+ */
+export interface CozePlatformConfig {
+  /** 扣子 API Token */
+  token: string;
+}
+
+/**
+ * 扣子 API 服务配置
+ */
+export interface CozeApiServiceConfig {
+  /** API Token */
+  token: string;
+  /** API 基础URL，默认 https://api.coze.cn */
+  apiBaseUrl?: string;
+  /** 请求超时时间，默认 10000ms */
+  timeout?: number;
+  /** 重试次数，默认 3 次 */
+  retryAttempts?: number;
+  /** 是否启用缓存，默认 true */
+  cacheEnabled?: boolean;
+}
+
+// ==================== 工作流参数配置相关类型 ====================
+
+/**
+ * 工作流参数定义
+ */
+export interface WorkflowParameter {
+  /** 英文字段名，用作参数标识符 */
+  fieldName: string;
+  /** 中英文描述，说明参数用途 */
+  description: string;
+  /** 参数类型 */
+  type: "string" | "number" | "boolean";
+  /** 是否必填参数 */
+  required: boolean;
+}
+
+/**
+ * 工作流参数配置
+ */
+export interface WorkflowParameterConfig {
+  /** 参数列表 */
+  parameters: WorkflowParameter[];
+}

--- a/src/server/types/hono.context.ts
+++ b/src/server/types/hono.context.ts
@@ -1,0 +1,130 @@
+/**
+ * Hono Context 类型扩展
+ * 为 Hono Context 添加项目特定的变量类型定义
+ */
+
+import type { Context } from "hono";
+import { Hono } from "hono";
+import type { EndpointManager } from "../../endpoint/index.js";
+import type { Logger } from "../Logger.js";
+import type { EndpointHandler } from "../handlers/index.js";
+import type { MCPServiceManager } from "../lib/mcp";
+import type { HandlerDependencies } from "../routes/types.js";
+
+// 导出 API 响应类型供其他模块使用
+export type {
+  ApiErrorResponse,
+  ApiPaginatedResponse,
+  ApiSuccessResponse,
+  PaginationInfo,
+  ApiResponse,
+} from "./api.response.js";
+
+/**
+ * WebServer 实例类型定义
+ * 避免与 WebServer 实现类的循环引用
+ * 使用类型断言的方式来定义接口
+ */
+export interface IWebServer {
+  /**
+   * 获取小智连接管理器实例
+   * 在 endpointManagerMiddleware 中使用
+   * WebServer 启动后始终返回有效的连接管理器实例
+   * 如果在启动前调用，会抛出错误
+   */
+  getEndpointManager(): EndpointManager;
+
+  /**
+   * 获取 MCP 服务管理器实例
+   * 在 mcpServiceManagerMiddleware 中使用
+   * WebServer 启动后始终返回有效的服务管理器实例
+   * 如果在启动前调用，会抛出错误
+   */
+  getMCPServiceManager(): MCPServiceManager;
+}
+
+/**
+ * 扩展 Hono Context 的 Variables 类型
+ * 定义了项目中所有通过中间件注入的变量
+ */
+export type AppContextVariables = {
+  /**
+   * Logger 实例
+   * 由 loggerMiddleware 注入
+   */
+  logger: Logger;
+
+  /**
+   * MCP 服务管理器实例
+   * 由 mcpServiceManagerMiddleware 注入
+   */
+  mcpServiceManager?: MCPServiceManager;
+
+  /**
+   * 路由处理器依赖
+   * 由 RouteManager 注入
+   */
+  dependencies?: HandlerDependencies;
+
+  /**
+   * WebServer 实例引用
+   * 用于获取运行时依赖
+   */
+  webServer?: IWebServer;
+
+  /**
+   * 小智连接管理器实例
+   * 由 endpointManagerMiddleware 注入
+   * WebServer 启动后始终可用的连接管理器实例
+   * 可能为 null（初始化失败时）
+   */
+  endpointManager: EndpointManager | null;
+
+  /**
+   * 端点处理器实例
+   * 由 endpointsMiddleware 注入
+   */
+  endpointHandler?: EndpointHandler | null;
+};
+
+/**
+ * 扩展的 Hono Context 类型
+ * 包含项目中所有自定义变量
+ */
+export type AppContext = {
+  Variables: AppContextVariables;
+};
+
+/**
+ * 创建类型化的 Hono 实例
+ * 使用这个类型来创建新的 Hono 应用，确保 Context 类型安全
+ */
+export const createApp = (): Hono<AppContext> => {
+  return new Hono<AppContext>();
+};
+
+/**
+ * 从 Context 中获取 MCPServiceManager 的类型安全方法
+ */
+export const getMCPServiceManager = (
+  c: Context<AppContext>
+): MCPServiceManager | undefined => {
+  return c.get("mcpServiceManager");
+};
+
+/**
+ * 要求必须存在 MCPServiceManager 的类型安全方法
+ */
+export const requireMCPServiceManager = (
+  c: Context<AppContext>
+): MCPServiceManager => {
+  const serviceManager = c.get("mcpServiceManager");
+
+  if (!serviceManager) {
+    throw new Error(
+      "MCPServiceManager 未初始化，请检查 mcpServiceManagerMiddleware 是否正确配置"
+    );
+  }
+
+  return serviceManager;
+};

--- a/src/server/types/index.ts
+++ b/src/server/types/index.ts
@@ -1,0 +1,88 @@
+/**
+ * 后端类型定义统一导出模块
+ *
+ * 此文件作为 apps/backend/types 的入口点，统一导出所有类型定义、工具函数和常量。
+ * 主要包括：
+ *
+ * - **MCP 核心类型**：
+ *   - {@link MCPMessage} - MCP 消息类型
+ *   - {@link MCPResponse} - MCP 响应类型
+ *   - {@link MCPError} - MCP 错误类型
+ *   - {@link ExtendedMCPToolsCache} - 扩展 MCP 工具缓存类型
+ *   - {@link EnhancedToolResultCache} - 增强工具结果缓存类型
+ *
+ * - **工具调用相关类型**：
+ *   - {@link ToolCallOptions} - 工具调用选项
+ *   - {@link ToolCallResponse} - 工具调用响应
+ *   - {@link ToolCallResult} - 工具调用结果
+ *
+ * - **缓存和状态类型**：
+ *   - {@link CacheStatistics} - 缓存统计信息
+ *   - {@link CacheStateTransition} - 缓存状态转换
+ *   - {@link CacheConfig} - 缓存配置
+ *   - {@link TimeoutConfig} - 超时配置
+ *
+ * - **任务相关类型**：
+ *   - {@link TaskStatus} - 任务状态
+ *   - {@link TaskInfo} - 任务信息
+ *
+ * - **工具函数**：
+ *   - {@link generateCacheKey} - 生成缓存键
+ *   - {@link formatTimestamp} - 格式化时间戳
+ *   - {@link isCacheExpired} - 检查缓存是否过期
+ *   - {@link shouldCleanupCache} - 判断是否需要清理缓存
+ *   - {@link isToolCallResult} - 类型守卫函数，判断是否为工具调用结果
+ *   - {@link isEnhancedToolResultCache} - 类型守卫函数，判断是否为增强工具结果缓存
+ *   - {@link isExtendedMCPToolsCache} - 类型守卫函数，判断是否为扩展 MCP 工具缓存
+ *
+ * - **常量**：
+ *   - {@link DEFAULT_CONFIG} - 后端默认配置
+ *
+ * - **其他导出**：
+ *   - 从 coze.js 导出的所有类型
+ *   - 从 timeout.js 导出的所有类型和函数
+ *   - 从 hono.context.js 导出的所有类型和函数
+ *
+ * @example
+ * ```typescript
+ * // 导入类型
+ * import type { MCPMessage, ToolCallOptions } from '../types';
+ *
+ * // 导入工具函数
+ * import { generateCacheKey, formatTimestamp } from '../types';
+ *
+ * // 导入默认配置
+ * import { DEFAULT_CONFIG } from '../types';
+ * ```
+ *
+ * @module apps/backend/types
+ */
+export type {
+  MCPMessage,
+  MCPResponse,
+  MCPError,
+  ExtendedMCPToolsCache,
+  EnhancedToolResultCache,
+  TaskStatus,
+  CacheStatistics,
+  CacheStateTransition,
+  ToolCallOptions,
+  CacheConfig,
+  TimeoutConfig,
+  TaskInfo,
+  ToolCallResponse,
+  ToolCallResult,
+} from "./mcp.js";
+export {
+  generateCacheKey,
+  formatTimestamp,
+  isCacheExpired,
+  shouldCleanupCache,
+  isToolCallResult,
+  isEnhancedToolResultCache,
+  isExtendedMCPToolsCache,
+  DEFAULT_CONFIG,
+} from "./mcp.js";
+export * from "./coze.js";
+export * from "./timeout.js";
+export * from "./hono.context.js";

--- a/src/server/types/mcp.ts
+++ b/src/server/types/mcp.ts
@@ -1,0 +1,276 @@
+/**
+ * MCP 相关类型定义
+ *
+ * 定义了与 MCP（Model Context Protocol）相关的所有类型，包括：
+ * - 工具调用结果和响应格式
+ * - JSON-RPC 2.0 消息和错误类型
+ * - MCP 工具缓存相关类型和工具函数
+ * - 超时处理和任务状态管理
+ *
+ * @module types/mcp
+ */
+
+import { createHash } from "node:crypto";
+import type { MCPToolsCache } from "../lib/mcp";
+import type { TimeoutResponse } from "./timeout.js";
+
+// 工具调用结果接口（与 MCPServiceManager 保持一致）
+export interface ToolCallResult {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown; // 支持其他未知字段，与 lib/mcp/types 保持兼容
+}
+
+// MCP 消息接口 - 定义 JSON-RPC 2.0 标准消息格式
+export interface MCPMessage {
+  jsonrpc: "2.0";
+  method: string;
+  params?: unknown;
+  id: string | number;
+}
+
+// MCP 响应接口 - 定义 JSON-RPC 2.0 标准响应格式
+export interface MCPResponse {
+  jsonrpc: "2.0";
+  id: string | number;
+  result?: unknown;
+  error?: MCPError;
+}
+
+// MCP 错误接口 - 定义 JSON-RPC 2.0 标准错误格式
+export interface MCPError {
+  code: number;
+  message: string;
+  data?: unknown;
+}
+
+/**
+ * 扩展的 MCP 工具缓存接口
+ * 增加对 CustomMCP 执行结果的支持
+ */
+export interface ExtendedMCPToolsCache extends MCPToolsCache {
+  customMCPResults?: Record<string, EnhancedToolResultCache>; // 增强的工具执行结果缓存
+}
+
+/**
+ * 增强的工具执行结果缓存
+ * 用于存储 CustomMCP 工具的执行结果和状态
+ */
+export interface EnhancedToolResultCache {
+  result: ToolCallResult;
+  timestamp: string; // ISO 8601 格式时间戳
+  ttl: number; // 过期时间（毫秒）
+  status: TaskStatus; // 任务状态
+  consumed: boolean; // 是否已被消费（一次性缓存机制）
+  taskId?: string; // 任务ID，用于查询
+  retryCount: number; // 重试次数
+}
+
+/**
+ * 任务状态类型
+ */
+export type TaskStatus =
+  | "pending"
+  | "completed"
+  | "failed"
+  | "consumed"
+  | "deleted";
+
+/**
+ * 缓存状态转换接口
+ */
+export interface CacheStateTransition {
+  from: TaskStatus;
+  to: TaskStatus;
+  reason: string;
+  timestamp: string;
+}
+
+/**
+ * 工具调用选项
+ */
+export interface ToolCallOptions {
+  timeout?: number; // 超时时间（毫秒）
+  retries?: number; // 重试次数
+  retryDelay?: number; // 重试延迟（毫秒）
+  enableCache?: boolean; // 是否启用缓存
+  taskId?: string; // 任务ID
+}
+
+/**
+ * 缓存配置选项
+ */
+export interface CacheConfig {
+  ttl?: number; // 缓存过期时间（毫秒），默认5分钟
+  cleanupInterval?: number; // 清理间隔（毫秒），默认1分钟
+  maxCacheSize?: number; // 最大缓存条目数
+  enableOneTimeCache?: boolean; // 是否启用一次性缓存
+}
+
+/**
+ * 超时配置选项
+ */
+export interface TimeoutConfig {
+  timeout?: number; // 超时时间（毫秒），默认8秒
+  enableFriendlyTimeout?: boolean; // 是否启用友好超时响应
+  backgroundProcessing?: boolean; // 是否启用后台处理
+}
+
+/**
+ * 任务信息接口
+ */
+export interface TaskInfo {
+  taskId: string;
+  toolName: string;
+  arguments: Record<string, unknown>;
+  status: TaskStatus;
+  startTime: string;
+  endTime?: string;
+  error?: string;
+  result?: ToolCallResult;
+}
+
+/**
+ * 缓存统计信息
+ */
+export interface CacheStatistics {
+  totalEntries: number;
+  pendingTasks: number;
+  completedTasks: number;
+  failedTasks: number;
+  consumedEntries: number;
+  cacheHitRate: number;
+  lastCleanupTime: string;
+  memoryUsage: number;
+}
+
+/**
+ * 工具调用结果联合类型
+ * 包含正常结果和超时响应
+ */
+export type ToolCallResponse = ToolCallResult | TimeoutResponse;
+
+/**
+ * 验证是否为工具调用结果
+ */
+export function isToolCallResult(
+  response: unknown
+): response is ToolCallResult {
+  return (
+    !!response &&
+    typeof response === "object" &&
+    response !== null &&
+    "content" in response &&
+    Array.isArray((response as ToolCallResult).content) &&
+    (response as ToolCallResult).content.length > 0 &&
+    (response as ToolCallResult).content[0]?.type === "text" &&
+    typeof (response as ToolCallResult).content[0]?.text === "string"
+  );
+}
+
+/**
+ * 验证是否为增强的工具结果缓存
+ */
+export function isEnhancedToolResultCache(
+  cache: unknown
+): cache is EnhancedToolResultCache {
+  const cacheObj = cache as EnhancedToolResultCache;
+  return (
+    !!cache &&
+    typeof cache === "object" &&
+    cache !== null &&
+    typeof cacheObj.timestamp === "string" &&
+    typeof cacheObj.ttl === "number" &&
+    typeof cacheObj.status === "string" &&
+    ["completed", "pending", "failed", "consumed"].includes(cacheObj.status) &&
+    typeof cacheObj.consumed === "boolean" &&
+    typeof cacheObj.retryCount === "number"
+  );
+}
+
+/**
+ * 验证是否为扩展的 MCP 工具缓存
+ */
+export function isExtendedMCPToolsCache(
+  cache: unknown
+): cache is ExtendedMCPToolsCache {
+  const cacheObj = cache as ExtendedMCPToolsCache;
+  return (
+    !!cache &&
+    typeof cache === "object" &&
+    cache !== null &&
+    typeof cacheObj.version === "string" &&
+    typeof cacheObj.mcpServers === "object" &&
+    cacheObj.mcpServers !== null &&
+    typeof cacheObj.metadata === "object" &&
+    cacheObj.metadata !== null
+  );
+}
+
+/**
+ * 生成缓存键的工具函数
+ */
+export function generateCacheKey(
+  toolName: string,
+  arguments_: Record<string, unknown>
+): string {
+  const argsHash = createHash("md5")
+    .update(JSON.stringify(arguments_ || {}))
+    .digest("hex");
+  return `${toolName}_${argsHash}`;
+}
+
+/**
+ * 格式化时间戳的工具函数
+ */
+export function formatTimestamp(timestamp: number | Date = Date.now()): string {
+  return new Date(timestamp).toISOString();
+}
+
+/**
+ * 检查缓存是否过期
+ */
+export function isCacheExpired(timestamp: string, ttl: number): boolean {
+  const cachedTime = new Date(timestamp).getTime();
+  const now = Date.now();
+  return now - cachedTime > ttl;
+}
+
+/**
+ * 检查是否应该清理缓存条目
+ */
+export function shouldCleanupCache(cache: EnhancedToolResultCache): boolean {
+  const now = Date.now();
+  const cachedTime = new Date(cache.timestamp).getTime();
+
+  // 已消费且超过清理时间（1分钟）
+  if (cache.consumed && now - cachedTime > DEFAULT_CONFIG.CLEANUP_INTERVAL) {
+    return true;
+  }
+
+  // 已过期
+  if (now - cachedTime > cache.ttl) {
+    return true;
+  }
+
+  // 失败的任务立即清理
+  if (cache.status === "failed") {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * 默认配置常量
+ */
+export const DEFAULT_CONFIG = {
+  TIMEOUT: 8000, // 8秒超时
+  CACHE_TTL: 300000, // 5分钟缓存
+  CLEANUP_INTERVAL: 60000, // 1分钟清理间隔
+  MAX_CACHE_SIZE: 1000, // 最大缓存条目数
+  ENABLE_ONE_TIME_CACHE: true, // 启用一次性缓存
+} as const;

--- a/src/server/types/timeout.ts
+++ b/src/server/types/timeout.ts
@@ -1,0 +1,131 @@
+/**
+ * 超时错误类型
+ */
+export class TimeoutError extends Error {
+  public override readonly name = "TimeoutError" as const;
+
+  constructor(message: string) {
+    super(message);
+    this.name = "TimeoutError";
+    Error.captureStackTrace(this, TimeoutError);
+  }
+
+  toJSON() {
+    return {
+      name: this.name,
+      message: this.message,
+      stack: this.stack,
+    };
+  }
+}
+
+/**
+ * 超时响应接口
+ */
+export interface TimeoutResponse {
+  content: Array<{
+    type: "text";
+    text: string;
+  }>;
+  isError: boolean;
+  taskId: string;
+  status: "timeout";
+  message: string;
+  nextAction: string;
+  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
+}
+
+/**
+ * 创建超时响应的工具函数
+ */
+export function createTimeoutResponse(
+  taskId: string,
+  toolName?: string
+): TimeoutResponse {
+  const toolSpecificMessage = toolName
+    ? getToolSpecificTimeoutMessage(toolName, taskId)
+    : getDefaultTimeoutMessage(taskId);
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: toolSpecificMessage,
+      },
+    ],
+    isError: false,
+    taskId,
+    status: "timeout",
+    message: "工具调用超时，正在后台处理中",
+    nextAction: "请稍后重试或等待任务完成",
+  };
+}
+
+/**
+ * 获取工具特定的超时提示信息
+ */
+function getToolSpecificTimeoutMessage(
+  toolName: string,
+  taskId: string
+): string {
+  const toolMessages: Record<string, string> = {
+    coze_workflow: `⏱️ 扣子工作流执行超时，正在后台处理中...
+    
+📋 任务信息：
+- 任务ID: ${taskId}
+- 工具类型: 扣子工作流
+- 状态: 处理中
+- 建议: 请等待30-60秒后重试查询
+
+🔄 后续操作：
+1. 使用相同参数重新调用工具
+2. 系统会自动返回已完成的任务结果
+3. 复杂工作流可能需要更长时间处理`,
+
+    default: getDefaultTimeoutMessage(taskId),
+  };
+
+  return toolMessages[toolName] || toolMessages.default;
+}
+
+/**
+ * 获取默认超时提示信息
+ */
+function getDefaultTimeoutMessage(taskId: string): string {
+  return `⏱️ 工具调用超时，正在后台处理中...
+    
+📋 任务信息：
+- 任务ID: ${taskId}
+- 状态: 处理中
+- 建议: 请等待30秒后重试查询
+
+🔄 后续操作：
+1. 使用相同的参数重新调用工具
+2. 系统会自动返回已完成的任务结果
+3. 如果长时间未完成，请联系管理员`;
+}
+
+/**
+ * 验证是否为超时响应
+ */
+export function isTimeoutResponse(response: any): response is TimeoutResponse {
+  return !!(
+    response &&
+    response.status === "timeout" &&
+    typeof response.taskId === "string" &&
+    Array.isArray(response.content) &&
+    response.content.length > 0 &&
+    response.content[0].type === "text"
+  );
+}
+
+/**
+ * 验证是否为超时错误
+ */
+export function isTimeoutError(error: any): error is TimeoutError {
+  return !!(
+    error &&
+    error.name === "TimeoutError" &&
+    error instanceof TimeoutError
+  );
+}

--- a/src/server/types/toolApi.ts
+++ b/src/server/types/toolApi.ts
@@ -1,0 +1,299 @@
+/**
+ * 工具添加 API 相关类型定义
+ * 支持多种工具类型的添加，包括 MCP 工具、Coze 工作流等
+ */
+
+import type { JSONSchema as LibJSONSchema } from "../lib/mcp/types.js";
+import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
+
+/**
+ * JSON Schema 类型
+ * 重新导出 ../lib/mcp/types.js 中的 JSONSchema
+ *
+ * 注意：此类型与 ../../../types/index.js 中的 JSONSchema 相同
+ * TODO：将来应从 shared-types 导入 JSONSchema 以消除重复定义
+ */
+export type JSONSchema = LibJSONSchema;
+
+/**
+ * 工具处理器配置相关类型
+ *
+ * 注意：这些类型与 ../../../types/index.js/src/mcp/tool-definition.ts 中定义的类型相同
+ * TODO：将 toolApi.ts 的类型迁移为从 shared-types 导入，消除重复定义
+ * 目前保持本地定义以避免 TypeScript 子路径解析问题（影响 tts、asr 等其他包）
+ *
+ * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts
+ */
+export type ToolHandlerConfig =
+  | MCPHandlerConfig
+  | ProxyHandlerConfig
+  | HttpHandlerConfig
+  | FunctionHandlerConfig;
+
+/**
+ * MCP 处理器配置
+ * 用于标准 MCP 服务中的工具
+ */
+export interface MCPHandlerConfig {
+  type: "mcp";
+  config: {
+    serviceName: string;
+    toolName: string;
+  };
+}
+
+/**
+ * 代理处理器配置
+ * 用于第三方平台代理（如 Coze、OpenAI 等）
+ */
+export interface ProxyHandlerConfig {
+  type: "proxy";
+  platform: "coze" | "openai" | "anthropic" | "custom";
+  config: Record<string, unknown>;
+}
+
+/**
+ * HTTP 处理器配置
+ * 用于 HTTP API 工具
+ */
+export interface HttpHandlerConfig {
+  type: "http";
+  config: {
+    url: string;
+    method?: string;
+    headers?: Record<string, string>;
+  };
+}
+
+/**
+ * 函数处理器配置
+ * 用于自定义函数工具
+ */
+export interface FunctionHandlerConfig {
+  type: "function";
+  config: {
+    module: string;
+    function: string;
+  };
+}
+
+/**
+ * CustomMCP 工具基础接口
+ *
+ * 注意：此类型与 ../../../types/index.js 中的 CustomMCPTool 相同
+ * TODO：将来应从 shared-types 导入 CustomMCPTool 以消除重复定义
+ */
+export interface CustomMCPToolBase {
+  /** 工具唯一标识符 */
+  name: string;
+  /** 工具描述信息 */
+  description: string;
+  /** 工具输入参数的 JSON Schema 定义 */
+  inputSchema: JSONSchema;
+  /** 处理器配置 */
+  handler: ToolHandlerConfig;
+}
+
+/**
+ * 带统计信息的 CustomMCP 工具
+ * 用于 API 响应，使用扁平的统计信息结构
+ *
+ * 注意：此类型与 ../../../types/index.js 中的 CustomMCPToolWithStats 类似
+ * 但不包含 `enabled` 字段。如需完整功能，请从 shared-types 导入
+ */
+export interface CustomMCPToolWithStats extends CustomMCPToolBase {
+  /** 工具使用次数（扁平结构，与 API 响应格式一致） */
+  usageCount?: number;
+  /** 最后使用时间（ISO 8601 格式） */
+  lastUsedTime?: string;
+}
+
+/**
+ * 工具类型枚举
+ */
+export enum ToolType {
+  /** MCP 工具（标准 MCP 服务中的工具） */
+  MCP = "mcp",
+  /** Coze 工作流工具 */
+  COZE = "coze",
+  /** HTTP API 工具（预留） */
+  HTTP = "http",
+  /** 自定义函数工具（预留） */
+  FUNCTION = "function",
+}
+
+/**
+ * MCP 工具数据
+ * 用于将标准 MCP 服务中的工具添加到 customMCP.tools 配置中
+ */
+export interface MCPToolData {
+  /** MCP 服务名称 */
+  serviceName: string;
+  /** 工具名称 */
+  toolName: string;
+  /** 可选的自定义名称 */
+  customName?: string;
+  /** 可选的自定义描述 */
+  customDescription?: string;
+}
+
+/**
+ * Coze 工作流数据
+ * 保持与现有格式的兼容性
+ */
+export interface CozeWorkflowData {
+  /** Coze 工作流信息 */
+  workflow: CozeWorkflow;
+  /** 可选的自定义名称 */
+  customName?: string;
+  /** 可选的自定义描述 */
+  customDescription?: string;
+  /** 可选的参数配置 */
+  parameterConfig?: WorkflowParameterConfig;
+}
+
+/**
+ * HTTP API 工具数据（预留）
+ */
+export interface HttpApiToolData {
+  /** API 地址 */
+  url: string;
+  /** HTTP 方法 */
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  /** API 描述 */
+  description: string;
+  /** 请求头 */
+  headers?: Record<string, string>;
+  /** 请求体模板 */
+  bodyTemplate?: string;
+  /** 认证配置 */
+  auth?: {
+    type: "bearer" | "basic" | "api_key";
+    token?: string;
+    username?: string;
+    password?: string;
+    apiKey?: string;
+    apiKeyHeader?: string;
+  };
+  /** 可选的自定义名称 */
+  customName?: string;
+  /** 可选的自定义描述 */
+  customDescription?: string;
+}
+
+/**
+ * 函数工具数据（预留）
+ */
+export interface FunctionToolData {
+  /** 模块路径 */
+  module: string;
+  /** 函数名 */
+  function: string;
+  /** 函数描述 */
+  description: string;
+  /** 函数执行上下文 */
+  context?: Record<string, any>;
+  /** 超时时间 */
+  timeout?: number;
+  /** 可选的自定义名称 */
+  customName?: string;
+  /** 可选的自定义描述 */
+  customDescription?: string;
+}
+
+/**
+ * 添加自定义工具的统一请求接口
+ */
+export interface AddCustomToolRequest {
+  /** 工具类型 */
+  type: ToolType;
+  /** 工具数据（根据类型不同而不同） */
+  data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
+}
+
+/**
+ * 工具验证错误类型
+ */
+export enum ToolValidationError {
+  /** 无效的工具类型 */
+  INVALID_TOOL_TYPE = "INVALID_TOOL_TYPE",
+  /** 缺少必需字段 */
+  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
+  /** 工具不存在 */
+  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
+  /** 服务不存在 */
+  SERVICE_NOT_FOUND = "SERVICE_NOT_FOUND",
+  /** 工具名称冲突 */
+  TOOL_NAME_CONFLICT = "TOOL_NAME_CONFLICT",
+  /** 配置验证失败 */
+  CONFIG_VALIDATION_FAILED = "CONFIG_VALIDATION_FAILED",
+  /** 系统配置错误 */
+  SYSTEM_CONFIG_ERROR = "SYSTEM_CONFIG_ERROR",
+  /** 资源限制超出 */
+  RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED",
+}
+
+/**
+ * 工具验证错误详情
+ */
+export interface ToolValidationErrorDetail {
+  /** 错误类型 */
+  error: ToolValidationError;
+  /** 错误消息 */
+  message: string;
+  /** 错误详情 */
+  details?: any;
+  /** 建议的解决方案 */
+  suggestions?: string[];
+}
+
+/**
+ * 添加工具的响应数据
+ */
+export interface AddToolResponse {
+  /** 成功添加的工具 */
+  tool: any;
+  /** 工具名称 */
+  toolName: string;
+  /** 工具类型 */
+  toolType: ToolType;
+  /** 添加时间戳 */
+  addedAt: string;
+}
+
+/**
+ * 工具元数据信息
+ */
+export interface ToolMetadata {
+  /** 工具原始来源 */
+  source: {
+    type: "mcp" | "coze" | "http" | "function";
+    serviceName?: string;
+    toolName?: string;
+    url?: string;
+  };
+  /** 添加时间 */
+  addedAt: string;
+  /** 最后更新时间 */
+  updatedAt?: string;
+  /** 版本信息 */
+  version?: string;
+}
+
+/**
+ * 工具配置选项
+ */
+export interface ToolConfigOptions {
+  /** 是否启用工具（默认 true） */
+  enabled?: boolean;
+  /** 超时时间（毫秒） */
+  timeout?: number;
+  /** 重试次数 */
+  retryCount?: number;
+  /** 重试间隔（毫秒） */
+  retryDelay?: number;
+  /** 自定义标签 */
+  tags?: string[];
+  /** 工具分组 */
+  group?: string;
+}

--- a/src/server/utils/__tests__/prompt-utils.test.ts
+++ b/src/server/utils/__tests__/prompt-utils.test.ts
@@ -1,0 +1,274 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
+/**
+ * 提示词解析工具单元测试
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { getDefaultSystemPrompt, resolvePrompt } from "../prompt-utils";
+
+// Mock configManager
+vi.mock("../../../config/index.js", () => ({
+  configManager: {
+    getConfigPath: vi.fn(() => "/test/config/xiaozhi.config.json"),
+  },
+}));
+
+// Mock fs module
+vi.mock("node:fs", () => ({
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  rmSync: vi.fn(),
+  writeFileSync: vi.fn(),
+}));
+
+describe("prompt-utils", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.resetAllMocks();
+  });
+
+  describe("getDefaultSystemPrompt", () => {
+    it("应该返回默认系统提示词", () => {
+      const prompt = getDefaultSystemPrompt();
+      expect(prompt).toBe(
+        "你是一个友好的语音助手，请用简洁的中文回答用户的问题。"
+      );
+    });
+  });
+
+  describe("resolvePrompt", () => {
+    describe("未配置或空字符串", () => {
+      it("未配置 prompt 时应返回默认提示词", () => {
+        const result = resolvePrompt(undefined);
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+
+      it("空字符串 prompt 时应返回默认提示词", () => {
+        const result = resolvePrompt("");
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+
+      it("仅包含空格的字符串应返回默认提示词", () => {
+        const result = resolvePrompt("   ");
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+    });
+
+    describe("纯字符串 prompt", () => {
+      it("纯字符串 prompt 应直接返回", () => {
+        const customPrompt = "这是一个自定义的提示词";
+        const result = resolvePrompt(customPrompt);
+        expect(result).toBe(customPrompt);
+      });
+
+      it("以 `.` 开头但不是路径的字符串应直接返回", () => {
+        const customPrompt = ".hidden prompt 内容";
+        const result = resolvePrompt(customPrompt);
+        expect(result).toBe(customPrompt);
+      });
+
+      it("多行文本应直接返回", () => {
+        const customPrompt = "第一行\n第二行\n第三行";
+        const result = resolvePrompt(customPrompt);
+        expect(result).toBe(customPrompt);
+      });
+    });
+
+    describe("绝对路径文件", () => {
+      it("绝对路径文件存在时应读取文件内容", () => {
+        const filePath = "/absolute/path/to/prompt.md";
+        const fileContent = "这是文件中的提示词内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(filePath);
+
+        expect(existsSync).toHaveBeenCalledWith(filePath);
+        expect(readFileSync).toHaveBeenCalledWith(filePath, "utf-8");
+        expect(result).toBe(fileContent);
+      });
+
+      it("绝对路径文件不存在时应返回默认提示词", () => {
+        const filePath = "/absolute/path/to/nonexistent.md";
+
+        vi.mocked(existsSync).mockReturnValue(false);
+
+        const result = resolvePrompt(filePath);
+
+        expect(existsSync).toHaveBeenCalledWith(filePath);
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+
+      it("文件读取失败时应返回默认提示词", () => {
+        const filePath = "/absolute/path/to/prompt.md";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockImplementation(() => {
+          throw new Error("读取失败");
+        });
+
+        const result = resolvePrompt(filePath);
+
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+
+      it("文件内容为空时应返回默认提示词", () => {
+        const filePath = "/absolute/path/to/empty.md";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue("");
+
+        const result = resolvePrompt(filePath);
+
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+
+      it("文件内容仅包含空白字符时应返回默认提示词", () => {
+        const filePath = "/absolute/path/to/whitespace.md";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue("   \n\t  ");
+
+        const result = resolvePrompt(filePath);
+
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+    });
+
+    describe("相对路径文件", () => {
+      it("相对路径 `./` 文件存在时应正确解析并读取", () => {
+        const relativePath = "./prompts/default.md";
+        const expectedAbsolutePath = resolve(
+          "/test/config",
+          "prompts/default.md"
+        );
+        const fileContent = "相对路径文件内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(existsSync).toHaveBeenCalledWith(expectedAbsolutePath);
+        expect(readFileSync).toHaveBeenCalledWith(
+          expectedAbsolutePath,
+          "utf-8"
+        );
+        expect(result).toBe(fileContent);
+      });
+
+      it("相对路径 `../` 文件存在时应正确解析并读取", () => {
+        const relativePath = "../prompts/parent.md";
+        const expectedAbsolutePath = resolve(
+          "/test/config",
+          "../prompts/parent.md"
+        );
+        const fileContent = "上级目录文件内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(existsSync).toHaveBeenCalledWith(expectedAbsolutePath);
+        expect(result).toBe(fileContent);
+      });
+
+      it("相对路径文件不存在时应返回默认提示词", () => {
+        const relativePath = "./prompts/nonexistent.md";
+
+        vi.mocked(existsSync).mockReturnValue(false);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(result).toBe(getDefaultSystemPrompt());
+      });
+    });
+
+    describe("Windows 路径兼容性", () => {
+      it("Windows 相对路径 `.\\` 应被正确识别", () => {
+        const relativePath = ".\\prompts\\default.md";
+        const expectedAbsolutePath = resolve(
+          "/test/config",
+          "prompts/default.md"
+        );
+        const fileContent = "Windows 相对路径内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(existsSync).toHaveBeenCalledWith(expectedAbsolutePath);
+        expect(result).toBe(fileContent);
+      });
+
+      it("Windows 相对路径 `..\\` 应被正确识别", () => {
+        const relativePath = "..\\prompts\\parent.md";
+        const expectedAbsolutePath = resolve(
+          "/test/config",
+          "../prompts/parent.md"
+        );
+        const fileContent = "Windows 上级目录内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(existsSync).toHaveBeenCalledWith(expectedAbsolutePath);
+        expect(result).toBe(fileContent);
+      });
+
+      it("混合路径分隔符应被正确处理", () => {
+        const relativePath = ".\\prompts/subfolder\\prompt.md";
+        const expectedAbsolutePath = resolve(
+          "/test/config",
+          "prompts/subfolder/prompt.md"
+        );
+        const fileContent = "混合分隔符路径内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(relativePath);
+
+        expect(existsSync).toHaveBeenCalledWith(expectedAbsolutePath);
+        expect(result).toBe(fileContent);
+      });
+    });
+
+    describe("边界情况", () => {
+      it("包含特殊字符的路径应正确处理", () => {
+        const filePath = "/path/with spaces/提示词.md";
+        const fileContent = "特殊字符路径内容";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(filePath);
+
+        expect(existsSync).toHaveBeenCalledWith(filePath);
+        expect(result).toBe(fileContent);
+      });
+
+      it("Markdown 格式的提示词文件应正确读取", () => {
+        const filePath = "/path/to/prompt.md";
+        const fileContent =
+          "# 系统提示词\n\n你是一个 AI 助手。\n\n## 规则\n1. 简洁回答";
+
+        vi.mocked(existsSync).mockReturnValue(true);
+        vi.mocked(readFileSync).mockReturnValue(fileContent);
+
+        const result = resolvePrompt(filePath);
+
+        expect(result).toBe(fileContent);
+      });
+    });
+  });
+});

--- a/src/server/utils/index.ts
+++ b/src/server/utils/index.ts
@@ -1,0 +1,8 @@
+/**
+ * Utils 统一导出模块
+ * 提供 utils 目录下所有工具类的统一导出接口
+ */
+
+export { PathUtils } from "./path-utils.js";
+// 重新导出 ../../../utils/version.js 以保持向后兼容
+export { VersionUtils } from "../../utils/version.js";

--- a/src/server/utils/path-utils.ts
+++ b/src/server/utils/path-utils.ts
@@ -1,0 +1,24 @@
+/**
+ * 路径处理工具
+ */
+
+import { tmpdir } from "node:os";
+
+/**
+ * 路径工具类
+ */
+export class PathUtils {
+  /**
+   * 获取配置目录路径
+   */
+  static getConfigDir(): string {
+    return process.env.XIAOZHI_CONFIG_DIR || process.cwd();
+  }
+
+  /**
+   * 获取临时目录路径
+   */
+  static getTempDir(): string {
+    return process.env.TMPDIR || process.env.TEMP || tmpdir();
+  }
+}

--- a/src/server/utils/prompt-utils.ts
+++ b/src/server/utils/prompt-utils.ts
@@ -1,0 +1,451 @@
+/**
+ * 提示词解析工具
+ *
+ * 支持三种格式的提示词配置：
+ * 1. 绝对路径：如 `/Users/xxx/prompts/default.md`
+ * 2. 相对路径：如 `./prompts/default.md`（相对于配置文件所在目录）
+ * 3. 纯字符串：直接作为提示词内容
+ */
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { dirname, isAbsolute, resolve } from "node:path";
+import { configManager } from "../../config/index.js";
+
+// 默认系统提示词
+const DEFAULT_SYSTEM_PROMPT =
+  "你是一个友好的语音助手，请用简洁的中文回答用户的问题。";
+
+/**
+ * 判断配置值是否为路径格式
+ *
+ * 路径格式的判断规则：
+ * - 相对路径：以 `./`、`../`、`.\` 或 `..\` 开头（支持 Windows 和 Unix 风格）
+ * - 绝对路径：使用 path.isAbsolute() 判断
+ * - 其他情况：视为纯字符串内容
+ *
+ * @param config - 提示词配置值
+ * @returns 是否为路径格式
+ */
+function isPromptPath(config: string): boolean {
+  // 将路径分隔符统一为正斜杠，便于跨平台判断
+  const normalizedConfig = config.replace(/\\/g, "/");
+
+  // 相对路径：以 ./ 或 ../ 开头
+  if (normalizedConfig.startsWith("./") || normalizedConfig.startsWith("../")) {
+    return true;
+  }
+  // 绝对路径
+  if (isAbsolute(config)) {
+    return true;
+  }
+  return false;
+}
+
+/**
+ * 从文件路径读取提示词内容
+ *
+ * @param promptPath - 提示词文件路径（绝对路径或相对路径）
+ * @returns 提示词内容，如果读取失败则返回 null
+ */
+function resolvePromptFromPath(promptPath: string): string | null {
+  try {
+    // 将 Windows 风格的反斜杠统一转换为正斜杠，便于跨平台解析
+    const normalizedPath = promptPath.replace(/\\/g, "/");
+
+    // 解析路径
+    let resolvedPath: string;
+    if (isAbsolute(normalizedPath)) {
+      // 绝对路径直接使用
+      resolvedPath = normalizedPath;
+    } else {
+      // 相对路径：相对于配置文件所在目录
+      const configFilePath = configManager.getConfigPath();
+      const configDir = dirname(configFilePath);
+      resolvedPath = resolve(configDir, normalizedPath);
+    }
+
+    // 检查文件是否存在
+    if (!existsSync(resolvedPath)) {
+      console.warn(
+        `[prompt-utils] 提示词文件不存在: ${resolvedPath}，将使用默认提示词`
+      );
+      return null;
+    }
+
+    // 读取文件内容
+    const content = readFileSync(resolvedPath, "utf-8").trim();
+
+    // 检查文件内容是否为空
+    if (!content) {
+      console.warn(
+        `[prompt-utils] 提示词文件内容为空: ${resolvedPath}，将使用默认提示词`
+      );
+      return null;
+    }
+
+    console.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
+    return content;
+  } catch (error) {
+    console.error(
+      `[prompt-utils] 读取提示词文件失败: ${promptPath}`,
+      error instanceof Error ? error.message : String(error)
+    );
+    return null;
+  }
+}
+
+/**
+ * 解析提示词配置
+ *
+ * 处理逻辑：
+ * 1. 未配置或空字符串 → 返回默认提示词
+ * 2. 是路径格式 → 尝试读取文件内容
+ * 3. 不是路径格式 → 直接返回作为纯字符串
+ *
+ * @param promptConfig - 提示词配置值（可选）
+ * @returns 解析后的提示词内容
+ */
+export function resolvePrompt(promptConfig?: string): string {
+  // 未配置或空字符串，返回默认提示词
+  if (!promptConfig || promptConfig.trim() === "") {
+    return DEFAULT_SYSTEM_PROMPT;
+  }
+
+  // 判断是否为路径格式
+  if (isPromptPath(promptConfig)) {
+    // 尝试从路径读取
+    const content = resolvePromptFromPath(promptConfig);
+    // 读取失败返回默认提示词
+    return content || DEFAULT_SYSTEM_PROMPT;
+  }
+
+  // 不是路径格式，直接作为纯字符串返回
+  return promptConfig;
+}
+
+/**
+ * 获取默认系统提示词
+ *
+ * @returns 默认系统提示词
+ */
+export function getDefaultSystemPrompt(): string {
+  return DEFAULT_SYSTEM_PROMPT;
+}
+
+/**
+ * 提示词文件信息
+ */
+export interface PromptFileInfo {
+  /** 文件名 */
+  fileName: string;
+  /** 相对路径（相对于配置文件所在目录） */
+  relativePath: string;
+}
+
+/**
+ * 获取 prompts 目录下的所有 .md 文件列表
+ *
+ * @returns 提示词文件信息数组
+ */
+export function listPromptFiles(): PromptFileInfo[] {
+  try {
+    const configFilePath = configManager.getConfigPath();
+    const configDir = dirname(configFilePath);
+    const promptsDir = resolve(configDir, "prompts");
+
+    // 检查 prompts 目录是否存在
+    if (!existsSync(promptsDir)) {
+      return [];
+    }
+
+    // 读取目录下的所有文件
+    const files = readdirSync(promptsDir);
+
+    // 过滤出 .md 文件并构建返回结果
+    const promptFiles: PromptFileInfo[] = files
+      .filter((file: string) => file.endsWith(".md"))
+      .map((file: string) => ({
+        fileName: file,
+        relativePath: `./prompts/${file}`,
+      }));
+
+    return promptFiles;
+  } catch (error) {
+    console.error(
+      "[prompt-utils] 获取提示词文件列表失败:",
+      error instanceof Error ? error.message : String(error)
+    );
+    return [];
+  }
+}
+
+// ==================== 提示词文件操作相关函数 ====================
+
+/** 最大文件大小限制（100KB） */
+const MAX_FILE_SIZE = 100 * 1024;
+
+/** 文件名验证正则：允许字母、数字、下划线、中划线、中文 */
+const FILE_NAME_REGEX = /^[\u4e00-\u9fa5a-zA-Z0-9_-]+\.md$/;
+
+/**
+ * 验证提示词文件路径是否安全
+ *
+ * 安全规则：
+ * 1. 必须是相对路径格式（以 ./prompts/ 开头）
+ * 2. 路径不能包含 ..（防止路径遍历攻击）
+ * 3. 文件名必须符合规范
+ *
+ * @param relativePath - 相对路径
+ * @returns 验证结果，包含是否有效和错误信息
+ */
+export function validatePromptPath(relativePath: string): {
+  valid: boolean;
+  error?: string;
+} {
+  // 将 Windows 风格的反斜杠统一转换为正斜杠，便于跨平台验证
+  const normalizedPath = relativePath.replace(/\\/g, "/");
+
+  // 检查路径格式（使用规范化后的路径）
+  if (!normalizedPath.startsWith("./prompts/")) {
+    return {
+      valid: false,
+      error: "路径格式错误，必须以 ./prompts/ 开头",
+    };
+  }
+
+  // 检查路径遍历攻击（使用规范化后的路径）
+  if (normalizedPath.includes("..")) {
+    return {
+      valid: false,
+      error: "路径不能包含 ..",
+    };
+  }
+
+  // 提取文件名并验证（使用规范化后的路径）
+  const fileName = normalizedPath.replace("./prompts/", "");
+  if (!FILE_NAME_REGEX.test(fileName)) {
+    return {
+      valid: false,
+      error:
+        "文件名只能包含字母、数字、下划线、中划线、中文，且必须以 .md 结尾",
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
+ * 验证提示词文件名是否合法
+ *
+ * @param fileName - 文件名
+ * @returns 验证结果
+ */
+export function validatePromptFileName(fileName: string): {
+  valid: boolean;
+  error?: string;
+} {
+  if (!FILE_NAME_REGEX.test(fileName)) {
+    return {
+      valid: false,
+      error:
+        "文件名只能包含字母、数字、下划线、中划线、中文，且必须以 .md 结尾",
+    };
+  }
+  return { valid: true };
+}
+
+/**
+ * 获取 prompts 目录的绝对路径
+ *
+ * @returns prompts 目录的绝对路径
+ */
+export function getPromptsDir(): string {
+  const configFilePath = configManager.getConfigPath();
+  const configDir = dirname(configFilePath);
+  return resolve(configDir, "prompts");
+}
+
+/**
+ * 将相对路径解析为绝对路径
+ *
+ * @param relativePath - 相对路径（如 ./prompts/default.md）
+ * @returns 绝对路径
+ */
+export function resolvePromptPath(relativePath: string): string {
+  const promptsDir = getPromptsDir();
+  const fileName = relativePath.replace("./prompts/", "");
+  return resolve(promptsDir, fileName);
+}
+
+/**
+ * 提示词文件内容信息
+ */
+export interface PromptFileContent {
+  /** 文件名 */
+  fileName: string;
+  /** 相对路径（相对于配置文件所在目录） */
+  relativePath: string;
+  /** 文件内容 */
+  content: string;
+}
+
+/**
+ * 读取提示词文件内容
+ *
+ * @param relativePath - 相对路径（如 ./prompts/default.md）
+ * @returns 文件内容信息
+ * @throws 如果路径无效或文件不存在
+ */
+export function readPromptFile(relativePath: string): PromptFileContent {
+  // 验证路径
+  const validation = validatePromptPath(relativePath);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 解析绝对路径
+  const absolutePath = resolvePromptPath(relativePath);
+
+  // 检查文件是否存在
+  if (!existsSync(absolutePath)) {
+    throw new Error(`文件不存在: ${relativePath}`);
+  }
+
+  // 检查文件大小
+  const stats = statSync(absolutePath);
+  if (stats.size > MAX_FILE_SIZE) {
+    throw new Error("文件大小超过限制（最大 100KB）");
+  }
+
+  // 读取文件内容
+  const content = readFileSync(absolutePath, "utf-8");
+
+  return {
+    fileName: relativePath.replace("./prompts/", ""),
+    relativePath,
+    content,
+  };
+}
+
+/**
+ * 更新提示词文件内容
+ *
+ * @param relativePath - 相对路径（如 ./prompts/default.md）
+ * @param content - 新的文件内容
+ * @throws 如果路径无效或文件不存在
+ */
+export function updatePromptFile(
+  relativePath: string,
+  content: string
+): PromptFileContent {
+  // 验证路径
+  const validation = validatePromptPath(relativePath);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 验证内容大小（按 UTF-8 字节数，与文件大小限制保持一致）
+  if (Buffer.byteLength(content, "utf8") > MAX_FILE_SIZE) {
+    throw new Error("内容大小超过限制（最大 100KB）");
+  }
+
+  // 解析绝对路径
+  const absolutePath = resolvePromptPath(relativePath);
+
+  // 检查文件是否存在
+  if (!existsSync(absolutePath)) {
+    throw new Error(`文件不存在: ${relativePath}`);
+  }
+
+  // 写入文件
+  writeFileSync(absolutePath, content, "utf-8");
+
+  return {
+    fileName: relativePath.replace("./prompts/", ""),
+    relativePath,
+    content,
+  };
+}
+
+/**
+ * 创建新的提示词文件
+ *
+ * @param fileName - 文件名（如 custom-prompt.md）
+ * @param content - 文件内容
+ * @returns 新创建的文件信息
+ * @throws 如果文件名无效或文件已存在
+ */
+export function createPromptFile(
+  fileName: string,
+  content: string
+): PromptFileContent {
+  // 验证文件名
+  const validation = validatePromptFileName(fileName);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 验证内容大小（按 UTF-8 字节数计算，避免多字节字符导致限制失真）
+  const contentSize = Buffer.byteLength(content, "utf8");
+  if (contentSize > MAX_FILE_SIZE) {
+    throw new Error("内容大小超过限制（最大 100KB）");
+  }
+
+  // 获取 prompts 目录
+  const promptsDir = getPromptsDir();
+
+  // 确保 prompts 目录存在
+  if (!existsSync(promptsDir)) {
+    mkdirSync(promptsDir, { recursive: true });
+  }
+
+  // 构建文件路径
+  const absolutePath = resolve(promptsDir, fileName);
+  const relativePath = `./prompts/${fileName}`;
+
+  // 检查文件是否已存在
+  if (existsSync(absolutePath)) {
+    throw new Error(`文件已存在: ${fileName}`);
+  }
+
+  // 写入文件
+  writeFileSync(absolutePath, content, "utf-8");
+
+  return {
+    fileName,
+    relativePath,
+    content,
+  };
+}
+
+/**
+ * 删除提示词文件
+ *
+ * @param relativePath - 相对路径（如 ./prompts/old-prompt.md）
+ * @throws 如果路径无效或文件不存在
+ */
+export function deletePromptFile(relativePath: string): void {
+  // 验证路径
+  const validation = validatePromptPath(relativePath);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 解析绝对路径
+  const absolutePath = resolvePromptPath(relativePath);
+
+  // 检查文件是否存在
+  if (!existsSync(absolutePath)) {
+    throw new Error(`文件不存在: ${relativePath}`);
+  }
+
+  // 删除文件
+  rmSync(absolutePath);
+}

--- a/src/server/utils/tool-sorters.test.ts
+++ b/src/server/utils/tool-sorters.test.ts
@@ -1,0 +1,362 @@
+/**
+ * toolSorters 工具函数测试
+ */
+
+import { describe, expect, it } from "vitest";
+import type { EnhancedToolInfo } from "../lib/mcp";
+import { sortTools, toolSorters } from "./toolSorters";
+
+// 创建模拟工具数据
+function createMockTool(
+  overrides: Partial<EnhancedToolInfo> = {}
+): EnhancedToolInfo {
+  return {
+    name: "test-server__test-tool",
+    originalName: "test-tool",
+    serviceName: "test-server",
+    description: "测试工具",
+    inputSchema: { type: "object" },
+    enabled: true,
+    usageCount: 0,
+    lastUsedTime: "2024-01-01 00:00:00",
+    ...overrides,
+  };
+}
+
+describe("toolSorters", () => {
+  describe("按名称排序", () => {
+    it("应该按服务名排序", () => {
+      const tools = [
+        createMockTool({
+          serviceName: "服务B",
+          originalName: "tool1",
+          name: "服务B__tool1",
+        }),
+        createMockTool({
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+        createMockTool({
+          serviceName: "服务C",
+          originalName: "tool3",
+          name: "服务C__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.name);
+
+      expect(sorted[0].serviceName).toBe("服务A");
+      expect(sorted[1].serviceName).toBe("服务B");
+      expect(sorted[2].serviceName).toBe("服务C");
+    });
+
+    it("服务名相同时应该按工具名排序", () => {
+      const tools = [
+        createMockTool({
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+        createMockTool({
+          serviceName: "服务A",
+          originalName: "tool1",
+          name: "服务A__tool1",
+        }),
+        createMockTool({
+          serviceName: "服务A",
+          originalName: "tool3",
+          name: "服务A__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.name);
+
+      expect(sorted[0].originalName).toBe("tool1");
+      expect(sorted[1].originalName).toBe("tool2");
+      expect(sorted[2].originalName).toBe("tool3");
+    });
+
+    it("应该正确处理中文排序", () => {
+      const tools = [
+        createMockTool({
+          serviceName: "张三",
+          originalName: "tool1",
+          name: "张三__tool1",
+        }),
+        createMockTool({
+          serviceName: "李四",
+          originalName: "tool2",
+          name: "李四__tool2",
+        }),
+        createMockTool({
+          serviceName: "王五",
+          originalName: "tool3",
+          name: "王五__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.name);
+
+      // 中文拼音排序：李四 < 王五 < 张三
+      expect(sorted[0].serviceName).toBe("李四");
+      expect(sorted[1].serviceName).toBe("王五");
+      expect(sorted[2].serviceName).toBe("张三");
+    });
+  });
+
+  describe("按启用状态排序", () => {
+    it("已启用的工具应该排在前面", () => {
+      const tools = [
+        createMockTool({
+          enabled: false,
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          enabled: true,
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+        createMockTool({
+          enabled: false,
+          originalName: "tool3",
+          name: "server__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.enabled);
+
+      expect(sorted[0].enabled).toBe(true);
+      expect(sorted[1].enabled).toBe(false);
+      expect(sorted[2].enabled).toBe(false);
+    });
+
+    it("同状态下应该按名称排序", () => {
+      const tools = [
+        createMockTool({
+          enabled: true,
+          serviceName: "服务B",
+          originalName: "tool1",
+          name: "服务B__tool1",
+        }),
+        createMockTool({
+          enabled: true,
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.enabled);
+
+      expect(sorted[0].serviceName).toBe("服务A");
+      expect(sorted[1].serviceName).toBe("服务B");
+    });
+  });
+
+  describe("按使用次数排序", () => {
+    it("使用次数多的工具应该排在前面", () => {
+      const tools = [
+        createMockTool({
+          usageCount: 5,
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          usageCount: 10,
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+        createMockTool({
+          usageCount: 1,
+          originalName: "tool3",
+          name: "server__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.usageCount);
+
+      expect(sorted[0].usageCount).toBe(10);
+      expect(sorted[1].usageCount).toBe(5);
+      expect(sorted[2].usageCount).toBe(1);
+    });
+
+    it("使用次数相同时应该按名称排序", () => {
+      const tools = [
+        createMockTool({
+          usageCount: 5,
+          serviceName: "服务B",
+          originalName: "tool1",
+          name: "服务B__tool1",
+        }),
+        createMockTool({
+          usageCount: 5,
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.usageCount);
+
+      expect(sorted[0].serviceName).toBe("服务A");
+      expect(sorted[1].serviceName).toBe("服务B");
+    });
+  });
+
+  describe("按最近使用时间排序", () => {
+    it("最近使用的工具应该排在前面", () => {
+      const tools = [
+        createMockTool({
+          lastUsedTime: "2024-01-01 00:00:00",
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          lastUsedTime: "2024-01-03 00:00:00",
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+        createMockTool({
+          lastUsedTime: "2024-01-02 00:00:00",
+          originalName: "tool3",
+          name: "server__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.lastUsedTime);
+
+      expect(sorted[0].lastUsedTime).toBe("2024-01-03 00:00:00");
+      expect(sorted[1].lastUsedTime).toBe("2024-01-02 00:00:00");
+      expect(sorted[2].lastUsedTime).toBe("2024-01-01 00:00:00");
+    });
+
+    it("未使用时间的工具应该排在后面", () => {
+      const tools = [
+        createMockTool({
+          lastUsedTime: "2024-01-01 00:00:00",
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          lastUsedTime: "",
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+        createMockTool({
+          lastUsedTime: "2024-01-02 00:00:00",
+          originalName: "tool3",
+          name: "server__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.lastUsedTime);
+
+      // 有时间的应该排在前面，没有时间的排在后面
+      expect(sorted[2].lastUsedTime).toBe("");
+    });
+
+    it("时间相同时应该按名称排序", () => {
+      const tools = [
+        createMockTool({
+          lastUsedTime: "2024-01-01 00:00:00",
+          serviceName: "服务B",
+          originalName: "tool1",
+          name: "服务B__tool1",
+        }),
+        createMockTool({
+          lastUsedTime: "2024-01-01 00:00:00",
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.lastUsedTime);
+
+      expect(sorted[0].serviceName).toBe("服务A");
+      expect(sorted[1].serviceName).toBe("服务B");
+    });
+  });
+
+  describe("边界情况处理", () => {
+    it("应该正确处理 null/undefined 值", () => {
+      const tools = [
+        createMockTool({
+          lastUsedTime: null as unknown as string,
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          lastUsedTime: undefined as unknown as string,
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+        createMockTool({
+          lastUsedTime: "2024-01-01 00:00:00",
+          originalName: "tool3",
+          name: "server__tool3",
+        }),
+      ];
+
+      const sorted = [...tools].sort(toolSorters.lastUsedTime);
+
+      // 有时间的应该排在前面
+      expect(sorted[0].lastUsedTime).toBe("2024-01-01 00:00:00");
+    });
+
+    it("空数组应该返回空数组", () => {
+      const sorted = sortTools([], { field: "name" });
+      expect(sorted).toEqual([]);
+    });
+
+    it("单个元素数组应该返回原数组", () => {
+      const tools = [createMockTool()];
+      const sorted = sortTools(tools, { field: "name" });
+      expect(sorted).toEqual(tools);
+    });
+  });
+
+  describe("sortTools 函数", () => {
+    it("应该正确应用排序配置", () => {
+      const tools = [
+        createMockTool({
+          usageCount: 5,
+          originalName: "tool1",
+          name: "server__tool1",
+        }),
+        createMockTool({
+          usageCount: 10,
+          originalName: "tool2",
+          name: "server__tool2",
+        }),
+      ];
+
+      const sorted = sortTools(tools, { field: "usageCount" });
+
+      expect(sorted[0].usageCount).toBe(10);
+      expect(sorted[1].usageCount).toBe(5);
+    });
+
+    it("不应该修改原数组", () => {
+      const tools = [
+        createMockTool({
+          serviceName: "服务B",
+          originalName: "tool1",
+          name: "服务B__tool1",
+        }),
+        createMockTool({
+          serviceName: "服务A",
+          originalName: "tool2",
+          name: "服务A__tool2",
+        }),
+      ];
+
+      const originalOrder = [...tools];
+      sortTools(tools, { field: "name" });
+
+      expect(tools).toEqual(originalOrder);
+    });
+  });
+});

--- a/src/server/utils/toolSorters.ts
+++ b/src/server/utils/toolSorters.ts
@@ -1,0 +1,104 @@
+/**
+ * MCP 工具排序工具模块
+ * 提供可扩展的排序策略，支持多种排序方式
+ */
+
+import { logger } from "../Logger.js";
+import type { EnhancedToolInfo } from "../lib/mcp";
+
+export type ToolSortField = "name" | "enabled" | "usageCount" | "lastUsedTime";
+
+export interface ToolSortConfig {
+  field: ToolSortField;
+}
+
+/**
+ * 排序函数类型
+ */
+type SortFn = (a: EnhancedToolInfo, b: EnhancedToolInfo) => number;
+
+/**
+ * 工具排序策略
+ * 新增排序方式只需在此处添加对应的排序函数
+ */
+export const toolSorters: Record<ToolSortField, SortFn> = {
+  /**
+   * 按名称排序（默认排序）
+   * 规则：服务名 a-z → 工具名 a-z
+   */
+  name: (a, b) => {
+    // 先按服务名排序
+    if (a.serviceName !== b.serviceName) {
+      return a.serviceName.localeCompare(b.serviceName, "zh-CN");
+    }
+    // 服务名相同时，按工具名排序
+    return a.originalName.localeCompare(b.originalName, "zh-CN");
+  },
+
+  /**
+   * 按启用状态排序
+   * 规则：已启用在前，已禁用在后；同状态内按名称排序
+   */
+  enabled: (a, b) => {
+    // 先按启用状态排序（已启用在前）
+    const enabledCompare = Number(b.enabled) - Number(a.enabled);
+    if (enabledCompare !== 0) {
+      return enabledCompare;
+    }
+    // 同状态内按名称排序
+    if (a.serviceName !== b.serviceName) {
+      return a.serviceName.localeCompare(b.serviceName, "zh-CN");
+    }
+    return a.originalName.localeCompare(b.originalName, "zh-CN");
+  },
+
+  /**
+   * 按使用次数排序
+   * 规则：使用次数多的在前；同次数时按名称排序
+   */
+  usageCount: (a, b) => {
+    // 按使用次数降序排序（次数多的在前）
+    const countCompare = b.usageCount - a.usageCount;
+    if (countCompare !== 0) return countCompare;
+    // 使用次数相同时，按服务名和工具名排序
+    if (a.serviceName !== b.serviceName) {
+      return a.serviceName.localeCompare(b.serviceName, "zh-CN");
+    }
+    return a.originalName.localeCompare(b.originalName, "zh-CN");
+  },
+
+  /**
+   * 按最近使用时间排序
+   * 规则：最近使用的在前；未使用时间的工具排在后面
+   */
+  lastUsedTime: (a, b) => {
+    // 未使用时间的工具排在后面
+    if (!a.lastUsedTime) return 1;
+    if (!b.lastUsedTime) return -1;
+    // 按时间降序排序（最近的在前）
+    const timeCompare =
+      new Date(b.lastUsedTime).getTime() - new Date(a.lastUsedTime).getTime();
+    if (timeCompare !== 0) return timeCompare;
+    // 时间相同时，按服务名和工具名排序
+    if (a.serviceName !== b.serviceName) {
+      return a.serviceName.localeCompare(b.serviceName, "zh-CN");
+    }
+    return a.originalName.localeCompare(b.originalName, "zh-CN");
+  },
+};
+
+/**
+ * 应用排序到工具列表
+ */
+export function sortTools(
+  tools: EnhancedToolInfo[],
+  config: ToolSortConfig
+): EnhancedToolInfo[] {
+  const sorter = toolSorters[config.field];
+  if (!sorter) {
+    logger.warn(`[sortTools] 未知的排序字段: ${config.field}`);
+    return tools;
+  }
+
+  return [...tools].sort(sorter);
+}

--- a/src/server/vitest.config.ts
+++ b/src/server/vitest.config.ts
@@ -1,0 +1,53 @@
+import { resolve } from "node:path";
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import tsconfigPaths from "vite-tsconfig-paths";
+import { defineConfig } from "vitest/config";
+
+// ESM 兼容的 __dirname
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+export default defineConfig({
+  plugins: [
+    // 添加 tsconfig 路径解析插件
+    tsconfigPaths(),
+  ],
+  // 定义构建时注入的常量，测试环境中使用占位符（version.ts 会自动回退到运行时读取）
+  define: {
+    __VERSION__: JSON.stringify("__VERSION__"),
+    __APP_NAME__: JSON.stringify("__APP_NAME__"),
+  },
+  test: {
+    globals: true,
+    environment: "node",
+    testTimeout: 10000,
+    hookTimeout: 10000,
+    include: ["**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}"],
+    exclude: ["**/node_modules", "dist", "templates/**/*"],
+    coverage: {
+      enabled: true,
+      provider: "v8",
+      reporter: ["text", "json", "html", "lcov"],
+      reportsDirectory: resolve(__dirname, "../coverage"),
+      exclude: [
+        "node_modules/**",
+        "dist/**",
+        "templates/**",
+        "**/*.d.ts",
+        "**/*.config.{js,ts}",
+        "coverage/**",
+      ],
+      include: [resolve(__dirname, "**/*.ts")],
+      all: true,
+      thresholds: {
+        global: {
+          branches: 80,
+          functions: 80,
+          lines: 80,
+          statements: 80,
+        },
+      },
+    },
+  },
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -40,6 +40,7 @@
   "exclude": ["node_modules", "dist", "scripts/**/*", "templates/**/*"],
   "references": [
     { "path": "./apps/backend" },
+    { "path": "./src/server" },
     { "path": "./src/cli" },
     { "path": "./src/web" },
     { "path": "./mcps/calculator-mcp" },


### PR DESCRIPTION
## Summary

- 将 `apps/backend/` 下 **135 个 .ts 文件**迁移至 `src/server/`
- 替换所有 `@xiaozhi-client/*` 跨包引用为**深度感知的相对路径**（87 处）
- 替换所有 `@/` 别名引用为相对路径（~100 处）
- 同步更新所有 `vi.mock` 和动态 `import()` 路径
- 新建 `src/server/tsconfig.json`（简化配置，移除手动 paths 映射）
- 新建 `src/server/tsup.config.ts`（**删除 ~160 行 alias 插件代码**）
- 新建 `src/server/vitest.config.ts`
- 更新根 `tsconfig.json` 添加 `src/server` reference
- 更新 `biome.json` 添加 `src/server/**` 到 overrides
- 标记 `apps/backend/package.json` 为 DEPRECATED

这是 monorepo → 单体多入口架构迁移的第 9 步，也是**最后一个大模块迁移**。完成此后所有实质性代码都在 `src/` 下。

## 验证结果

| 检查项 | 结果 |
|--------|------|
| `tsc --noEmit` | ✅ 0 错误 |
| `vitest run` | ✅ 44 文件 \| 852 通过 \| 0 失败 |
| `tsup build` | ✅ 构建成功 (`dist/backend/`) |
| `biome lint` | ✅ 0 问题 |

## 迁移进度

```
已完成 (9/10):
  version     → src/utils/version.ts      ✅
  shared-types→ src/types/                 ✅
  mcp-core    → src/mcp-core/              ✅
  config      → src/config/                ✅
  endpoint    → src/endpoint/              ✅
  esp32       → src/esp32/                 ✅
  cli         → src/cli/                   ✅
  frontend    → src/web/                   ✅
  backend     → src/server/                ✅ ← 本次

下一步:
  清理废弃壳 + 最终收尾                    📋 Planned
```

## Test plan

- [ ] `pnpm typecheck` 通过（含新 src/server 项目）
- [ ] `cd src/server && npx vitest run` 全部 44 个测试文件通过
- [ ] `pnpm build` 构建成功，产物输出到 `dist/backend/`
- [ ] `pnpm lint` 通过