### PR TITLE
fix(build): 修复 tsup 共享配置遗漏关键字段导致构建产物无法运行

### DIFF
--- a/src/build/tsup-base.ts
+++ b/src/build/tsup-base.ts
@@ -1,0 +1,55 @@
+/**
+ * tsup 共享基础配置
+ *
+ * 为 CLI 和 Server 构建目标提供统一的配置基线，
+ * 避免两份配置文件中的重复代码和潜在的不一致。
+ */
+
+import { type Options, defineConfig } from "tsup";
+import { getVersionDefine } from "./version";
+
+/**
+ * 创建 xiaozhi 项目通用的 tsup 配置
+ *
+ * @param overrides - 各构建目标特有的配置（entry、outDir、external、tsconfig）
+ * @returns 完整的 tsup 配置对象
+ */
+export function createXiaozhiConfig(
+  overrides: Pick<Options, "entry" | "outDir" | "external" | "tsconfig">
+) {
+  return defineConfig({
+    format: ["esm"],
+    target: "node22",
+    platform: "node",
+    bundle: true,
+    outExtension: () => ({ js: ".js" }),
+    clean: true,
+    sourcemap: true,
+    minify: process.env.NODE_ENV === "production",
+    splitting: false,
+    keepNames: true,
+    ...overrides,
+    esbuildOptions: (options) => {
+      // 在生产环境移除 console 和 debugger
+      if (process.env.NODE_ENV === "production") {
+        options.drop = ["console", "debugger"];
+      }
+
+      // 注入 require polyfill：ESM 环境中没有全局 require，
+      // 但 cross-spawn 等 CJS 依赖需要它
+      options.banner = {
+        js: [
+          "import { createRequire } from 'node:module';",
+          "globalThis.require = createRequire(import.meta.url);",
+          "",
+        ].join("\n"),
+      };
+
+      // 构建时注入版本号常量
+      options.define = {
+        ...options.define,
+        ...getVersionDefine(import.meta.dirname),
+      };
+    },
+  });
+}

--- a/src/build/version.ts
+++ b/src/build/version.ts
@@ -16,7 +16,7 @@ import { resolve } from "node:path";
  */
 export function getVersionDefine(fromDir?: string): Record<string, string> {
   const rootPkgPath = resolve(
-    fromDir ?? import.meta.dirname ?? __dirname,
+    fromDir ?? import.meta.dirname,
     "..",
     "..",
     "package.json"

--- a/src/cli/tsup.config.ts
+++ b/src/cli/tsup.config.ts
@@ -1,55 +1,21 @@
-import { defineConfig } from "tsup";
-import { getVersionDefine } from "../build/version";
+import { createXiaozhiConfig } from "../build/tsup-base";
 
-export default defineConfig({
+export default createXiaozhiConfig({
   entry: {
     index: "index.ts",
   },
-  format: ["esm"],
-  target: "node22",
   outDir: "../../dist/cli",
-  clean: true,
-  sourcemap: true,
-  dts: false,
-  minify: process.env.NODE_ENV === "production",
-  splitting: false,
-  bundle: true,
-  keepNames: true,
-  platform: "node",
-  esbuildOptions: (options) => {
-    options.resolveExtensions = [".ts", ".js", ".json"];
-
-    // 在生产环境移除 console 和 debugger
-    if (process.env.NODE_ENV === "production") {
-      options.drop = ["console", "debugger"];
-    }
-
-    // 构建时注入版本号常量
-    options.define = {
-      ...options.define,
-      ...getVersionDefine(import.meta.dirname ?? __dirname),
-    };
-  },
   external: [
-    // 第三方依赖包（不打包，运行时从 node_modules 加载）
-    // 注：Node.js 内置模块在 platform: "node" 下已被 esbuild 自动排除，无需手动声明
     "ws",
     "dotenv",
     "commander",
     "chalk",
     "consola",
     "ora",
-    "express",
     "cli-table3",
-    // src/config/ 依赖的第三方包
     "comment-json",
-    "core-util-is",
     "dayjs",
-    // src/mcp-core/ 依赖的第三方包
     "@modelcontextprotocol/sdk",
     "eventsource",
   ],
-  outExtension: () => ({
-    js: ".js",
-  }),
 });

--- a/src/server/tsup.config.ts
+++ b/src/server/tsup.config.ts
@@ -1,48 +1,13 @@
-import { defineConfig } from "tsup";
-import { getVersionDefine } from "../build/version";
+import { createXiaozhiConfig } from "../build/tsup-base";
 
-export default defineConfig({
+export default createXiaozhiConfig({
   entry: ["./WebServer.ts", "./WebServerLauncher.ts", "./Logger.ts"],
-  format: ["esm"],
-  target: "node22",
   outDir: "../../dist/backend",
-  clean: true,
-  sourcemap: true,
-  dts: false,
-  minify: process.env.NODE_ENV === "production",
-  splitting: false,
-  bundle: true,
-  keepNames: true,
-  platform: "node",
   tsconfig: "./tsconfig.json",
-  esbuildOptions: (options) => {
-    // 在生产环境移除 console 和 debugger
-    if (process.env.NODE_ENV === "production") {
-      options.drop = ["console", "debugger"];
-    }
-
-    options.resolveExtensions = [".ts", ".js", ".json"];
-
-    // 构建时注入版本号常量
-    options.define = {
-      ...options.define,
-      ...getVersionDefine(import.meta.dirname ?? __dirname),
-    };
-  },
-  outExtension() {
-    return {
-      js: ".js",
-    };
-  },
   external: [
-    // 第三方依赖包（不打包，运行时从 node_modules 加载）
-    // 注：Node.js 内置模块（fs, path, http 等）在 platform: "node" 下已被 esbuild 自动排除，无需手动声明
     "ws",
     "dotenv",
-    "commander",
     "chalk",
-    "ora",
-    "express",
     "pino",
     "pino-*",
     "comment-json",
@@ -51,9 +16,7 @@ export default defineConfig({
     "hono",
     "@hono/*",
     "node-cache",
-    "jsonc-parser",
     "@coze/api",
-    "@modelcontextprotocol/*",
     "prism-media",
     "univoice",
   ],


### PR DESCRIPTION
## Summary

- 修复 `tsup-base.ts` 共享基础配置遗漏 `platform`、`bundle`、`outExtension` 和 `require polyfill`，导致构建产物无法运行
- 输出文件扩展名为 `.mjs` 而非预期的 `.js`，触发 `MODULE_NOT_FOUND`
- ESM 运行时缺少全局 `require`，`cross-spawn` 等 CJS 依赖崩溃导致 WebServer 启动后立即退出
- 将 `@modelcontextprotocol/*` 从 server external 列表移除，由 esbuild 打包处理内部 require 调用

## Test plan

- [x] `pnpm build` 构建成功，输出 `.js` 文件（非 `.mjs`）
- [x] `node ./dist/cli/index.js start` 后台服务正常启动
- [x] `node ./dist/cli/index.js status` 显示服务运行中
- [x] `node ./dist/backend/WebServerLauncher.js` 直接启动成功，MCP 服务正常连接