### PR TITLE
fix(web): 替换 schema-utils.ts 中的 any 类型为 JSONSchema 类型

### DIFF
--- a/src/web/lib/schema-utils.ts
+++ b/src/web/lib/schema-utils.ts
@@ -1,9 +1,12 @@
+import type { JSONSchema } from "@/types/mcp/schema";
 import { z } from "zod";
 
 /**
  * 根据 JSON Schema 动态生成 Zod schema
  */
-export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
+export function createZodSchemaFromJsonSchema(
+  jsonSchema: JSONSchema
+): z.ZodTypeAny {
   if (!jsonSchema || typeof jsonSchema !== "object") {
     return z.any();
   }
@@ -92,7 +95,7 @@ export function createZodSchemaFromJsonSchema(jsonSchema: any): z.ZodTypeAny {
 /**
  * 获取字段的默认值
  */
-export function getDefaultValueForSchema(schema: any): any {
+export function getDefaultValueForSchema(schema: JSONSchema): unknown {
   if (!schema) return undefined;
 
   switch (schema.type) {
@@ -112,7 +115,7 @@ export function getDefaultValueForSchema(schema: any): any {
 
     case "object":
       if (schema.properties) {
-        const defaults: Record<string, any> = {};
+        const defaults: Record<string, unknown> = {};
         for (const [key, propSchema] of Object.entries(schema.properties)) {
           defaults[key] = getDefaultValueForSchema(propSchema);
         }
@@ -128,10 +131,12 @@ export function getDefaultValueForSchema(schema: any): any {
 /**
  * 根据 JSON Schema 生成默认值对象
  */
-export function createDefaultValues(jsonSchema: any): Record<string, any> {
+export function createDefaultValues(
+  jsonSchema: JSONSchema
+): Record<string, unknown> {
   if (!jsonSchema || !jsonSchema.properties) return {};
 
-  const defaults: Record<string, any> = {};
+  const defaults: Record<string, unknown> = {};
   const requiredFields = jsonSchema.required || [];
 
   for (const [key, propSchema] of Object.entries(jsonSchema.properties)) {


### PR DESCRIPTION
- 导入 JSONSchema 类型从 @/types/mcp/schema
- createZodSchemaFromJsonSchema 参数从 any 改为 JSONSchema
- getDefaultValueForSchema 参数从 any 改为 JSONSchema，返回值改为 unknown
- createDefaultValues 参数从 any 改为 JSONSchema，返回值改为 Record<string, unknown>
- 内部变量 defaults 从 Record<string, any> 改为 Record<string, unknown>

修复 #3453

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3453