### PR TITLE
docs: 修复 ESP32 文档过时的独立包名引用

### DIFF
--- a/docs/content/esp32/architecture.mdx
+++ b/docs/content/esp32/architecture.mdx
@@ -1,13 +1,13 @@
 ---
-title: "ESP32 SDK 架构设计"
-description: "深入理解 @xiaozhi-client/esp32 的架构分层、核心模块设计和关键设计决策。"
+title: "ESP32 模块架构设计"
+description: "深入理解 ESP32 模块的架构分层、核心模块设计和关键设计决策。"
 ---
 
 import { Callout, Tabs } from "nextra/components";
 
 # 架构设计
 
-本文档深入介绍 `@xiaozhi-client/esp32` 的内部架构设计，适合需要理解设计原理的贡献者和深度集成者。
+本文档深入介绍 ESP32 模块的内部架构设计，适合需要理解设计原理的贡献者和深度集成者。
 
 ## 整体架构分层
 
@@ -65,7 +65,7 @@ graph TB
 
 ### ESP32DeviceManager — 设备编排层
 
-**文件**: `packages/esp32/src/esp32-manager.ts`
+**文件**: `src/esp32/esp32-manager.ts`
 
 这是 SDK 的**核心入口类**，负责协调所有子模块的工作：
 
@@ -85,7 +85,7 @@ graph TB
 
 ### ESP32Connection — 连接管理层
 
-**文件**: `packages/esp32/src/connection.ts`
+**文件**: `src/esp32/connection.ts`
 
 管理**单个设备**的 WebSocket 连接生命周期：
 
@@ -101,7 +101,7 @@ graph TB
 
 ### DeviceRegistryService — 设备注册表
 
-**文件**: `packages/esp32/src/device-registry.ts`
+**文件**: `src/esp32/device-registry.ts`
 
 维护所有已注册 ESP32 设备的状态信息：
 
@@ -112,7 +112,7 @@ graph TB
 
 ### ASRService — 语音识别服务
 
-**文件**: `packages/esp32/src/services/asr.service.ts`
+**文件**: `src/esp32/services/asr.service.ts`
 
 负责将设备上传的 Opus 音频数据转换为文本：
 
@@ -123,7 +123,7 @@ graph TB
 
 ### LLMService — 大语言模型服务
 
-**文件**: `packages/esp32/src/services/llm.service.ts`
+**文件**: `src/esp32/services/llm.service.ts`
 
 将 ASR 识别出的文本发送给大语言模型获取回复：
 
@@ -133,7 +133,7 @@ graph TB
 
 ### TTSService — 语音合成服务
 
-**文件**: `packages/esp32/src/services/tts.service.ts`
+**文件**: `src/esp32/services/tts.service.ts`
 
 将 LLM 的文本回复合成为 Opus 音频并发送给设备：
 
@@ -144,7 +144,7 @@ graph TB
 
 ### audio-protocol.ts — 二进制协议编解码
 
-**文件**: `packages/esp32/src/audio-protocol.ts`
+**文件**: `src/esp32/audio-protocol.ts`
 
 处理固件上传的二进制音频数据的编解码：
 

--- a/docs/content/esp32/integration.mdx
+++ b/docs/content/esp32/integration.mdx
@@ -1,13 +1,13 @@
 ---
-title: "ESP32 SDK 集成指南"
-description: "学习如何在你的项目中完整集成 @xiaozhi-client/esp32，包含实际代码示例和最佳实践。"
+title: "ESP32 模块集成指南"
+description: "学习如何在项目中使用 ESP32 模块，包含实际代码示例和最佳实践。"
 ---
 
 import { Callout, Steps, Tabs } from "nextra/components";
 
 # 集成指南
 
-本文档以 `src/server`（项目的 Web 服务器）为实际案例，详细说明如何在自己的项目中完整集成 `@xiaozhi-client/esp32`。
+本文档以 `src/server`（项目的 Web 服务器）为实际案例，详细说明如何使用 ESP32 模块。
 
 <Callout type="info">
   在开始之前，建议先阅读 [快速上手](/esp32/quick-start) 了解基本概念。
