### PR TITLE
refactor(types): 消除 mcp-core/types.ts 与 server/lib/mcp/types.ts 的重复类型定义

### DIFF
--- a/src/mcp-core/index.ts
+++ b/src/mcp-core/index.ts
@@ -12,7 +12,10 @@
 export type {
   // 配置相关
   MCPServiceConfig,
+  InternalMCPServiceConfig,
+  LegacyMCPServiceConfig,
   ModelScopeSSEOptions,
+  HeartbeatConfig,
   UnifiedServerConfig,
   // 状态相关
   MCPServiceStatus,
@@ -22,6 +25,7 @@ export type {
   // 工具相关
   ToolInfo,
   EnhancedToolInfo,
+  ToolStatusFilter,
   ToolCallResult,
   ToolCallParams,
   ValidatedToolCallParams,
@@ -30,8 +34,12 @@ export type {
   JSONSchema,
   // 传输相关
   MCPServerTransport,
+  MCPTransportTypeInput,
+  MCPTransportTypeString,
   // 事件相关
   MCPServiceEventCallbacks,
+  // 向后兼容性别名
+  ServiceStatus,
 } from "./types.js";
 
 // =========================

--- a/src/mcp-core/types.ts
+++ b/src/mcp-core/types.ts
@@ -391,3 +391,14 @@ export class ToolCallError extends Error {
     this.name = "ToolCallError";
   }
 }
+
+// =========================
+// 向后兼容性别名
+// =========================
+
+/**
+ * 向后兼容：ServiceStatus 别名
+ * 为了与现有代码保持兼容，暂时保留此别名
+ * @deprecated 请使用 MCPServiceConnectionStatus
+ */
+export type ServiceStatus = MCPServiceConnectionStatus;

--- a/src/server/lib/mcp/index.ts
+++ b/src/server/lib/mcp/index.ts
@@ -29,10 +29,41 @@
  * const result = await manager.callTool('tool-name', { param: 'value' });
  * ```
  */
-export * from "../../lib/mcp/manager.js";
-export * from "../../lib/mcp/connection.js";
+
+// =========================
+// 从 manager.ts 导出（server 本地实现）
+// =========================
+
+export { MCPServiceManager } from "../../lib/mcp/manager.js";
+
+// =========================
+// 从 connection.ts 导出
+// =========================
+
+export { MCPService } from "../../lib/mcp/connection.js";
+
+// =========================
+// 从 types.ts 导出（选择性重新导出 + 自定义类型）
+// =========================
+
 export * from "../../lib/mcp/types.js";
-export * from "../../lib/mcp/utils.js";
+
+// =========================
+// 从 utils.ts 导出（server 本地实现）
+// 注意：inferTransportTypeFromUrl, inferTransportTypeFromConfig, validateToolCallParams
+// 在 mcp-core 中也有定义，这里导出 server 版本
+// =========================
+
+export {
+  inferTransportTypeFromUrl,
+  inferTransportTypeFromConfig,
+  validateToolCallParams,
+} from "../../lib/mcp/utils.js";
+
+// =========================
+// 其他模块导出
+// =========================
+
 export * from "./message.js";
 export * from "../../lib/mcp/cache.js";
 export * from "./custom.js";

--- a/src/server/lib/mcp/types.ts
+++ b/src/server/lib/mcp/types.ts
@@ -1,122 +1,82 @@
 /**
  * MCP 核心库类型定义
  * 统一管理所有 MCP 相关的类型定义，避免重复定义和导入路径混乱
- */
-
-import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-
-// =========================
-// 1. 基础传输类型
-// =========================
-
-/**
- * MCP 传输层联合类型定义
- * 支持 STDIO、SSE、StreamableHTTP 三种传输协议
- */
-export type MCPServerTransport =
-  | StdioClientTransport
-  | SSEClientTransport
-  | StreamableHTTPClientTransport;
-
-/**
- * 通信方式枚举
- * 定义 MCP 支持的传输类型
- */
-export enum MCPTransportType {
-  STDIO = "stdio",
-  SSE = "sse",
-  HTTP = "http",
-}
-
-// =========================
-// 2. 配置接口类型
-// =========================
-
-/**
- * ModelScope SSE 自定义选项接口
- * 专门用于 ModelScope 相关的 SSE 配置
- */
-export interface ModelScopeSSEOptions {
-  eventSourceInit?: {
-    fetch?: (
-      url: string | URL | Request,
-      init?: RequestInit
-    ) => Promise<Response>;
-  };
-  requestInit?: RequestInit;
-}
-
-/**
- * MCP 服务配置接口
- * 包含所有 MCP 服务的配置选项
  *
- * 注意：符合 @modelcontextprotocol 官方标准，不包含 name 字段
- * name 应该作为服务标识符独立管理，不是配置的一部分
+ * 说明：
+ * - 大多数类型从 @xiaozhi-client/mcp-core 重新导出
+ * - ToolCallResult 保持自定义定义，与 endpoint 包保持兼容
+ * - UnifiedServerStatus 保持自定义定义（无 transportCount）
  */
-export interface MCPServiceConfig {
-  type?: MCPTransportType; // 现在是可选的，支持自动推断
-  // stdio 配置
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>; // 环境变量配置
-  // 网络配置
-  url?: string;
-  // 认证配置
-  apiKey?: string;
-  headers?: Record<string, string>;
-  customSSEOptions?: ModelScopeSSEOptions;
-}
 
-/**
- * 内部使用的 MCP 服务配置接口（包含 name 字段）
- * 用于 MCPService 类等内部函数，保持向后兼容
- */
-export interface InternalMCPServiceConfig extends MCPServiceConfig {
-  name: string;
-}
+// 先导入需要在自定义类型中使用的类型
+import type {
+  MCPServiceConnectionStatus,
+  ManagerStatus,
+  UnifiedServerConfig,
+} from "@xiaozhi-client/mcp-core";
 
 // =========================
-// 3. 状态枚举类型
+// 从 mcp-core 重新导出的类型（完全相同）
 // =========================
 
-/**
- * 连接状态枚举
- * 合并了 connection.ts 和 TransportAdapter.ts 中的定义
- */
-export enum ConnectionState {
-  DISCONNECTED = "disconnected",
-  CONNECTING = "connecting",
-  CONNECTED = "connected",
-  RECONNECTING = "reconnecting",
-  FAILED = "failed",
-  ERROR = "error", // 从 TransportAdapter.ts 合并的额外状态
-}
-
-/**
- * MCP 服务状态接口
- * 描述 MCP 服务的运行时状态信息
- */
-export interface MCPServiceStatus {
-  name: string;
-  connected: boolean;
-  initialized: boolean;
-  transportType: MCPTransportType;
-  toolCount: number;
-  lastError?: string;
-  connectionState: ConnectionState;
-}
+export type {
+  // 配置相关
+  MCPServiceConfig,
+  InternalMCPServiceConfig,
+  ModelScopeSSEOptions,
+  // 状态相关
+  MCPServiceStatus,
+  // 工具相关
+  ToolInfo,
+  EnhancedToolInfo,
+  ToolCallParams,
+  ValidatedToolCallParams,
+  ToolCallValidationOptions,
+  CustomMCPTool,
+  JSONSchema,
+  ToolStatusFilter,
+  // 传输相关
+  MCPServerTransport,
+  // 重新导出上面导入的类型
+  ManagerStatus,
+  UnifiedServerConfig,
+  MCPServiceConnectionStatus,
+} from "@xiaozhi-client/mcp-core";
 
 // =========================
-// 4. 工具调用相关类型
+// 枚举导出
+// =========================
+
+export {
+  MCPTransportType,
+  ConnectionState,
+  ToolCallErrorCode,
+} from "@xiaozhi-client/mcp-core";
+
+// =========================
+// 类导出
+// =========================
+
+export { ToolCallError } from "@xiaozhi-client/mcp-core";
+
+// =========================
+// 函数导出
+// =========================
+
+export {
+  isValidToolJSONSchema,
+  ensureToolJSONSchema,
+} from "@xiaozhi-client/mcp-core";
+
+// =========================
+// 保留的自定义类型（与 mcp-core 有差异）
 // =========================
 
 /**
  * 工具调用结果接口
  * 使用简化的类型定义，保持向后兼容性
- * 注意：这与 ../../../../../mcp-core/index.js 中的 ToolCallResult 类型不同
+ * 注意：这与 mcp-core 的 ToolCallResult（CompatibilityCallToolResult）不同
+ * mcp-core 使用 SDK 类型，这里保持自定义接口以兼容 endpoint 包
  */
 export interface ToolCallResult {
   content: Array<{
@@ -128,159 +88,9 @@ export interface ToolCallResult {
 }
 
 /**
- * JSON Schema 类型定义
- * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
- */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>; // 允许更宽松的格式以保持向后兼容
-
-/**
- * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
- */
-export function isValidToolJSONSchema(obj: unknown): obj is {
-  type: "object";
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "type" in obj &&
-    (obj as { type?: unknown }).type === "object"
-  );
-}
-
-/**
- * 确保对象符合 MCP Tool JSON Schema 格式
- * 如果不符合，会返回一个默认的空对象 schema
- */
-export function ensureToolJSONSchema(schema: JSONSchema): {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  if (isValidToolJSONSchema(schema)) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
-  }
-
-  // 如果不符合标准格式，返回默认的空对象 schema
-  return {
-    type: "object",
-    properties: {} as Record<string, object>,
-    required: [],
-    additionalProperties: true,
-  };
-}
-
-/**
- * CustomMCP 工具类型定义
- * 统一了 manager.ts 和 configManager.ts 中的定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
-  };
-}
-
-/**
- * 工具信息接口
- * 用于缓存工具映射关系，保持向后兼容性
- */
-export interface ToolInfo {
-  serviceName: string;
-  originalName: string;
-  tool: Tool;
-}
-
-// =========================
-// 5. 增强工具信息类型
-// =========================
-
-/**
- * 工具状态过滤选项
- * 用于 getAllTools() 方法过滤不同状态的工具
- */
-export type ToolStatusFilter = "enabled" | "disabled" | "all";
-
-/**
- * 增强的工具信息接口
- * 扩展自 ToolInfo 概念，包含工具的启用状态和使用统计信息
- *
- * @remarks
- * 此接口用于 MCPServiceManager.getAllTools() 方法的返回值，
- * 提供比基础 ToolInfo 更丰富的工具元数据信息。
- *
- * @example
- * ```typescript
- * const tools: EnhancedToolInfo[] = manager.getAllTools('enabled');
- * tools.forEach(tool => {
- *   console.log(`工具: ${tool.name}`);
- *   console.log(`状态: ${tool.enabled ? '已启用' : '已禁用'}`);
- *   console.log(`使用次数: ${tool.usageCount}`);
- * });
- * ```
- */
-export interface EnhancedToolInfo {
-  /** 工具唯一标识符，格式为 "{serviceName}__{originalName}" */
-  name: string;
-
-  /** 工具描述信息 */
-  description: string;
-
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-
-  /** 工具所属的 MCP 服务名称 */
-  serviceName: string;
-
-  /** 工具在 MCP 服务中的原始名称 */
-  originalName: string;
-
-  /** 工具是否启用 (true=已启用，false=已禁用) */
-  enabled: boolean;
-
-  /** 工具使用次数统计 */
-  usageCount: number;
-
-  /** 工具最后使用时间 (ISO 8601 格式字符串) */
-  lastUsedTime: string;
-}
-
-// =========================
-// 6. 服务器配置类型
-// =========================
-
-/**
- * 统一服务器配置接口
- * 从 UnifiedMCPServer 移入，用于统一服务器配置管理
- */
-export interface UnifiedServerConfig {
-  name?: string;
-  enableLogging?: boolean;
-  logLevel?: string;
-  configs?: Record<string, MCPServiceConfig>; // MCPService 配置
-}
-
-/**
  * 统一服务器状态接口
  * 从 UnifiedMCPServer 移入，用于统一服务器状态管理
+ * 注意：与 mcp-core 的 UnifiedServerStatus 不同（缺少 transportCount）
  */
 export interface UnifiedServerStatus {
   isRunning: boolean;
@@ -291,98 +101,6 @@ export interface UnifiedServerStatus {
   services?: Record<string, MCPServiceConnectionStatus>;
   totalTools?: number;
   availableTools?: string[];
-}
-
-// =========================
-// 6. 管理器相关类型
-// =========================
-
-/**
- * MCP 服务连接状态接口
- * 重命名原 ServiceStatus 为 MCPServiceConnectionStatus 避免与 CLI 的 ServiceStatus 冲突
- */
-export interface MCPServiceConnectionStatus {
-  connected: boolean;
-  clientName: string;
-}
-
-/**
- * 管理器状态接口
- * 描述 MCP 服务管理器的整体状态
- */
-export interface ManagerStatus {
-  services: Record<string, MCPServiceConnectionStatus>;
-  totalTools: number;
-  availableTools: string[];
-}
-
-// =========================
-// 7. 参数校验相关类型
-// =========================
-
-/**
- * 工具调用参数接口
- * 定义标准工具调用参数结构
- */
-export interface ToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 验证后的工具调用参数
- * 参数校验通过后的标准化参数结构
- */
-export interface ValidatedToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 工具调用验证选项
- * 提供灵活的参数校验配置
- */
-export interface ToolCallValidationOptions {
-  /** 是否验证工具名称，默认为 true */
-  validateName?: boolean;
-  /** 是否验证参数格式，默认为 true */
-  validateArguments?: boolean;
-  /** 是否允许空参数，默认为 true */
-  allowEmptyArguments?: boolean;
-  /** 自定义验证函数 */
-  customValidator?: (params: ToolCallParams) => string | null;
-}
-
-/**
- * 工具调用错误码枚举
- * 统一的工具调用错误码定义
- */
-export enum ToolCallErrorCode {
-  /** 无效参数 */
-  INVALID_PARAMS = -32602,
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = -32601,
-  /** 服务不可用 */
-  SERVICE_UNAVAILABLE = -32001,
-  /** 调用超时 */
-  TIMEOUT = -32002,
-  /** 工具执行错误 */
-  TOOL_EXECUTION_ERROR = -32000,
-}
-
-/**
- * 工具调用错误类
- * 统一的工具调用错误处理
- */
-export class ToolCallError extends Error {
-  constructor(
-    public code: ToolCallErrorCode,
-    message: string,
-    public data?: unknown
-  ) {
-    super(message);
-    this.name = "ToolCallError";
-  }
 }
 
 // =========================


### PR DESCRIPTION
## 问题
- 两个文件存在约310行完全重复的类型定义，违反DRY原则
- ToolCallResult 类型定义不一致（mcp-core使用SDK版本，server使用自定义版本）
- mcp-core/index.ts 未导出所有必要类型

## 解决方案
1. 更新 mcp-core/index.ts 导出所有必要类型（包括 InternalMCPServiceConfig、HeartbeatConfig、ToolStatusFilter 等）
2. 将 server/lib/mcp/types.ts 改为选择性重新导出：
   - 完全相同的类型：从 @xiaozhi-client/mcp-core 重新导出
   - 有意差异的类型：保留自定义定义（ToolCallResult、UnifiedServerStatus）
3. 更新 server/lib/mcp/index.ts 避免重复导出冲突
4. 在 mcp-core/types.ts 添加 ServiceStatus 向后兼容别名

## 变更统计
- 净减少约232行重复代码
- 保持向后兼容性
- 所有测试通过（2455个测试）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3335