### PR TITLE
fix: vitest.config.ts 从 package.json 动态读取版本号

### DIFF
--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -1,6 +1,11 @@
+import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vitest/config";
+
+// 读取根目录 package.json 获取版本号
+const rootPkgPath = resolve(__dirname, "../package.json");
+const pkg = JSON.parse(readFileSync(rootPkgPath, "utf-8"));
 
 export default defineConfig({
   plugins: [react()],
@@ -14,8 +19,8 @@ export default defineConfig({
   },
   // 顶层 define 用于替换全局常量（Vitest 3.x 使用 oxc 而非 esbuild）
   define: {
-    __VERSION__: JSON.stringify("2.3.0-beta.6"),
-    __APP_NAME__: JSON.stringify("xiaozhi-client"),
+    __VERSION__: JSON.stringify(pkg.version),
+    __APP_NAME__: JSON.stringify(pkg.name),
   },
   resolve: {
     alias: {


### PR DESCRIPTION
- 移除硬编码版本号 "2.3.0-beta.6" 和应用名称 "xiaozhi-client"
- 从 package.json 动态读取 version 和 name 字段
- 与 tsup.config.ts 保持一致的实现方式
- 符合单一数据源原则，避免版本发布时的手动同步问题

Fixes #3372

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3372