@@ -15,7 +15,7 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## 集成模式总览
 
-集成 `@xiaozhi-client/esp32` 需要在你的 HTTP 服务中完成以下工作：
+使用 ESP32 模块需要在你的 HTTP 服务中完成以下工作：
 
 ```mermaid
 graph LR
@@ -37,35 +37,28 @@ graph LR
 
 <Steps>
 
-## 步骤 1：安装依赖与声明 peerDependencies
+## 步骤 1：确认依赖已安装
+
+ESP32 模块已包含在 `xiaozhi-client` 包中。确保你的项目已安装该包：
 
 ```bash
-# 安装 ESP32 SDK
-pnpm add @xiaozhi-client/esp32
-
-# 安装 peer dependencies
-pnpm add ws @xiaozhi-client/config
+pnpm add xiaozhi-client
 ```
 
-如果你的项目使用 pnpm workspace，还需要在 `package.json` 中声明 peerDependencies：
+同时需要安装 WebSocket 依赖（peer dependency）：
 
-```json
-{
-  "peerDependencies": {
-    "ws": "^8.x",
-    "@xiaozhi-client/config": "workspace:*"
-  }
-}
+```bash
+pnpm add ws
 ```
 
 ## 步骤 2：实现 IESP32ConfigProvider 接口
 
-`IESP32ConfigProvider` 是 SDK 与你的配置系统之间的桥梁。你需要实现以下四个方法：
+`IESP32ConfigProvider` 是 ESP32 模块与你的配置系统之间的桥梁。你需要实现以下四个方法：
 
 ```typescript
-import type { IESP32ConfigProvider } from "@xiaozhi-client/esp32";
-import type { ASRConfig, LLMConfig, TTSConfig } from "@xiaozhi-client/shared-types";
-import { configManager } from "@xiaozhi-client/config";
+import type { IESP32ConfigProvider } from "@/esp32";
+import type { ASRConfig, LLMConfig, TTSConfig } from "@/types";
+import { configManager } from "@/config";
 
 /**
  * 基于 configManager 的配置提供者实现
@@ -116,13 +109,13 @@ export const esp32ConfigProvider = new Esp32ConfigProvider();
 ```
 
 <Callout type="info">
-  以上代码来自 `src/server/WebServer.ts` 中的实际实现。如果你不使用 `@xiaozhi-client/config`，可以从任何来源返回配置对象——文件、数据库、环境变量均可。
+  以上代码来自 `src/server/WebServer.ts` 中的实际实现。如果不使用 `@/config`，可以从任何来源返回配置对象——文件、数据库、环境变量均可。
 </Callout>
 
 ## 步骤 3：创建 ESP32DeviceManager 实例
 
 ```typescript
-import { ESP32DeviceManager } from "@xiaozhi-client/esp32";
+import { ESP32DeviceManager } from "@/esp32";
 import { esp32ConfigProvider } from "./Esp32ConfigProvider";
 import { logger } from "./Logger"; // 你的日志实现
 
@@ -139,13 +132,13 @@ const esp32Manager = new ESP32DeviceManager({
 
 ## 步骤 4：处理 OTA HTTP 请求（薄适配层模式）
 
-ESP32 设备上电后的第一个动作是向 OTA 接口发送 HTTP POST 请求。你需要一个**薄适配层**将 HTTP 请求转化为 SDK 方法调用：
+ESP32 设备上电后的第一个动作是向 OTA 接口发送 HTTP POST 请求。你需要一个**薄适配层**将 HTTP 请求转化为 ESP32 模块方法调用：
 
 ```typescript
 // src/server/handlers/esp32.handler.ts（简化版）
 import type { Context } from "hono";
