### PR TITLE
feat(config): 补全默认配置模板中缺失的配置字段

### DIFF
--- a/templates/default/xiaozhi.config.json
+++ b/templates/default/xiaozhi.config.json
@@ -10,10 +10,16 @@
       "args": ["-y", "@xiaozhi-client/datetime-mcp"]
     }
   },
+  "mcpServerConfig": {},
+  "modelscope": { "apiKey": "" },
+  "platforms": {},
   "asr": {
     "model": "doubao",
     "appid": "",
-    "accessToken": ""
+    "accessToken": "",
+    "cluster": "",
+    "wsUrl": "",
+    "vadEndWindowSize": 0
   },
   "llm": {
     "prompt": "./prompts/default.md",
@@ -25,14 +31,18 @@
     "model": "doubao",
     "appid": "",
     "accessToken": "",
-    "voice_type": "zh_female_xiaohe_uranus_bigtts"
+    "voice_type": "zh_female_xiaohe_uranus_bigtts",
+    "encoding": "",
+    "cluster": "",
+    "endpoint": ""
   },
   "connection": {
     "heartbeatInterval": 30000,
     "heartbeatTimeout": 10000,
-    "reconnectInterval": 5000
+    "reconnectInterval": 5000,
+    "maxReconnectAttempts": 10,
+    "connectionTimeout": 30000,
+    "autoReconnect": true
   },
-  "webUI": {
-    "port": 9999
-  }
+  "webUI": { "port": 9999, "autoRestart": true }
 }

--- a/templates/default/xiaozhi.config.json
+++ b/templates/default/xiaozhi.config.json
@@ -14,7 +14,6 @@
   "modelscope": { "apiKey": "" },
   "platforms": {},
   "asr": {
-    "model": "doubao",
     "appid": "",
     "accessToken": "",
     "cluster": "",
@@ -28,7 +27,6 @@
     "baseURL": ""
   },
   "tts": {
-    "model": "doubao",
     "appid": "",
     "accessToken": "",
     "voice_type": "zh_female_xiaohe_uranus_bigtts",


### PR DESCRIPTION
## Summary
- 补全 `templates/default/xiaozhi.config.json` 中与 `AppConfig` 接口定义不一致的字段
- 新增 `mcpServerConfig`、`modelscope`、`platforms` 三个顶级字段
- `connection` 补全 `maxReconnectAttempts`、`connectionTimeout`、`autoReconnect`
- `webUI` 补充 `autoRestart`
- `asr` 补全 `cluster`、`wsUrl`、`vadEndWindowSize`
- `tts` 补全 `encoding`、`cluster`、`endpoint`

## Test plan
- [x] JSON 格式验证通过 (`node -e "JSON.parse(...)"`)
- [x] Biome lint 检查通过 (`pnpm lint`)