### PR TITLE
refactor(server): 消除 prompt-utils.ts 路径验证逻辑重复

### DIFF
--- a/src/server/utils/prompt-utils.ts
+++ b/src/server/utils/prompt-utils.ts
@@ -285,6 +285,31 @@ export function resolvePromptPath(relativePath: string): string {
 }
 
 /**
+ * 验证并解析路径，确保文件存在
+ *
+ * @param relativePath - 相对路径（如 ./prompts/default.md）
+ * @returns 绝对路径
+ * @throws 如果路径无效或文件不存在
+ */
+function validateAndResolvePath(relativePath: string): string {
+  // 验证路径
+  const validation = validatePromptPath(relativePath);
+  if (!validation.valid) {
+    throw new Error(validation.error);
+  }
+
+  // 解析绝对路径
+  const absolutePath = resolvePromptPath(relativePath);
+
+  // 检查文件是否存在
+  if (!existsSync(absolutePath)) {
+    throw new Error(`文件不存在: ${relativePath}`);
+  }
+
+  return absolutePath;
+}
+
+/**
  * 提示词文件内容信息
  */
 export interface PromptFileContent {
@@ -304,19 +329,7 @@ export interface PromptFileContent {
  * @throws 如果路径无效或文件不存在
  */
 export function readPromptFile(relativePath: string): PromptFileContent {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 检查文件大小
   const stats = statSync(absolutePath);
@@ -345,24 +358,12 @@ export function updatePromptFile(
   relativePath: string,
   content: string
 ): PromptFileContent {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
   // 验证内容大小（按 UTF-8 字节数，与文件大小限制保持一致）
   if (Buffer.byteLength(content, "utf8") > MAX_FILE_SIZE) {
     throw new Error("内容大小超过限制（最大 100KB）");
   }
 
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 写入文件
   writeFileSync(absolutePath, content, "utf-8");
@@ -432,19 +433,7 @@ export function createPromptFile(
  * @throws 如果路径无效或文件不存在
  */
 export function deletePromptFile(relativePath: string): void {
-  // 验证路径
-  const validation = validatePromptPath(relativePath);
-  if (!validation.valid) {
-    throw new Error(validation.error);
-  }
-
-  // 解析绝对路径
-  const absolutePath = resolvePromptPath(relativePath);
-
-  // 检查文件是否存在
-  if (!existsSync(absolutePath)) {
-    throw new Error(`文件不存在: ${relativePath}`);
-  }
+  const absolutePath = validateAndResolvePath(relativePath);
 
   // 删除文件
   rmSync(absolutePath);


### PR DESCRIPTION
抽取 validateAndResolvePath 辅助函数，消除 readPromptFile、
updatePromptFile、deletePromptFile 中约 15 行重复的路径验证代码。

修复前：三处函数各自包含相同的验证、解析、存在性检查逻辑
修复后：统一使用 validateAndResolvePath 函数，减少约 30 行代码

Fixes #3421

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3421