### PR TITLE
fix(test): 修复 Web 前端测试路径别名解析和浏览器 API polyfill 问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "@commitlint/config-conventional": "^20.5.0",
     "@types/node": "^24.10.0",
     "@types/semver": "^7.7.1",
+    "@vitejs/plugin-react": "^5.1.2",
     "@vitest/coverage-v8": "^3.2.4",
     "concurrently": "^9.2.1",
     "cross-env": "^10.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       '@types/semver':
         specifier: ^7.7.1
         version: 7.7.1
+      '@vitejs/plugin-react':
+        specifier: ^5.1.2
+        version: 5.1.2(vite@8.0.8(@types/node@24.10.9)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(esbuild@0.27.3)(happy-dom@20.8.9)(jiti@2.6.1)(jsdom@29.0.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))
@@ -217,13 +220,13 @@ importers:
         version: 4.1.18
       next:
         specifier: '>=16.2.3'
-        version: 16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
+        version: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
       nextra:
         specifier: ^4.6.0
-        version: 4.6.1(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+        version: 4.6.1(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       nextra-theme-docs:
         specifier: ^4.6.0
-        version: 4.6.1(@types/react@19.2.2)(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(nextra@4.6.1(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
+        version: 4.6.1(@types/react@19.2.2)(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(nextra@4.6.1(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4))
       postcss:
         specifier: ^8.5.6
         version: 8.5.6
@@ -9162,6 +9165,18 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@vitejs/plugin-react@5.1.2(vite@8.0.8(@types/node@24.10.9)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))':
+    dependencies:
+      '@babel/core': 7.29.0
+      '@babel/plugin-transform-react-jsx-self': 7.27.1(@babel/core@7.29.0)
+      '@babel/plugin-transform-react-jsx-source': 7.27.1(@babel/core@7.29.0)
+      '@rolldown/pluginutils': 1.0.0-beta.53
+      '@types/babel__core': 7.20.5
+      react-refresh: 0.18.0
+      vite: 8.0.8(@types/node@24.10.9)(esbuild@0.27.3)(jiti@2.6.1)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3)
+    transitivePeerDependencies:
+      - supports-color
+
   '@vitest/coverage-v8@3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.10.9)(esbuild@0.27.3)(happy-dom@20.8.9)(jiti@1.21.7)(jsdom@29.0.2)(sass@1.97.3)(tsx@4.21.0)(yaml@2.8.3))':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -11843,7 +11858,7 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3):
+  next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3):
     dependencies:
       '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
@@ -11852,7 +11867,7 @@ snapshots:
       postcss: 8.4.31
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
-      styled-jsx: 5.1.6(react@19.2.4)
+      styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
       '@next/swc-darwin-arm64': 16.2.3
       '@next/swc-darwin-x64': 16.2.3
@@ -11868,13 +11883,13 @@ snapshots:
       - '@babel/core'
       - babel-plugin-macros
 
-  nextra-theme-docs@4.6.1(@types/react@19.2.2)(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(nextra@4.6.1(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
+  nextra-theme-docs@4.6.1(@types/react@19.2.2)(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(nextra@4.6.1(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(use-sync-external-store@1.6.0(react@19.2.4)):
     dependencies:
       '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       clsx: 2.1.1
-      next: 16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
+      next: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
       next-themes: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
-      nextra: 4.6.1(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
+      nextra: 4.6.1(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3)
       react: 19.2.4
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
@@ -11886,7 +11901,7 @@ snapshots:
       - immer
       - use-sync-external-store
 
-  nextra@4.6.1(next@16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
+  nextra@4.6.1(next@16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(typescript@5.9.3):
     dependencies:
       '@formatjs/intl-localematcher': 0.6.2
       '@headlessui/react': 2.2.9(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -11907,7 +11922,7 @@ snapshots:
       mdast-util-gfm: 3.1.0
       mdast-util-to-hast: 13.2.1
       negotiator: 1.0.0
-      next: 16.2.3(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
+      next: 16.2.3(@babel/core@7.29.0)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(sass@1.97.3)
       react: 19.2.4
       react-compiler-runtime: 19.1.0-rc.3(react@19.2.4)
       react-dom: 19.2.4(react@19.2.4)
@@ -13081,10 +13096,12 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
-  styled-jsx@5.1.6(react@19.2.4):
+  styled-jsx@5.1.6(@babel/core@7.29.0)(react@19.2.4):
     dependencies:
       client-only: 0.0.1
       react: 19.2.4
+    optionalDependencies:
+      '@babel/core': 7.29.0
 
   stylis@4.3.6: {}
 

--- a/src/cli/utils/__tests__/path-utils.executable.test.ts
+++ b/src/cli/utils/__tests__/path-utils.executable.test.ts
@@ -174,7 +174,9 @@ describe("PathUtils - 可执行文件路径", () => {
         npmRealPath.replace("/dist/cli/index.js", "/src/cli/utils/PathUtils.js")
       );
       const webServerPath = PathUtils.getWebServerLauncherPath();
-      expect(webServerPath).toContain(path.join("dist", "WebServerLauncher.js"));
+      expect(webServerPath).toContain(
+        path.join("dist", "WebServerLauncher.js")
+      );
     });
 
     it("应该确保多次调用结果一致", () => {

--- a/src/config/__tests__/adapter.test.ts
+++ b/src/config/__tests__/adapter.test.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { Mock } from "vitest";
 import {

--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,19 +1,21 @@
 import { resolve } from "node:path";
+import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
 
 export default defineConfig({
+  plugins: [react()],
   test: {
     environment: "node",
     globals: true,
     // Web 前端测试使用 jsdom 环境
     environmentMatchGlobs: [["src/web/**", "jsdom"]],
+    // 全局 setup 文件（内部会根据环境条件执行）
+    setupFiles: [resolve(__dirname, "./web/test/setup.ts")],
   },
-  esbuild: {
-    define: {
-      // 构建时注入的版本号常量（测试环境使用固定值）
-      __VERSION__: JSON.stringify("2.3.0-beta.6"),
-      __APP_NAME__: JSON.stringify("xiaozhi-client"),
-    },
+  // 顶层 define 用于替换全局常量（Vitest 3.x 使用 oxc 而非 esbuild）
+  define: {
+    __VERSION__: JSON.stringify("2.3.0-beta.6"),
+    __APP_NAME__: JSON.stringify("xiaozhi-client"),
   },
   resolve: {
     alias: {
@@ -25,8 +27,18 @@ export default defineConfig({
       "@xiaozhi-client/esp32": resolve(__dirname, "./esp32"),
       "@xiaozhi-client/version": resolve(__dirname, "./utils/version.ts"),
       "@xiaozhi-client/cli": resolve(__dirname, "./cli"),
-      // Web 前端路径别名
-      "@/*": resolve(__dirname, "./web"),
+      // Web 前端路径别名（与 src/web/vitest.config.ts 保持一致）
+      "@": resolve(__dirname, "./web"),
+      "@components": resolve(__dirname, "./web/components"),
+      "@hooks": resolve(__dirname, "./web/hooks"),
+      "@services": resolve(__dirname, "./web/services"),
+      "@stores": resolve(__dirname, "./web/stores"),
+      "@utils": resolve(__dirname, "./web/utils"),
+      "@types": resolve(__dirname, "./web/types"),
+      "@lib": resolve(__dirname, "./web/lib"),
+      "@pages": resolve(__dirname, "./web/pages"),
+      "@providers": resolve(__dirname, "./web/providers"),
+      "@ui": resolve(__dirname, "./web/components/ui"),
     },
   },
 });

--- a/src/web/components/__tests__/McpEndpointSettingButton.test.tsx
+++ b/src/web/components/__tests__/McpEndpointSettingButton.test.tsx
@@ -28,6 +28,15 @@ Object.defineProperty(document, "execCommand", {
 const originalConsoleError = console.error;
 beforeEach(() => {
   console.error = vi.fn();
+
+  // Mock navigator.clipboard 以确保复制功能走主路径（而非降级方案）
+  Object.defineProperty(navigator, "clipboard", {
+    value: {
+      writeText: vi.fn().mockResolvedValue(undefined),
+    },
+    writable: true,
+    configurable: true,
+  });
 });
 
 afterEach(() => {

--- a/src/web/test/CozeWorkflowIntegration.integration.test.tsx
+++ b/src/web/test/CozeWorkflowIntegration.integration.test.tsx
@@ -97,6 +97,24 @@ describe("CozeWorkflowIntegration - 集成测试", () => {
       writable: true,
       value: true,
     });
+    // 确保 ResizeObserver 可用（jsdom 不支持，Radix UI 依赖它）
+    const _ResizeObserverMock = vi.fn(function (
+      this: {
+        observe: ReturnType<typeof vi.fn>;
+        unobserve: ReturnType<typeof vi.fn>;
+        disconnect: ReturnType<typeof vi.fn>;
+      },
+      _callback: (...args: unknown[]) => void
+    ) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+    });
+    Object.defineProperty(window, "ResizeObserver", {
+      writable: true,
+      configurable: true,
+      value: _ResizeObserverMock,
+    });
   });
 
   afterEach(() => {

--- a/src/web/test/CozeWorkflowIntegration.parameterConfig.test.tsx
+++ b/src/web/test/CozeWorkflowIntegration.parameterConfig.test.tsx
@@ -96,6 +96,25 @@ describe("CozeWorkflowIntegration - 参数配置功能", () => {
       writable: true,
       value: true,
     });
+
+    // 确保 ResizeObserver 可用（jsdom 不支持，Radix UI 依赖它）
+    const _ResizeObserverMock = vi.fn(function (
+      this: {
+        observe: ReturnType<typeof vi.fn>;
+        unobserve: ReturnType<typeof vi.fn>;
+        disconnect: ReturnType<typeof vi.fn>;
+      },
+      _callback: (...args: unknown[]) => void
+    ) {
+      this.observe = vi.fn();
+      this.unobserve = vi.fn();
+      this.disconnect = vi.fn();
+    });
+    Object.defineProperty(window, "ResizeObserver", {
+      writable: true,
+      configurable: true,
+      value: _ResizeObserverMock,
+    });
   });
 
   afterEach(() => {

--- a/src/web/test/setup.ts
+++ b/src/web/test/setup.ts
@@ -1,41 +1,82 @@
-import "@testing-library/jest-dom";
 import { vi } from "vitest";
 
-// Mock window.matchMedia
-Object.defineProperty(window, "matchMedia", {
-  writable: true,
-  value: vi.fn().mockImplementation((query) => ({
-    matches: false,
-    media: query,
-    onchange: null,
-    addListener: vi.fn(), // deprecated
-    removeListener: vi.fn(), // deprecated
-    addEventListener: vi.fn(),
-    removeEventListener: vi.fn(),
-    dispatchEvent: vi.fn(),
-  })),
-});
+// 仅在浏览器环境（jsdom）下执行以下设置
+const isBrowserEnvironment =
+  typeof window !== "undefined" && typeof document !== "undefined";
 
-// Mock window.open
-Object.defineProperty(window, "open", {
-  writable: true,
-  value: vi.fn(),
-});
+if (isBrowserEnvironment) {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  require("@testing-library/jest-dom");
 
-// Mock document.execCommand
-Object.defineProperty(document, "execCommand", {
-  value: vi.fn(),
-  writable: true,
-});
+  // Polyfill jsdom 缺少的浏览器 API
+  if (!HTMLElement.prototype.hasPointerCapture) {
+    HTMLElement.prototype.hasPointerCapture = vi.fn(() => false);
+  }
+  if (!HTMLElement.prototype.setPointerCapture) {
+    HTMLElement.prototype.setPointerCapture = vi.fn();
+  }
+  if (!Element.prototype.scrollIntoView) {
+    Element.prototype.scrollIntoView = vi.fn();
+  }
 
-// Global test setup and cleanup
+  // Polyfill ResizeObserver（jsdom 不支持，Radix UI 等库依赖它）
+  // 使用 class 形式确保 new ResizeObserver() 返回正确结构的实例
+  const _ResizeObserverMock = vi.fn(function (
+    this: {
+      observe: ReturnType<typeof vi.fn>;
+      unobserve: ReturnType<typeof vi.fn>;
+      disconnect: ReturnType<typeof vi.fn>;
+    },
+    _callback: (...args: unknown[]) => void
+  ) {
+    this.observe = vi.fn();
+    this.unobserve = vi.fn();
+    this.disconnect = vi.fn();
+  });
+  Object.defineProperty(window, "ResizeObserver", {
+    writable: true,
+    configurable: true,
+    value: _ResizeObserverMock,
+  });
+
+  // Mock window.matchMedia
+  Object.defineProperty(window, "matchMedia", {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(), // deprecated
+      removeListener: vi.fn(), // deprecated
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  });
+
+  // Mock window.open
+  Object.defineProperty(window, "open", {
+    writable: true,
+    value: vi.fn(),
+  });
+
+  // Mock document.execCommand
+  Object.defineProperty(document, "execCommand", {
+    value: vi.fn(),
+    writable: true,
+  });
+}
+
+// Global test setup and cleanup（仅在浏览器环境下执行 DOM 操作）
 beforeEach(() => {
+  if (!isBrowserEnvironment) return;
+
   // Clean up clipboard before each test to avoid conflicts with userEvent.setup()
   try {
     if (navigator && "clipboard" in navigator) {
       (navigator as any).clipboard = undefined;
     }
-  } catch (e) {
+  } catch {
     // Ignore errors when cleaning up clipboard
   }
 
@@ -88,7 +129,6 @@ beforeEach(() => {
       value: string,
       priority?: string
     ) {
-      // 使用类型断言来访问 parentElement
       const parentElement = (this as any).parentElement as
         | HTMLElement
         | undefined;
@@ -132,7 +172,6 @@ beforeEach(() => {
   } else {
     const root = document.createElement("div");
     root.id = "root";
-    // 确保容器可以被 React 使用
     root.style.pointerEvents = "auto";
     root.style.visibility = "visible";
     root.style.position = "relative";
@@ -145,7 +184,6 @@ beforeEach(() => {
   } else {
     const modalRoot = document.createElement("div");
     modalRoot.id = "modal-root";
-    // 确保容器可以被 React 使用
     modalRoot.style.pointerEvents = "auto";
     modalRoot.style.visibility = "visible";
     modalRoot.style.position = "relative";
@@ -172,7 +210,6 @@ beforeEach(() => {
       ) {
         el.remove();
       }
-      // 重置可能导致问题的属性和样式
       if (el.hasAttribute("data-scroll-locked")) {
         el.removeAttribute("data-scroll-locked");
       }
@@ -197,12 +234,14 @@ beforeEach(() => {
         }
       }
     }
-  } catch (e) {
+  } catch {
     // Ignore errors during cleanup
   }
 });
 
 afterEach(() => {
+  if (!isBrowserEnvironment) return;
+
   // Clean up all dynamically created elements after each test
   try {
     const elementsToRemove = document.querySelectorAll("*");
@@ -216,7 +255,6 @@ afterEach(() => {
       ) {
         el.remove();
       }
-      // 重置可能导致问题的属性和样式
       if (el.hasAttribute("data-scroll-locked")) {
         el.removeAttribute("data-scroll-locked");
       }
@@ -267,7 +305,7 @@ afterEach(() => {
     if (document.body.style) {
       document.body.style.pointerEvents = "auto";
     }
-  } catch (e) {
+  } catch {
     // Ignore errors during cleanup
   }
 });


### PR DESCRIPTION
## Summary

- 修复根级 `vitest.config.ts` 中 `@/*` 通配符别名无法解析的问题，替换为完整的 web 路径别名列表（`@`, `@components`, `@services`, `@lib`, `@stores` 等）
- 添加 `@vitejs/plugin-react` 插件支持 JSX/TSX 转换
- 引入 `src/web/test/setup.ts` 作为全局 setup 文件，补充 jsdom 缺少的浏览器 API polyfill（`hasPointerCapture`、`scrollIntoView`、`ResizeObserver` 等）
- 将 `esbuild.define` 迁移为顶层 `define`（适配 Vitest 3.x 的 oxc 替代）
- 修复 `McpEndpointSettingButton` 测试中 `navigator.clipboard` 未 mock 的问题
- 修复 `CozeWorkflowIntegration` 测试中 `ResizeObserver` mock 不生效的问题

**测试结果：124 个测试文件全部通过（修复前 34 个失败）**

## Test plan

- [x] `pnpm test` 全部 124 个测试文件通过，0 失败
- [x] `pnpm typecheck` 通过（pre-commit hook 自动执行）
- [x] `pnpm lint` 通过（pre-commit hook 自动执行）