### PR TITLE
fix(endpoint): 将相对路径导入改为 @/config 路径别名

### DIFF
--- a/src/endpoint/internal-mcp-manager.ts
+++ b/src/endpoint/internal-mcp-manager.ts
@@ -4,8 +4,8 @@
  * 使用 @/mcp-core 的 MCPManager 实现真实的 MCP 功能
  */
 
+import { normalizeServiceConfig } from "@/config";
 import { MCPManager } from "@/mcp-core";
-import { normalizeServiceConfig } from "../config";
 import type { EnhancedToolInfo, ToolCallResult } from "./types.js";
 import type { IMCPServiceManager } from "./types.js";
 import type { EndpointConfig } from "./types.js";


### PR DESCRIPTION
修复 src/endpoint/internal-mcp-manager.ts 中路径别名使用不一致问题：
- 将 `"../config"` 改为 `"@/config"` 以符合项目路径别名规范
- 与同文件中的 "@/mcp-core" 导入保持一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>
Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3463