### PR TITLE
refactor(mcp): 统一 ToolCallResult 类型定义，明确 MCP 管理器分层

### DIFF
--- a/.agents/skills/issue-hunter/SKILL.md
+++ b/.agents/skills/issue-hunter/SKILL.md
@@ -213,11 +213,11 @@ pnpm outdated
 **正确模式**:
 ```typescript
 // ✅ 推荐（使用路径别名）
-import { MCPServiceManager } from "@/mcp-core";
+import { MCPManager } from "@/mcp-core";
 import { ConfigService } from "@/config";
 
 // ❌ 避免（相对路径）
-import { MCPServiceManager } from "../mcp-core";
+import { MCPManager } from "../mcp-core";
 import { ConfigService } from "../config";
 ```
 

--- a/src/endpoint/types.ts
+++ b/src/endpoint/types.ts
@@ -16,7 +16,7 @@ import type {
 } from "../types";
 
 // 本地接口定义需要用到的类型（从 @/mcp-core 导入）
-import type { EnhancedToolInfo } from "@/mcp-core";
+import type { EnhancedToolInfo, ToolCallResult } from "@/mcp-core";
 import type { ConnectionState } from "@/mcp-core";
 
 // 向后兼容：re-export MCP 服务配置类型
@@ -52,21 +52,8 @@ import { ensureToolJSONSchema } from "@/mcp-core";
 export type { JSONSchema };
 export { ensureToolJSONSchema };
 
-/**
- * 工具调用结果接口
- *
- * 注意：此类型与 server/lib/mcp/types.ts 中的 ToolCallResult 保持一致。
- * 由于 lint 规则 useImportRestrictions 禁止跨模块导入，此处保留本地定义。
- * 任何修改都应同步更新 server/lib/mcp/types.ts 中的对应定义。
- */
-export interface ToolCallResult {
-  content: Array<{
-    type: string;
-    text?: string;
-  }>;
-  isError?: boolean;
-  [key: string]: unknown;
-}
+// 工具调用结果接口（从 mcp-core 导入的 canonical 定义）
+export type { ToolCallResult };
 
 // =========================
 // Endpoint 专属类型