-import type { ESP32DeviceManager, ESP32DeviceReport } from "@xiaozhi-client/esp32";
-import { ESP32ErrorCode } from "@xiaozhi-client/esp32";
+import type { ESP32DeviceManager, ESP32DeviceReport } from "@/esp32";
+import { ESP32ErrorCode } from "@/esp32";
 
 export class ESP32Handler {
   constructor(private esp32Manager: ESP32DeviceManager) {}
@@ -217,12 +210,12 @@ export class ESP32Handler {
 ```
 
 <Callout type="info">
-  **薄适配层模式**：Handler 本身不做业务逻辑，只负责从 HTTP 请求中提取参数，然后委托给 `ESP32DeviceManager` 处理。这样 SDK 的核心逻辑完全独立于 HTTP 框架。
+  **薄适配层模式**：Handler 本身不做业务逻辑，只负责从 HTTP 请求中提取参数，然后委托给 `ESP32DeviceManager` 处理。这样 ESP32 模块的核心逻辑完全独立于 HTTP 框架。
 </Callout>
 
 ## 步骤 5：处理 WebSocket 连接升级
 
-设备获取到 WebSocket URL 后会发起 WebSocket 连接。你需要在 WebSocket 服务器的 `connection` 事件中将连接委托给 SDK：
+设备获取到 WebSocket URL 后会发起 WebSocket 连接。你需要在 WebSocket 服务器的 `connection` 事件中将连接委托给 ESP32 模块：
 
 ```typescript
 // 在你的 HTTP 服务器启动代码中
@@ -271,7 +264,7 @@ wss.on("connection", (ws: WebSocket, req) => {
 
 ## 步骤 6：生命周期管理（destroy）
 
-当你的服务关闭时，必须调用 `destroy()` 方法清理 SDK 占用的资源：
+当你的服务关闭时，必须调用 `destroy()` 方法清理 ESP32 模块占用的资源：
 
 ```typescript
 class MyServer {

--- a/docs/content/esp32/overview.mdx
+++ b/docs/content/esp32/overview.mdx
@@ -1,16 +1,18 @@
 ---
-title: "ESP32 SDK 概览"
-description: "了解 @xiaozhi-client/esp32 包的核心能力、适用场景和安装方式。"
+title: "ESP32 模块概览"
+description: "了解 ESP32 模块的核心能力、适用场景和内部使用方式。"
 ---
 
 import { Callout, Tabs } from "nextra/components";
 
-# ESP32 SDK 概览
+# ESP32 模块概览
 
-`@xiaozhi-client/esp32` 是一个独立的 npm 包，负责 **ESP32 硬件设备**的全部通信逻辑。它从 `src/server` 中抽取出来，使设备通信能力可以被任何 Node.js 项目独立使用。
+> **注意**: ESP32 模块已集成在 xiaozhi-client 单体包中，无需单独安装。本文档面向项目开发者，说明 ESP32 模块的功能和内部使用方式。
+
+ESP32 模块（位于 `src/esp32/`）负责 **ESP32 硬件设备**的全部通信逻辑。它提供设备连接管理、语音交互流水线、二进制音频协议处理等核心能力。
 
 <Callout type="info">
-  本包不绑定任何 HTTP 框架（Express、Hono、Fastify 等），通过接口注入实现解耦，可灵活集成到各类服务端项目中。
+  ESP32 模块不绑定任何 HTTP 框架（Express、Hono、Fastify 等），通过接口注入实现解耦，可灵活集成到各类服务端项目中。
 </Callout>
 
 ## 核心能力
@@ -23,7 +25,7 @@ import { Callout, Tabs } from "nextra/components";
 | **OTA 配置下发** | 设备首次连接时自动激活，返回 WebSocket 地址、服务器时间、固件信息等配置 |
 | **设备注册表** | 维护所有已注册设备的状态信息（在线/离线、最后活跃时间等） |
 
-## 与项目其他包的关系
+## 与项目其他模块的关系
 
 ```mermaid
 graph TB
@@ -31,7 +33,7 @@ graph TB
         APP[应用层<br/>HTTP Server / CLI]
     end
 
-    subgraph "@xiaozhi-client/esp32<br/>（本包）"
+    subgraph "ESP32 模块<br/>（src/esp32/）"
         MGR[ESP32DeviceManager<br/>设备编排层]
         CONN[ESP32Connection<br/>连接管理层]
         REG[DeviceRegistryService<br/>设备注册表]
@@ -41,9 +43,12 @@ graph TB
         AP[audio-protocol.ts<br/>二进制协议]
     end
 
+    subgraph "项目内部依赖"
+        CONFIG["src/config/<br/>配置管理"]
+        TYPES["src/types/<br/>共享类型"]
+    end
+
     subgraph "外部依赖"
-        CONFIG["@xiaozhi-client/config<br/>配置管理"]
-        SHARED["@xiaozhi-client/shared-types<br/>共享类型"]
         WS["ws<br/>WebSocket"]
     end
 
@@ -57,42 +62,23 @@ graph TB
     ASR -->|"获取 ASR/LLM/TTS 配置"| CONFIG
     LLM --> CONFIG
     TTS --> CONFIG
-    ASR -->|"ASRConfig, LLMConfig, TTSConfig"| SHARED
+    ASR -->|"ASRConfig, LLMConfig, TTSConfig"| TYPES
     CONN --> WS
 ```
 
 ## 适用场景
 
-- **自建小智服务端**：在自己的 Node.js 服务中集成 ESP32 设备支持
+- **自建小智服务端**：在 xiaozhi-client 项目中集成 ESP32 设备支持
 - **定制化网关**：在现有系统中添加硬件设备接入能力
-- **二次开发**：基于本包构建具有特定业务逻辑的 IoT 网关
+- **二次开发**：基于 xiaozhi-client 构建具有特定业务逻辑的 IoT 网关
 - **测试与调试**：独立使用设备通信能力进行功能验证
 
-## 安装
+## 项目内使用
 
-<Tabs items={["pnpm", "npm"]}>
-  <Tabs.Tab>
-  ```bash
-  pnpm add @xiaozhi-client/esp32
-  ```
-  </Tabs.Tab>
-  <Tabs.Tab>
-  ```bash
-  npm install @xiaozhi-client/esp32
-  ```
-  </Tabs.Tab>
-</Tabs>
-
-### Peer Dependencies
-
-本包依赖以下 peer dependency，需要在使用方项目中自行安装：
-
-| 包名 | 用途 |
-|------|------|
-| `ws` | WebSocket 通信 |
+ESP32 模块已包含在 xiaozhi-client 包中，无需额外安装。你只需安装 `xiaozhi-client` 包即可使用所有功能：
 
 ```bash
-pnpm add ws
+pnpm add xiaozhi-client
 ```
 
 ## 快速体验
@@ -100,7 +86,7 @@ pnpm add ws
 最简单的使用方式——创建设备管理器并处理一次 OTA 请求：
 
 ```typescript
-import { ESP32DeviceManager } from "@xiaozhi-client/esp32";
+import { ESP32DeviceManager } from "@/esp32";
 
 // 创建设备管理器
 const manager = new ESP32DeviceManager({
@@ -131,22 +117,22 @@ console.log(otaResponse);
 
 ```typescript
 // 核心类
-import { ESP32DeviceManager } from "@xiaozhi-client/esp32";
-import { ESP32Connection } from "@xiaozhi-client/esp32";
-import { DeviceRegistryService } from "@xiaozhi-client/esp32";
+import { ESP32DeviceManager } from "@/esp32";
+import { ESP32Connection } from "@/esp32";
+import { DeviceRegistryService } from "@/esp32";
 
 // 接口
-import type { ILogger, IESP32ConfigProvider, IDeviceConnection } from "@xiaozhi-client/esp32";
+import type { ILogger, IESP32ConfigProvider, IDeviceConnection } from "@/esp32";
 
 // 类型
-import type { ESP32Device, ESP32WSMessage, ESP32OTAResponse, ... } from "@xiaozhi-client/esp32";
+import type { ESP32Device, ESP32WSMessage, ESP32OTAResponse, ... } from "@/esp32";
 
 // 音频协议工具
-import { detectAudioProtocol, parseBinaryProtocol2, encodeBinaryProtocol2, ... } from "@xiaozhi-client/esp32";
+import { detectAudioProtocol, parseBinaryProtocol2, encodeBinaryProtocol2, ... } from "@/esp32";
 
 // 工具函数
-import { extractDeviceInfo, camelToSnakeCase } from "@xiaozhi-client/esp32";
+import { extractDeviceInfo, camelToSnakeCase } from "@/esp32";
 
 // 语音服务
-import { ASRService, LLMService, TTSService } from "@xiaozhi-client/esp32";
+import { ASRService, LLMService, TTSService } from "@/esp32";
 ```

--- a/docs/content/esp32/quick-start.mdx
+++ b/docs/content/esp32/quick-start.mdx
@@ -1,5 +1,5 @@
 ---
-title: "ESP32 SDK 快速上手"
+title: "ESP32 模块快速上手"
 description: "5 分钟跑通 ESP32 设备连接和完整语音交互流程。"
 ---
 
@@ -7,7 +7,7 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 # 快速上手
 
-本指南将引导你在 5 分钟内完成 `@xiaozhi-client/esp32` 的基本集成，实现从设备连接到语音交互的完整流程。
+本指南将引导你在 5 分钟内完成 ESP32 模块的基本集成，实现从设备连接到语音交互的完整流程。
 
 <Callout type="info">
   **前提条件**
@@ -21,11 +21,13 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## 安装依赖
 
+ESP32 模块已包含在 `xiaozhi-client` 包中，安装该包即可：
+
 <Tabs items={['pnpm', 'npm']}>
   <Tabs.Tab>
   ```bash
-  # 安装 ESP32 SDK
-  pnpm add @xiaozhi-client/esp32
+  # 安装 xiaozhi-client（包含 ESP32 模块）
+  pnpm add xiaozhi-client
 
   # 安装 WebSocket 依赖（peer dependency）
   pnpm add ws
@@ -33,8 +35,8 @@ import { Callout, Steps, Tabs } from "nextra/components";
   </Tabs.Tab>
   <Tabs.Tab>
   ```bash
-  # 安装 ESP32 SDK
-  npm install @xiaozhi-client/esp32
+  # 安装 xiaozhi-client（包含 ESP32 模块）
+  npm install xiaozhi-client
 
   # 安装 WebSocket 依赖（peer dependency）
   npm install ws
@@ -44,14 +46,14 @@ import { Callout, Steps, Tabs } from "nextra/components";
 
 ## 创建设备管理器
 
-首先创建 `ESP32DeviceManager` 实例，它是整个 SDK 的核心入口：
+首先创建 `ESP32DeviceManager` 实例，它是整个 ESP32 模块的核心入口：
 
 ```typescript
-import { ESP32DeviceManager, type IESP32ConfigProvider } from "@xiaozhi-client/esp32";
+import { ESP32DeviceManager, type IESP32ConfigProvider } from "@/esp32";
 import { createServer } from "node:http";
 import { WebSocketServer } from "ws";
 
-// 1. 定义配置提供者（将 ASR/LLM/TTS 配置注入给 SDK）
+// 1. 定义配置提供者（将 ASR/LLM/TTS 配置注入给 ESP32 模块）
 const configProvider: IESP32ConfigProvider = {
   getASRConfig() {
     // 返回你的 ASR 配置，例如豆包 ASR


### PR DESCRIPTION
项目已从 Nx Monorepo 迁移为单体架构，ESP32 模块现已包含在
xiaozhi-client 包中，不再是独立的 npm 包。

本次更新修复以下文档问题：
- overview.mdx: 更新定位为"模块"而非"独立包"，删除错误安装命令
- architecture.mdx: 更新文件路径引用 (packages/esp32 → src/esp32)
- integration.mdx: 更新导入路径 (@xiaozhi-client/esp32 → @/esp32)
- quick-start.mdx: 更新安装说明，删除独立包安装命令

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: GLM-5.1 <noreply@bigmodel.cn>\n\nFixes issue: #3485