### PR TITLE
fix: 使用路径别名 @/config 替代相对路径导入

### DIFF
--- a/src/server/utils/prompt-utils.ts
+++ b/src/server/utils/prompt-utils.ts
@@ -16,7 +16,7 @@ import {
   writeFileSync,
 } from "node:fs";
 import { dirname, isAbsolute, resolve } from "node:path";
-import { configManager } from "../../config/index.js";
+import { configManager } from "@/config";
 
 // 默认系统提示词
 const DEFAULT_SYSTEM_PROMPT =


### PR DESCRIPTION
修复 src/server/utils/prompt-utils.ts 中违反路径别名规范的问题：
- 将 "../../config/index.js" 改为 "@/config"
- 符合项目路径别名规范
- 提高代码可维护性

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3487