### PR TITLE
fix: 使用 @/config 别名替代四层相对路径导入

### DIFF
--- a/src/server/lib/mcp/custom.ts
+++ b/src/server/lib/mcp/custom.ts
@@ -1,11 +1,11 @@
 #!/usr/bin/env node
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import type {
   CustomMCPTool,
   HandlerConfig,
   ProxyHandlerConfig,
-} from "../../../config/index.js";
-import { configManager } from "../../../config/index.js";
+} from "@/config";
+import { configManager } from "@/config";
+import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 /**
  * 自定义 MCP 工具处理器模块
  *

--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -5,10 +5,10 @@
  */
 
 import { EventEmitter } from "node:events";
+import { isModelScopeURL } from "@/config";
+import type { MCPToolConfig } from "@/config";
+import { configManager } from "@/config";
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-import { isModelScopeURL } from "../../../config/index.js";
-import type { MCPToolConfig } from "../../../config/index.js";
-import { configManager } from "../../../config/index.js";
 import { logger } from "../../Logger.js";
 import { MCPService } from "../../lib/mcp";
 import { MCPCacheManager } from "../../lib/mcp";


### PR DESCRIPTION
将 src/server/lib/mcp/manager.ts 和 custom.ts 中的
../../../config/index.js 导入改为 @/config 路径别名，
符合项目 tsconfig.json 配置的路径别名规范。

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3479