### PR TITLE
fix: 统一 CustomMCPTool 类型定义，消除重复定义

### DIFF
--- a/src/config/manager.ts
+++ b/src/config/manager.ts
@@ -144,113 +144,38 @@ export interface ToolCallLogConfig {
   logFilePath?: string; // 自定义日志文件路径（可选）
 }
 
-// CustomMCP 相关接口定义
+// CustomMCP 相关类型定义（从 @/types 导入，统一权威定义）
+import type {
+  ChainHandlerConfig,
+  CustomMCPToolConfig,
+  FunctionHandlerConfig,
+  HttpHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  ScriptHandlerConfig,
+  ToolHandlerConfig,
+} from "@/types";
 
-// 代理处理器配置
-export interface ProxyHandlerConfig {
-  type: "proxy";
-  platform: "coze" | "openai" | "anthropic" | "custom";
-  config: {
-    // Coze 平台配置
-    workflow_id?: string;
-    bot_id?: string;
-    api_key?: string;
-    base_url?: string;
-    // 通用配置
-    timeout?: number;
-    retry_count?: number;
-    retry_delay?: number;
-    headers?: Record<string, unknown>;
-    params?: Record<string, unknown>;
-  };
-}
+// 为配置管理器内部使用，将 CustomMCPToolConfig 别名为 CustomMCPTool
+// 保持向后兼容性，同时使用权威类型定义
+type CustomMCPTool = CustomMCPToolConfig;
 
-// HTTP 处理器配置
-export interface HttpHandlerConfig {
-  type: "http";
-  url: string;
-  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
-  headers?: Record<string, string>;
-  timeout?: number;
-  retry_count?: number;
-  retry_delay?: number;
-  auth?: {
-    type: "bearer" | "basic" | "api_key";
-    token?: string;
-    username?: string;
-    password?: string;
-    api_key?: string;
-    api_key_header?: string;
-  };
-  body_template?: string; // 支持模板变量替换
-  response_mapping?: {
-    success_path?: string; // JSONPath 表达式
-    error_path?: string;
-    data_path?: string;
-  };
-}
+// HandlerConfig 别名，用于内部类型检查
+type HandlerConfig = ToolHandlerConfig;
 
-// 函数处理器配置
-export interface FunctionHandlerConfig {
-  type: "function";
-  module: string; // 模块路径
-  function: string; // 函数名
-  timeout?: number;
-  context?: Record<string, unknown>; // 函数执行上下文
-}
+// 重新导出类型，保持向后兼容（其他文件从 @/config 导入这些类型）
+export type {
+  ChainHandlerConfig,
+  FunctionHandlerConfig,
+  HttpHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  ScriptHandlerConfig,
+  ToolHandlerConfig as HandlerConfig,
+  CustomMCPToolConfig as CustomMCPTool,
+};
 
