### PR TITLE
fix(web): 移除 WebServer stop() 中未清理的事件监听器

### DIFF
--- a/src/server/WebServer.ts
+++ b/src/server/WebServer.ts
@@ -887,6 +887,8 @@ export class WebServer {
       (async () => {
         try {
           if (this.endpointManager) {
+            // 移除所有外部注册的事件监听器，避免监听器累积
+            this.endpointManager.removeAllListeners();
             await this.endpointManager.cleanup();
             this.logger.debug("连接管理器已清理");
           }


### PR DESCRIPTION
WebServer 在 setupEndpointManager() 中向 EndpointManager 注册了
endpointAdded 和 endpointRemoved 事件监听器，但在 stop() 方法中
没有移除这些监听器。如果 WebServer 多次启动停止，监听器会累积。

修复方案：在 stop() 方法中调用 endpointManager.removeAllListeners()
移除所有外部注册的事件监听器，然后再执行 cleanup()。

Closes #3439

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3439