### PR TITLE
fix(endpoint): reconnect 方法添加 await 和错误处理

### DIFF
--- a/src/endpoint/endpoint.ts
+++ b/src/endpoint/endpoint.ts
@@ -462,8 +462,13 @@ export class Endpoint {
   public async reconnect(): Promise<void> {
     console.info(`重连小智接入点: ${sliceEndpoint(this.endpointUrl)}`);
 
-    // 先断开连接
-    this.disconnect();
+    try {
+      // 先断开连接（等待完成）
+      await this.disconnect();
+    } catch (error) {
+      console.error("断开连接失败:", error);
+      // 继续尝试重连，因为目标是要重新连接
+    }
 
     // 等待可配置的时间确保连接完全断开
     await new Promise((resolve) => setTimeout(resolve, this.reconnectDelay));


### PR DESCRIPTION
修复 reconnect 方法调用 disconnect() 时缺少 await 的问题：
- 添加 await 等待 disconnect() 完成
- 添加 try-catch 错误处理，防止 unhandled promise rejection
- 即使断开失败也会继续尝试重连

Fixes #3462

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3462