### PR TITLE
fix(deps): 更新 dotenv 版本到 ^17.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "comment-json": "^4.2.5",
     "consola": "^3.4.2",
     "dayjs": "^1.11.13",
-    "dotenv": "^17.2.1",
+    "dotenv": "^17.4.2",
     "eventsource": "^4.0.0",
     "express": "^5.1.0",
     "hono": "^4.12.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -95,8 +95,8 @@ importers:
         specifier: ^1.11.13
         version: 1.11.19
       dotenv:
-        specifier: ^17.2.1
-        version: 17.2.3
+        specifier: ^17.4.2
+        version: 17.4.2
       eventsource:
         specifier: ^4.0.0
         version: 4.1.0
@@ -4133,8 +4133,8 @@ packages:
     resolution: {integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==}
     engines: {node: '>=8'}
 
-  dotenv@17.2.3:
-    resolution: {integrity: sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==}
+  dotenv@17.4.2:
+    resolution: {integrity: sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==}
     engines: {node: '>=12'}
 
   dunder-proto@1.0.1:
@@ -10344,7 +10344,7 @@ snapshots:
       chokidar: 5.0.0
       confbox: 0.2.4
       defu: 6.1.7
-      dotenv: 17.2.3
+      dotenv: 17.4.2
       exsolve: 1.0.8
       giget: 2.0.0
       jiti: 2.6.1
@@ -11064,7 +11064,7 @@ snapshots:
     dependencies:
       is-obj: 2.0.0
 
-  dotenv@17.2.3: {}
+  dotenv@17.4.2: {}
 
   dunder-proto@1.0.1:
     dependencies:


### PR DESCRIPTION
将 dotenv 依赖版本从 ^17.2.1 更新到 ^17.4.2，解决版本声明与实际安装版本不一致的问题。

修复 Issue #3436

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3436