### PR TITLE
fix: 修复 undici WebSocket Client 未处理异常漏洞 (CWE-248)

### DIFF
--- a/package.json
+++ b/package.json
@@ -171,7 +171,8 @@
       "mathjs@<15.2.0": ">=15.2.0",
       "picomatch": ">=4.0.4",
       "yaml": ">=2.8.3",
-      "cosmiconfig": ">=7.1.0"
+      "cosmiconfig": ">=7.1.0",
+      "undici@<6.24.0": ">=6.24.0"
     }
   },
   "lint-staged": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,7 @@ overrides:
   picomatch: '>=4.0.4'
   yaml: '>=2.8.3'
   cosmiconfig: '>=7.1.0'
+  undici@<6.24.0: '>=6.24.0'
 
 importers:
 
@@ -6990,10 +6991,6 @@ packages:
   undici-types@7.16.0:
     resolution: {integrity: sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==}
 
-  undici@6.23.0:
-    resolution: {integrity: sha512-VfQPToRA5FZs/qJxLIinmU59u0r7LXqoJkCzinq3ckNJp3vKEh7jTWN589YQ5+aoAC/TGRLyJLCPKcLQbM8r9g==}
-    engines: {node: '>=18.17'}
-
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
     engines: {node: '>=20.18.1'}
@@ -13819,7 +13816,7 @@ snapshots:
       proxy-agent: 6.5.0
       semver: 7.7.3
       tinyglobby: 0.2.15
-      undici: 6.23.0
+      undici: 7.25.0
       url-join: 5.0.0
       wildcard-match: 5.1.4
       yargs-parser: 21.1.1
@@ -14609,8 +14606,6 @@ snapshots:
     optional: true
 
   undici-types@7.16.0: {}
-
-  undici@6.23.0: {}
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
添加 pnpm overrides 强制 undici >= 6.24.0，修复 release-it
传递依赖的 undici 6.23.0 WebSocket Client Unhandled Exception 漏洞。

修复后 undici 版本：7.25.0

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)\n\nFixes issue: #3432