### PR TITLE
perf: 优化 getAllTools 方法，避免循环中 N 次深拷贝

### DIFF
--- a/src/server/lib/mcp/__tests__/manager.test.ts
+++ b/src/server/lib/mcp/__tests__/manager.test.ts
@@ -28,6 +28,7 @@ vi.mock("../../../../config/index.js", () => ({
   configManager: {
     getCustomMCPTools: vi.fn(),
     getMcpServers: vi.fn(),
+    getMcpServerConfig: vi.fn().mockReturnValue({}),
     getToolCallLogConfig: vi.fn().mockReturnValue({
       maxRecords: 100,
     }),

--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -437,22 +437,21 @@ export class MCPServiceManager extends EventEmitter {
   getAllTools(status: ToolStatusFilter = "all"): EnhancedToolInfo[] {
     const allTools: EnhancedToolInfo[] = [];
 
+    // 在循环开始前获取配置，避免循环中重复深拷贝
+    const mcpServerConfig = configManager.getMcpServerConfig();
+
     // 1. 收集所有已连接服务的工具（包含启用状态过滤）
     for (const [serviceName, service] of this.services) {
       try {
         if (service.isConnected()) {
           const serviceTools = service.getTools();
+          const serviceToolsConfig = mcpServerConfig[serviceName]?.tools || {};
+
           for (const tool of serviceTools) {
             try {
-              // 检查工具启用状态 - 这个调用可能会抛出异常
-              const isEnabled = configManager.isToolEnabled(
-                serviceName,
-                tool.name
-              );
-              const toolConfig =
-                configManager.getMcpServerConfig()[serviceName].tools[
-                  tool.name
-                ];
+              // 检查工具启用状态 - 使用缓存的配置
+              const toolConfig = serviceToolsConfig[tool.name];
+              const isEnabled = toolConfig?.enable !== false; // 默认启用
 
               // 根据 status 参数过滤工具
               if (status === "enabled" && !isEnabled) {
@@ -470,8 +469,8 @@ export class MCPServiceManager extends EventEmitter {
                 serviceName,
                 originalName: tool.name,
                 enabled: isEnabled,
-                usageCount: toolConfig.usageCount ?? 0,
-                lastUsedTime: toolConfig.lastUsedTime ?? "",
+                usageCount: toolConfig?.usageCount ?? 0,
+                lastUsedTime: toolConfig?.lastUsedTime ?? "",
               });
             } catch (toolError) {
               logger.warn(


### PR DESCRIPTION
在循环开始前缓存 getMcpServerConfig() 结果，避免每个工具
调用时重复执行 structuredClone 深拷贝操作。

性能改进：从 2N 次深拷贝 → 1 次深拷贝

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3324