--- a/src/mcp-core/__tests__/manager.test.ts
+++ b/src/mcp-core/__tests__/manager.test.ts
@@ -1,0 +1,463 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MCPManager } from "../manager.js";
+import { MCPTransportType } from "../types.js";
+import type { MCPServiceConfig } from "../types.js";
+
+// Mock MCPConnection
+vi.mock("../connection.js", () => {
+  const mockIsConnected = vi.fn();
+  const mockConnect = vi.fn();
+  const mockDisconnect = vi.fn();
+  const mockCallTool = vi.fn();
+  const mockGetTools = vi.fn(() => []);
+  const mockGetStatus = vi.fn(() => ({ connected: false, toolCount: 0 }));
+
+  class MockMCPConnection {
+    isConnected = mockIsConnected;
+    connect = mockConnect;
+    disconnect = mockDisconnect;
+    callTool = mockCallTool;
+    getTools = mockGetTools;
+    getStatus = mockGetStatus;
+
+    constructor(
+      _name: string,
+      _config: MCPServiceConfig,
+      callbacks?: {
+        onConnected?: (data: unknown) => void;
+        onDisconnected?: (data: unknown) => void;
+        onConnectionFailed?: (data: unknown) => void;
+      }
+    ) {
+      // 存储回调以便测试中使用
+      (this as unknown as Record<string, unknown>)._callbacks = callbacks;
+    }
+  }
+
+  return {
+    MCPConnection: MockMCPConnection,
+    __mocks: {
+      mockIsConnected,
+      mockConnect,
+      mockDisconnect,
+      mockCallTool,
+      mockGetTools,
+      mockGetStatus,
+    },
+  };
+});
+
+// 获取 mock 函数引用
+let mocks: {
+  mockIsConnected: ReturnType<typeof vi.fn>;
+  mockConnect: ReturnType<typeof vi.fn>;
+  mockDisconnect: ReturnType<typeof vi.fn>;
+  mockCallTool: ReturnType<typeof vi.fn>;
+  mockGetTools: ReturnType<typeof vi.fn>;
+  mockGetStatus: ReturnType<typeof vi.fn>;
+};
+
+describe("MCPManager", () => {
+  let manager: MCPManager;
+
+  beforeEach(async () => {
+    const mod = await import("../connection.js");
+    mocks = (mod as unknown as { __mocks: typeof mocks }).__mocks;
+    manager = new MCPManager();
+  });
+
+  afterEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // =========================
+  // addServer / removeServer
+  // =========================
+
+  describe("服务配置管理", () => {
+    it("应该能够添加服务配置", () => {
+      manager.addServer("test-service", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+        args: ["server.js"],
+      });
+
+      expect(manager.getServerNames()).toContain("test-service");
+    });
+
+    it("添加重复名称的服务应该抛出错误", () => {
+      manager.addServer("dup", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+
+      expect(() =>
+        manager.addServer("dup", {
+          type: MCPTransportType.STDIO,
+          command: "node",
+        })
+      ).toThrow("服务 dup 已存在");
+    });
+
+    it("应该能够移除服务配置", () => {
+      manager.addServer("removable", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      const result = manager.removeServer("removable");
+
+      expect(result).toBe(true);
+      expect(manager.getServerNames()).not.toContain("removable");
+    });
+
+    it("移除不存在的服务应该返回 false", () => {
+      const result = manager.removeServer("nonexistent");
+
+      expect(result).toBe(false);
+    });
+
+    it("应该将字符串类型的 http 标准化为枚举值", () => {
+      manager.addServer("http-svc", {
+        type: "http" as unknown as MCPTransportType,
+        url: "http://localhost:3000/mcp",
+      });
+
+      expect(manager.getServerNames()).toContain("http-svc");
+    });
+
+    it("应该将字符串类型的 sse 标准化为枚举值", () => {
+      manager.addServer("sse-svc", {
+        type: "sse" as unknown as MCPTransportType,
+        url: "http://localhost:3000/sse",
+      });
+
+      expect(manager.getServerNames()).toContain("sse-svc");
+    });
+  });
+
+  // =========================
+  // connect / disconnect
+  // =========================
+
+  describe("连接管理", () => {
+    it("连接时应该发射 connect 事件", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+
+      const emitSpy = vi.spyOn(manager, "emit");
+      await manager.connect();
+
+      expect(emitSpy).toHaveBeenCalledWith("connect");
+    });
+
+    it("连接成功后应该建立连接实例", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      expect(mocks.mockConnect).toHaveBeenCalledOnce();
+    });
+
+    it("断开连接时应该发射 disconnect 事件", async () => {
+      mocks.mockDisconnect.mockResolvedValue(undefined);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const emitSpy = vi.spyOn(manager, "emit");
+      await manager.disconnect();
+
+      expect(emitSpy).toHaveBeenCalledWith("disconnect");
+    });
+
+    it("断开连接后应该清空所有连接", async () => {
+      mocks.mockDisconnect.mockResolvedValue(undefined);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+      await manager.disconnect();
+
+      expect(manager.getConnectedServerNames()).toHaveLength(0);
+    });
+
+    it("无服务时 connect 和 disconnect 应该正常完成", async () => {
+      await expect(manager.connect()).resolves.toBeUndefined();
+      await expect(manager.disconnect()).resolves.toBeUndefined();
+    });
+  });
+
+  // =========================
+  // callTool
+  // =========================
+
+  describe("工具调用", () => {
+    it("调用不存在服务的工具应该抛出错误", async () => {
+      await expect(manager.callTool("nonexistent", "tool", {})).rejects.toThrow(
+        "服务 nonexistent 不存在"
+      );
+    });
+
+    it("调用未连接服务的工具应该抛出错误", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(false);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      await expect(manager.callTool("svc1", "some-tool", {})).rejects.toThrow(
+        "服务 svc1 未连接"
+      );
+    });
+
+    it("调用已连接服务的工具应该返回结果", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+      const mockResult = { content: [{ type: "text", text: "result" }] };
+      mocks.mockCallTool.mockResolvedValue(mockResult);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const result = await manager.callTool("svc1", "some-tool", {
+        key: "value",
+      });
+
+      expect(result).toEqual(mockResult);
+      expect(mocks.mockCallTool).toHaveBeenCalledWith("some-tool", {
+        key: "value",
+      });
+    });
+  });
+
+  // =========================
+  // listTools
+  // =========================
+
+  describe("工具列表", () => {
+    it("无连接时应返回空列表", () => {
+      const tools = manager.listTools();
+
+      expect(tools).toEqual([]);
+    });
+
+    it("已连接服务有工具时应返回工具列表", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+      mocks.mockGetTools.mockReturnValue([
+        { name: "tool-a", description: "工具A", inputSchema: {} },
+        {
+          name: "tool-b",
+          description: "工具B",
+          inputSchema: { type: "object" },
+        },
+      ]);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const tools = manager.listTools();
+
+      expect(tools).toHaveLength(2);
+      expect(tools[0]).toEqual({
+        name: "tool-a",
+        serverName: "svc1",
+        description: "工具A",
+        inputSchema: {},
+      });
+    });
+
+    it("未连接的服务不应出现在工具列表中", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(false);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const tools = manager.listTools();
+
+      expect(tools).toEqual([]);
+    });
+  });
+
+  // =========================
+  // getServerStatus / getAllServerStatus
+  // =========================
+
+  describe("状态查询", () => {
+    it("获取不存在的服务状态应返回 null", () => {
+      const status = manager.getServerStatus("nonexistent");
+
+      expect(status).toBeNull();
+    });
+
+    it("获取已连接服务的状态应返回正确信息", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+      mocks.mockGetStatus.mockReturnValue({ connected: true, toolCount: 5 });
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const status = manager.getServerStatus("svc1");
+
+      expect(status).toEqual({ connected: true, toolCount: 5 });
+    });
+
+    it("获取所有服务状态应包含所有已连接服务", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+      mocks.mockGetStatus.mockReturnValue({ connected: true, toolCount: 3 });
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      manager.addServer("svc2", {
+        type: MCPTransportType.HTTP,
+        url: "http://localhost",
+      });
+      await manager.connect();
+
+      const statuses = manager.getAllServerStatus();
+
+      expect(Object.keys(statuses)).toContain("svc1");
+      expect(Object.keys(statuses)).toContain("svc2");
+      expect(statuses.svc1).toEqual({ connected: true, toolCount: 3 });
+    });
+
+    it("无连接服务时 getAllServerStatus 应返回空对象", () => {
+      const statuses = manager.getAllServerStatus();
+
+      expect(statuses).toEqual({});
+    });
+  });
+
+  // =========================
+  // isConnected
+  // =========================
+
+  describe("连接检查", () => {
+    it("不存在的服务应返回 false", () => {
+      expect(manager.isConnected("nonexistent")).toBe(false);
+    });
+
+    it("已连接的服务应返回 true", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      expect(manager.isConnected("svc1")).toBe(true);
+    });
+
+    it("未连接的服务应返回 false", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(false);
+
+      manager.addServer("svc1", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      expect(manager.isConnected("svc1")).toBe(false);
+    });
+  });
+
+  // =========================
+  // getServerNames / getConnectedServerNames
+  // =========================
+
+  describe("服务列表查询", () => {
+    it("getServerNames 应返回所有已配置的服务名", () => {
+      manager.addServer("svc-a", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      manager.addServer("svc-b", {
+        type: MCPTransportType.HTTP,
+        url: "http://x",
+      });
+
+      const names = manager.getServerNames();
+
+      expect(names).toContain("svc-a");
+      expect(names).toContain("svc-b");
+      expect(names).toHaveLength(2);
+    });
+
+    it("无配置服务时 getServerNames 应返回空数组", () => {
+      expect(manager.getServerNames()).toEqual([]);
+    });
+
+    it("getConnectedServerNames 应只返回已连接的服务", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(true);
+
+      manager.addServer("svc-a", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      manager.addServer("svc-b", {
+        type: MCPTransportType.HTTP,
+        url: "http://x",
+      });
+      await manager.connect();
+
+      const connected = manager.getConnectedServerNames();
+
+      // 两个服务都已连接，应都出现在列表中
+      expect(connected).toContain("svc-a");
+      expect(connected).toContain("svc-b");
+      expect(connected).toHaveLength(2);
+    });
+
+    it("所有服务未连接时 getConnectedServerNames 应返回空数组", async () => {
+      mocks.mockConnect.mockResolvedValue(undefined);
+      mocks.mockIsConnected.mockReturnValue(false);
+
+      manager.addServer("svc-a", {
+        type: MCPTransportType.STDIO,
+        command: "node",
+      });
+      await manager.connect();
+
+      const connected = manager.getConnectedServerNames();
+
+      expect(connected).toEqual([]);
+    });
+  });
+});

