### PR TITLE
fix: src/web 目录使用 @/types 路径别名替代相对路径

### DIFF
--- a/src/web/hooks/useCozeWorkflows.ts
+++ b/src/web/hooks/useCozeWorkflows.ts
@@ -4,13 +4,13 @@
  */
 
 import { cozeApiClient } from "@/services/cozeApi";
-import { useCallback, useEffect, useMemo, useState } from "react";
 import type {
   CozeUIState,
   CozeWorkflow,
   CozeWorkflowsParams,
   CozeWorkspace,
-} from "../../types";
+} from "@/types";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 /**
  * Hook 返回值类型

--- a/src/web/hooks/useNetworkService.ts
+++ b/src/web/hooks/useNetworkService.ts
@@ -7,8 +7,8 @@
 import { networkService } from "@/services/index";
 import { useConfigStore } from "@/stores/config";
 import { useStatusStore } from "@/stores/status";
+import type { AppConfig } from "@/types";
 import { useCallback, useEffect, useRef, useState } from "react";
-import type { AppConfig } from "../../types";
 
 interface PortChangeStatus {
   status:

--- a/src/web/services/api.ts
+++ b/src/web/services/api.ts
@@ -15,7 +15,7 @@ import type {
   MCPServerListResponse,
   MCPServerStatus,
   VoicesResponse,
-} from "../../types";
+} from "@/types";
 
 /**
  * CustomMCPTool 接口定义

--- a/src/web/services/cozeApi.ts
+++ b/src/web/services/cozeApi.ts
@@ -7,7 +7,7 @@ import type {
   CozeWorkflowsParams,
   CozeWorkflowsResult,
   CozeWorkspace,
-} from "../../types";
+} from "@/types";
 
 /**
  * API 响应格式

--- a/src/web/services/index.ts
+++ b/src/web/services/index.ts
@@ -3,7 +3,7 @@
  * 整合 HTTP API 客户端
  */
 
-import type { AppConfig, ClientStatus } from "../../types";
+import type { AppConfig, ClientStatus } from "@/types";
 import { type ApiClient, apiClient } from "./api";
 
 /**

--- a/src/web/services/toolsApi.ts
+++ b/src/web/services/toolsApi.ts
@@ -13,7 +13,7 @@ import type {
   CozeWorkflow,
   JSONSchema,
   WorkflowParameterConfig,
-} from "../../types";
+} from "@/types";
 import { apiClient } from "./api";
 
 /**

--- a/src/web/stores/config.ts
+++ b/src/web/stores/config.ts
@@ -9,9 +9,6 @@
  */
 
 import { apiClient } from "@/services/api";
-import { create } from "zustand";
-import { devtools } from "zustand/middleware";
-import { useShallow } from "zustand/react/shallow";
 import type {
   AppConfig,
   ConnectionConfig,
@@ -19,7 +16,10 @@ import type {
   MCPServerStatus,
   ModelScopeConfig,
   WebUIConfig,
-} from "../../types";
+} from "@/types";
+import { create } from "zustand";
+import { devtools } from "zustand/middleware";
+import { useShallow } from "zustand/react/shallow";
 
 /**
  * 配置加载状态

--- a/src/web/stores/status.ts
+++ b/src/web/stores/status.ts
@@ -10,10 +10,10 @@
  */
 
 import { apiClient } from "@/services/api";
+import type { ClientStatus } from "@/types";
 import { create } from "zustand";
 import { devtools } from "zustand/middleware";
 import { useShallow } from "zustand/react/shallow";
-import type { ClientStatus } from "../../types";
 
 /**
  * 重启状态接口

--- a/src/web/utils/formatUtils.ts
+++ b/src/web/utils/formatUtils.ts
@@ -2,7 +2,7 @@
  * 格式化工具函数
  */
 
-import type { ToolCallRecord } from "../../types";
+import type { ToolCallRecord } from "@/types";
 
 /**
  * 格式化时间戳为本地化字符串

--- a/src/web/utils/mcpFormConverter.ts
+++ b/src/web/utils/mcpFormConverter.ts
@@ -2,6 +2,7 @@
  * MCP 服务表单数据与 API 配置的双向转换工具
  */
 
+import type { MCPServerConfig } from "@/types";
 import type {
   HttpFormData,
   McpServerFormData,
@@ -9,7 +10,6 @@ import type {
   SseFormData,
   StdioFormData,
 } from "@/types/mcp-form";
-import type { MCPServerConfig } from "../../types";
 
 // ============ 表单 → API 配置 ============
 

--- a/src/web/utils/mcpServerUtils.ts
+++ b/src/web/utils/mcpServerUtils.ts
@@ -3,7 +3,7 @@
  * 用于判断 MCP 服务的通信类型
  */
 
-import type { MCPServerConfig } from "../../types";
+import type { MCPServerConfig } from "@/types";
 
 /** MCP 服务通信类型 */
 type MCPCommunicationType = "stdio" | "sse" | "streamable-http";

--- a/src/web/utils/mcpValidation.ts
+++ b/src/web/utils/mcpValidation.ts
@@ -3,7 +3,7 @@
  * 用于验证高级模式下的 JSON 配置
  */
 
-import type { MCPServerConfig } from "../../types";
+import type { MCPServerConfig } from "@/types";
 
 // 验证结果接口
 export interface ValidationResult {


### PR DESCRIPTION
修复 12 个文件中的路径导入，使用项目规范的 @/types 别名：
- src/web/utils/formatUtils.ts
- src/web/utils/mcpServerUtils.ts
- src/web/utils/mcpValidation.ts
- src/web/utils/mcpFormConverter.ts
- src/web/stores/status.ts
- src/web/stores/config.ts
- src/web/services/cozeApi.ts
- src/web/services/api.ts
- src/web/services/index.ts
- src/web/services/toolsApi.ts
- src/web/hooks/useNetworkService.ts
- src/web/hooks/useCozeWorkflows.ts

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3389