### PR TITLE
docs: 添加 local-voice.mdx 文件的 frontmatter

### DIFF
--- a/docs/content/usage/local-voice.mdx
+++ b/docs/content/usage/local-voice.mdx
@@ -1,3 +1,8 @@
+---
+title: "使用本地语音互动 - Xiaozhi Client"
+description: "学习如何配置 ASR/LLM/TTS 服务实现本地语音互动，无需依赖小智服务端。"
+---
+
 import { ImageZoom, Steps, Tabs, Callout } from "nextra/components";
 
 # 使用本地语音互动


### PR DESCRIPTION
修复 docs/content/usage/local-voice.mdx 文件缺少 frontmatter 的问题，
添加了 title 和 description 元数据，与其他文档保持一致。

Closes #3488

Co-authored-by: shenjingnan <shenjingnan@users.noreply.github.com>\n\nFixes issue: #3488