### PR TITLE
feat(esp32): 在 OTA 响应中添加 24kHz 采样率音频参数

### DIFF
--- a/src/esp32/__tests__/esp32-manager.test.ts
+++ b/src/esp32/__tests__/esp32-manager.test.ts
@@ -156,6 +156,14 @@ describe("ESP32DeviceManager", () => {
         .server_time as unknown as Record<string, unknown>;
       expect(Number(serverTime.timestamp)).toBeGreaterThan(0);
       expect(typeof serverTime.timezone_offset).toBe("number");
+
+      // 验证 audioParams 经 camelToSnakeCase 转换后存在且值正确
+      expect(response).toHaveProperty("audio_params");
+      const audioParams = response.audio_params as Record<string, unknown>;
+      expect(audioParams.format).toBe("opus");
+      expect(audioParams.sample_rate).toBe(24000);
+      expect(audioParams.channels).toBe(1);
+      expect(audioParams.frame_duration).toBe(60);
     });
 
     it("新设备自动注册", async () => {

--- a/src/esp32/esp32-manager.ts
+++ b/src/esp32/esp32-manager.ts
@@ -331,6 +331,13 @@ export class ESP32DeviceManager {
         url: this.options.firmwareUrl,
         force: this.options.forceUpdate,
       },
+      // 音频参数：告知硬件端 TTS 下发和播放使用的采样率
+      audioParams: {
+        format: "opus",
+        sampleRate: 24000,
+        channels: 1,
+        frameDuration: 60,
+      },
     };
 
     // 转换为下划线命名后返回

--- a/src/esp32/types.ts
+++ b/src/esp32/types.ts
@@ -179,6 +179,17 @@ export interface ESP32OTAResponse {
   serverTime?: ESP32ServerTime;
   /** 固件信息（可选） */
   firmware?: ESP32FirmwareInfo;
+  /** 音频参数（告知硬件端采样率等音频配置） */
+  audioParams?: {
+    /** 音频格式 */
+    format: "opus" | "pcm";
+    /** 采样率（Hz） */
+    sampleRate: number;
+    /** 声道数 */
+    channels: number;
+    /** 帧时长（毫秒） */
+    frameDuration: number;
+  };
 }
 
 /**


### PR DESCRIPTION
## Summary
- 在 `/xiaozhi/ota` 接口响应中新增 `audioParams` 字段，告知硬件端 TTS 下发和播放使用 **24kHz** 采样率
- 参数：`format=opus, sampleRate=24000, channels=1, frameDuration=60`
- 与 WebSocket ServerHello（`connection.ts`）和 TTS 服务（`tts.service.ts`）保持一致
- ASR 接收保持 **16kHz** 不变

## 修改文件
| 文件 | 改动 |
|------|------|
| `src/esp32/types.ts` | `ESP32OTAResponse` 新增 `audioParams` 可选字段 |
| `src/esp32/esp32-manager.ts` | OTA 响应添加 audioParams 数据 |
| `src/esp32/__tests__/esp32-manager.test.ts` | 新增 audio_params 断言验证 |

## Test plan
- [x] 单元测试全部通过（2708 passed）
- [x] TypeScript 类型检查通过
- [x] Biome lint 检查通过