### PR TITLE
refactor: 统一 timeout 类型定义，消除跨目录重复

### DIFF
--- a/src/server/types/timeout.ts
+++ b/src/server/types/timeout.ts
@@ -1,39 +1,20 @@
 /**
- * 超时错误类型
+ * 超时处理类型定义（server 层）
+ *
+ * 本文件从 @/types/utils/timeout.js 导入基础类型定义，
+ * 并提供 server 层特有的超时响应创建功能。
  */
-export class TimeoutError extends Error {
-  public override readonly name = "TimeoutError" as const;
 
-  constructor(message: string) {
-    super(message);
-    this.name = "TimeoutError";
-    Error.captureStackTrace(this, TimeoutError);
-  }
+// 从统一类型目录导入共享定义，消除重复
+import {
+  TimeoutError,
+  TimeoutResponse,
+  isTimeoutError,
+  isTimeoutResponse,
+} from "../../types/utils/timeout";
 
-  toJSON() {
-    return {
-      name: this.name,
-      message: this.message,
-      stack: this.stack,
-    };
-  }
-}
-
-/**
- * 超时响应接口
- */
-export interface TimeoutResponse {
-  content: Array<{
-    type: "text";
-    text: string;
-  }>;
-  isError: boolean;
-  taskId: string;
-  status: "timeout";
-  message: string;
-  nextAction: string;
-  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
-}
+// 导出从 @/types 导入的类型，保持向后兼容
+export { TimeoutError, TimeoutResponse, isTimeoutResponse, isTimeoutError };
 
 /**
  * 创建超时响应的工具函数
@@ -70,7 +51,7 @@ function getToolSpecificTimeoutMessage(
 ): string {
   const toolMessages: Record<string, string> = {
     coze_workflow: `⏱️ 扣子工作流执行超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 工具类型: 扣子工作流
@@ -93,7 +74,7 @@ function getToolSpecificTimeoutMessage(
  */
 function getDefaultTimeoutMessage(taskId: string): string {
   return `⏱️ 工具调用超时，正在后台处理中...
-    
+
 📋 任务信息：
 - 任务ID: ${taskId}
 - 状态: 处理中
@@ -103,29 +84,4 @@ function getDefaultTimeoutMessage(taskId: string): string {
 1. 使用相同的参数重新调用工具
 2. 系统会自动返回已完成的任务结果
 3. 如果长时间未完成，请联系管理员`;
-}
-
-/**
- * 验证是否为超时响应
- */
-export function isTimeoutResponse(response: any): response is TimeoutResponse {
-  return !!(
-    response &&
-    response.status === "timeout" &&
-    typeof response.taskId === "string" &&
-    Array.isArray(response.content) &&
-    response.content.length > 0 &&
-    response.content[0].type === "text"
-  );
-}
-
-/**
- * 验证是否为超时错误
- */
-export function isTimeoutError(error: any): error is TimeoutError {
-  return !!(
-    error &&
-    error.name === "TimeoutError" &&
-    error instanceof TimeoutError
-  );
 }

--- a/src/types/utils/timeout.ts
+++ b/src/types/utils/timeout.ts
@@ -36,6 +36,7 @@ export interface TimeoutResponse {
   status: "timeout";
   message: string;
   nextAction: string;
+  [key: string]: unknown; // 支持其他未知字段，与 ToolCallResult 保持兼容
 }
 
 /**


### PR DESCRIPTION
- src/types/utils/timeout.ts: 基础类型定义位置
  - TimeoutError 类
  - TimeoutResponse 接口（添加 [key: string]: unknown 字段以兼容 ToolCallResult）
  - isTimeoutResponse 函数
  - isTimeoutError 函数

- src/server/types/timeout.ts: 从基础类型导入并重新导出
  - 保留 server 特有的功能：
    - createTimeoutResponse 函数
    - getToolSpecificTimeoutMessage 函数
    - getDefaultTimeoutMessage 函数

消除约 60 行重复代码，遵循 DRY 原则，确保类型定义统一管理。

Fixes #3473

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3473