### PR TITLE
fix: 修复 InternalMCPManagerAdapter 事件监听器泄漏问题

### DIFF
--- a/src/endpoint/__tests__/internal-mcp-manager.test.ts
+++ b/src/endpoint/__tests__/internal-mcp-manager.test.ts
@@ -39,6 +39,7 @@ describe("InternalMCPManagerAdapter", () => {
         content: [{ type: "text", text: "Success" }],
       }),
       on: vi.fn(),
+      off: vi.fn(),
     };
 
     MCPManagerMock.mockImplementation(() => mockMCPManager);
@@ -369,6 +370,27 @@ describe("InternalMCPManagerAdapter", () => {
       await adapter.cleanup();
 
       expect(mockMCPManager.disconnect).toHaveBeenCalled();
+    });
+
+    it("应该移除事件监听器", async () => {
+      const adapter = new InternalMCPManagerAdapter({
+        mcpServers: {
+          "test-service": { command: "node", args: ["server.js"] },
+        },
+      });
+
+      await adapter.initialize();
+      await adapter.cleanup();
+
+      // 验证移除了事件监听器
+      expect(mockMCPManager.off).toHaveBeenCalledWith(
+        "connected",
+        expect.any(Function)
+      );
+      expect(mockMCPManager.off).toHaveBeenCalledWith(
+        "error",
+        expect.any(Function)
+      );
     });
 
     it("清理后应该清空工具列表", async () => {

--- a/src/endpoint/internal-mcp-manager.ts
+++ b/src/endpoint/internal-mcp-manager.ts
@@ -19,6 +19,13 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
   private tools: Map<string, EnhancedToolInfo> = new Map();
   private isInitialized = false;
 
+  // 事件监听器引用，用于在 cleanup() 中移除
+  private connectedListener: (data: {
+    serverName: string;
+    tools: unknown[];
+  }) => void;
+  private errorListener: (data: { serverName: string; error: unknown }) => void;
+
   constructor(private config: EndpointConfig) {
     this.mcpManager = new MCPManager();
 
@@ -30,16 +37,19 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
       this.mcpManager.addServer(serviceName, mcpConfig);
     }
 
-    // 设置事件监听
-    this.mcpManager.on("connected", (data) => {
+    // 设置事件监听（保存引用以便后续移除）
+    this.connectedListener = (data) => {
       console.info(
         `MCP 服务 ${data.serverName} 已连接，工具数: ${data.tools.length}`
       );
-    });
+    };
 
-    this.mcpManager.on("error", (data) => {
+    this.errorListener = (data) => {
       console.error(`MCP 服务 ${data.serverName} 出错:`, data.error);
-    });
+    };
+
+    this.mcpManager.on("connected", this.connectedListener);
+    this.mcpManager.on("error", this.errorListener);
   }
 
   /**
@@ -88,6 +98,10 @@ export class InternalMCPManagerAdapter implements IMCPServiceManager {
    * 清理资源
    */
   async cleanup(): Promise<void> {
+    // 移除事件监听器以防止泄漏
+    this.mcpManager.off("connected", this.connectedListener);
+    this.mcpManager.off("error", this.errorListener);
+
     await this.mcpManager.disconnect();
     this.tools.clear();
     this.isInitialized = false;


### PR DESCRIPTION
- 添加 connectedListener 和 errorListener 私有属性存储监听器引用
- 在 cleanup() 方法中使用 off() 移除监听器以防止内存泄漏
- 更新测试 mock 添加 off 方法并新增监听器移除测试

Fixes #3384

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3384