### PR TITLE
fix: asrService 调试音频写入失败时记录日志而非静默忽略

### DIFF
--- a/src/esp32/services/asr.service.ts
+++ b/src/esp32/services/asr.service.ts
@@ -334,7 +334,9 @@ export class ASRService implements IASRService {
 
     import("node:fs/promises")
       .then((fs) => fs.writeFile(filePath, opusData))
-      .catch(() => {}); // 写入失败静默忽略
+      .catch((error) => {
+        this.logger.debug(`调试音频文件写入失败: ${filePath}`, error);
+      });
   }
 
   /** 静音超时时间（毫秒），超过此时间无新音频数据则认为语音结束 */


### PR DESCRIPTION
将空 catch 块替换为带有 debug 级别日志记录的错误处理，
便于开发者了解调试音频文件写入是否成功。

Closes #3408

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3408