### PR TITLE
fix(server): npm manager 进程启动失败使用 logger.error 替代 console.log

### DIFF
--- a/src/server/lib/npm/manager.ts
+++ b/src/server/lib/npm/manager.ts
@@ -87,7 +87,7 @@ export class NPMManager {
       // 监听进程启动失败事件
       npmProcess.on("error", (error) => {
         const errorMessage = `进程启动失败: ${error.message}`;
-        console.log(errorMessage, { error });
+        logger.error(errorMessage, { error });
 
         // 清理资源
         cleanup();


### PR DESCRIPTION
修复 src/server/lib/npm/manager.ts:90 处使用 console.log 记录错误的问题，
改为使用已导入的 logger.error，保持与项目日志规范一致。

Closes #3434

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3434