### PR TITLE
fix(log): 将 endpoint.ts 和 manager.ts 中的 console 替换为 logger (#3336)

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -57,7 +57,12 @@
   },
   "overrides": [
     {
-      "include": ["src/cli/**", "src/web/**", "src/server/**"],
+      "include": [
+        "src/cli/**",
+        "src/web/**",
+        "src/server/**",
+        "src/endpoint/**"
+      ],
       "linter": {
         "rules": {
           "nursery": {

--- a/src/endpoint/__tests__/endpoint.test.ts
+++ b/src/endpoint/__tests__/endpoint.test.ts
@@ -5,6 +5,16 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { ConnectionState } from "../types.js";
 
+// Mock Logger
+vi.mock("../../server/Logger.js", () => ({
+  logger: {
+    info: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 // Mock WebSocket
 vi.mock("ws", () => {
   const { EventEmitter } = require("node:events");
@@ -83,6 +93,7 @@ vi.mock("../internal-mcp-manager.js", () => ({
 }));
 
 // 导入在 mock 之后
+import { logger } from "../../server/Logger.js";
 import { Endpoint } from "../endpoint.js";
 import type { IMCPServiceManager } from "../types.js";
 import { ToolCallError as ToolCallErrorClass } from "../types.js";
@@ -443,8 +454,8 @@ describe("Endpoint", () => {
 
   describe("sendErrorResponse", () => {
     it("应该成功发送错误响应", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error");
-      const consoleDebugSpy = vi.spyOn(console, "debug");
+      const loggerErrorSpy = vi.spyOn(logger, "error");
+      const loggerDebugSpy = vi.spyOn(logger, "debug");
 
       // 创建一个会抛出错误的 MCP 管理器
       const errorMCPManager = createMockMCPManager(async () => {
@@ -474,17 +485,17 @@ describe("Endpoint", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // 验证有错误日志输出
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
         "工具调用失败",
         expect.any(Object)
       );
 
-      consoleErrorSpy.mockRestore();
-      consoleDebugSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
+      loggerDebugSpy.mockRestore();
     });
 
     it("应该在 ws.send 抛出异常时记录错误", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error");
+      const loggerErrorSpy = vi.spyOn(logger, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
       const errorMCPManager = createMockMCPManager(async () => {
@@ -520,7 +531,7 @@ describe("Endpoint", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // 验证错误被记录
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
           "发送错误响应失败:",
           expect.objectContaining({
             id: "test-2",
@@ -535,11 +546,11 @@ describe("Endpoint", () => {
         ws.send = originalSend;
       }
 
-      consoleErrorSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     });
 
     it("应该在连接未建立时记录错误", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error");
+      const loggerErrorSpy = vi.spyOn(logger, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
       const errorMCPManager = createMockMCPManager(async () => {
@@ -567,7 +578,7 @@ describe("Endpoint", () => {
       await new Promise((resolve) => setTimeout(resolve, 100));
 
       // 验证无法发送错误响应的日志
-      expect(consoleErrorSpy).toHaveBeenCalledWith(
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
         "无法发送错误响应",
         expect.objectContaining({
           id: "test-3",
@@ -575,11 +586,11 @@ describe("Endpoint", () => {
         })
       );
 
-      consoleErrorSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     });
 
     it("应该在 WebSocket 非 OPEN 状态时记录错误", async () => {
-      const consoleErrorSpy = vi.spyOn(console, "error");
+      const loggerErrorSpy = vi.spyOn(logger, "error");
 
       // 创建一个会抛出错误的 MCP 管理器
       const errorMCPManager = createMockMCPManager(async () => {
@@ -612,7 +623,7 @@ describe("Endpoint", () => {
         await new Promise((resolve) => setTimeout(resolve, 100));
 
         // 验证无法发送错误响应的日志
-        expect(consoleErrorSpy).toHaveBeenCalledWith(
+        expect(loggerErrorSpy).toHaveBeenCalledWith(
           "无法发送错误响应",
           expect.objectContaining({
             id: "test-4",
@@ -625,7 +636,7 @@ describe("Endpoint", () => {
         ws.readyState = originalReadyState;
       }
 
-      consoleErrorSpy.mockRestore();
+      loggerErrorSpy.mockRestore();
     });
   });
 

--- a/src/endpoint/endpoint.ts
+++ b/src/endpoint/endpoint.ts
@@ -13,6 +13,7 @@
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import WebSocket from "ws";
+import { logger } from "../server/Logger.js";
 import type { ExtendedMCPMessage, MCPMessage } from "./mcp.js";
 import type {
   EndpointConnectionStatus,
@@ -184,7 +185,7 @@ export class Endpoint {
         inputSchema: ensureToolJSONSchemaFn(toolInfo.inputSchema),
       }));
     } catch (error) {
-      console.error(
+      logger.error(
         `获取工具列表失败: ${error instanceof Error ? error.message : String(error)}`
       );
       return [];
@@ -214,7 +215,7 @@ export class Endpoint {
    */
   private async attemptConnection(): Promise<void> {
     this.connectionState = ConnectionState.CONNECTING;
-    console.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.debug(`正在连接小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     return new Promise((resolve, reject) => {
       // 设置连接超时
@@ -236,7 +237,7 @@ export class Endpoint {
           const message: MCPMessage = JSON.parse(data.toString());
           this.handleMessage(message);
         } catch (error) {
-          console.error("MCP 消息解析错误:", error);
+          logger.error("MCP 消息解析错误:", error);
         }
       });
 
@@ -264,7 +265,7 @@ export class Endpoint {
     this.connectionStatus = true;
     this.connectionState = ConnectionState.CONNECTED;
 
-    console.debug("MCP WebSocket 连接已建立");
+    logger.debug("MCP WebSocket 连接已建立");
   }
 
   /**
@@ -280,7 +281,7 @@ export class Endpoint {
       this.connectionTimeout = null;
     }
 
-    console.error("MCP WebSocket 错误:", error.message);
+    logger.error("MCP WebSocket 错误:", error.message);
 
     // 清理当前连接
     this.cleanupConnection();
@@ -293,7 +294,7 @@ export class Endpoint {
     this.connectionStatus = false;
     this.serverInitialized = false;
     this.connectionState = ConnectionState.DISCONNECTED;
-    console.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
+    logger.info(`小智连接已关闭 (代码: ${code}, 原因: ${reason})`);
   }
 
   /**
@@ -311,7 +312,7 @@ export class Endpoint {
           this.ws.terminate();
         }
       } catch (error) {
-        console.debug("WebSocket 关闭时出现错误（已忽略）:", error);
+        logger.debug("WebSocket 关闭时出现错误（已忽略）:", error);
       }
 
       this.ws = null;
@@ -338,7 +339,7 @@ export class Endpoint {
     // console.debug("收到 MCP 消息:", JSON.stringify(message, null, 2));
 
     if (!message.method) {
-      console.debug("收到没有 method 字段的消息，忽略");
+      logger.debug("收到没有 method 字段的消息，忽略");
       return;
     }
 
@@ -357,19 +358,19 @@ export class Endpoint {
           },
         });
         this.serverInitialized = true;
-        console.debug("MCP 服务器初始化完成");
+        logger.debug("MCP 服务器初始化完成");
         break;
 
       case "tools/list": {
         const toolsList = this.getTools();
         this.sendResponse(message.id, { tools: toolsList });
-        console.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
+        logger.debug(`MCP 工具列表已发送 (${toolsList.length}个工具)`);
         break;
       }
 
       case "tools/call": {
         this.handleToolCall(message).catch((error) => {
-          console.error("处理工具调用时发生未捕获错误:", error);
+          logger.error("处理工具调用时发生未捕获错误:", error);
         });
         break;
       }
@@ -380,7 +381,7 @@ export class Endpoint {
         break;
 
       default:
-        console.warn(`未知的 MCP 请求: ${message.method}`);
+        logger.warn(`未知的 MCP 请求: ${message.method}`);
     }
   }
 
@@ -401,18 +402,18 @@ export class Endpoint {
 
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("响应已发送", {
+        logger.debug("响应已发送", {
           id,
           responseSize: JSON.stringify(response).length,
         });
       } catch (error) {
-        console.error("发送响应失败", {
+        logger.error("发送响应失败", {
           id,
           error,
         });
       }
     } else {
-      console.error("无法发送响应", {
+      logger.error("无法发送响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,
@@ -447,7 +448,7 @@ export class Endpoint {
    * 主动断开小智连接
    */
   public async disconnect(): Promise<void> {
-    console.info("主动断开小智连接");
+    logger.info("主动断开小智连接");
 
     // 清理 MCP 适配器
     await this.mcpAdapter.cleanup();
@@ -460,7 +461,7 @@ export class Endpoint {
    * 重连小智接入点
    */
   public async reconnect(): Promise<void> {
-    console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
+    logger.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
     // 先断开连接
     this.disconnect();
@@ -489,7 +490,7 @@ export class Endpoint {
     try {
       const params = validateToolCallParams(request.params);
 
-      console.info("开始处理工具调用", {
+      logger.info("开始处理工具调用", {
         requestId,
         toolName: params.name,
         hasArguments: !!params.arguments,
@@ -508,7 +509,7 @@ export class Endpoint {
         isError: result.isError || false,
       });
 
-      console.info("工具调用成功", {
+      logger.info("工具调用成功", {
         requestId,
         toolName: params.name,
         duration: `${Date.now() - startTime}ms`,
@@ -598,7 +599,7 @@ export class Endpoint {
 
     this.sendErrorResponse(requestId, errorResponse);
 
-    console.error("工具调用失败", {
+    logger.error("工具调用失败", {
       requestId,
       duration: `${duration}ms`,
       error: errorResponse,
@@ -620,10 +621,10 @@ export class Endpoint {
       };
       try {
         this.ws.send(JSON.stringify(response));
-        console.debug("已发送错误响应:", response);
+        logger.debug("已发送错误响应:", response);
       } catch (sendError) {
         // 发送错误响应失败，记录日志但不抛出异常
-        console.error("发送错误响应失败:", {
+        logger.error("发送错误响应失败:", {
           id,
           errorResponse: error,
           sendError:
@@ -633,7 +634,7 @@ export class Endpoint {
         });
       }
     } else {
-      console.error("无法发送错误响应", {
+      logger.error("无法发送错误响应", {
         id,
         isConnected: this.connectionStatus,
         wsReadyState: this.ws?.readyState,

--- a/src/endpoint/manager.ts
+++ b/src/endpoint/manager.ts
@@ -20,6 +20,7 @@
  */
 
 import { EventEmitter } from "node:events";
+import { logger } from "../server/Logger.js";
 import type { Endpoint } from "./endpoint.js";
 import { Endpoint as EndpointClass } from "./endpoint.js";
 import { SharedMCPAdapter } from "./shared-mcp-adapter.js";
@@ -66,7 +67,7 @@ export class EndpointManager extends EventEmitter {
    */
   constructor(private config?: EndpointManagerConfig) {
     super();
-    console.debug("[EndpointManager] 实例已创建");
+    logger.debug("[EndpointManager] 实例已创建");
   }
 
   /**
@@ -88,13 +89,13 @@ export class EndpointManager extends EventEmitter {
     if ("on" in mcpManager && typeof mcpManager.on === "function") {
       const connectedHandler = (...args: unknown[]) => {
         const data = args[0] as MCPConnectedEvent;
-        console.info(
+        logger.info(
           `[EndpointManager] MCP 服务已连接: ${data.serverName}, 工具数: ${data.tools?.length || 0}`
         );
       };
       const errorHandler = (...args: unknown[]) => {
         const data = args[0] as MCPErrorEvent;
-        console.error(
+        logger.error(
           `[EndpointManager] MCP 服务连接失败: ${data.serverName}`,
           data.error
         );
@@ -107,7 +108,7 @@ export class EndpointManager extends EventEmitter {
       this.mcpEventListeners.push(connectedHandler, errorHandler);
     }
 
-    console.info("[EndpointManager] MCPManager 已设置");
+    logger.info("[EndpointManager] MCPManager 已设置");
   }
 
   /**
@@ -153,13 +154,13 @@ export class EndpointManager extends EventEmitter {
     const url = endpoint.getUrl();
 
     if (this.endpoints.has(url)) {
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点 ${sliceEndpoint(url)} 已存在，跳过添加`
       );
       return;
     }
 
-    console.debug(`[EndpointManager] 添加接入点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 添加接入点: ${sliceEndpoint(url)}`);
 
     this.endpoints.set(url, endpoint);
     this.connectionStates.set(url, {
@@ -181,13 +182,13 @@ export class EndpointManager extends EventEmitter {
     const url = endpoint.getUrl();
 
     if (!this.endpoints.has(url)) {
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点 ${sliceEndpoint(url)} 不存在，跳过移除`
       );
       return;
     }
 
-    console.debug(`[EndpointManager] 移除接入点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 移除接入点: ${sliceEndpoint(url)}`);
 
     // 断开连接
     await endpoint.disconnect();
@@ -217,7 +218,7 @@ export class EndpointManager extends EventEmitter {
 
       const status = this.connectionStates.get(endpoint);
       if (status?.connected) {
-        console.debug(
+        logger.debug(
           `[EndpointManager] 接入点已连接，跳过: ${sliceEndpoint(endpoint)}`
         );
         return;
@@ -228,7 +229,7 @@ export class EndpointManager extends EventEmitter {
     }
 
     // 连接所有未连接的 Endpoint
-    console.debug(
+    logger.debug(
       `[EndpointManager] 开始连接接入点，总数: ${this.endpoints.size}`
     );
 
@@ -239,7 +240,7 @@ export class EndpointManager extends EventEmitter {
 
       // 跳过已连接的端点
       if (status?.connected) {
-        console.debug(
+        logger.debug(
           `[EndpointManager] 接入点已连接，跳过: ${sliceEndpoint(url)}`
         );
         continue;
@@ -247,7 +248,7 @@ export class EndpointManager extends EventEmitter {
 
       promises.push(
         this.connectSingleEndpoint(url, endpoint).catch((error) => {
-          console.error(
+          logger.error(
             `[EndpointManager] 连接失败: ${sliceEndpoint(url)}`,
             error
           );
@@ -270,7 +271,7 @@ export class EndpointManager extends EventEmitter {
       (s) => s.connected
     ).length;
 
-    console.info(
+    logger.info(
       `[EndpointManager] 连接完成: 成功 ${connectedCount}/${this.endpoints.size}`
     );
   }
@@ -298,14 +299,14 @@ export class EndpointManager extends EventEmitter {
         status.initialized = false;
       }
 
-      console.debug(
+      logger.debug(
         `[EndpointManager] 接入点已断开: ${sliceEndpoint(endpoint)}`
       );
       return;
     }
 
     // 断开所有连接
-    console.debug("[EndpointManager] 开始断开所有连接");
+    logger.debug("[EndpointManager] 开始断开所有连接");
 
     const promises: Promise<void>[] = [];
 
@@ -325,7 +326,7 @@ export class EndpointManager extends EventEmitter {
       status.initialized = false;
     }
 
-    console.debug("[EndpointManager] 所有接入点已断开连接");
+    logger.debug("[EndpointManager] 所有接入点已断开连接");
   }
 
   /**
@@ -390,33 +391,33 @@ export class EndpointManager extends EventEmitter {
    *               注意：此参数只控制断开和重新连接之间的等待时间，不影响底层 Endpoint 实例的重连延迟
    */
   async reconnect(endpoint?: string, delay = 1000): Promise<void> {
-    console.info("[EndpointManager] 开始重连");
+    logger.info("[EndpointManager] 开始重连");
 
     // 先断开连接
     await this.disconnect(endpoint);
 
     // 等待一段时间
-    console.debug(`[EndpointManager] 等待 ${delay}ms 后重连`);
+    logger.debug(`[EndpointManager] 等待 ${delay}ms 后重连`);
     await new Promise((resolve) => setTimeout(resolve, delay));
 
     // 再重新连接
     await this.connect(endpoint);
 
-    console.info("[EndpointManager] 重连完成");
+    logger.info("[EndpointManager] 重连完成");
   }
 
   /**
    * 重连所有端点
    */
   async reconnectAll(): Promise<void> {
-    console.info("[EndpointManager] 开始重连所有接入点");
+    logger.info("[EndpointManager] 开始重连所有接入点");
 
     const promises: Promise<void>[] = [];
 
     for (const [url, endpoint] of this.endpoints) {
       promises.push(
         this.reconnectSingleEndpoint(url, endpoint).catch((error) => {
-          console.error(
+          logger.error(
             `[EndpointManager] 重连失败: ${sliceEndpoint(url)}`,
             error
           );
@@ -447,7 +448,7 @@ export class EndpointManager extends EventEmitter {
    * 注意：此方法不会清理 MCPManager，MCPManager 的生命周期由外部管理
    */
   async clearEndpoints(): Promise<void> {
-    console.debug("[EndpointManager] 清除所有接入点");
+    logger.debug("[EndpointManager] 清除所有接入点");
 
     await this.disconnect();
 
@@ -458,7 +459,7 @@ export class EndpointManager extends EventEmitter {
     // this.mcpManager = null;
     // this.sharedMCPAdapter = null;
 
-    console.info("[EndpointManager] 所有接入点已清除");
+    logger.info("[EndpointManager] 所有接入点已清除");
   }
 
   /**
@@ -467,7 +468,7 @@ export class EndpointManager extends EventEmitter {
    * 注意：此方法不会清理 MCPManager，MCPManager 的生命周期由外部管理
    */
   async cleanup(): Promise<void> {
-    console.debug("[EndpointManager] 开始清理资源");
+    logger.debug("[EndpointManager] 开始清理资源");
 
     // 移除 MCP 服务事件监听器
     if (
@@ -484,7 +485,7 @@ export class EndpointManager extends EventEmitter {
 
     await this.clearEndpoints();
 
-    console.debug("[EndpointManager] 资源清理完成");
+    logger.debug("[EndpointManager] 资源清理完成");
   }
 
   // ==================== 私有方法 ====================
@@ -501,7 +502,7 @@ export class EndpointManager extends EventEmitter {
       throw new Error(`端点状态不存在: ${sliceEndpoint(url)}`);
     }
 
-    console.debug(`[EndpointManager] 连接端点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 连接端点: ${sliceEndpoint(url)}`);
 
     // 更新状态为连接中
     status.connected = false;
@@ -516,7 +517,7 @@ export class EndpointManager extends EventEmitter {
     status.lastConnected = new Date();
     status.lastError = undefined;
 
-    console.info(`[EndpointManager] 端点连接成功: ${sliceEndpoint(url)}`);
+    logger.info(`[EndpointManager] 端点连接成功: ${sliceEndpoint(url)}`);
   }
 
   /**
@@ -531,7 +532,7 @@ export class EndpointManager extends EventEmitter {
       throw new Error(`端点状态不存在: ${sliceEndpoint(url)}`);
     }
 
-    console.debug(`[EndpointManager] 重连端点: ${sliceEndpoint(url)}`);
+    logger.debug(`[EndpointManager] 重连端点: ${sliceEndpoint(url)}`);
 
     // 执行重连
     await endpoint.reconnect();
@@ -542,6 +543,6 @@ export class EndpointManager extends EventEmitter {
     status.lastConnected = new Date();
     status.lastError = undefined;
 
-    console.info(`[EndpointManager] 端点重连成功: ${sliceEndpoint(url)}`);
+    logger.info(`[EndpointManager] 端点重连成功: ${sliceEndpoint(url)}`);
   }
 }


### PR DESCRIPTION
- 在 endpoint.ts 中添加 logger 导入，替换所有 console 调用
- 在 manager.ts 中添加 logger 导入，替换所有 console 调用
- 更新 endpoint.test.ts 使用 logger mock 替代 console mock
- 在 biome.json 中添加 src/endpoint/** 到 useImportRestrictions 排除列表

修复了 Issue #3336 中指出的日志规范违规问题，现在所有日志输出
都使用项目统一的 Pino Logger 系统，支持结构化日志、日志轮转
和统一的日志级别管理。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3336