### PR TITLE
fix(web): 排除 node_modules 避免 Tailwind CSS 构建性能警告

### DIFF
--- a/src/web/tailwind.config.js
+++ b/src/web/tailwind.config.js
@@ -1,7 +1,7 @@
 /** @type {import('tailwindcss').Config} */
 export default {
   darkMode: ["class"],
-  content: ["./index.html", "./**/*.{js,ts,jsx,tsx}"],
+  content: ["./index.html", "./**/*.{js,ts,jsx,tsx}", "!./node_modules/**"],
   theme: {
     container: {
       center: true,


### PR DESCRIPTION
## Summary
- 修复 Tailwind CSS `content` 配置中 `./**/*.ts` 模式误匹配 `node_modules` 目录的问题，消除构建时的性能警告

## Test plan
- [ ] `cd src/web && vite build` 确认不再出现 content pattern 警告
- [ ] 访问 http://localhost:9999/dashboard 确认样式正常渲染