### PR TITLE
fix: prompt-utils.ts 使用 logger 替代 console

### DIFF
--- a/src/server/utils/prompt-utils.ts
+++ b/src/server/utils/prompt-utils.ts
@@ -17,6 +17,7 @@ import {
 } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
 import { configManager } from "../../config/index.js";
+import { logger } from "../Logger.js";
 
 // 默认系统提示词
 const DEFAULT_SYSTEM_PROMPT =
@@ -73,9 +74,7 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件是否存在
     if (!existsSync(resolvedPath)) {
-      console.warn(
-        `[prompt-utils] 提示词文件不存在: ${resolvedPath}，将使用默认提示词`
-      );
+      logger.warn(`提示词文件不存在: ${resolvedPath}，将使用默认提示词`);
       return null;
     }
 
@@ -84,17 +83,15 @@ function resolvePromptFromPath(promptPath: string): string | null {
 
     // 检查文件内容是否为空
     if (!content) {
-      console.warn(
-        `[prompt-utils] 提示词文件内容为空: ${resolvedPath}，将使用默认提示词`
-      );
+      logger.warn(`提示词文件内容为空: ${resolvedPath}，将使用默认提示词`);
       return null;
     }
 
-    console.info(`[prompt-utils] 成功从文件加载提示词: ${resolvedPath}`);
+    logger.info(`成功从文件加载提示词: ${resolvedPath}`);
     return content;
   } catch (error) {
-    console.error(
-      `[prompt-utils] 读取提示词文件失败: ${promptPath}`,
+    logger.error(
+      `读取提示词文件失败: ${promptPath}`,
       error instanceof Error ? error.message : String(error)
     );
     return null;
@@ -178,8 +175,8 @@ export function listPromptFiles(): PromptFileInfo[] {
 
     return promptFiles;
   } catch (error) {
-    console.error(
-      "[prompt-utils] 获取提示词文件列表失败:",
+    logger.error(
+      "获取提示词文件列表失败:",
       error instanceof Error ? error.message : String(error)
     );
     return [];


### PR DESCRIPTION
将 prompt-utils.ts 中的 console.warn、console.info、console.error
替换为项目统一的 logger 方法，符合项目日志规范。

修复位置：
- 提示词文件不存在警告
- 提示词文件内容为空警告
- 成功加载提示词信息
- 读取提示词文件失败错误
- 获取提示词文件列表失败错误

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3351