### PR TITLE
docs: 添加核心 API 参考文档

### DIFF
--- a/docs/content/_meta.ts
+++ b/docs/content/_meta.ts
@@ -4,6 +4,7 @@ const meta: MetaRecord = {
   index: "介绍",
   quickstart: "快速上手",
   usage: "使用姿势",
+  api: "API 参考",
   esp32: "ESP32 SDK",
   reference: "参考手册",
   release: "发布方法",

--- a/docs/content/api/_meta.ts
+++ b/docs/content/api/_meta.ts
@@ -1,0 +1,11 @@
+import type { MetaRecord } from "nextra";
+
+const meta: MetaRecord = {
+  mcp_service_manager: "MCPServiceManager",
+  mcp_service: "MCPService",
+  esp32_device_manager: "ESP32DeviceManager",
+  event_bus: "EventBus",
+  config_system: "配置系统",
+};
+
+export default meta;

--- a/docs/content/api/config-system.mdx
+++ b/docs/content/api/config-system.mdx
@@ -1,0 +1,513 @@
+---
+title: "配置系统 - Xiaozhi Client"
+description: "配置管理系统的 API 参考文档，负责配置文件的加载、解析、验证和更新。"
+---
+
+# 配置系统
+
+配置管理系统是 xiaozhi-client 的核心组件，负责配置文件的加载、解析、验证和更新。支持 JSON、JSON5、JSONC 格式，提供单例访问和类型安全的配置操作。
+
+## 模块导出
+
+```typescript
+import {
+  ConfigManager,
+  configManager,
+  ConfigResolver,
+  ConfigInitializer
+} from "@/config/index.js";
+```
+
+## ConfigManager
+
+配置管理类，负责管理应用配置，提供只读访问和安全的配置更新功能。
+
+### 获取实例
+
+```typescript
+import { configManager } from "@/config/index.js";
+
+// 使用单例实例
+const config = configManager.getConfig();
+
+// 或通过静态方法获取
+const manager = ConfigManager.getInstance();
+```
+
+### 主要方法
+
+#### getConfig
+
+获取配置（只读）。使用缓存机制避免频繁的文件 I/O 操作。
+
+**返回值：** `Readonly<AppConfig>`
+
+**示例：**
+
+```typescript
+const config = configManager.getConfig();
+console.log("MCP 端点:", config.mcpEndpoint);
+```
+
+#### configExists
+
+检查配置文件是否存在。
+
+**返回值：** `boolean`
+
+#### initConfig
+
+初始化配置文件。从默认模板复制到目标位置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 默认值 | 说明 |
+|--------|------|------|--------|------|
+| format | `"json"` \| `"json5"` \| `"jsonc"` | 否 | `"json"` | 配置文件格式 |
+
+#### getMcpEndpoints
+
+获取所有 MCP 端点。
+
+**返回值：** `string[]`
+
+**示例：**
+
+```typescript
+const endpoints = configManager.getMcpEndpoints();
+console.log("端点列表:", endpoints);
+```
+
+#### getMcpServers
+
+获取 MCP 服务配置。
+
+**返回值：** `Readonly<Record<string, MCPServerConfig>>`
+
+#### getMcpServerConfig
+
+获取 MCP 服务工具配置。
+
+**返回值：** `Readonly<Record<string, MCPServerToolsConfig>>`
+
+#### isToolEnabled
+
+检查工具是否启用。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serverName | string | 是 | 服务名称 |
+| toolName | string | 是 | 工具名称 |
+
+**返回值：** `boolean`（默认启用）
+
+#### updateMcpEndpoint
+
+更新 MCP 端点（支持字符串或数组）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| endpoint | string \| string[] | 是 | 新的端点配置 |
+
+#### addMcpEndpoint
+
+添加 MCP 端点。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| endpoint | string | 是 | 要添加的端点 |
+
+#### removeMcpEndpoint
+
+移除 MCP 端点。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| endpoint | string | 是 | 要移除的端点 |
+
+#### updateMcpServer
+
+更新 MCP 服务配置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serverName | string | 是 | 服务名称 |
+| serverConfig | MCPServerConfig | 是 | 服务配置 |
+
+#### removeMcpServer
+
+删除 MCP 服务配置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serverName | string | 是 | 服务名称 |
+
+#### updateServerToolsConfig
+
+更新服务工具配置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serverName | string | 是 | 服务名称 |
+| toolsConfig | `Record<string, MCPToolConfig>` | 是 | 工具配置 |
+
+#### setToolEnabled
+
+设置工具启用状态。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serverName | string | 是 | 服务名称 |
+| toolName | string | 是 | 工具名称 |
+| enabled | boolean | 是 | 启用状态 |
+| description | string | 否 | 工具描述 |
+
+### 连接配置方法
+
+#### getConnectionConfig
+
+获取连接配置（包含默认值）。
+
+**返回值：** `Required<ConnectionConfig>`
+
+```typescript
+interface ConnectionConfig {
+  heartbeatInterval: number; // 心跳检测间隔（默认 30000ms）
+  heartbeatTimeout: number;  // 心跳超时时间（默认 10000ms）
+  reconnectInterval: number; // 重连间隔（默认 5000ms）
+}
+```
+
+#### setHeartbeatInterval
+
+设置心跳检测间隔。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| interval | number | 是 | 间隔时间（毫秒） |
+
+#### setHeartbeatTimeout
+
+设置心跳超时时间。
+
+#### setReconnectInterval
+
+设置重连间隔。
+
+### ModelScope 配置方法
+
+#### getModelScopeConfig
+
+获取 ModelScope 配置。
+
+**返回值：** `Readonly<ModelScopeConfig>`
+
+#### getModelScopeApiKey
+
+获取 ModelScope API Key。优先从配置文件读取，其次从环境变量读取。
+
+**返回值：** `string | undefined`
+
+#### setModelScopeApiKey
+
+设置 ModelScope API Key。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| apiKey | string | 是 | API Key |
+
+### CustomMCP 配置方法
+
+#### getCustomMCPConfig
+
+获取 customMCP 配置。
+
+**返回值：** `CustomMCPConfig | null`
+
+#### getCustomMCPTools
+
+获取 customMCP 工具列表。
+
+**返回值：** `CustomMCPTool[]`
+
+#### addCustomMCPTool
+
+添加自定义 MCP 工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| tool | CustomMCPTool | 是 | 工具配置 |
+
+#### addCustomMCPTools
+
+批量添加自定义 MCP 工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| tools | CustomMCPTool[] | 是 | 工具配置数组 |
+
+**返回值：** `Promise<void>`
+
+#### removeCustomMCPTool
+
+删除自定义 MCP 工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| toolName | string | 是 | 工具名称 |
+
+#### updateCustomMCPTool
+
+更新单个自定义 MCP 工具配置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| toolName | string | 是 | 工具名称 |
+| updatedTool | CustomMCPTool | 是 | 更新后的工具配置 |
+
+### Web UI 配置方法
+
+#### getWebUIConfig
+
+获取 Web UI 配置。
+
+**返回值：** `Readonly<WebUIConfig>`
+
+#### getWebUIPort
+
+获取 Web UI 端口号。
+
+**返回值：** `number`（默认 9999）
+
+#### setWebUIPort
+
+设置 Web UI 端口号。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| port | number | 是 | 端口号（1-65535） |
+
+### 语音服务配置方法
+
+#### getTTSConfig
+
+获取 TTS 配置。
+
+**返回值：** `Readonly<TTSConfig>`
+
+#### getASRConfig
+
+获取 ASR 配置。
+
+**返回值：** `Readonly<ASRConfig>`
+
+#### getLLMConfig
+
+获取 LLM 配置。
+
+**返回值：** `LLMConfig | null`
+
+#### isLLMConfigValid
+
+检查 LLM 配置是否有效。
+
+**返回值：** `boolean`
+
+### 事件监听
+
+#### on
+
+注册事件监听器。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| eventName | string | 是 | 事件名称（如 `config:updated`） |
+| callback | `(data: unknown) => void` | 是 | 回调函数 |
+
+**示例：**
+
+```typescript
+configManager.on("config:updated", (data) => {
+  const payload = data as {
+    type: string;
+    timestamp: Date;
+    serviceName?: string;
+  };
+
+  console.log(`配置已更新，类型: ${payload.type}`);
+});
+```
+
+## 配置类型定义
+
+### AppConfig
+
+```typescript
+interface AppConfig {
+  mcpEndpoint: string | string[];     // MCP 接入点
+  mcpServers: Record<string, MCPServerConfig>; // MCP 服务配置
+  mcpServerConfig?: Record<string, MCPServerToolsConfig>; // 工具配置
+  customMCP?: CustomMCPConfig;        // CustomMCP 配置
+  connection?: ConnectionConfig;      // 连接配置
+  modelscope?: ModelScopeConfig;      // ModelScope 配置
+  webUI?: WebUIConfig;                // Web UI 配置
+  platforms?: PlatformsConfig;        // 平台配置
+  toolCallLog?: ToolCallLogConfig;    // 工具调用日志配置
+  tts?: TTSConfig;                    // TTS 配置
+  asr?: ASRConfig;                    // ASR 配置
+  llm?: LLMConfig;                    // LLM 配置
+}
+```
+
+### MCPServerConfig
+
+```typescript
+type MCPServerConfig =
+  | LocalMCPServerConfig     // 本地 MCP 服务
+  | SSEMCPServerConfig       // SSE MCP 服务
+  | HTTPMCPServerConfig;     // HTTP MCP 服务
+
+interface LocalMCPServerConfig {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+interface SSEMCPServerConfig {
+  type: "sse";
+  url: string;
+  headers?: Record<string, string>;
+}
+
+interface HTTPMCPServerConfig {
+  type?: "http" | "streamable-http";
+  url: string;
+  headers?: Record<string, string>;
+}
+```
+
+### CustomMCPTool
+
+```typescript
+interface CustomMCPTool {
+  name: string;
+  description: string;
+  inputSchema: Record<string, unknown>;
+  handler: HandlerConfig;
+  stats?: {
+    usageCount?: number;
+    lastUsedTime?: string;
+  };
+}
+```
+
+## 配置文件位置
+
+配置文件查找优先级：
+
+1. 环境变量 `XIAOZHI_CONFIG_DIR` 指定的目录
+2. 当前工作目录
+3. 用户家目录 `~/.xiaozhi-client/`
+
+支持格式：`.json5` > `.jsonc` > `.json`
+
+## 使用示例
+
+### 基础使用
+
+```typescript
+import { configManager } from "@/config";
+
+// 获取配置
+const config = configManager.getConfig();
+
+// 获取 MCP 端点
+const endpoints = configManager.getMcpEndpoints();
+
+// 检查工具是否启用
+const isEnabled = configManager.isToolEnabled("weather-service", "get_weather");
+```
+
+### 更新配置
+
+```typescript
+// 更新端点
+configManager.updateMcpEndpoint("wss://new-endpoint.example.com/mcp");
+
+// 添加服务
+configManager.updateMcpServer("new-service", {
+  url: "http://localhost:4000/mcp",
+  type: "http"
+});
+
+// 设置工具启用状态
+configManager.setToolEnabled("weather-service", "get_weather", true);
+```
+
+### 添加 CustomMCP 工具
+
+```typescript
+configManager.addCustomMCPTool({
+  name: "my_custom_tool",
+  description: "自定义工具",
+  inputSchema: {
+    type: "object",
+    properties: {
+      param1: { type: "string" }
+    }
+  },
+  handler: {
+    type: "http",
+    url: "https://api.example.com/tool",
+    method: "POST"
+  }
+});
+```
+
+### 监听配置更新
+
+```typescript
+configManager.on("config:updated", (data) => {
+  console.log("配置已更新:", data);
+});
+```
+
+## 源码位置
+
+- `src/config/manager.ts` - ConfigManager 主类
+- `src/config/resolver.ts` - ConfigResolver 配置解析器
+- `src/config/adapter.ts` - 配置适配器
+- `src/config/initializer.ts` - 配置初始化器
+- `src/config/json5-adapter.ts` - JSON5 适配器

--- a/docs/content/api/esp32-device-manager.mdx
+++ b/docs/content/api/esp32-device-manager.mdx
@@ -1,0 +1,291 @@
+---
+title: "ESP32DeviceManager - Xiaozhi Client"
+description: "ESP32 设备管理器的 API 参考文档，负责管理所有 ESP32 设备的连接和消息路由。"
+---
+
+# ESP32DeviceManager
+
+ESP32DeviceManager 是 ESP32 设备管理器，负责所有 ESP32 设备的连接管理和消息路由（编排层）。这是 ESP32 SDK 的核心导出类，整合了 OTA 配置下发、WebSocket 连接管理、ASR → LLM → TTS 语音交互流水线。
+
+## 类定义
+
+```typescript
+import { ESP32DeviceManager } from "@/esp32/esp32-manager.js";
+```
+
+## 构造函数
+
+### constructor
+
+创建 ESP32DeviceManager 实例。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| options | ESP32DeviceManagerOptions | 否 | 配置选项 |
+
+**配置选项结构：**
+
+```typescript
+interface ESP32DeviceManagerOptions {
+  logger?: ILogger;                   // 日志器（可选）
+  configProvider?: IESP32ConfigProvider; // 配置提供者（可选）
+  buildWebSocketUrl?: (host: string) => string; // 自定义 WebSocket URL 构建函数
+  firmwareVersion?: string;           // 固件版本（默认：2.2.2）
+  firmwareUrl?: string;               // 固件下载 URL
+  forceUpdate?: boolean;              // 是否强制更新固件
+}
+```
+
+**示例：**
+
+```typescript
+import { ESP32DeviceManager } from "@/esp32/esp32-manager.js";
+
+const manager = new ESP32DeviceManager({
+  firmwareVersion: "2.2.2",
+  forceUpdate: false
+});
+```
+
+## 主要方法
+
+### handleOTARequest
+
+处理 OTA 请求。设备首次连接时自动激活，直接返回 WebSocket 配置。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| deviceId | string | 是 | 设备 ID（MAC 地址） |
+| clientId | string | 是 | 客户端 ID（设备 UUID） |
+| report | ESP32DeviceReport | 是 | 设备上报信息 |
+| headerInfo | `{ deviceModel?, deviceVersion? }` | 否 | 从请求头获取的设备信息 |
+| host | string | 否 | 请求的 Host 头 |
+
+**返回值：** `Promise<ESP32OTAResponse>`
+
+**返回值结构：**
+
+```typescript
+interface ESP32OTAResponse {
+  websocket: {
+    url: string;      // WebSocket URL
+    token: string;    // 认证 Token（空字符串）
+    version: number;  // 协议版本
+  };
+  server_time: {
+    timestamp: number;      // 服务器时间戳
+    timezone_offset: number; // 时区偏移
+  };
+  firmware: {
+    version: string;  // 固件版本
+    url: string;      // 固件下载 URL
+    force: boolean;   // 是否强制更新
+  };
+}
+```
+
+**示例：**
+
+```typescript
+const response = await manager.handleOTARequest(
+  "AA:BB:CC:DD:EE:FF",
+  "device-uuid-123",
+  { board_type: "esp32-s3", app_version: "2.0.0" },
+  { deviceModel: "ESP32-S3" },
+  "192.168.1.100:8080"
+);
+
+console.log("WebSocket URL:", response.websocket.url);
+```
+
+### handleWebSocketConnection
+
+处理 WebSocket 连接。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| ws | WebSocket | 是 | WebSocket 实例 |
+| deviceId | string | 是 | 设备 ID |
+| clientId | string | 是 | 客户端 ID |
+| token | string | 否 | 认证 Token（向后兼容） |
+
+**返回值：** `Promise<void>`
+
+**示例：**
+
+```typescript
+import WebSocket from "ws";
+
+// 当 WebSocket 连接建立时调用
+manager.handleWebSocketConnection(ws, deviceId, clientId);
+```
+
+### getConnection
+
+获取设备连接。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| deviceId | string | 是 | 设备 ID |
+
+**返回值：** `ESP32Connection | undefined`
+
+### getDevice
+
+获取设备信息。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| deviceId | string | 是 | 设备 ID |
+
+**返回值：** `ESP32Device | null`
+
+**返回值结构：**
+
+```typescript
+interface ESP32Device {
+  id: string;         // 设备 ID
+  boardType: string;  // 板卡类型
+  appVersion: string; // 应用版本
+  status: "active" | "offline"; // 设备状态
+  lastSeen: Date;     // 最后活跃时间
+}
+```
+
+### getASRService
+
+获取 ASR 服务实例。
+
+**返回值：** `ASRService`
+
+### destroy
+
+销毁服务，断开所有设备连接。
+
+**返回值：** `Promise<void>`
+
+**示例：**
+
+```typescript
+await manager.destroy();
+console.log("设备管理器已销毁");
+```
+
+## 使用示例
+
+### 基础使用
+
+```typescript
+import { ESP32DeviceManager } from "@/esp32/esp32-manager.js";
+import { createServer } from "http";
+import WebSocket from "ws";
+
+// 创建设备管理器
+const manager = new ESP32DeviceManager({
+  firmwareVersion: "2.2.2"
+});
+
+// 创建 HTTP 服务器处理 OTA 请求
+const server = createServer(async (req, res) => {
+  if (req.url?.startsWith("/ota")) {
+    const deviceId = req.headers["x-device-id"] as string;
+    const clientId = req.headers["x-client-id"] as string;
+
+    const response = await manager.handleOTARequest(
+      deviceId,
+      clientId,
+      { board_type: "esp32-s3" },
+      {},
+      req.headers.host
+    );
+
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(response));
+  }
+});
+
+// 创建 WebSocket 服务器
+const wsServer = new WebSocket.Server({ server });
+
+wsServer.on("connection", async (ws, req) => {
+  const deviceId = req.headers["x-device-id"] as string;
+  const clientId = req.headers["x-client-id"] as string;
+
+  await manager.handleWebSocketConnection(ws, deviceId, clientId);
+});
+```
+
+### 配置语音服务
+
+```typescript
+import { ESP32DeviceManager } from "@/esp32/esp32-manager.js";
+
+// 配置提供者实现
+class MyConfigProvider implements IESP32ConfigProvider {
+  getASRConfig() {
+    return {
+      appid: "your-appid",
+      accessToken: "your-token",
+      cluster: "volcengine_streaming_common"
+    };
+  }
+
+  getLLMConfig() {
+    return {
+      model: "gpt-4",
+      apiKey: "your-api-key",
+      baseURL: "https://api.openai.com/v1"
+    };
+  }
+
+  getTTSConfig() {
+    return {
+      appid: "your-appid",
+      accessToken: "your-token",
+      voice_type: "zh_female_tianmeixiaoyuan_moon_bigtts"
+    };
+  }
+}
+
+const manager = new ESP32DeviceManager({
+  configProvider: new MyConfigProvider()
+});
+```
+
+## 消息类型处理
+
+ESP32DeviceManager 处理以下设备消息类型：
+
+| 消息类型 | 说明 | 处理方式 |
+|----------|------|----------|
+| `hello` | 初始化消息 | 建立 ASR 连接 |
+| `listen` | 监听状态消息 | 处理唤醒词检测和监听状态 |
+| `audio` | 音频数据 | 传递给 ASR 服务处理 |
+| `text` | 文本消息 | 日志记录 |
+| `stt` | STT 结果 | 发送到设备端 |
+| `tts` | TTS 结果 | 日志记录 |
+
+## 语音交互流水线
+
+ESP32DeviceManager 实现完整的语音交互流水线：
+
+1. **唤醒词检测**：设备检测到唤醒词后发送 `listen` 消息（state: "detect"）
+2. **ASR 初始化**：管理器初始化 ASR 服务连接
+3. **音频传输**：设备发送音频数据，管理器转发给 ASR 服务
+4. **语音识别**：ASR 服务返回文本结果
+5. **LLM 处理**：管理器调用 LLM 服务生成回复
+6. **TTS 输出**：管理器调用 TTS 服务将回复转换为语音并发送给设备
+
+## 源码位置
+
+`src/esp32/esp32-manager.ts`

--- a/docs/content/api/event-bus.mdx
+++ b/docs/content/api/event-bus.mdx
@@ -1,0 +1,296 @@
+---
+title: "EventBus - Xiaozhi Client"
+description: "事件总线的 API 参考文档，提供统一的事件发布订阅机制，用于解耦各个模块之间的通信。"
+---
+
+# EventBus
+
+EventBus 是事件总线服务，提供统一的事件发布订阅机制，用于解耦各个模块之间的通信。支持配置更新、状态变更、接入点状态、服务重启、MCP 服务、工具调用等多种事件类型。
+
+## 类定义
+
+```typescript
+import { EventBus, getEventBus, destroyEventBus } from "@/server/services/event-bus.service.js";
+```
+
+## 获取实例
+
+### getEventBus
+
+获取事件总线单例实例。
+
+**返回值：** `EventBus`
+
+**示例：**
+
+```typescript
+import { getEventBus } from "@/server/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+```
+
+### destroyEventBus
+
+销毁事件总线单例。
+
+**示例：**
+
+```typescript
+import { destroyEventBus } from "@/server/services/event-bus.service.js";
+
+destroyEventBus();
+```
+
+## 主要方法
+
+### emitEvent
+
+发射事件（类型安全）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| eventName | keyof EventBusEvents | 是 | 事件名称 |
+| data | EventBusEvents[K] | 是 | 事件数据 |
+
+**返回值：** `boolean`
+
+**示例：**
+
+```typescript
+eventBus.emitEvent("mcp:service:connected", {
+  serviceName: "weather-service",
+  tools: [{ name: "get_weather", description: "获取天气" }],
+  connectionTime: new Date()
+});
+```
+
+### onEvent
+
+监听事件（类型安全）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| eventName | keyof EventBusEvents | 是 | 事件名称 |
+| listener | `(data: EventBusEvents[K]) => void` | 是 | 监听回调函数 |
+
+**返回值：** `this`
+
+**示例：**
+
+```typescript
+eventBus.onEvent("mcp:service:connected", (data) => {
+  console.log(`服务 ${data.serviceName} 已连接`);
+  console.log(`可用工具: ${data.tools.map(t => t.name).join(", ")}`);
+});
+```
+
+### onceEvent
+
+一次性监听事件（类型安全）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| eventName | keyof EventBusEvents | 是 | 事件名称 |
+| listener | `(data: EventBusEvents[K]) => void` | 是 | 监听回调函数 |
+
+**返回值：** `this`
+
+**说明：** 监听器只会在事件首次触发时执行一次，执行后自动移除。
+
+**示例：**
+
+```typescript
+eventBus.onceEvent("service:restart:completed", (data) => {
+  console.log(`服务 ${data.serviceName} 重启完成`);
+});
+```
+
+### offEvent
+
+移除事件监听器（类型安全）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| eventName | keyof EventBusEvents | 是 | 事件名称 |
+| listener | `(data: EventBusEvents[K]) => void` | 是 | 要移除的监听回调函数 |
+
+**返回值：** `this`
+
+**示例：**
+
+```typescript
+const listener = (data) => {
+  console.log("配置已更新:", data);
+};
+
+eventBus.onEvent("config:updated", listener);
+
+// 后续移除监听器
+eventBus.offEvent("config:updated", listener);
+```
+
+### getEventStats
+
+获取事件统计信息。
+
+**返回值：** `Record<string, { count: number; lastEmitted: Date }>`
+
+### getListenerStats
+
+获取监听器统计信息。
+
+**返回值：** `Record<string, number>`
+
+### clearEventStats
+
+清理事件统计。
+
+### getStatus
+
+获取事件总线状态。
+
+**返回值：**
+
+```typescript
+{
+  totalEvents: number;
+  totalListeners: number;
+  eventStats: Record<string, { count: number; lastEmitted: Date }>;
+  listenerStats: Record<string, number>;
+}
+```
+
+### destroy
+
+销毁事件总线，移除所有监听器并清理统计。
+
+## 事件类型
+
+EventBus 支持以下事件类型：
+
+### 配置相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `config:updated` | 配置更新 | `{ type, serviceName?, platformName?, timestamp }` |
+| `config:error` | 配置错误 | `{ error, operation }` |
+
+### 状态相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `status:updated` | 状态更新 | `{ status, source }` |
+| `status:error` | 状态错误 | `{ error, operation }` |
+
+### 接入点状态事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `endpoint:status:changed` | 接入点状态变更 | `{ endpoint, connected, operation, success, message?, timestamp, source }` |
+| `endpoint:reconnect:completed` | 接入点重连完成 | `{ trigger, serverName?, endpointCount, timestamp }` |
+| `endpoint:reconnect:failed` | 接入点重连失败 | `{ trigger, serverName?, error, timestamp }` |
+
+### 服务相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `service:restart:requested` | 服务重启请求 | `{ serviceName, reason?, delay, attempt, timestamp, source? }` |
+| `service:restart:started` | 服务重启开始 | `{ serviceName, reason?, attempt, timestamp }` |
+| `service:restart:completed` | 服务重启完成 | `{ serviceName, reason?, attempt, timestamp }` |
+| `service:restart:failed` | 服务重启失败 | `{ serviceName, error, attempt, timestamp }` |
+| `service:health:changed` | 服务健康状态变更 | `{ serviceName, oldStatus, newStatus, timestamp }` |
+
+### MCP 服务相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `mcp:service:connected` | MCP 服务连接成功 | `{ serviceName, tools, connectionTime }` |
+| `mcp:service:disconnected` | MCP 服务断开连接 | `{ serviceName, reason?, disconnectionTime }` |
+| `mcp:service:connection:failed` | MCP 服务连接失败 | `{ serviceName, error, attempt }` |
+| `mcp:server:added` | MCP 服务添加 | `{ serverName, config, tools, timestamp }` |
+| `mcp:server:removed` | MCP 服务移除 | `{ serverName, affectedTools, timestamp }` |
+| `mcp:server:status_changed` | MCP 服务状态变更 | `{ serverName, oldStatus, newStatus, timestamp, reason? }` |
+| `mcp:server:tools:updated` | MCP 服务工具更新 | `{ serverName, tools, addedTools, removedTools, timestamp }` |
+| `mcp:server:batch_added` | MCP 服务批量添加 | `{ totalServers, addedCount, failedCount, ... }` |
+
+### WebSocket 相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `websocket:client:connected` | WebSocket 客户端连接 | `{ clientId, timestamp }` |
+| `websocket:client:disconnected` | WebSocket 客户端断开 | `{ clientId, timestamp }` |
+| `websocket:message:received` | WebSocket 消息接收 | `{ type, data, clientId }` |
+
+### NPM 安装相关事件
+
+| 事件名 | 说明 | 数据结构 |
+|--------|------|----------|
+| `npm:install:started` | NPM 安装开始 | `{ version, installId, timestamp }` |
+| `npm:install:log` | NPM 安装日志 | `{ version, installId, type, message, timestamp }` |
+| `npm:install:completed` | NPM 安装完成 | `{ version, installId, success, duration, timestamp }` |
+| `npm:install:failed` | NPM 安装失败 | `{ version, installId, error, duration, timestamp }` |
+
+## 使用示例
+
+### 监听 MCP 服务连接
+
+```typescript
+import { getEventBus } from "@/server/services/event-bus.service.js";
+
+const eventBus = getEventBus();
+
+// 监听服务连接成功
+eventBus.onEvent("mcp:service:connected", (data) => {
+  console.log(`[${data.connectionTime}] 服务 ${data.serviceName} 已连接`);
+  console.log(`加载了 ${data.tools.length} 个工具`);
+});
+
+// 监听服务断开连接
+eventBus.onEvent("mcp:service:disconnected", (data) => {
+  console.log(`服务 ${data.serviceName} 已断开，原因: ${data.reason || "未知"}`);
+});
+```
+
+### 监听配置更新
+
+```typescript
+eventBus.onEvent("config:updated", (data) => {
+  console.log(`配置已更新，类型: ${data.type}`);
+  console.log(`时间: ${data.timestamp}`);
+
+  if (data.serviceName) {
+    console.log(`服务: ${data.serviceName}`);
+  }
+});
+```
+
+### 发射自定义事件
+
+```typescript
+// 发射服务状态变更事件
+eventBus.emitEvent("service:health:changed", {
+  serviceName: "weather-service",
+  oldStatus: "healthy",
+  newStatus: "unhealthy",
+  timestamp: Date.now()
+});
+```
+
+## 最佳实践
+
+1. **使用类型安全方法**：优先使用 `emitEvent`、`onEvent`、`offEvent` 而不是原生 EventEmitter 方法
+2. **及时移除监听器**：在模块销毁时移除事件监听器，避免内存泄漏
+3. **使用 onceEvent**：对于只需要监听一次的事件，使用 `onceEvent`
+4. **错误处理**：监听器内部错误会自动发射到 `error` 事件，可以统一监听处理
+
+## 源码位置
+
+`src/server/services/event-bus.service.ts`

--- a/docs/content/api/mcp-service-manager.mdx
+++ b/docs/content/api/mcp-service-manager.mdx
@@ -1,0 +1,318 @@
+---
+title: "MCPServiceManager - Xiaozhi Client"
+description: "MCP 服务管理器的 API 参考文档，负责管理多个 MCP 服务的连接、工具聚合和路由调用。"
+---
+
+# MCPServiceManager
+
+MCPServiceManager 是 MCP 服务管理器，负责管理多个 MCP 服务的连接、工具聚合和路由调用。它是项目核心 API 之一。
+
+## 类定义
+
+```typescript
+import { MCPServiceManager } from "@/server/lib/mcp/manager.js";
+```
+
+## 构造函数
+
+### constructor
+
+创建 MCPServiceManager 实例。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| configs | `Record<string, MCPServiceConfig>` 或 `UnifiedServerConfig` | 否 | 可选的初始服务配置或服务器配置 |
+
+**示例：**
+
+```typescript
+// 使用服务配置
+const manager = new MCPServiceManager({
+  "weather-service": {
+    url: "http://localhost:3000/mcp",
+    type: "http"
+  }
+});
+
+// 使用 UnifiedServerConfig 格式
+const manager = new MCPServiceManager({
+  name: "MCPServiceManager",
+  enableLogging: true,
+  logLevel: "info",
+  configs: {
+    "weather-service": { url: "http://localhost:3000/mcp" }
+  }
+});
+```
+
+## 主要方法
+
+### startAllServices
+
+启动所有 MCP 服务。
+
+**返回值：** `Promise<void>`
+
+**示例：**
+
+```typescript
+await manager.startAllServices();
+```
+
+### startService
+
+启动单个 MCP 服务。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serviceName | string | 是 | 服务名称 |
+
+**返回值：** `Promise<void>`
+
+**示例：**
+
+```typescript
+await manager.startService("weather-service");
+```
+
+### stopService
+
+停止单个服务。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| serviceName | string | 是 | 服务名称 |
+
+**返回值：** `Promise<void>`
+
+### stopAllServices
+
+停止所有服务。
+
+**返回值：** `Promise<void>`
+
+### addServiceConfig
+
+添加服务配置。
+
+**参数（两参数版本）：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| name | string | 是 | 服务名称 |
+| config | MCPServiceConfig | 是 | 服务配置对象 |
+
+**参数（单参数版本）：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| config | InternalMCPServiceConfig | 是 | 包含 name 的完整配置对象 |
+
+**示例：**
+
+```typescript
+// 两参数版本
+manager.addServiceConfig("weather-service", {
+  url: "http://localhost:3000/mcp",
+  type: "http"
+});
+
+// 单参数版本
+manager.addServiceConfig({
+  name: "weather-service",
+  url: "http://localhost:3000/mcp",
+  type: "http"
+});
+```
+
+### getAllTools
+
+获取所有可用工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 默认值 | 说明 |
+|--------|------|------|--------|------|
+| status | `'enabled'` \| `'disabled'` \| `'all'` | 否 | `'all'` | 工具状态过滤 |
+
+**返回值：** `EnhancedToolInfo[]`
+
+**示例：**
+
+```typescript
+// 获取所有工具
+const allTools = manager.getAllTools();
+
+// 仅获取已启用的工具
+const enabledTools = manager.getAllTools("enabled");
+
+// 仅获取已禁用的工具
+const disabledTools = manager.getAllTools("disabled");
+```
+
+### callTool
+
+调用 MCP 工具（支持标准 MCP 工具和 customMCP 工具）。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| toolName | string | 是 | 工具名称 |
+| arguments_ | `Record<string, unknown>` | 是 | 工具参数 |
+| options | `{ timeout?: number }` | 否 | 可选配置 |
+
+**返回值：** `Promise<ToolCallResult>`
+
+**示例：**
+
+```typescript
+const result = await manager.callTool("weather-service__get_weather", {
+  city: "北京"
+});
+```
+
+### hasTool
+
+检查是否存在指定工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| toolName | string | 是 | 工具名称 |
+
+**返回值：** `boolean`
+
+### getService
+
+获取指定服务实例。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| name | string | 是 | 服务名称 |
+
+**返回值：** `MCPService | undefined`
+
+### getConnectedServices
+
+获取所有已连接的服务名称。
+
+**返回值：** `string[]`
+
+### getStatus
+
+获取服务器状态（兼容 UnifiedServerStatus 格式）。
+
+**返回值：** `UnifiedServerStatus`
+
+**返回值结构：**
+
+```typescript
+interface UnifiedServerStatus {
+  isRunning: boolean;
+  serviceStatus: ManagerStatus;
+  activeConnections: number;
+  config: UnifiedServerConfig;
+  services: Record<string, ServiceInfo>;
+  totalTools: number;
+  availableTools: string[];
+}
+```
+
+### getRetryStats
+
+获取重试统计信息。
+
+**返回值：**
+
+```typescript
+{
+  failedServices: string[];
+  activeRetries: string[];
+  totalFailed: number;
+  totalActiveRetries: number;
+}
+```
+
+### getCustomMCPTools
+
+获取所有 customMCP 工具列表。
+
+**返回值：** `Tool[]`
+
+### getCustomMCPHandler
+
+获取 CustomMCP 处理器实例。
+
+**返回值：** `CustomMCPHandler`
+
+## 生命周期方法
+
+### start
+
+启动管理器。
+
+**返回值：** `Promise<void>`
+
+### stop
+
+停止管理器。
+
+**返回值：** `Promise<void>`
+
+### cleanup
+
+清理资源（实现 IMCPServiceManager 接口）。
+
+**返回值：** `Promise<void>`
+
+## 相关类型
+
+### MCPServiceConfig
+
+```typescript
+type MCPServiceConfig =
+  | LocalMCPServerConfig    // 本地 MCP 服务
+  | SSEMCPServerConfig      // SSE MCP 服务
+  | HTTPMCPServerConfig;    // HTTP MCP 服务
+```
+
+### EnhancedToolInfo
+
+```typescript
+interface EnhancedToolInfo {
+  name: string;           // 工具名称（格式：服务名__工具名）
+  description: string;    // 工具描述
+  inputSchema: object;    // 输入参数 Schema
+  serviceName: string;    // 所属服务名
+  originalName: string;   // 原始工具名
+  enabled: boolean;       // 是否启用
+  usageCount: number;     // 使用次数
+  lastUsedTime: string;   // 最后使用时间
+}
+```
+
+## 事件系统
+
+MCPServiceManager 通过 EventBus 发射以下事件：
+
+| 事件名 | 说明 |
+|--------|------|
+| `mcp:service:connected` | 服务连接成功 |
+| `mcp:service:disconnected` | 服务断开连接 |
+| `mcp:service:connection:failed` | 服务连接失败 |
+| `mcp:server:added` | MCP 服务添加 |
+| `mcp:server:removed` | MCP 服务移除 |
+
+## 源码位置
+
+`src/server/lib/mcp/manager.ts`

--- a/docs/content/api/mcp-service.mdx
+++ b/docs/content/api/mcp-service.mdx
@@ -1,0 +1,217 @@
+---
+title: "MCPService - Xiaozhi Client"
+description: "MCP 服务连接类的 API 参考文档，负责管理单个 MCP 服务的连接和工具调用。"
+---
+
+# MCPService
+
+MCPService 是 MCP 服务连接类（向后兼容包装器），负责管理单个 MCP 服务的连接、工具管理和调用。它包装了 `mcp-core` 的 MCPConnection 类，使用 EventBus 发射事件。
+
+## 类定义
+
+```typescript
+import { MCPService } from "@/server/lib/mcp/connection.js";
+```
+
+## 构造函数
+
+### constructor
+
+创建 MCPService 实例。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| config | InternalMCPServiceConfig | 是 | 服务配置对象 |
+
+**配置结构：**
+
+```typescript
+interface InternalMCPServiceConfig {
+  name: string;           // 服务名称
+  url?: string;           // HTTP/SSE 服务 URL
+  command?: string;       // 本地服务命令
+  args?: string[];        // 命令参数
+  env?: Record<string, string>; // 环境变量
+  type?: "http" | "sse";  // 传输类型
+  headers?: Record<string, string>; // HTTP headers
+}
+```
+
+**示例：**
+
+```typescript
+const service = new MCPService({
+  name: "weather-service",
+  url: "http://localhost:3000/mcp",
+  type: "http"
+});
+```
+
+## 主要方法
+
+### connect
+
+连接到 MCP 服务。
+
+**返回值：** `Promise<void>`
+
+**示例：**
+
+```typescript
+await service.connect();
+```
+
+### disconnect
+
+断开连接。
+
+**返回值：** `Promise<void>`
+
+### callTool
+
+调用工具。
+
+**参数：**
+
+| 参数名 | 类型 | 必填 | 说明 |
+|--------|------|------|------|
+| name | string | 是 | 工具名称 |
+| arguments_ | `Record<string, unknown>` | 是 | 工具参数 |
+
+**返回值：** `Promise<ToolCallResult>`
+
+**示例：**
+
+```typescript
+const result = await service.callTool("get_weather", {
+  city: "北京"
+});
+```
+
+### getTools
+
+获取工具列表。
+
+**返回值：** `Tool[]`
+
+**返回值结构：**
+
+```typescript
+interface Tool {
+  name: string;           // 工具名称
+  description?: string;   // 工具描述
+  inputSchema: object;    // 输入参数 Schema
+}
+```
+
+### getConfig
+
+获取服务配置。
+
+**返回值：** 服务配置对象
+
+### getStatus
+
+获取服务状态。
+
+**返回值：**
+
+```typescript
+interface ServiceStatus {
+  connected: boolean;     // 是否已连接
+  connectionTime?: Date;  // 连接时间
+  error?: Error;          // 错误信息
+}
+```
+
+### isConnected
+
+检查是否已连接。
+
+**返回值：** `boolean`
+
+## 使用示例
+
+### 创建并连接服务
+
+```typescript
+import { MCPService } from "@/server/lib/mcp/connection.js";
+
+// 创建服务实例
+const service = new MCPService({
+  name: "my-service",
+  url: "http://localhost:3000/mcp",
+  type: "http"
+});
+
+// 连接服务
+try {
+  await service.connect();
+  console.log("服务已连接");
+
+  // 获取工具列表
+  const tools = service.getTools();
+  console.log("可用工具:", tools.map(t => t.name));
+} catch (error) {
+  console.error("连接失败:", error);
+}
+```
+
+### 调用工具
+
+```typescript
+// 检查连接状态
+if (service.isConnected()) {
+  const result = await service.callTool("some_tool", {
+    param1: "value1",
+    param2: "value2"
+  });
+
+  if (result.isError) {
+    console.error("工具调用失败:", result.content);
+  } else {
+    console.log("工具调用成功:", result.content);
+  }
+}
+```
+
+### 断开连接
+
+```typescript
+await service.disconnect();
+console.log("服务已断开");
+```
+
+## 事件发射
+
+MCPService 通过 EventBus 发射以下事件：
+
+| 事件名 | 触发时机 | 数据结构 |
+|--------|----------|----------|
+| `mcp:service:connected` | 服务连接成功 | `{ serviceName, tools, connectionTime }` |
+| `mcp:service:disconnected` | 服务断开连接 | `{ serviceName, reason?, disconnectionTime }` |
+| `mcp:service:connection:failed` | 服务连接失败 | `{ serviceName, error, attempt }` |
+
+## 与 MCPServiceManager 的关系
+
+MCPService 通常不直接使用，而是通过 MCPServiceManager 进行管理：
+
+```typescript
+import { MCPServiceManager } from "@/server/lib/mcp/manager.js";
+
+const manager = new MCPServiceManager();
+manager.addServiceConfig("my-service", { url: "..." });
+await manager.startAllServices();
+
+// 通过管理器获取服务实例
+const service = manager.getService("my-service");
+
+// 或直接调用工具
+const result = await manager.callTool("my-service__tool_name", { ... });
+```
+
+## 源码位置
+
+`src/server/lib/mcp/connection.ts`


### PR DESCRIPTION
生成以下 API 参考文档：
- docs/content/api/mcp-service-manager.mdx - MCPServiceManager API 参考
- docs/content/api/mcp-service.mdx - MCPService API 参考
- docs/content/api/esp32-device-manager.mdx - ESP32DeviceManager API 参考
- docs/content/api/event-bus.mdx - EventBus API 参考
- docs/content/api/config-system.mdx - 配置系统 API 参考

解决了 Issue #3399 中缺失 API 参考文档的问题。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3399