### PR TITLE
refactor(types): 消除 toolApi.ts 类型定义重复问题

### DIFF
--- a/src/server/types/toolApi.ts
+++ b/src/server/types/toolApi.ts
@@ -1,16 +1,18 @@
 /**
  * 工具添加 API 相关类型定义
  * 支持多种工具类型的添加，包括 MCP 工具、Coze 工作流等
+ *
+ * 注意：此文件包含服务端特有的类型定义，并重新导出共享类型
+ * 共享类型定义位于 ../../types/api/toolApi.ts
  */
 
 import type { JSONSchema as LibJSONSchema } from "../lib/mcp/types.js";
-import type { CozeWorkflow, WorkflowParameterConfig } from "./coze.js";
 
 /**
  * JSON Schema 类型
  * 重新导出 ../lib/mcp/types.js 中的 JSONSchema
  *
- * 注意：此类型与 ../../../types/index.js 中的 JSONSchema 相同
+ * 注意：此类型与 ../../types/index.js 中的 JSONSchema 相同
  * TODO：将来应从 shared-types 导入 JSONSchema 以消除重复定义
  */
 export type JSONSchema = LibJSONSchema;
@@ -18,11 +20,11 @@ export type JSONSchema = LibJSONSchema;
 /**
  * 工具处理器配置相关类型
  *
- * 注意：这些类型与 ../../../types/index.js/src/mcp/tool-definition.ts 中定义的类型相同
+ * 注意：这些类型与 ../../types/mcp/tool-definition.ts 中定义的类型相同
  * TODO：将 toolApi.ts 的类型迁移为从 shared-types 导入，消除重复定义
  * 目前保持本地定义以避免 TypeScript 子路径解析问题（影响 tts、asr 等其他包）
  *
- * 权威定义位置：packages/shared-types/src/mcp/tool-definition.ts
+ * 权威定义位置：src/types/mcp/tool-definition.ts
  */
 export type ToolHandlerConfig =
   | MCPHandlerConfig
