### PR TITLE
refactor(build): 简化 tsup 构建配置 — 移除冗余的文件复制和 polyfill 逻辑

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xiaozhi-client": "dist/cli/index.js"
   },
   "scripts": {
-    "build": "pnpm run clean:dist && pnpm run build:server && pnpm run build:cli && pnpm run build:web",
+    "build": "pnpm run clean:dist && pnpm run build:server && pnpm run build:cli && cp -r templates dist/cli/templates && pnpm run build:web",
     "build:server": "cd src/server && tsup",
     "build:cli": "cd src/cli && tsup",
     "build:web": "cd src/web && vite build",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "xiaozhi-client": "dist/cli/index.js"
   },
   "scripts": {
-    "build": "pnpm run clean:dist && pnpm run build:server && pnpm run build:cli && cp -r templates dist/cli/templates && pnpm run build:web",
+    "build": "pnpm run clean:dist && pnpm run build:server && pnpm run build:cli && node -e \"import('node:fs').then(({ cpSync }) => cpSync('templates', 'dist/cli/templates', { recursive: true }))\" && pnpm run build:web",
     "build:server": "cd src/server && tsup",
     "build:cli": "cd src/cli && tsup",
     "build:web": "cd src/web && vite build",

--- a/src/server/tsup.config.ts
+++ b/src/server/tsup.config.ts
@@ -1,46 +1,5 @@
-import {
-  copyFileSync,
-  existsSync,
-  mkdirSync,
-  readdirSync,
-  statSync,
-} from "node:fs";
-import { join } from "node:path";
 import { defineConfig } from "tsup";
 import { getVersionDefine } from "../build/version";
-
-/**
- * 递归复制目录 - 跨平台实现
- */
-function copyDirectory(
-  src: string,
-  dest: string,
-  excludePatterns: string[] = []
-): void {
-  // 创建目标目录
-  if (!existsSync(dest)) {
-    mkdirSync(dest, { recursive: true });
-  }
-
-  const items = readdirSync(src);
-
-  for (const item of items) {
-    // 检查是否应该排除此项
-    if (excludePatterns.some((pattern) => item.includes(pattern))) {
-      continue;
-    }
-
-    const srcPath = join(src, item);
-    const destPath = join(dest, item);
-    const stat = statSync(srcPath);
-
-    if (stat.isDirectory()) {
-      copyDirectory(srcPath, destPath, excludePatterns);
-    } else {
-      copyFileSync(srcPath, destPath);
-    }
-  }
-}
 
 export default defineConfig({
   entry: ["./WebServer.ts", "./WebServerLauncher.ts", "./Logger.ts"],
@@ -68,15 +27,6 @@ export default defineConfig({
     options.define = {
       ...options.define,
       ...getVersionDefine(import.meta.dirname ?? __dirname),
-    };
-
-    // 注入 require polyfill：让打包的 CJS 依赖中的 require() 在 ESM 环境下正常工作
-    options.banner = {
-      js: [
-        "import { createRequire } from 'node:module';",
-        "const require = createRequire(import.meta.url);",
-        "var __require = require;",
-      ].join("\n"),
     };
   },
   outExtension() {
@@ -107,40 +57,4 @@ export default defineConfig({
     "prism-media",
     "univoice",
   ],
-  onSuccess: async () => {
-    // 复制配置文件到 dist/backend
-    const distDir = "../../dist/backend";
-
-    // 确保 dist/backend 目录存在
-    if (!existsSync(distDir)) {
-      mkdirSync(distDir, { recursive: true });
-    }
-
-    // 复制 xiaozhi.config.default.json
-    if (existsSync("../../xiaozhi.config.default.json")) {
-      copyFileSync(
-        "../../xiaozhi.config.default.json",
-        join(distDir, "xiaozhi.config.default.json")
-      );
-      console.log("✅ 已复制 xiaozhi.config.default.json 到 dist/backend/");
-    }
-
-    // 复制 package.json 到 dist/backend 目录，以便运行时能读取版本号
-    if (existsSync("../../package.json")) {
-      copyFileSync("../../package.json", join(distDir, "package.json"));
-      console.log("✅ 已复制 package.json 到 dist/backend/");
-    }
-
-    // 复制 templates 目录到 dist/backend 目录
-    if (existsSync("../../templates")) {
-      try {
-        copyDirectory("../../templates", join(distDir, "templates"));
-        console.log("✅ 已复制 templates 目录到 dist/backend/");
-      } catch (error) {
-        console.warn("⚠️ 复制 templates 目录失败:", error);
-      }
-    }
-
-    console.log("✅ 构建完成，产物现在为 ESM 格式");
-  },
 });


### PR DESCRIPTION
## Summary

- 从 `src/server/tsup.config.ts` 中移除 `copyDirectory` 递归复制函数（~30 行）
- 移除 `require` polyfill banner 注入（不再需要）
- 移除 `onSuccess` 钩子中的配置文件和模板目录复制逻辑（~40 行）
- 将 `templates` 目录复制迁移到 `package.json` 的 `build` 脚本中直接执行

**净效果**：tsup 配置文件从 ~110 行简化到 ~60 行，移除了 87 行冗余代码。

## 变更详情

| 文件 | 变更 |
|------|------|
| `package.json` | build 脚本增加 `cp -r templates dist/cli/templates` |
| `src/server/tsup.config.ts` | 删除 copyDirectory 函数、banner 注入、onSuccess 钩子 |

## 测试计划

- [ ] `pnpm build` 验证构建产物正确
- [ ] 确认 `dist/cli/templates/` 目录存在且内容完整
- [ ] 确认 `dist/backend/` 目录结构符合预期