### PR TITLE
refactor(build): 清理未使用的 @/server 路径别名

### DIFF
--- a/src/vitest.config.ts
+++ b/src/vitest.config.ts
@@ -26,7 +26,6 @@ export default defineConfig({
       "@/endpoint": resolve(__dirname, "./endpoint"),
       "@/esp32": resolve(__dirname, "./esp32"),
       "@/cli": resolve(__dirname, "./cli"),
-      "@/server": resolve(__dirname, "./server"),
       // Web 前端路径别名（与 src/web/vitest.config.ts 保持一致）
       "@": resolve(__dirname, "./web"),
       "@components": resolve(__dirname, "./web/components"),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -30,8 +30,7 @@
       "@/endpoint": ["./src/endpoint"],
       "@/esp32": ["./src/esp32"],
       "@/cli": ["./src/cli"],
-      "@/utils": ["./src/utils"],
-      "@/server": ["./src/server"]
+      "@/utils": ["./src/utils"]
     }
   },
   "include": ["mcps/**/*", "src/**/*"],


### PR DESCRIPTION
## Summary

- 移除 `tsconfig.json` 中未使用的 `@/server` 路径别名定义
- 移除 `src/vitest.config.ts` 中对应的 `@/server` 映射
- 源码中已无任何文件使用 `from "@/server/..."` 导入，这些定义为残留物
- 属于 tsup 构建配置简化计划的 **Phase 2**

## Test plan

- [x] `pnpm build` 构建成功
- [x] `pnpm typecheck` 类型检查通过
- [x] `pnpm lint` 代码规范检查通过（438 文件无问题）
- [x] `pnpm test` 全部测试通过（125 文件 / 2462 测试）
- [x] 确认源码中无 `@/server` 引用残留