### PR TITLE
docs: 修复 unified-response-format.mdx 中的无效链接

### DIFF
--- a/docs/content/contribution/unified-response-format.mdx
+++ b/docs/content/contribution/unified-response-format.mdx
@@ -624,5 +624,4 @@ return c.json({ success: false, error: { code, message } });
 ## 相关文档
 
 - [Hono 官方文档](https://hono.dev/)
-- [xiaozhi-client 中间件系统](/docs/reference/middleware)
-- [API 路由开发指南](/docs/development/api-routes)
+- [快速上手](/quickstart)


### PR DESCRIPTION
移除两个不存在的文档引用链接：
- /docs/reference/middleware
- /docs/development/api-routes

替换为有效的快速上手文档链接 (/quickstart)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3401