### PR TITLE
fix: 同步 dependencies 版本声明与 pnpm overrides

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@coze/api": "^1.3.9",
     "@discordjs/opus": "^0.10.0",
-    "@hono/node-server": "^1.19.10",
+    "@hono/node-server": "^1.19.13",
     "@modelcontextprotocol/sdk": "^1.26.0",
     "ajv": "^8.18.0",
     "chalk": "^5.6.0",
@@ -73,7 +73,7 @@
     "dotenv": "^17.2.1",
     "eventsource": "^4.0.0",
     "express": "^5.1.0",
-    "hono": "^4.12.7",
+    "hono": "^4.12.12",
     "node-cache": "^5.1.2",
     "openai": "^6.24.0",
     "ora": "^8.2.0",


### PR DESCRIPTION
将 dependencies 中的版本声明更新为与 overrides 强制的最低版本一致：
- hono: ^4.12.7 → ^4.12.12
- @hono/node-server: ^1.19.10 → ^1.19.13

修复 #3354：避免版本声明与实际安装版本不一致导致维护混淆

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3354