--- a/src/mcp-core/index.ts
+++ b/src/mcp-core/index.ts
@@ -26,6 +26,7 @@ export type {
   ToolInfo,
   EnhancedToolInfo,
   ToolCallResult,
+  CoreToolCallResult,
   ToolCallParams,
   ValidatedToolCallParams,
   ToolCallValidationOptions,
@@ -56,7 +57,7 @@ export {
 
 export { ToolCallError } from "./types.js";
 export { MCPConnection } from "./connection.js";
-export { MCPManager, MCPServiceManager } from "./manager.js";
+export { MCPManager } from "./manager.js";
 
 // =========================
 // 传输工厂导出

--- a/src/mcp-core/manager.ts
+++ b/src/mcp-core/manager.ts
@@ -1,6 +1,14 @@
 /**
- * MCP 服务管理器
- * 提供简洁的 API 来管理多个 MCP 服务
+ * MCP 协议层管理器（轻量级）
+ *
+ * 定位：提供纯净的 MCP 协议操作能力，不包含任何业务逻辑。
+ * 适用场景：Endpoint 层、CLI 工具、嵌入式集成等轻量级消费方。
+ *
+ * 与 server/lib/mcp 的 MCPServiceManager 分工：
+ * - 本类（MCPManager）：协议层 — 连接管理、工具发现、工具调用
+ * - MCPServiceManager：业务层 — 在协议层之上增加缓存、统计、CustomMCP、日志、重试等
+ *
+ * 如果需要完整的业务功能，请使用 server/lib/mcp 的 MCPServiceManager。
  */
 
 import { EventEmitter } from "node:events";
@@ -349,5 +357,5 @@ export class MCPManager extends EventEmitter {
   }
 }
 
-// 为了向后兼容，保留旧的 MCPServiceManager 类名作为别名
-export { MCPManager as MCPServiceManager };
+// 注意：MCPManager 是协议层管理器（轻量级），仅提供基础的连接管理和工具调用
+// 如需完整的业务功能（缓存、统计、CustomMCP、日志等），请使用 server/lib/mcp 的 MCPServiceManager

--- a/src/mcp-core/types.ts
+++ b/src/mcp-core/types.ts
@@ -176,9 +176,27 @@ export interface MCPServiceStatus {
 // 4. 工具调用相关类型
 // =========================
 
-// 从 MCP SDK 重新导出工具调用结果类型
-// 使用 CompatibilityCallToolResult 以支持新旧协议版本
-export type { CompatibilityCallToolResult as ToolCallResult } from "@modelcontextprotocol/sdk/types.js";
+// 从 MCP SDK 重新导出工具调用结果类型（原始 SDK 类型，供需要严格匹配的场景）
+export type { CompatibilityCallToolResult as CoreToolCallResult } from "@modelcontextprotocol/sdk/types.js";
+
+/**
+ * 工具调用结果接口（canonical 定义）
+ *
+ * 定义位置：mcp-core/types.ts（三方均可访问的公共层）
+ * 使用方：server/lib/mcp、endpoint 等所有模块均从此处导入
+ *
+ * 与 SDK 原始类型 CoreToolCallResult 的差异：
+ * - 使用自定义 interface + 索引签名，支持扩展字段
+ * - SDK 类型过于严格，无法满足跨模块数据传递的灵活性需求
+ */
+export interface ToolCallResult {
+  content?: Array<{
+    type: string;
+    text?: string;
+  }>;
+  isError?: boolean;
+  [key: string]: unknown;
+}
 
 /**
  * JSON Schema 类型定义

--- a/src/server/lib/mcp/types.ts
+++ b/src/server/lib/mcp/types.ts
@@ -68,29 +68,11 @@ export type {
 // =========================
 
 /**
- * 工具调用结果接口
+ * 工具调用结果类型（从 mcp-core 导入的 canonical 定义）
  *
- * 与 mcp-core 版本（从 SDK re-export 的 CompatibilityCallToolResult）的差异：
- * - 使用自定义 interface + [key: string]: unknown 索引签名，支持扩展字段
- * - 服务端需要兼容 endpoint 包传入的额外字段
- *
- * 原因：SDK 类型过于严格，无法满足服务端跨模块数据传递的灵活性需求
+ * canonical 定义位于 mcp-core/types.ts，此处仅做 re-export。
  */
-export interface ToolCallResult {
-  content: Array<{
-    type: string;
-    text?: string;
-  }>;
-  isError?: boolean;
-  [key: string]: unknown; // 支持其他未知字段，与 endpoint 包保持兼容
-}
-
-/**
- * 向后兼容：SDK 原始工具调用结果类型
- *
- * 保留了从 SDK re-export 的原始类型，供需要严格类型匹配的场景使用。
- */
-export type { CompatibilityCallToolResult as CoreToolCallResult } from "@modelcontextprotocol/sdk/types.js";
+export type { ToolCallResult, CoreToolCallResult } from "@/mcp-core";
 
 // =========================
 // 向后兼容性别名

--- a/src/server/types/__tests__/mcp.test.ts
+++ b/src/server/types/__tests__/mcp.test.ts
@@ -1,0 +1,140 @@
+import { describe, expect, it } from "vitest";
+import { isToolCallResult } from "../mcp.js";
+
+describe("isToolCallResult 类型守卫", () => {
+  // =========================
+  // 有效结果
+  // =========================
+
+  describe("有效工具调用结果", () => {
+    it("标准文本内容应返回 true", () => {
+      const result = {
+        content: [{ type: "text", text: "hello" }],
+      };
+
+      expect(isToolCallResult(result)).toBe(true);
+    });
+
+    it("多段文本内容应返回 true", () => {
+      const result = {
+        content: [
+          { type: "text", text: "first" },
+          { type: "text", text: "second" },
+        ],
+      };
+
+      expect(isToolCallResult(result)).toBe(true);
+    });
+
+    it("包含 isError 字段的错误结果应返回 true", () => {
+      const result = {
+        content: [{ type: "text", text: "error msg" }],
+        isError: true,
+      };
+
+      expect(isToolCallResult(result)).toBe(true);
+    });
+
+    it("包含额外扩展字段的结果应返回 true", () => {
+      const result = {
+        content: [{ type: "text", text: "ok" }],
+        customField: "value",
+        metadata: { id: 123 },
+      };
+
+      expect(isToolCallResult(result)).toBe(true);
+    });
+  });
+
+  // =========================
+  // 无效结果
+  // =========================
+
+  describe("无效输入", () => {
+    it("null 应返回 false", () => {
+      expect(isToolCallResult(null)).toBe(false);
+    });
+
+    it("undefined 应返回 false", () => {
+      expect(isToolCallResult(undefined)).toBe(false);
+    });
+
+    it("字符串应返回 false", () => {
+      expect(isToolCallResult("not an object")).toBe(false);
+    });
+
+    it("数字应返回 false", () => {
+      expect(isToolCallResult(42)).toBe(false);
+    });
+
+    it("布尔值应返回 false", () => {
+      expect(isToolCallResult(true)).toBe(false);
+    });
+
+    it("空对象（无 content 字段）应返回 false", () => {
+      expect(isToolCallResult({})).toBe(false);
+    });
+
+    it("content 为非数组值应返回 false", () => {
+      expect(isToolCallResult({ content: "not-array" })).toBe(false);
+    });
+
+    it("content 为空数组应返回 false", () => {
+      expect(isToolCallResult({ content: [] })).toBe(false);
+    });
+
+    it("content 中元素缺少 type 字段应返回 false", () => {
+      expect(
+        isToolCallResult({
+          content: [{ text: "no type field" }],
+        })
+      ).toBe(false);
+    });
+
+    it("content 中元素 type 非 text 应返回 false", () => {
+      expect(
+        isToolCallResult({
+          content: [{ type: "image", data: "abc" }],
+        })
+      ).toBe(false);
+    });
+
+    it("content 中元素 text 非字符串应返回 false", () => {
+      expect(
+        isToolCallResult({
+          content: [{ type: "text", text: 123 }],
+        })
+      ).toBe(false);
+    });
+  });
+
+  // =========================
+  // 边界场景
+  // =========================
+
+  describe("边界场景", () => {
+    it("content 为 undefined 但有其他字段应返回 false", () => {
+      const result = { content: undefined } as unknown;
+
+      expect(isToolCallResult(result)).toBe(false);
+    });
+
+    it("content 缺失但存在其他字段应返回 false", () => {
+      const result = { isError: false, other: "value" } as unknown;
+
+      expect(isToolCallResult(result)).toBe(false);
+    });
+
+    it("空数组 content 的对象应返回 false", () => {
+      expect(isToolCallResult({ content: [] })).toBe(false);
+    });
+
+    it("text 为空字符串的有效结构应返回 true", () => {
+      expect(
+        isToolCallResult({
+          content: [{ type: "text", text: "" }],
+        })
+      ).toBe(true);
+    });
+  });
+});

--- a/src/server/types/mcp.ts
+++ b/src/server/types/mcp.ts
@@ -153,11 +153,12 @@ export type ToolCallResponse = ToolCallResult | TimeoutResponse;
 export function isToolCallResult(
   response: unknown
 ): response is ToolCallResult {
+  if (!response || typeof response !== "object" || response === null) {
+    return false;
+  }
+
   const content = (response as ToolCallResult).content;
   return (
-    !!response &&
-    typeof response === "object" &&
-    response !== null &&
     "content" in response &&
     Array.isArray(content) &&
     content.length > 0 &&

--- a/src/server/types/mcp.ts
+++ b/src/server/types/mcp.ts
@@ -153,15 +153,16 @@ export type ToolCallResponse = ToolCallResult | TimeoutResponse;
 export function isToolCallResult(
   response: unknown
 ): response is ToolCallResult {
+  const content = (response as ToolCallResult).content;
   return (
     !!response &&
     typeof response === "object" &&
     response !== null &&
     "content" in response &&
-    Array.isArray((response as ToolCallResult).content) &&
-    (response as ToolCallResult).content.length > 0 &&
-    (response as ToolCallResult).content[0]?.type === "text" &&
-    typeof (response as ToolCallResult).content[0]?.text === "string"
+    Array.isArray(content) &&
+    content.length > 0 &&
+    content[0]?.type === "text" &&
+    typeof content[0]?.text === "string"
   );
 }
 


### PR DESCRIPTION
## Summary

- 将 **ToolCallResult** canonical 定义收敛到 `mcp-core/types.ts`，消除 mcp-core / server / endpoint 三处重复定义
- SDK 原始类型改名为 **CoreToolCallResult**，自定义 interface（带索引签名）作为主要导出
- `server/lib/mcp/types.ts` 和 `endpoint/types.ts` 改为从 `@/mcp-core` re-export，删除本地重复定义
- 删除 `mcp-core` 中混淆的 **MCPServiceManager** 别名导出（`export { MCPManager as MCPServiceManager }`）
- 更新 **MCPManager** 类注释，明确定位为「协议层管理器（轻量级）」，与 `server/lib/mcp` 的 `MCPServiceManager`（业务层/重量级）形成清晰分层

## 背景

分析报告 (`todos/2026-04-28-src-code-analysis.md`) 标记的 P0 问题：MCP 管理器存在双重实现（354+1835=2189 行），且 ToolCallResult 类型在三处定义方式不一致。本次重构采用「明确分层」策略：

| 层级 | 管理器 | 定位 |
|------|--------|------|
| `mcp-core/manager.ts` | MCPManager (354行) | 协议层：连接管理、工具发现、工具调用 |
| `server/lib/mcp/manager.ts` | MCPServiceManager (1835行) | 业务层：缓存、统计、CustomMCP、日志、重试等 |

## Test plan

- [x] `pnpm typecheck` — TypeScript 类型检查通过
- [x] `pnpm test` — 126 测试文件 / 2708 用例全部通过
- [x] `pnpm lint` — Biome linter 检查通过（437 文件无问题）