### PR TITLE
refactor: 消除 src/server/types 与 src/types 之间的重复类型定义

### DIFF
--- a/src/server/types/coze.ts
+++ b/src/server/types/coze.ts
@@ -1,190 +1,37 @@
 /**
- * 扣子 API 相关类型定义
- * 基于 docs/coze-api.md 中的 API 文档
+ * 扣子 API 相关类型定义（重新导出）
+ *
+ * 此文件从 ../../types/coze 重新导出所有扣子相关类型，
+ * 保持向后兼容性，同时遵循 DRY 原则。
+ *
+ * @see ../../types/coze - 规范的扣子类型定义来源
  */
 
-/**
- * 扣子工作空间接口
- */
-export interface CozeWorkspace {
-  /** 工作空间ID */
-  id: string;
-  /** 工作空间名称 */
-  name: string;
-  /** 工作空间描述 */
-  description: string;
-  /** 工作空间类型 */
-  workspace_type: "personal" | "team";
-  /** 企业ID */
-  enterprise_id: string;
-  /** 管理员用户ID列表 */
-  admin_uids: string[];
-  /** 工作空间图标URL */
-  icon_url: string;
-  /** 用户在工作空间中的角色类型 */
-  role_type: "owner" | "admin" | "member";
-  /** 加入状态 */
-  joined_status: "joined" | "pending" | "rejected";
-  /** 所有者用户ID */
-  owner_uid: string;
-}
+// 重新导出所有扣子相关类型
+export type {
+  CozeWorkspace,
+  CozeWorkspacesData,
+} from "../../types/coze/workspace.js";
 
-/**
- * 扣子工作流创建者信息
- */
-export interface CozeWorkflowCreator {
-  /** 创建者ID */
-  id: string;
-  /** 创建者名称 */
-  name: string;
-}
+export type {
+  CozeWorkflowCreator,
+  CozeWorkflow,
+  CozeWorkflowsData,
+  CozeWorkflowsParams,
+  WorkflowParameter,
+  WorkflowParameterConfig,
+} from "../../types/coze/workflow.js";
 
-/**
- * 扣子工作流接口
- */
-export interface CozeWorkflow {
-  /** 工作流ID */
-  workflow_id: string;
-  /** 工作流名称 */
-  workflow_name: string;
-  /** 工作流描述 */
-  description: string;
-  /** 工作流图标URL */
-  icon_url: string;
-  /** 关联应用ID */
-  app_id: string;
-  /** 创建者信息 */
-  creator: CozeWorkflowCreator;
-  /** 创建时间戳 */
-  created_at: number;
-  /** 更新时间戳 */
-  updated_at: number;
-}
+export type {
+  CozeApiDetail,
+  CozeApiResponse,
+  CozeWorkspacesResponse,
+  CozeWorkflowsResponse,
+  CozeApiError,
+  CacheItem,
+} from "../../types/coze/api.js";
 
-/**
- * 扣子 API 响应详情
- */
-export interface CozeApiDetail {
-  /** 日志ID */
-  logid: string;
-}
-
-/**
- * 扣子 API 基础响应接口
- */
-export interface CozeApiResponse<T = any> {
-  /** 响应状态码，0表示成功 */
-  code: number;
-  /** 响应数据 */
-  data: T;
-  /** 响应消息 */
-  msg: string;
-  /** 响应详情 */
-  detail: CozeApiDetail;
-}
-
-/**
- * 获取工作空间列表的响应数据
- */
-export interface CozeWorkspacesData {
-  /** 工作空间总数 */
-  total_count: number;
-  /** 工作空间列表 */
-  workspaces: CozeWorkspace[];
-}
-
-/**
- * 获取工作空间列表的完整响应
- */
-export interface CozeWorkspacesResponse
-  extends CozeApiResponse<CozeWorkspacesData> {}
-
-/**
- * 获取工作流列表的响应数据
- */
-export interface CozeWorkflowsData {
-  /** 是否有更多数据 */
-  has_more: boolean;
-  /** 工作流列表 */
-  items: CozeWorkflow[];
-}
-
-/**
- * 获取工作流列表的完整响应
- */
-export interface CozeWorkflowsResponse
-  extends CozeApiResponse<CozeWorkflowsData> {}
-
-/**
- * 获取工作流列表的请求参数
- */
-export interface CozeWorkflowsParams {
-  /** 工作空间ID */
-  workspace_id: string;
-  /** 页码，从1开始 */
-  page_num?: number;
-  /** 每页数量，默认20 */
-  page_size?: number;
-  /** 工作流模式，默认为 workflow */
-  workflow_mode?: "workflow";
-}
-
-/**
- * 扣子 API 错误响应
- */
-export interface CozeApiError extends Error {
-  /** 错误代码 */
-  code: string;
-  /** HTTP 状态码 */
-  statusCode?: number;
-  /** 原始响应数据 */
-  response?: any;
-}
-
-/**
- * 扣子平台配置接口
- */
-export interface CozePlatformConfig {
-  /** 扣子 API Token */
-  token: string;
-}
-
-/**
- * 扣子 API 服务配置
- */
-export interface CozeApiServiceConfig {
-  /** API Token */
-  token: string;
-  /** API 基础URL，默认 https://api.coze.cn */
-  apiBaseUrl?: string;
-  /** 请求超时时间，默认 10000ms */
-  timeout?: number;
-  /** 重试次数，默认 3 次 */
-  retryAttempts?: number;
-  /** 是否启用缓存，默认 true */
-  cacheEnabled?: boolean;
-}
-
-// ==================== 工作流参数配置相关类型 ====================
-
-/**
- * 工作流参数定义
- */
-export interface WorkflowParameter {
-  /** 英文字段名，用作参数标识符 */
-  fieldName: string;
-  /** 中英文描述，说明参数用途 */
-  description: string;
-  /** 参数类型 */
-  type: "string" | "number" | "boolean";
-  /** 是否必填参数 */
-  required: boolean;
-}
-
-/**
- * 工作流参数配置
- */
-export interface WorkflowParameterConfig {
-  /** 参数列表 */
-  parameters: WorkflowParameter[];
-}
+export type {
+  CozePlatformConfig,
+  CozeApiServiceConfig,
+} from "../../types/coze/config.js";

