### PR TITLE
fix: 使用 logger 替代 console 输出，符合项目日志规范

### DIFF
--- a/src/server/lib/mcp/utils.ts
+++ b/src/server/lib/mcp/utils.ts
@@ -7,6 +7,7 @@
  */
 
 import { TypeFieldNormalizer } from "../../../mcp-core/index.js";
+import { logger } from "../../Logger.js";
 import { MCPTransportType, ToolCallError, ToolCallErrorCode } from "./types.js";
 import type {
   MCPServiceConfig,
@@ -41,16 +42,16 @@ export function inferTransportTypeFromUrl(
       return MCPTransportType.HTTP;
     }
 
-    // 默认类型 - 使用 console 输出
+    // 默认类型 - 使用 logger 输出
     if (options?.serviceName) {
-      console.info(
+      logger.info(
         `[MCP-${options.serviceName}] URL 路径 ${pathname} 不匹配特定规则，默认推断为 http 类型`
       );
     }
     return MCPTransportType.HTTP;
   } catch (error) {
     if (options?.serviceName) {
-      console.warn(
+      logger.warn(
         `[MCP-${options.serviceName}] URL 解析失败，默认推断为 http 类型`,
         error
       );


### PR DESCRIPTION
将 inferTransportTypeFromUrl 函数中的 console.info 和 console.warn
替换为 logger.info 和 logger.warn，以符合项目统一的日志管理要求。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3442