-// 脚本处理器配置
-export interface ScriptHandlerConfig {
-  type: "script";
-  script: string; // 脚本内容或文件路径
-  interpreter?: "node" | "python" | "bash";
-  timeout?: number;
-  env?: Record<string, string>; // 环境变量
-}
-
-// 链式处理器配置
-export interface ChainHandlerConfig {
-  type: "chain";
-  tools: string[]; // 要链式调用的工具名称
-  mode: "sequential" | "parallel"; // 执行模式
-  error_handling: "stop" | "continue" | "retry"; // 错误处理策略
-}
-
-// MCP 处理器配置（用于同步的工具）
-export interface MCPHandlerConfig {
-  type: "mcp";
-  config: {
-    serviceName: string;
-    toolName: string;
-  };
-}
-
-export type HandlerConfig =
-  | ProxyHandlerConfig
-  | HttpHandlerConfig
-  | FunctionHandlerConfig
-  | ScriptHandlerConfig
-  | ChainHandlerConfig
-  | MCPHandlerConfig;
-
-// CustomMCP 工具接口
-// TODO: 注意：此定义应与 @/types 中的 CustomMCPToolConfig 保持一致
-// 未来将迁移到从 shared-types 导入
-export interface CustomMCPTool {
-  // 确保必填字段
-  name: string;
-  description: string;
-  inputSchema: Record<string, unknown>;
-  handler: HandlerConfig;
-
-  // 使用统计信息（可选）
-  stats?: {
-    usageCount?: number; // 工具使用次数
-    lastUsedTime?: string; // 最后使用时间（ISO 8601格式）
-  };
-}
-
-// CustomMCP 配置接口
+// CustomMCP 配置接口（使用权威类型）
 export interface CustomMCPConfig {
   tools: CustomMCPTool[];
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -25,6 +25,14 @@ export type {
   CustomMCPToolWithStats,
   CustomMCPToolConfig,
   JSONSchema,
+  // 处理器配置类型
+  ToolHandlerConfig,
+  MCPHandlerConfig,
+  ProxyHandlerConfig,
+  HttpHandlerConfig,
+  FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
 } from "./mcp";
 
 // 工具API相关类型

--- a/src/types/mcp/index.ts
+++ b/src/types/mcp/index.ts
@@ -57,6 +57,8 @@ export type {
   ProxyHandlerConfig,
   HttpHandlerConfig,
   FunctionHandlerConfig,
+  ScriptHandlerConfig,
+  ChainHandlerConfig,
 } from "./tool-definition";
 
 // JSON Schema 类型

--- a/src/types/mcp/schema.ts
+++ b/src/types/mcp/schema.ts
@@ -5,19 +5,23 @@
 
 /**
  * JSON Schema 类型
- * 带类型守卫的严格 JSON Schema 类型定义
+ * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
+ *
+ * 注意：此定义与 src/server/lib/mcp/types.ts 中的 JSONSchema 保持一致
+ * 支持严格的结构化定义和宽松的 Record<string, unknown> 格式
  */
-export interface JSONSchema {
-  type?: string | string[];
-  properties?: Record<string, JSONSchema>;
-  required?: string[];
-  items?: JSONSchema;
-  additionalProperties?: boolean | JSONSchema;
-  description?: string;
-  enum?: unknown[];
-  const?: unknown;
-  [key: string]: unknown;
-}
+export type JSONSchema =
+  | (Record<string, unknown> & {
+      type?: string | string[];
+      properties?: Record<string, unknown>;
+      required?: string[];
+      items?: unknown;
+      additionalProperties?: boolean | unknown;
+      description?: string;
+      enum?: unknown[];
+      const?: unknown;
+    })
+  | Record<string, unknown>;
 
 /**
  * 检查值是否为有效的 JSON Schema

--- a/src/types/mcp/tool-definition.ts
+++ b/src/types/mcp/tool-definition.ts
@@ -7,12 +7,15 @@ import type { JSONSchema } from "./schema.js";
 
 /**
  * 工具处理器配置联合类型
+ * 包含所有支持的处理器类型
  */
 export type ToolHandlerConfig =
   | MCPHandlerConfig
   | ProxyHandlerConfig
   | HttpHandlerConfig
-  | FunctionHandlerConfig;
+  | FunctionHandlerConfig
+  | ScriptHandlerConfig
+  | ChainHandlerConfig;
 
 /**
  * MCP 处理器配置
@@ -33,7 +36,19 @@ export interface MCPHandlerConfig {
 export interface ProxyHandlerConfig {
   type: "proxy";
   platform: "coze" | "openai" | "anthropic" | "custom";
-  config: Record<string, unknown>;
+  config: {
+    // Coze 平台配置
+    workflow_id?: string;
+    bot_id?: string;
+    api_key?: string;
+    base_url?: string;
+    // 通用配置
+    timeout?: number;
+    retry_count?: number;
+    retry_delay?: number;
+    headers?: Record<string, unknown>;
+    params?: Record<string, unknown>;
+  };
 }
 
 /**
@@ -42,10 +57,25 @@ export interface ProxyHandlerConfig {
  */
 export interface HttpHandlerConfig {
   type: "http";
-  config: {
-    url: string;
-    method?: string;
-    headers?: Record<string, string>;
+  url: string;
+  method?: "GET" | "POST" | "PUT" | "DELETE" | "PATCH";
+  headers?: Record<string, string>;
+  timeout?: number;
+  retry_count?: number;
+  retry_delay?: number;
+  auth?: {
+    type: "bearer" | "basic" | "api_key";
+    token?: string;
+    username?: string;
+    password?: string;
+    api_key?: string;
+    api_key_header?: string;
+  };
+  body_template?: string;
+  response_mapping?: {
+    success_path?: string;
+    error_path?: string;
+    data_path?: string;
   };
 }
 
@@ -55,10 +85,33 @@ export interface HttpHandlerConfig {
  */
 export interface FunctionHandlerConfig {
   type: "function";
-  config: {
-    module: string;
-    function: string;
-  };
+  module: string;
+  function: string;
+  timeout?: number;
+  context?: Record<string, unknown>;
+}
+
+/**
+ * 脚本处理器配置
+ * 用于脚本执行工具
+ */
+export interface ScriptHandlerConfig {
+  type: "script";
+  script: string;
+  interpreter?: "node" | "python" | "bash";
+  timeout?: number;
+  env?: Record<string, string>;
+}
+
+/**
+ * 链式处理器配置
+ * 用于链式调用多个工具
+ */
+export interface ChainHandlerConfig {
+  type: "chain";
+  tools: string[];
+  mode: "sequential" | "parallel";
+  error_handling: "stop" | "continue" | "retry";
 }
 
 /**


### PR DESCRIPTION
问题：
- src/config/manager.ts 和 src/types/mcp/tool-definition.ts 存在重复的
  CustomMCPTool 和 HandlerConfig 类型定义
- 违反 DRY 原则，增加维护成本和潜在不一致风险

解决方案：
1. 将所有 HandlerConfig 类型（包括 ScriptHandlerConfig、ChainHandlerConfig）
   统一到 src/types/mcp/tool-definition.ts 作为权威定义源
2. src/config/manager.ts 从 @/types 导入类型，移除重复定义
3. 更新 JSONSchema 类型使其更灵活，兼容配置场景
4. 保持向后兼容性：manager.ts 重新导出导入的类型

变更文件：
- src/types/mcp/tool-definition.ts: 增加详细的 HandlerConfig 类型定义
- src/types/mcp/schema.ts: 更新 JSONSchema 为更灵活的联合类型
- src/config/manager.ts: 从 @/types 导入类型，移除重复定义
- src/types/index.ts: 导出新增的 HandlerConfig 类型
- src/types/mcp/index.ts: 导出 ScriptHandlerConfig、ChainHandlerConfig

Closes #3410

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3410