### PR TITLE
docs: 添加项目 logo 并更新 README 展示

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
-<br />
 <div align="center">
-  <img style="height: 60px;" src="https://raw.githubusercontent.com/shenjingnan/xiaozhi-client/main/docs/public/images/logo.png" alt="xiaozhi-client logo" />
+  <br />
+  <br />
+  <img src="logo.svg" alt="Univoice" width="400" height="100" />
+  <br />
+  <br />
+  <br />
 </div>
-<br />
 
 <div align="center">
 <a href="https://www.npmjs.com/package/xiaozhi-client" target="_blank"><img src="https://img.shields.io/npm/v/xiaozhi-client" alt="npm version" /></a>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <div align="center">
   <br />
   <br />
-  <img src="logo.svg" alt="Univoice" width="400" height="100" />
+  <img src="logo.svg" alt="Xiaozhi Client" width="400" height="100" />
   <br />
   <br />
   <br />

--- a/cspell.json
+++ b/cspell.json
@@ -12,6 +12,7 @@
   ],
   "dictionaries": ["xiaozhi-words"],
   "ignorePaths": [
+    "logo.svg",
     "docs/content/音色列表.md",
     "node_modules/**",
     "reports/jscpd",

--- a/logo.svg
+++ b/logo.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 210 28" width="210" height="28">
+  <text x="0" y="25" font-family="-apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif" font-size="32" font-weight="700">
+    <tspan fill="#1677FF" font-size="34">X</tspan><tspan fill="#000000">iaozhi Client</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
## Summary
- 新增 `logo.svg` 项目标识（首字母 X 蓝色高亮风格，与 univoice/openmanual 保持一致的设计语言）
- 更新 README 顶部 logo 展示，使用本地 SVG 资源替代远程图片引用

## Test plan
- [ ] 确认 `logo.svg` 在浏览器中正确渲染
- [ ] 确认 README 顶部 logo 展示正常