--- a/src/server/types/timeout.ts
+++ b/src/server/types/timeout.ts
@@ -1,38 +1,25 @@
 /**
- * 超时错误类型
+ * 超时处理相关类型定义（服务器扩展版本）
+ *
+ * 此文件从 ../../types/utils/timeout 导入基础类型，
+ * 并添加服务器特有的功能函数和扩展类型。
+ *
+ * @see ../../types/utils/timeout - 基础超时类型定义
  */
-export class TimeoutError extends Error {
-  public override readonly name = "TimeoutError" as const;
 
-  constructor(message: string) {
-    super(message);
-    this.name = "TimeoutError";
-    Error.captureStackTrace(this, TimeoutError);
-  }
+// 从基础模块导入 TimeoutError 类
+export { TimeoutError } from "../../types/utils/timeout.js";
 
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      stack: this.stack,
-    };
-  }
-}
+// 导入基础 TimeoutResponse 类型用于扩展
+import type { TimeoutResponse as BaseTimeoutResponse } from "../../types/utils/timeout.js";
 
 /**
- * 超时响应接口
+ * 超时响应接口（服务器扩展版本）
+ * 扩展基础类型，添加索引签名以支持与其他类型的兼容性
  */
-export interface TimeoutResponse {
-  content: Array<{
-    type: "text";
-    text: string;
-  }>;
-  isError: boolean;
-  taskId: string;
-  status: "timeout";
-  message: string;
-  nextAction: string;
-  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
+export interface TimeoutResponse extends BaseTimeoutResponse {
+  /** 支持其他未知字段，与 ToolCallResult 保持兼容 */
+  [key: string]: unknown;
 }
 
 /**
@@ -70,7 +57,7 @@ function getToolSpecificTimeoutMessage(
 ): string {
   const toolMessages: Record<string, string> = {
     coze_workflow: `⏱️ 扣子工作流执行超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 工具类型: 扣子工作流
@@ -81,7 +68,6 @@ function getToolSpecificTimeoutMessage(
 1. 使用相同参数重新调用工具
 2. 系统会自动返回已完成的任务结果
 3. 复杂工作流可能需要更长时间处理`,
-
     default: getDefaultTimeoutMessage(taskId),
   };
 
@@ -93,7 +79,7 @@ function getToolSpecificTimeoutMessage(
  */
 function getDefaultTimeoutMessage(taskId: string): string {
   return `⏱️ 工具调用超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 状态: 处理中
@@ -108,24 +94,29 @@ function getDefaultTimeoutMessage(taskId: string): string {
 /**
  * 验证是否为超时响应
  */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
-  return !!(
+export function isTimeoutResponse(
+  response: unknown
+): response is TimeoutResponse {
+  if (
     response &&
+    typeof response === "object" &&
+    "status" in response &&
     response.status === "timeout" &&
+    "taskId" in response &&
     typeof response.taskId === "string" &&
+    "content" in response &&
     Array.isArray(response.content) &&
     response.content.length > 0 &&
+    "type" in response.content[0] &&
     response.content[0].type === "text"
-  );
+  ) {
+    return true;
+  }
+  return false;
 }
 
 /**
  * 验证是否为超时错误
+ * 从基础模块重新导出
  */
-export function isTimeoutError(error: any): error is TimeoutError {
-  return !!(
-    error &&
-    error.name === "TimeoutError" &&
-    error instanceof TimeoutError
-  );
-}
+export { isTimeoutError } from "../../types/utils/timeout.js";


### PR DESCRIPTION
将 src/server/types/coze.ts 和 src/server/types/timeout.ts 修改为重新导出模式：
- coze.ts: 从 ../../types/coze 重新导出所有扣子相关类型
- timeout.ts: 导入 TimeoutError 类，扩展 TimeoutResponse 接口，保留服务器特有函数

遵循 DRY 原则，消除约 118 行重复代码，同时保持向后兼容性。

Closes #3380

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3380