### PR TITLE
fix: 修复 undici WebSocket 长度溢出漏洞 (CVE-2026-1528)

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
       "mathjs@<15.2.0": ">=15.2.0",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
-      "cosmiconfig": ">=7.1.0"
+      "cosmiconfig": ">=7.1.0",
+      "undici": ">=6.24.0"
     }
   },
   "lint-staged": {


### PR DESCRIPTION
添加 pnpm overrides 强制使用 undici >=6.24.0，修复 release-it 传递依赖的安全漏洞。

漏洞详情:
- CVE ID: CVE-2026-1528
- 严重程度: High (CVSS 7.5)
- 影响版本: undici >=6.0.0 <6.24.0
- 修复版本: undici >=6.24.0

修复方案: 使用 pnpm overrides 强制升级到安全版本，避免 release-it 主版本升级带来的迁移成本。

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3382