### PR TITLE
fix: toolCallLogger.createPinoLogger 使用 logger 替代 console.log

### DIFF
--- a/src/server/lib/mcp/log.ts
+++ b/src/server/lib/mcp/log.ts
@@ -105,9 +105,9 @@ export class ToolCallLogger {
           try {
             const logObj = JSON.parse(chunk);
             const message = this.formatConsoleMessage(logObj);
-            console.log("[工具调用]", { message });
+            logger.info("[工具调用]", { message });
           } catch {
-            console.log("[工具调用]", { chunk: chunk.trim() });
+            logger.info("[工具调用]", { chunk: chunk.trim() });
           }
         },
       },


### PR DESCRIPTION
修复 src/server/lib/mcp/log.ts 文件中 createPinoLogger 方法的控制台流
使用项目标准的 logger.info 替代 console.log，保持日志规范一致性。

修复位置：第 108-110 行

相关 Issue: #3341

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3341