### PR TITLE
fix: 修复 Tailwind CSS content 配置匹配 node_modules 导致构建性能问题

### DIFF
--- a/src/web/tailwind.config.js
+++ b/src/web/tailwind.config.js
@@ -1,7 +1,11 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ["class"],
-  content: ["./index.html", "./**/*.{js,ts,jsx,tsx}"],
+  content: [
+    "./index.html",
+    "./**/*.{js,ts,jsx,tsx}",
+    "!./node_modules/**",
+  ],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
更新 tailwind.config.js 的 content 配置，添加负向模式排除 node_modules 目录：
- 原配置: ["./index.html", "./**/*.{js,ts,jsx,tsx}"]
- 新配置: ["./index.html", "./**/*.{js,ts,jsx,tsx}", "!./node_modules/**"]

此修复解决了 Tailwind CSS 在构建时扫描大量 node_modules 文件的问题，
消除了构建警告并提升了构建性能。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3348