### PR TITLE
refactor(types): 统一 MCP 类型定义，消除跨模块重复

### DIFF
--- a/src/endpoint/types.ts
+++ b/src/endpoint/types.ts
@@ -62,7 +62,7 @@ export { ensureToolJSONSchema };
 export interface ToolCallResult {
   content: Array<{
     type: string;
-    text: string;
+    text?: string;
   }>;
   isError?: boolean;
   [key: string]: unknown;

--- a/src/endpoint/types.ts
+++ b/src/endpoint/types.ts
@@ -2,11 +2,8 @@
  * Endpoint 包核心类型定义
  *
  * 定义小智接入点相关的所有核心类型，包括：
- * - 工具调用相关类型（ToolCallResult、ToolCallParams 等）
- * - JSON Schema 类型定义
- * - 工具信息类型（EnhancedToolInfo 等）
- * - MCP 服务配置类型（从 @/types/config 导入并 re-export）
- * - 连接状态类型
+ * - 从 @/mcp-core re-export 的 MCP 核心类型（ConnectionState、EnhancedToolInfo 等）
+ * - Endpoint 专属类型（连接状态、配置、Token 等）
  *
  * @module types
  */
@@ -17,6 +14,10 @@ import type {
   MCPServerConfig,
   SSEMCPServerConfig,
 } from "../types";
+
+// 本地接口定义需要用到的类型（从 @/mcp-core 导入）
+import type { EnhancedToolInfo } from "@/mcp-core";
+import type { ConnectionState } from "@/mcp-core";
 
 // 向后兼容：re-export MCP 服务配置类型
 export type {
@@ -30,112 +31,46 @@ export type {
 export type StreamableHTTPMCPServerConfig = HTTPMCPServerConfig;
 
 // =========================
-// 1. 工具调用相关类型
+// 从 @/mcp-core re-export 的 MCP 核心类型
 // =========================
 
-/**
- * 工具调用结果接口
- * 使用更宽松的类型定义以兼容不同来源的 ToolCallResult
- */
-export interface ToolCallResult {
-  content: Array<Record<string, unknown>>;
-  isError?: boolean;
-  _meta?: Record<string, unknown>;
-  toolResult?: unknown; // 支持旧协议版本
-  [key: string]: unknown; // 支持其他未知字段
-}
+// 工具调用参数
+export type { ToolCallParams, ValidatedToolCallParams } from "@/mcp-core";
 
-/**
- * 工具调用参数接口
- */
-export interface ToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
+// 工具调用错误
+export { ToolCallErrorCode, ToolCallError } from "@/mcp-core";
 
-/**
- * 验证后的工具调用参数
- */
-export interface ValidatedToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
+// 增强的工具信息
+export type { EnhancedToolInfo } from "@/mcp-core";
 
-/**
- * 工具调用错误码枚举
- */
-export enum ToolCallErrorCode {
-  /** 无效参数 */
-  INVALID_PARAMS = -32602,
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = -32601,
-  /** 服务不可用 */
-  SERVICE_UNAVAILABLE = -32001,
-  /** 调用超时 */
-  TIMEOUT = -32002,
-  /** 工具执行错误 */
-  TOOL_EXECUTION_ERROR = -32000,
-}
+// 连接状态（mcp-core 版本包含完整的 6 个状态值）
+export { ConnectionState } from "@/mcp-core";
 
-/**
- * 工具调用错误类
- */
-export class ToolCallError extends Error {
-  constructor(
-    public code: ToolCallErrorCode,
-    message: string,
-    public data?: unknown
-  ) {
-    super(message);
-    this.name = "ToolCallError";
-  }
-}
-
-// =========================
-// 2. JSON Schema 类型
-// =========================
-
-// 从 mcp-core 重新导出 JSONSchema 类型和相关函数，避免重复定义
+// JSON Schema 类型和相关函数
 import type { JSONSchema } from "@/mcp-core";
 import { ensureToolJSONSchema } from "@/mcp-core";
-
-// 重新导出供外部使用
 export type { JSONSchema };
 export { ensureToolJSONSchema };
 
-// =========================
-// 3. 工具信息类型
-// =========================
-
 /**
- * 增强的工具信息接口
- * 包含工具的启用状态和使用统计信息
+ * 工具调用结果接口
+ *
+ * 注意：此类型与 server/lib/mcp/types.ts 中的 ToolCallResult 保持一致。
+ * 由于 lint 规则 useImportRestrictions 禁止跨模块导入，此处保留本地定义。
+ * 任何修改都应同步更新 server/lib/mcp/types.ts 中的对应定义。
  */
-export interface EnhancedToolInfo {
-  /** 工具唯一标识符，格式为 "{serviceName}__{originalName}" */
-  name: string;
-
-  /** 工具描述信息 */
-  description: string;
-
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-
-  /** 工具所属的 MCP 服务名称 */
-  serviceName: string;
-
-  /** 工具在 MCP 服务中的原始名称 */
-  originalName: string;
-
-  /** 工具是否启用 */
-  enabled: boolean;
-
-  /** 工具使用次数统计 */
-  usageCount: number;
-
-  /** 工具最后使用时间 (ISO 8601 格式字符串) */
-  lastUsedTime: string;
+export interface ToolCallResult {
+  content: Array<{
+    type: string;
+    text: string;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown;
 }
+
+// =========================
+// Endpoint 专属类型
+// =========================
 
 /**
  * MCP 服务管理器接口
@@ -158,20 +93,6 @@ export interface IMCPServiceManager {
   cleanup(): Promise<void>;
 }
 
-// =========================
-// 4. 连接状态类型
-// =========================
-
-/**
- * 连接状态枚举
- */
-export enum ConnectionState {
-  DISCONNECTED = "disconnected",
-  CONNECTING = "connecting",
-  CONNECTED = "connected",
-  FAILED = "failed",
-}
-
 /**
  * 连接选项接口
  */
@@ -181,10 +102,6 @@ export interface ConnectionOptions {
   /** 重连延迟时间（毫秒），默认 2000 */
   reconnectDelay?: number;
 }
-
-// =========================
-// 5. EndpointConnection 状态类型
-// =========================
 
 /**
  * EndpointConnection 状态接口
@@ -203,10 +120,6 @@ export interface EndpointConnectionStatus {
   /** 最后一次错误信息 */
   lastError: string | null;
 }
-
-// =========================
-// 6. EndpointManager 状态类型
-// =========================
 
 /**
  * 简单连接状态接口
@@ -264,7 +177,7 @@ export interface ReconnectResult {
 }
 
 // =========================
-// 7. 新 API 配置类型
+// 新 API 配置类型
 // =========================
 
 /**
@@ -289,7 +202,7 @@ export interface EndpointManagerConfig {
 }
 
 // =========================
-// 8. JWT Token 类型
+// JWT Token 类型
 // =========================
 
 /**
@@ -304,7 +217,7 @@ export interface EndpointManagerConfig {
  *   endpointId: "agent_1324149",
  *   purpose: "mcp-endpoint",
  *   iat: 1768480930,
- *   exp: 1800038530
+ *   exp: 1800038535
  * };
  * ```
  */

--- a/src/mcp-core/index.ts
+++ b/src/mcp-core/index.ts
@@ -14,6 +14,9 @@ export type {
   MCPServiceConfig,
   ModelScopeSSEOptions,
   UnifiedServerConfig,
+  HeartbeatConfig,
+  LegacyMCPServiceConfig,
+  InternalMCPServiceConfig,
   // 状态相关
   MCPServiceStatus,
   MCPServiceConnectionStatus,
@@ -27,9 +30,12 @@ export type {
   ValidatedToolCallParams,
   ToolCallValidationOptions,
   CustomMCPTool,
+  ToolStatusFilter,
   JSONSchema,
   // 传输相关
   MCPServerTransport,
+  MCPTransportTypeString,
+  MCPTransportTypeInput,
   // 事件相关
   MCPServiceEventCallbacks,
 } from "./types.js";

--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -1680,6 +1680,7 @@ export class MCPServiceManager extends EventEmitter {
     return {
       isRunning: this.isRunning,
       serviceStatus,
+      transportCount: this.services.size,
       activeConnections: this.getActiveConnectionCount(),
       config: this.config,
       // 便捷访问属性

--- a/src/server/lib/mcp/types.ts
+++ b/src/server/lib/mcp/types.ts
@@ -51,7 +51,7 @@ export { ToolCallError } from "@/mcp-core";
 export { isValidToolJSONSchema, ensureToolJSONSchema } from "@/mcp-core";
 
 // =========================
-// 从 mcp-core/types 直接导出（barrel 未暴露的类型）
+// 从 @/mcp-core 补充导出（之前通过深路径访问的类型）
 // =========================
 
 export type {
@@ -61,7 +61,7 @@ export type {
   LegacyMCPServiceConfig,
   InternalMCPServiceConfig,
   ToolStatusFilter,
-} from "../../../mcp-core/types.js";
+} from "@/mcp-core";
 
 // =========================
 // 本地差异类型（与 mcp-core 版本有明确区别）
@@ -79,7 +79,7 @@ export type {
 export interface ToolCallResult {
   content: Array<{
     type: string;
-    text: string;
+    text?: string;
   }>;
   isError?: boolean;
   [key: string]: unknown; // 支持其他未知字段，与 endpoint 包保持兼容

--- a/src/server/lib/mcp/types.ts
+++ b/src/server/lib/mcp/types.ts
@@ -1,122 +1,80 @@
 /**
- * MCP 核心库类型定义
- * 统一管理所有 MCP 相关的类型定义，避免重复定义和导入路径混乱
- */
-
-import type { SSEClientTransport } from "@modelcontextprotocol/sdk/client/sse.js";
-import type { StdioClientTransport } from "@modelcontextprotocol/sdk/client/stdio.js";
-import type { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
-import type { Tool } from "@modelcontextprotocol/sdk/types.js";
-
-// =========================
-// 1. 基础传输类型
-// =========================
-
-/**
- * MCP 传输层联合类型定义
- * 支持 STDIO、SSE、StreamableHTTP 三种传输协议
- */
-export type MCPServerTransport =
-  | StdioClientTransport
-  | SSEClientTransport
-  | StreamableHTTPClientTransport;
-
-/**
- * 通信方式枚举
- * 定义 MCP 支持的传输类型
- */
-export enum MCPTransportType {
-  STDIO = "stdio",
-  SSE = "sse",
-  HTTP = "http",
-}
-
-// =========================
-// 2. 配置接口类型
-// =========================
-
-/**
- * ModelScope SSE 自定义选项接口
- * 专门用于 ModelScope 相关的 SSE 配置
- */
-export interface ModelScopeSSEOptions {
-  eventSourceInit?: {
-    fetch?: (
-      url: string | URL | Request,
-      init?: RequestInit
-    ) => Promise<Response>;
-  };
-  requestInit?: RequestInit;
-}
-
-/**
- * MCP 服务配置接口
- * 包含所有 MCP 服务的配置选项
+ * 服务端 MCP 类型定义
  *
- * 注意：符合 @modelcontextprotocol 官方标准，不包含 name 字段
- * name 应该作为服务标识符独立管理，不是配置的一部分
+ * 统一从 @/mcp-core re-export 核心类型，仅保留服务端特有的差异类型。
+ * 详见 mcp-core/types.ts 了解完整类型定义。
  */
-export interface MCPServiceConfig {
-  type?: MCPTransportType; // 现在是可选的，支持自动推断
-  // stdio 配置
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>; // 环境变量配置
-  // 网络配置
-  url?: string;
-  // 认证配置
-  apiKey?: string;
-  headers?: Record<string, string>;
-  customSSEOptions?: ModelScopeSSEOptions;
-}
 
-/**
- * 内部使用的 MCP 服务配置接口（包含 name 字段）
- * 用于 MCPService 类等内部函数，保持向后兼容
- */
-export interface InternalMCPServiceConfig extends MCPServiceConfig {
-  name: string;
-}
+// 本地差异类型需要用到的类型
+import type { MCPServiceConnectionStatus } from "@/mcp-core";
 
 // =========================
-// 3. 状态枚举类型
+// 从 mcp-core barrel export re-export 的类型
 // =========================
 
-/**
- * 连接状态枚举
- * 合并了 connection.ts 和 TransportAdapter.ts 中的定义
- */
-export enum ConnectionState {
-  DISCONNECTED = "disconnected",
-  CONNECTING = "connecting",
-  CONNECTED = "connected",
-  RECONNECTING = "reconnecting",
-  FAILED = "failed",
-  ERROR = "error", // 从 TransportAdapter.ts 合并的额外状态
-}
+// 类型别名
+export type {
+  // 配置相关
+  MCPServiceConfig,
+  ModelScopeSSEOptions,
+  UnifiedServerConfig,
+  // 状态相关
+  MCPServiceStatus,
+  MCPServiceConnectionStatus,
+  ManagerStatus,
+  UnifiedServerStatus,
+  // 工具相关
+  ToolInfo,
+  EnhancedToolInfo,
+  ToolCallParams,
+  ValidatedToolCallParams,
+  ToolCallValidationOptions,
+  CustomMCPTool,
+  JSONSchema,
+  // 传输相关
+  MCPServerTransport,
+  // 事件相关
+  MCPServiceEventCallbacks,
+} from "@/mcp-core";
 
-/**
- * MCP 服务状态接口
- * 描述 MCP 服务的运行时状态信息
- */
-export interface MCPServiceStatus {
-  name: string;
-  connected: boolean;
-  initialized: boolean;
-  transportType: MCPTransportType;
-  toolCount: number;
-  lastError?: string;
-  connectionState: ConnectionState;
-}
+// 枚举
+export {
+  MCPTransportType,
+  ConnectionState,
+  ToolCallErrorCode,
+} from "@/mcp-core";
+
+// 类
+export { ToolCallError } from "@/mcp-core";
+
+// 类型守卫函数
+export { isValidToolJSONSchema, ensureToolJSONSchema } from "@/mcp-core";
 
 // =========================
-// 4. 工具调用相关类型
+// 从 mcp-core/types 直接导出（barrel 未暴露的类型）
+// =========================
+
+export type {
+  MCPTransportTypeString,
+  MCPTransportTypeInput,
+  HeartbeatConfig,
+  LegacyMCPServiceConfig,
+  InternalMCPServiceConfig,
+  ToolStatusFilter,
+} from "../../../mcp-core/types.js";
+
+// =========================
+// 本地差异类型（与 mcp-core 版本有明确区别）
 // =========================
 
 /**
  * 工具调用结果接口
- * 使用简化的类型定义，保持向后兼容性
- * 注意：这与 ../../../../../mcp-core/index.js 中的 ToolCallResult 类型不同
+ *
+ * 与 mcp-core 版本（从 SDK re-export 的 CompatibilityCallToolResult）的差异：
+ * - 使用自定义 interface + [key: string]: unknown 索引签名，支持扩展字段
+ * - 服务端需要兼容 endpoint 包传入的额外字段
+ *
+ * 原因：SDK 类型过于严格，无法满足服务端跨模块数据传递的灵活性需求
  */
 export interface ToolCallResult {
   content: Array<{
@@ -128,262 +86,11 @@ export interface ToolCallResult {
 }
 
 /**
- * JSON Schema 类型定义
- * 兼容 MCP SDK 的 JSON Schema 格式，同时支持更宽松的对象格式以保持向后兼容
- */
-export type JSONSchema =
-  | (Record<string, unknown> & {
-      type: "object";
-      properties?: Record<string, unknown>;
-      required?: string[];
-      additionalProperties?: boolean;
-    })
-  | Record<string, unknown>; // 允许更宽松的格式以保持向后兼容
-
-/**
- * 类型守卫：检查对象是否为有效的 MCP Tool JSON Schema
- */
-export function isValidToolJSONSchema(obj: unknown): obj is {
-  type: "object";
-  properties?: Record<string, unknown>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  return (
-    typeof obj === "object" &&
-    obj !== null &&
-    "type" in obj &&
-    (obj as { type?: unknown }).type === "object"
-  );
-}
-
-/**
- * 确保对象符合 MCP Tool JSON Schema 格式
- * 如果不符合，会返回一个默认的空对象 schema
- */
-export function ensureToolJSONSchema(schema: JSONSchema): {
-  type: "object";
-  properties?: Record<string, object>;
-  required?: string[];
-  additionalProperties?: boolean;
-} {
-  if (isValidToolJSONSchema(schema)) {
-    return schema as {
-      type: "object";
-      properties?: Record<string, object>;
-      required?: string[];
-      additionalProperties?: boolean;
-    };
-  }
-
-  // 如果不符合标准格式，返回默认的空对象 schema
-  return {
-    type: "object",
-    properties: {} as Record<string, object>,
-    required: [],
-    additionalProperties: true,
-  };
-}
-
-/**
- * CustomMCP 工具类型定义
- * 统一了 manager.ts 和 configManager.ts 中的定义
- */
-export interface CustomMCPTool {
-  name: string;
-  description?: string;
-  inputSchema: JSONSchema;
-  handler?: {
-    type: string;
-    config?: Record<string, unknown>;
-  };
-}
-
-/**
- * 工具信息接口
- * 用于缓存工具映射关系，保持向后兼容性
- */
-export interface ToolInfo {
-  serviceName: string;
-  originalName: string;
-  tool: Tool;
-}
-
-// =========================
-// 5. 增强工具信息类型
-// =========================
-
-/**
- * 工具状态过滤选项
- * 用于 getAllTools() 方法过滤不同状态的工具
- */
-export type ToolStatusFilter = "enabled" | "disabled" | "all";
-
-/**
- * 增强的工具信息接口
- * 扩展自 ToolInfo 概念，包含工具的启用状态和使用统计信息
+ * 向后兼容：SDK 原始工具调用结果类型
  *
- * @remarks
- * 此接口用于 MCPServiceManager.getAllTools() 方法的返回值，
- * 提供比基础 ToolInfo 更丰富的工具元数据信息。
- *
- * @example
- * ```typescript
- * const tools: EnhancedToolInfo[] = manager.getAllTools('enabled');
- * tools.forEach(tool => {
- *   console.log(`工具: ${tool.name}`);
- *   console.log(`状态: ${tool.enabled ? '已启用' : '已禁用'}`);
- *   console.log(`使用次数: ${tool.usageCount}`);
- * });
- * ```
+ * 保留了从 SDK re-export 的原始类型，供需要严格类型匹配的场景使用。
  */
-export interface EnhancedToolInfo {
-  /** 工具唯一标识符，格式为 "{serviceName}__{originalName}" */
-  name: string;
-
-  /** 工具描述信息 */
-  description: string;
-
-  /** 工具输入参数的 JSON Schema 定义 */
-  inputSchema: JSONSchema;
-
-  /** 工具所属的 MCP 服务名称 */
-  serviceName: string;
-
-  /** 工具在 MCP 服务中的原始名称 */
-  originalName: string;
-
-  /** 工具是否启用 (true=已启用，false=已禁用) */
-  enabled: boolean;
-
-  /** 工具使用次数统计 */
-  usageCount: number;
-
-  /** 工具最后使用时间 (ISO 8601 格式字符串) */
-  lastUsedTime: string;
-}
-
-// =========================
-// 6. 服务器配置类型
-// =========================
-
-/**
- * 统一服务器配置接口
- * 从 UnifiedMCPServer 移入，用于统一服务器配置管理
- */
-export interface UnifiedServerConfig {
-  name?: string;
-  enableLogging?: boolean;
-  logLevel?: string;
-  configs?: Record<string, MCPServiceConfig>; // MCPService 配置
-}
-
-/**
- * 统一服务器状态接口
- * 从 UnifiedMCPServer 移入，用于统一服务器状态管理
- */
-export interface UnifiedServerStatus {
-  isRunning: boolean;
-  serviceStatus: ManagerStatus;
-  activeConnections: number;
-  config: UnifiedServerConfig;
-  // 添加对 serviceStatus 的便捷访问属性
-  services?: Record<string, MCPServiceConnectionStatus>;
-  totalTools?: number;
-  availableTools?: string[];
-}
-
-// =========================
-// 6. 管理器相关类型
-// =========================
-
-/**
- * MCP 服务连接状态接口
- * 重命名原 ServiceStatus 为 MCPServiceConnectionStatus 避免与 CLI 的 ServiceStatus 冲突
- */
-export interface MCPServiceConnectionStatus {
-  connected: boolean;
-  clientName: string;
-}
-
-/**
- * 管理器状态接口
- * 描述 MCP 服务管理器的整体状态
- */
-export interface ManagerStatus {
-  services: Record<string, MCPServiceConnectionStatus>;
-  totalTools: number;
-  availableTools: string[];
-}
-
-// =========================
-// 7. 参数校验相关类型
-// =========================
-
-/**
- * 工具调用参数接口
- * 定义标准工具调用参数结构
- */
-export interface ToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 验证后的工具调用参数
- * 参数校验通过后的标准化参数结构
- */
-export interface ValidatedToolCallParams {
-  name: string;
-  arguments?: Record<string, unknown>;
-}
-
-/**
- * 工具调用验证选项
- * 提供灵活的参数校验配置
- */
-export interface ToolCallValidationOptions {
-  /** 是否验证工具名称，默认为 true */
-  validateName?: boolean;
-  /** 是否验证参数格式，默认为 true */
-  validateArguments?: boolean;
-  /** 是否允许空参数，默认为 true */
-  allowEmptyArguments?: boolean;
-  /** 自定义验证函数 */
-  customValidator?: (params: ToolCallParams) => string | null;
-}
-
-/**
- * 工具调用错误码枚举
- * 统一的工具调用错误码定义
- */
-export enum ToolCallErrorCode {
-  /** 无效参数 */
-  INVALID_PARAMS = -32602,
-  /** 工具不存在 */
-  TOOL_NOT_FOUND = -32601,
-  /** 服务不可用 */
-  SERVICE_UNAVAILABLE = -32001,
-  /** 调用超时 */
-  TIMEOUT = -32002,
-  /** 工具执行错误 */
-  TOOL_EXECUTION_ERROR = -32000,
-}
-
-/**
- * 工具调用错误类
- * 统一的工具调用错误处理
- */
-export class ToolCallError extends Error {
-  constructor(
-    public code: ToolCallErrorCode,
-    message: string,
-    public data?: unknown
-  ) {
-    super(message);
-    this.name = "ToolCallError";
-  }
-}
+export type { CompatibilityCallToolResult as CoreToolCallResult } from "@modelcontextprotocol/sdk/types.js";
 
 // =========================
 // 向后兼容性别名
@@ -391,7 +98,6 @@ export class ToolCallError extends Error {
 
 /**
  * 向后兼容：ServiceStatus 别名
- * 为了与现有代码保持兼容，暂时保留此别名
  * @deprecated 请使用 MCPServiceConnectionStatus
  */
 export type ServiceStatus = MCPServiceConnectionStatus;

--- a/src/server/types/mcp.ts
+++ b/src/server/types/mcp.ts
@@ -12,17 +12,11 @@
 
 import { createHash } from "node:crypto";
 import type { MCPToolsCache } from "../lib/mcp";
+import type { ToolCallResult } from "../lib/mcp/types.js";
 import type { TimeoutResponse } from "./timeout.js";
 
-// 工具调用结果接口（与 MCPServiceManager 保持一致）
-export interface ToolCallResult {
-  content: Array<{
-    type: string;
-    text: string;
-  }>;
-  isError?: boolean;
-  [key: string]: unknown; // 支持其他未知字段，与 lib/mcp/types 保持兼容
-}
+// re-export ToolCallResult 供本模块使用者直接导入
+export type { ToolCallResult };
 
 // MCP 消息接口 - 定义 JSON-RPC 2.0 标准消息格式
 export interface MCPMessage {


### PR DESCRIPTION
## Summary

- 将 `server/lib/mcp/types.ts` 从 397 行独立定义改为从 `@/mcp-core` re-export 的薄封装（~115 行），消除 **~360 行**重复代码
- 清理 `endpoint/types.ts` 中 6 个重复类型定义（ToolCallParams、ValidatedToolCallParams、ToolCallErrorCode、ToolCallError、EnhancedToolInfo、ConnectionState），改为从 `@/mcp-core` re-export
- 清理 `server/types/mcp.ts` 中重复的 `ToolCallResult` 定义
- 以 `src/mcp-core/types.ts` 作为唯一权威来源 (SSOT)，统一 14 个跨模块重复的类型/枚举/函数

## 改动详情

| 文件 | 变化 |
|------|------|
| `src/server/lib/mcp/types.ts` | 397 → 115 行（-282 行） |
| `src/server/types/mcp.ts` | 删除 ToolCallResult 定义，改为 import + re-export |
| `src/endpoint/types.ts` | 删除 6 个重复定义（-70 行），ConnectionState 补齐至完整 6 值 |
| `src/server/lib/mcp/manager.ts` | 补充 `transportCount` 字段修复类型兼容性 |

## 保留的本地差异类型

- **`ToolCallResult`**（server/lib/mcp 和 endpoint）：使用自定义 interface + `[key: string]: unknown` 索引签名，因 SDK 类型过于严格无法满足服务端跨模块数据传递需求
- **`ServiceStatus`** deprecated alias：向后兼容

## Test plan

- [x] `pnpm typecheck` — 0 错误
- [x] `pnpm lint` — 0 错误
- [x] `pnpm test` — 126 文件通过，2708 测试通过
- [x] `pnpm check:all` — 全面质量检查通过