### PR TITLE
fix(server): 使用 logger 替代 console.error 修复日志规范问题

### DIFF
--- a/src/server/routes/domains/endpoint.route.ts
+++ b/src/server/routes/domains/endpoint.route.ts
@@ -43,7 +43,7 @@ const withEndpointHandler = async (
     // 使用类型安全的方式调用方法
     return await endpointHandler[handlerName](c);
   } catch (error) {
-    console.error(`端点处理器错误 [${handlerName}]:`, error);
+    c.logger.error(`端点处理器错误 [${handlerName}]:`, error);
     return c.fail(
       "ENDPOINT_HANDLER_ERROR",
       error instanceof Error ? error.message : "端点处理失败",


### PR DESCRIPTION
将 endpoint.route.ts 中的 console.error 替换为 c.logger.error，
确保日志输出符合项目日志规范。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nFixes issue: #3429