### PR TITLE
perf(web): 启用 Rolldown 作为 Vite 打包引擎

### DIFF
--- a/src/web/vite.config.ts
+++ b/src/web/vite.config.ts
@@ -4,9 +4,17 @@ import { visualizer } from "rollup-plugin-visualizer";
 import { defineConfig } from "vite";
 
 export default defineConfig({
+  // 启用 Rolldown 作为底层打包引擎（替代 Rollup）
+  // Rolldown 由 Rust 编写，构建速度显著更快
+  experimental: {
+    rolldown: true,
+  },
   plugins: [
     react(),
     // Bundle analyzer - 只在需要时启用
+    // 注意：rollup-plugin-visualizer 依赖 moduleParsed hook，
+    // 在 rolldown 模式下可能无法正常工作。如需分析包体积，
+    // 可临时禁用 experimental.rolldown 或使用其他分析工具。
     process.env.ANALYZE &&
       visualizer({
         filename: "dist/stats.html",
@@ -35,8 +43,10 @@ export default defineConfig({
   build: {
     outDir: "../../dist/frontend",
     sourcemap: true,
-    // 代码分割优化配置
-    rollupOptions: {
+    // 使用 Oxc 压缩器（与 Rolldown 集成更好，压缩速度更快）
+    minify: "oxc",
+    // 代码分割优化配置（使用 rolldown 原生配置）
+    rolldownOptions: {
       output: {
         // 动态分包策略 - 只为实际使用的库创建 chunk
         manualChunks: (id) => {


### PR DESCRIPTION
## Summary

- 将 Web 前端构建从 Rollup 迁移至 **Rolldown**（Rust 编写），提升构建速度
- 添加 `experimental.rolldown: true` 启用 Rolldown 打包引擎
- 将 `rollupOptions` 迁移为 `rolldownOptions`（Rolldown 原生配置入口）
- 使用 **Oxc 压缩器**替代 esbuild，与 Rolldown 集成更好，压缩速度更快
- 为 `rollup-plugin-visualizer` 添加兼容性提示（该插件依赖 `moduleParsed` hook，rolldown 不支持）

## 背景

项目 CLI/Server/MCP 子包已迁移至基于 Rolldown 的 tsdown 构建工具（PR #3443, #3444）。本次变更将 Web 前端也统一到 Rolldown 技术栈，实现全项目构建工具一致性。

## 测试计划

- [x] `pnpm build` — 生产构建成功（1.20s），产物含 `rolldown-runtime-*.js`
- [x] `pnpm test` — 511 个测试全部通过
- [ ] CI 全量构建验证