### PR TITLE
docs: 更新 coze-workflow.mdx 版本号说明

### DIFF
--- a/docs/content/usage/coze-workflow.mdx
+++ b/docs/content/usage/coze-workflow.mdx
@@ -8,7 +8,7 @@ import { ImageZoom, Callout, Steps } from "nextra/components";
 # 集成扣子工作流
 
 <Callout type="info">
-  **前期准备**: 请先将 xiaozhi-client 升级到 1.7.4 及以上版本
+  **前期准备**: 请使用最新版本的 xiaozhi-client
 </Callout>
 
 <Steps>


### PR DESCRIPTION
将文档中的版本要求从过时的 "1.7.4 及以上版本" 更改为
"请使用最新版本的 xiaozhi-client"，避免用户误解。

Closes #3405

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3405