### PR TITLE
fix(TTSService): 添加 waitForBufferDrain 中 sendStopAndCleanup 的 .catch() 处理

### DIFF
--- a/src/esp32/services/tts.service.ts
+++ b/src/esp32/services/tts.service.ts
@@ -227,7 +227,12 @@ export class TTSService implements ITTSService {
         `[TTSService] 缓冲区排空检查: deviceId=${deviceId}, buffer=${buffer?.length}, isProcessing=${isProcessing}`
       );
       if ((!buffer || buffer.length === 0) && !isProcessing) {
-        this.sendStopAndCleanup(deviceId);
+        void this.sendStopAndCleanup(deviceId).catch((error) => {
+          this.logger.error(
+            `[TTSService] sendStopAndCleanup 执行失败: deviceId=${deviceId}`,
+            error
+          );
+        });
         return true;
       }
 


### PR DESCRIPTION
修复 waitForBufferDrain 方法中调用 sendStopAndCleanup 时缺少 .catch() 处理的问题，
防止未处理的 Promise rejection 导致潜在的生产环境问题。

问题位置: src/esp32/services/tts.service.ts:230

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3362