### PR TITLE
docs: 清理 monorepo 迁移后的文档和代码残留引用

### DIFF
--- a/docs/content/esp32/integration.mdx
+++ b/docs/content/esp32/integration.mdx
@@ -7,7 +7,7 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 # 集成指南
 
-本文档以 `apps/backend`（项目的 Web 服务器）为实际案例，详细说明如何在自己的项目中完整集成 `@xiaozhi-client/esp32`。
+本文档以 `src/server`（项目的 Web 服务器）为实际案例，详细说明如何在自己的项目中完整集成 `@xiaozhi-client/esp32`。
 
 <Callout type="info">
   在开始之前，建议先阅读 [快速上手](/esp32/quick-start) 了解基本概念。
@@ -116,7 +116,7 @@ export const esp32ConfigProvider = new Esp32ConfigProvider();
 ```
 
 <Callout type="info">
-  以上代码来自 `apps/backend/WebServer.ts` 中的实际实现。如果你不使用 `@xiaozhi-client/config`，可以从任何来源返回配置对象——文件、数据库、环境变量均可。
+  以上代码来自 `src/server/WebServer.ts` 中的实际实现。如果你不使用 `@xiaozhi-client/config`，可以从任何来源返回配置对象——文件、数据库、环境变量均可。
 </Callout>
 
 ## 步骤 3：创建 ESP32DeviceManager 实例
@@ -142,7 +142,7 @@ const esp32Manager = new ESP32DeviceManager({
 ESP32 设备上电后的第一个动作是向 OTA 接口发送 HTTP POST 请求。你需要一个**薄适配层**将 HTTP 请求转化为 SDK 方法调用：
 
 ```typescript
-// apps/backend/handlers/esp32.handler.ts（简化版）
+// src/server/handlers/esp32.handler.ts（简化版）
 import type { Context } from "hono";
 import type { ESP32DeviceManager, ESP32DeviceReport } from "@xiaozhi-client/esp32";
 import { ESP32ErrorCode } from "@xiaozhi-client/esp32";

--- a/docs/content/esp32/overview.mdx
+++ b/docs/content/esp32/overview.mdx
@@ -7,7 +7,7 @@ import { Callout, Tabs } from "nextra/components";
 
 # ESP32 SDK 概览
 
-`@xiaozhi-client/esp32` 是一个独立的 npm 包，负责 **ESP32 硬件设备**的全部通信逻辑。它从 `apps/backend` 中抽取出来，使设备通信能力可以被任何 Node.js 项目独立使用。
+`@xiaozhi-client/esp32` 是一个独立的 npm 包，负责 **ESP32 硬件设备**的全部通信逻辑。它从 `src/server` 中抽取出来，使设备通信能力可以被任何 Node.js 项目独立使用。
 
 <Callout type="info">
   本包不绑定任何 HTTP 框架（Express、Hono、Fastify 等），通过接口注入实现解耦，可灵活集成到各类服务端项目中。

--- a/docs/content/release.mdx
+++ b/docs/content/release.mdx
@@ -33,14 +33,11 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## 发布的包
 
-项目采用多包发布策略，每次发布会同时发布以下包：
+项目采用单包发布策略，每次发布会发布以下包：
 
-- `xiaozhi-client` - 主包，CLI 工具
-- `@xiaozhi-client/cli` - CLI 核心库
-- `@xiaozhi-client/config` - 配置管理库
-- `@xiaozhi-client/shared-types` - 共享类型定义
+- `xiaozhi-client` - 主包（包含 CLI 工具、Web 服务器、全部功能模块）
 
-所有包使用相同的版本号，由 nx release 自动管理。
+版本号由 `scripts/release.ts` 脚本统一管理。
 
 ## 发布步骤
 
@@ -155,9 +152,6 @@ ls -la dist/
 ```bash
 # 标记包为已废弃
 npm deprecate xiaozhi-client@VERSION "This version has issues"
-npm deprecate @xiaozhi-client/cli@VERSION "This version has issues"
-npm deprecate @xiaozhi-client/config@VERSION "This version has issues"
-npm deprecate @xiaozhi-client/shared-types@VERSION "This version has issues"
 ```
 
 ### Git 标签回滚
@@ -174,10 +168,9 @@ git push origin :refs/tags/vVERSION
 
 ```bash
 # 恢复 package.json 版本到上一个提交
-git checkout HEAD~1 -- package.json packages/*/package.json
+git checkout HEAD~1 -- package.json
 
-# 或者使用 nx release 重新指定正确的版本
-nx release version --version 1.9.4
+# 或者手动编辑 package.json 中的 version 字段后重新提交
 ```
 
 ## 常见问题
@@ -195,7 +188,7 @@ nx release version --version 1.9.4
 
 <Callout type="info" emoji="ℹ️">
   **版本同步**
-  nx release 会自动同步所有包的版本号，所有包将使用相同的版本号（固定版本模式）。
+  `pnpm release` 脚本会自动更新 package.json 的版本号并生成 CHANGELOG。
 </Callout>
 
 ## 手动触发发布（备用）
@@ -209,5 +202,5 @@ nx release version --version 1.9.4
 
 <Callout type="info">
   **推荐使用标准流程**
-  标准流程（本地命令 + 自动发布）更符合 Nx 最佳实践，可以预览版本变更后再推送。
+  标准流程（本地命令 + 自动发布）可以预览版本变更后再推送，简单可靠。
 </Callout>

--- a/src/cli/tsup.config.ts
+++ b/src/cli/tsup.config.ts
@@ -36,8 +36,7 @@ export default defineConfig({
       __APP_NAME__: JSON.stringify(pkg.name),
     };
 
-    // 注意：旧的 @xiaozhi-client/* alias 插件已移除
-    // 所有源码已迁移至 @/ 路径别名体系
+    // 源码使用 @/ 路径别名体系（见根 tsconfig.json paths 配置）
   },
   external: [
     // Node.js 内置模块


### PR DESCRIPTION
## Summary

- 更新发布文档 (`release.mdx`)：将多包发布策略修正为单包发布，移除所有 Nx 工作流引用，简化回滚命令
- 更新 ESP32 文档：将过时的 `apps/backend` 路径引用更新为 `src/server`
- 清理 `tsup.config.ts` 中的过时注释

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（436 文件无问题）
- [x] `pnpm test` 全量通过（124 测试文件 / 2455 用例）
- [x] 文档残留扫描确认无遗漏的内部包引用