@@ -80,7 +82,7 @@ export interface FunctionHandlerConfig {
 /**
  * CustomMCP 工具基础接口
  *
- * 注意：此类型与 ../../../types/index.js 中的 CustomMCPTool 相同
+ * 注意：此类型与 ../../types/mcp/tool-definition.ts 中的 CustomMCPTool 相同
  * TODO：将来应从 shared-types 导入 CustomMCPTool 以消除重复定义
  */
 export interface CustomMCPToolBase {
@@ -98,8 +100,8 @@ export interface CustomMCPToolBase {
  * 带统计信息的 CustomMCP 工具
  * 用于 API 响应，使用扁平的统计信息结构
  *
- * 注意：此类型与 ../../../types/index.js 中的 CustomMCPToolWithStats 类似
- * 但不包含 `enabled` 字段。如需完整功能，请从 shared-types 导入
+ * 注意：此类型与 ../../types/mcp/tool-definition.ts 中的 CustomMCPToolWithStats 类似
+ * 但不包含 `enabled` 字段。如需完整功能，请从 ../../types/mcp/tool-definition.ts 导入
  */
 export interface CustomMCPToolWithStats extends CustomMCPToolBase {
   /** 工具使用次数（扁平结构，与 API 响应格式一致） */
@@ -108,192 +110,27 @@ export interface CustomMCPToolWithStats extends CustomMCPToolBase {
   lastUsedTime?: string;
 }
 
+// ==================== 重新导出共享类型 ====================
+// 以下类型从 ../../types/api/toolApi.ts 重新导出，消除重复定义
+
 /**
  * 工具类型枚举
+ * @see ../../types/api/toolApi.ts
  */
-export enum ToolType {
-  /** MCP 工具（标准 MCP 服务中的工具） */
-  MCP = "mcp",
-  /** Coze 工作流工具 */
-  COZE = "coze",
-  /** HTTP API 工具（预留） */
-  HTTP = "http",
-  /** 自定义函数工具（预留） */
-  FUNCTION = "function",
-}
+export { ToolType, ToolValidationError } from "../../types/api/toolApi.js";
 
 /**
- * MCP 工具数据
- * 用于将标准 MCP 服务中的工具添加到 customMCP.tools 配置中
+ * 工具数据类型
+ * @see ../../types/api/toolApi.ts
  */
-export interface MCPToolData {
-  /** MCP 服务名称 */
-  serviceName: string;
-  /** 工具名称 */
-  toolName: string;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * Coze 工作流数据
- * 保持与现有格式的兼容性
- */
-export interface CozeWorkflowData {
-  /** Coze 工作流信息 */
-  workflow: CozeWorkflow;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-  /** 可选的参数配置 */
-  parameterConfig?: WorkflowParameterConfig;
-}
-
-/**
- * HTTP API 工具数据（预留）
- */
-export interface HttpApiToolData {
-  /** API 地址 */
-  url: string;
-  /** HTTP 方法 */
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  /** API 描述 */
-  description: string;
-  /** 请求头 */
-  headers?: Record<string, string>;
-  /** 请求体模板 */
-  bodyTemplate?: string;
-  /** 认证配置 */
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    apiKey?: string;
-    apiKeyHeader?: string;
-  };
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 函数工具数据（预留）
- */
-export interface FunctionToolData {
-  /** 模块路径 */
-  module: string;
-  /** 函数名 */
-  function: string;
-  /** 函数描述 */
-  description: string;
-  /** 函数执行上下文 */
-  context?: Record<string, any>;
-  /** 超时时间 */
-  timeout?: number;
-  /** 可选的自定义名称 */
-  customName?: string;
-  /** 可选的自定义描述 */
-  customDescription?: string;
-}
-
-/**
- * 添加自定义工具的统一请求接口
- */
-export interface AddCustomToolRequest {
-  /** 工具类型 */
-  type: ToolType;
-  /** 工具数据（根据类型不同而不同） */
-  data: MCPToolData | CozeWorkflowData | HttpApiToolData | FunctionToolData;
-}
-
-/**
- * 工具验证错误类型
- */
-export enum ToolValidationError {
-  /** 无效的工具类型 */
-  INVALID_TOOL_TYPE = "INVALID_TOOL_TYPE",
-  /** 缺少必需字段 */
-  MISSING_REQUIRED_FIELD = "MISSING_REQUIRED_FIELD",
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = "TOOL_NOT_FOUND",
-  /** 服务不存在 */
-  SERVICE_NOT_FOUND = "SERVICE_NOT_FOUND",
-  /** 工具名称冲突 */
-  TOOL_NAME_CONFLICT = "TOOL_NAME_CONFLICT",
-  /** 配置验证失败 */
-  CONFIG_VALIDATION_FAILED = "CONFIG_VALIDATION_FAILED",
-  /** 系统配置错误 */
-  SYSTEM_CONFIG_ERROR = "SYSTEM_CONFIG_ERROR",
-  /** 资源限制超出 */
-  RESOURCE_LIMIT_EXCEEDED = "RESOURCE_LIMIT_EXCEEDED",
-}
-
-/**
- * 工具验证错误详情
- */
-export interface ToolValidationErrorDetail {
-  /** 错误类型 */
-  error: ToolValidationError;
-  /** 错误消息 */
-  message: string;
-  /** 错误详情 */
-  details?: any;
-  /** 建议的解决方案 */
-  suggestions?: string[];
-}
-
-/**
- * 添加工具的响应数据
- */
-export interface AddToolResponse {
-  /** 成功添加的工具 */
-  tool: any;
-  /** 工具名称 */
-  toolName: string;
-  /** 工具类型 */
-  toolType: ToolType;
-  /** 添加时间戳 */
-  addedAt: string;
-}
-
-/**
- * 工具元数据信息
- */
-export interface ToolMetadata {
-  /** 工具原始来源 */
-  source: {
-    type: "mcp" | "coze" | "http" | "function";
-    serviceName?: string;
-    toolName?: string;
-    url?: string;
-  };
-  /** 添加时间 */
-  addedAt: string;
-  /** 最后更新时间 */
-  updatedAt?: string;
-  /** 版本信息 */
-  version?: string;
-}
-
-/**
- * 工具配置选项
- */
-export interface ToolConfigOptions {
-  /** 是否启用工具（默认 true） */
-  enabled?: boolean;
-  /** 超时时间（毫秒） */
-  timeout?: number;
-  /** 重试次数 */
-  retryCount?: number;
-  /** 重试间隔（毫秒） */
-  retryDelay?: number;
-  /** 自定义标签 */
-  tags?: string[];
-  /** 工具分组 */
-  group?: string;
-}
+export type {
+  MCPToolData,
+  CozeWorkflowData,
+  HttpApiToolData,
+  FunctionToolData,
+  AddCustomToolRequest,
+  AddToolResponse,
+  ToolMetadata,
+  ToolConfigOptions,
+  ToolValidationErrorDetail,
+} from "../../types/api/toolApi.js";


### PR DESCRIPTION
将 src/server/types/toolApi.ts 中的重复类型定义改为重新导出
src/types/api/toolApi.ts 中的共享类型，遵循 DRY 原则。

变更内容：
- 保留服务端特有的类型定义（JSONSchema、ToolHandlerConfig 等）
- 重新导出共享类型（ToolType、MCPToolData 等）
- 移除约 188 行重复代码

修复 GitHub Issue #3332

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3332