### PR TITLE
refactor: 修复 handlers 目录中的三层相对路径导入

### DIFF
--- a/src/server/handlers/config.handler.ts
+++ b/src/server/handlers/config.handler.ts
@@ -1,6 +1,6 @@
+import type { AppConfig } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
-import type { AppConfig } from "../../config/index.js";
-import { configManager } from "../../config/index.js";
 /**
  * 配置 API HTTP 路由处理器
  * 提供配置读取、配置更新等配置相关的 RESTful API 接口

--- a/src/server/handlers/coze.handler.ts
+++ b/src/server/handlers/coze.handler.ts
@@ -3,8 +3,8 @@
  * 提供扣子工作空间和工作流相关的 RESTful API 接口
  */
 
+import { configManager } from "@xiaozhi-client/config";
 import type { Context } from "hono";
-import { configManager } from "../../config/index.js";
 import { CozeApiService } from "../lib/coze";
 import type { CozeWorkflowsParams } from "../types/coze";
 import type { AppContext } from "../types/hono.context.js";

--- a/src/server/handlers/endpoint.handler.ts
+++ b/src/server/handlers/endpoint.handler.ts
@@ -1,9 +1,9 @@
-import type { Context } from "hono";
-import type { ConfigManager } from "../../config/index.js";
+import type { ConfigManager } from "@xiaozhi-client/config";
 import type {
   ConnectionStatus,
   EndpointManager,
-} from "../../endpoint/index.js";
+} from "@xiaozhi-client/endpoint";
+import type { Context } from "hono";
 /**
  * 接入点管理 Handler
  *

--- a/src/server/handlers/esp32.handler.ts
+++ b/src/server/handlers/esp32.handler.ts
@@ -5,12 +5,12 @@
  * 作为薄适配层，将 Hono 请求委托给 ESP32DeviceManager 处理
  */
 
-import type { Context } from "hono";
 import type {
   ESP32DeviceManager,
   ESP32DeviceReport,
-} from "../../esp32/index.js";
-import { ESP32ErrorCode } from "../../esp32/index.js";
+} from "@xiaozhi-client/esp32";
+import { ESP32ErrorCode } from "@xiaozhi-client/esp32";
+import type { Context } from "hono";
 import type { AppContext } from "../types/hono.context.js";
 import { BaseHandler } from "./base.handler.js";
 

--- a/src/server/handlers/mcp-manage.handler.ts
+++ b/src/server/handlers/mcp-manage.handler.ts
@@ -13,10 +13,10 @@
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
+import type { ConfigManager, MCPServerConfig } from "@xiaozhi-client/config";
+import { normalizeServiceConfig } from "@xiaozhi-client/config";
+import { TypeFieldNormalizer } from "@xiaozhi-client/mcp-core";
 import type { Context } from "hono";
-import type { ConfigManager, MCPServerConfig } from "../../config/index.js";
-import { normalizeServiceConfig } from "../../config/index.js";
-import { TypeFieldNormalizer } from "../../mcp-core/index.js";
 import type { Logger } from "../Logger.js";
 import { logger } from "../Logger.js";
 import { ErrorCategory, MCPError, MCPErrorCode } from "../errors/mcp-errors.js";

--- a/src/server/handlers/mcp-tool.handler.ts
+++ b/src/server/handlers/mcp-tool.handler.ts
@@ -3,11 +3,11 @@
  * 处理通过 HTTP API 调用 MCP 工具的请求
  */
 
+import type { CustomMCPTool, ProxyHandlerConfig } from "@xiaozhi-client/config";
+import { configManager } from "@xiaozhi-client/config";
 import Ajv from "ajv";
 import dayjs from "dayjs";
 import type { Context } from "hono";
-import { configManager } from "../../config/index.js";
-import type { CustomMCPTool, ProxyHandlerConfig } from "../../config/index.js";
 import type { Logger } from "../Logger.js";
 import { logger } from "../Logger.js";
 import { HTTP_TIMEOUTS } from "../constants/timeout.constants.js";

--- a/src/server/handlers/tts.handler.ts
+++ b/src/server/handlers/tts.handler.ts
@@ -3,11 +3,11 @@
  * 提供语音合成 RESTful API 接口
  */
 
+import { configManager } from "@xiaozhi-client/config";
+import { mapClusterToResourceId } from "@xiaozhi-client/esp32";
+import type { VoiceInfo, VoicesResponse } from "@xiaozhi-client/shared-types";
 import type { Context } from "hono";
 import { createTTS } from "univoice";
-import { configManager } from "../../config/index.js";
-import { mapClusterToResourceId } from "../../esp32/index.js";
-import type { VoiceInfo, VoicesResponse } from "../../types/tts/index.js";
 import { TTS_VOICES, getVoiceScenes } from "../constants/voices.js";
 import type { AppContext } from "../types/hono.context.js";
 import { BaseHandler } from "./base.handler.js";

--- a/src/server/middlewares/endpoints.middleware.ts
+++ b/src/server/middlewares/endpoints.middleware.ts
@@ -3,9 +3,9 @@
  * 负责创建和管理 EndpointHandler 实例
  */
 
+import { configManager } from "@xiaozhi-client/config";
+import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { MiddlewareHandler } from "hono";
-import { configManager } from "../../config/index.js";
-import type { EndpointManager } from "../../endpoint/index.js";
 import { EndpointHandler } from "../handlers/endpoint.handler.js";
 import type { AppContext } from "../types/hono.context.js";
 

--- a/src/server/types/hono.context.ts
+++ b/src/server/types/hono.context.ts
@@ -3,9 +3,9 @@
  * 为 Hono Context 添加项目特定的变量类型定义
  */
 
+import type { EndpointManager } from "@xiaozhi-client/endpoint";
 import type { Context } from "hono";
 import { Hono } from "hono";
-import type { EndpointManager } from "../../endpoint/index.js";
 import type { Logger } from "../Logger.js";
 import type { EndpointHandler } from "../handlers/index.js";
 import type { MCPServiceManager } from "../lib/mcp";


### PR DESCRIPTION
将 src/server/handlers 和相关目录中的三层相对路径导入替换为路径别名，
提升代码可读性和维护性。

修复内容：
- handlers 目录（16处）
  - mcp-tool.handler.ts: ../../config → @xiaozhi-client/config
  - config.handler.ts: ../../config → @xiaozhi-client/config
  - tts.handler.ts: ../../config → @xiaozhi-client/config
  - tts.handler.ts: ../../esp32 → @xiaozhi-client/esp32
  - tts.handler.ts: ../../types/tts → @xiaozhi-client/shared-types
  - coze.handler.ts: ../../config → @xiaozhi-client/config
  - mcp-manage.handler.ts: ../../config → @xiaozhi-client/config
  - mcp-manage.handler.ts: ../../mcp-core → @xiaozhi-client/mcp-core
  - endpoint.handler.ts: ../../config → @xiaozhi-client/config
  - endpoint.handler.ts: ../../endpoint → @xiaozhi-client/endpoint
  - esp32.handler.ts: ../../esp32 → @xiaozhi-client/esp32

- middlewares 目录（2处）
  - endpoints.middleware.ts: ../../config → @xiaozhi-client/config
  - endpoints.middleware.ts: ../../endpoint → @xiaozhi-client/endpoint

- types 目录（1处）
  - hono.context.ts: ../../endpoint → @xiaozhi-client/endpoint

相关 issue: #3338

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3338