### PR TITLE
fix(ci): 移除 workflow 中冗余的 pnpm 版本配置

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -17,8 +17,6 @@ jobs:
 
       - name: 设置 pnpm
         uses: pnpm/action-setup@v5
-        with:
-          version: 10
 
       - name: 设置 Node.js
         uses: actions/setup-node@v6


### PR DESCRIPTION
## Summary
- 移除 `npm-publish.yml` 中 `pnpm/action-setup@v5` 的显式 `version: 10` 配置
- 解决 pnpm/action-setup@v5 检测到版本冲突（workflow vs packageManager）导致发布流程失败的问题
- 让 action 自动从 `package.json` 的 `packageManager` 字段读取精确版本 `pnpm@10.13.1`

## Test plan
- [ ] 触发一次 release（如 `pnpm release:beta`），确认 GitHub Actions 发布流程正常完成，不再报 pnpm 版本冲突错误