### PR TITLE
perf: 优化 MCPServiceManager.getActiveConnectionCount() 消除冗余 filter 操作

### DIFF
--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -1665,9 +1665,14 @@ export class MCPServiceManager extends EventEmitter {
    * @returns 活跃连接数量
    */
   public getActiveConnectionCount(): number {
-    return this.getAllConnections().filter(
-      (conn) => conn.state === ConnectionState.CONNECTED
-    ).length;
+    // 直接遍历计算，避免创建临时数组
+    let count = 0;
+    for (const [, service] of this.services) {
+      if (service.isConnected()) {
+        count++;
+      }
+    }
+    return count;
   }
 
   // ===== 从 UnifiedMCPServer 移入的方法 =====


### PR DESCRIPTION
移除不必要的 filter 操作，直接遍历计算活跃连接数量：
- getAllConnections() 只返回 CONNECTED 状态的连接
- filter 条件永远为 true，导致 O(n) 冗余操作
- 直接遍历避免创建临时数组，减少 GC 压力

Fixes #3325

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3325