### PR TITLE
refactor(mcp): 拆分 callTool 方法降低圈复杂度

### DIFF
--- a/src/server/lib/mcp/__tests__/manager.test.ts
+++ b/src/server/lib/mcp/__tests__/manager.test.ts
@@ -1,11 +1,12 @@
 /**
- * MCPServiceManager customMCP 功能测试
- * 测试新增的 hasCustomMCPTool 和 getCustomMCPTools 方法
+ * MCPServiceManager 功能测试
+ * 测试 hasCustomMCPTool、getCustomMCPTools、callTool 重构后的子方法
  */
 
 import type { Tool } from "@modelcontextprotocol/sdk/types.js";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MCPServiceManager } from "../../../lib/mcp";
+import type { ToolInfo } from "../../../lib/mcp/types";
 import type { CustomMCPHandler } from "../custom.js";
 
 // Mock dependencies
@@ -358,6 +359,369 @@ describe("MCPServiceManager - customMCP 支持", () => {
       // Assert - 应该返回空数组而不是抛出异常
       expect(result).toEqual([]);
     });
+  });
+});
+
+describe("MCPServiceManager - resolveToolTarget 工具目标解析", () => {
+  let serviceManager: MCPServiceManager;
+  let mockCustomMCPHandler: ReturnType<typeof vi.mocked<CustomMCPHandler>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceManager = new MCPServiceManager();
+    mockCustomMCPHandler = vi.mocked(serviceManager.getCustomMCPHandler());
+
+    // 确保基础 mock 方法存在
+    if (!mockCustomMCPHandler.hasTool) {
+      mockCustomMCPHandler.hasTool = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolInfo) {
+      mockCustomMCPHandler.getToolInfo = vi.fn();
+    }
+
+    // 默认：不是 customMCP 工具
+    mockCustomMCPHandler.hasTool.mockReturnValue(false);
+    mockCustomMCPHandler.getToolInfo.mockReturnValue(undefined);
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * 通过 spyOn 访问私有方法 resolveToolTarget
+   */
+  function spyResolveToolTarget() {
+    return vi.spyOn(
+      serviceManager,
+      "resolveToolTarget" as keyof MCPServiceManager
+    ) as unknown as ReturnType<typeof vi.spyOn>;
+  }
+
+  describe("custom-mcp 类型工具", () => {
+    it("应该正确解析 handler.type === 'mcp' 的 customMCP 工具", () => {
+      // Arrange
+      const toolName = "mcp_sync_tool";
+      const mcpCustomTool = {
+        name: toolName,
+        description: "MCP 同步工具",
+        inputSchema: { type: "object" as const },
+        handler: {
+          type: "mcp" as const,
+          config: {
+            serviceName: "mcp-server-1",
+            toolName: "original_mcp_tool",
+          },
+        },
+      };
+
+      mockCustomMCPHandler.hasTool.mockReturnValue(true);
+      mockCustomMCPHandler.getToolInfo.mockReturnValue(
+        mcpCustomTool as unknown as (typeof mockCustomMCPHandler)["getToolInfo"] extends (
+          ...args: any
+        ) => infer R
+          ? R
+          : never
+      );
+
+      const spy = spyResolveToolTarget();
+
+      // Act
+      const result = (serviceManager as any).resolveToolTarget(toolName);
+
+      // Assert
+      expect(result.type).toBe("custom-mcp");
+      expect(result.toolName).toBe(toolName);
+      expect(result.statsServiceName).toBe("mcp-server-1");
+      expect(result.statsOriginalName).toBe("original_mcp_tool");
+      expect(result.customTool).toBe(mcpCustomTool);
+      expect(spy).toHaveBeenCalledWith(toolName);
+    });
+  });
+
+  describe("custom-other 类型工具", () => {
+    it("应该正确解析非 mcp 类型的 customMCP 工具（如 coze）", () => {
+      // Arrange
+      const toolName = "coze_workflow";
+      const cozeCustomTool = {
+        name: toolName,
+        description: "Coze 工作流",
+        inputSchema: { type: "object" as const },
+        handler: {
+          type: "coze" as const,
+          config: { workflowId: "wf_123" },
+        },
+      };
+
+      mockCustomMCPHandler.hasTool.mockReturnValue(true);
+      mockCustomMCPHandler.getToolInfo.mockReturnValue(
+        cozeCustomTool as unknown as (typeof mockCustomMCPHandler)["getToolInfo"] extends (
+          ...args: any
+        ) => infer R
+          ? R
+          : never
+      );
+
+      // Act
+      const result = (serviceManager as any).resolveToolTarget(toolName);
+
+      // Assert
+      expect(result.type).toBe("custom-other");
+      expect(result.toolName).toBe(toolName);
+      expect(result.statsServiceName).toBe("customMCP");
+      expect(result.statsOriginalName).toBe(toolName);
+      expect(result.customTool).toBe(cozeCustomTool);
+    });
+  });
+
+  describe("standard 标准类型工具", () => {
+    it("应该正确解析标准 MCP 工具", () => {
+      // Arrange
+      const toolName = "standard_tool";
+      const toolInfo: ToolInfo = {
+        serviceName: "server-a",
+        originalName: "original_standard_tool",
+        tool: {
+          name: toolName,
+          description: "标准工具",
+          inputSchema: { type: "object" as const },
+        } as Tool,
+      };
+
+      // 注入 tools Map — 通过设置内部状态模拟已注册的工具
+      (serviceManager as any).tools = new Map<string, ToolInfo>([
+        [toolName, toolInfo],
+      ]);
+
+      mockCustomMCPHandler.hasTool.mockReturnValue(false);
+
+      // Act
+      const result = (serviceManager as any).resolveToolTarget(toolName);
+
+      // Assert
+      expect(result.type).toBe("standard");
+      expect(result.toolName).toBe(toolName);
+      expect(result.logServerName).toBe("server-a");
+      expect(result.originalToolName).toBe("original_standard_tool");
+      expect(result.statsServiceName).toBe("server-a");
+      expect(result.statsOriginalName).toBe("original_standard_tool");
+      expect(result.toolInfo).toBe(toolInfo);
+    });
+  });
+
+  describe("工具不存在", () => {
+    it("当标准 MCP 工具不存在时应该抛出错误", () => {
+      // Arrange - 既不是 customMCP，也不在标准工具中
+      mockCustomMCPHandler.hasTool.mockReturnValue(false);
+      (serviceManager as any).tools = new Map<string, ToolInfo>();
+
+      // Act & Assert
+      expect(() => {
+        (serviceManager as any).resolveToolTarget("nonexistent_tool");
+      }).toThrow("未找到工具: nonexistent_tool");
+    });
+  });
+});
+
+describe("MCPServiceManager - recordToolCallStats 统计记录", () => {
+  let serviceManager: MCPServiceManager;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceManager = new MCPServiceManager();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("成功调用时应该以 isSuccess=true 调用 updateToolStatsSafe", () => {
+    // Arrange
+    const spy = vi.spyOn(serviceManager, "updateToolStatsSafe" as any);
+    const target = {
+      type: "standard" as const,
+      toolName: "test_tool",
+      logServerName: "server-1",
+      originalToolName: "original_test",
+      statsServiceName: "server-1",
+      statsOriginalName: "original_test",
+    };
+
+    // Act
+    (serviceManager as any).recordToolCallStats(target, true);
+
+    // Assert
+    expect(spy).toHaveBeenCalledWith(
+      "test_tool",
+      "server-1",
+      "original_test",
+      true
+    );
+  });
+
+  it("失败调用时应该以 isSuccess=false 调用 updateToolStatsSafe", () => {
+    // Arrange
+    const spy = vi.spyOn(serviceManager, "updateToolStatsSafe" as any);
+    const target = {
+      type: "custom-other" as const,
+      toolName: "coze_tool",
+      logServerName: "coze",
+      originalToolName: "coze_tool",
+      statsServiceName: "customMCP",
+      statsOriginalName: "coze_tool",
+    };
+
+    // Act
+    (serviceManager as any).recordToolCallStats(target, false);
+
+    // Assert
+    expect(spy).toHaveBeenCalledWith(
+      "coze_tool",
+      "customMCP",
+      "coze_tool",
+      false
+    );
+  });
+
+  it("custom-mcp 类型工具应该使用正确的统计字段", () => {
+    // Arrange
+    const spy = vi.spyOn(serviceManager, "updateToolStatsSafe" as any);
+    const target = {
+      type: "custom-mcp" as const,
+      toolName: "sync_tool",
+      logServerName: "mcp-server-1",
+      originalToolName: "real_tool",
+      statsServiceName: "mcp-server-1",
+      statsOriginalName: "real_tool",
+    };
+
+    // Act
+    (serviceManager as any).recordToolCallStats(target, true);
+
+    // Assert
+    expect(spy).toHaveBeenCalledWith(
+      "sync_tool",
+      "mcp-server-1",
+      "real_tool",
+      true
+    );
+  });
+});
+
+describe("MCPServiceManager - callTool 编排流程", () => {
+  let serviceManager: MCPServiceManager;
+  let mockCustomMCPHandler: ReturnType<typeof vi.mocked<CustomMCPHandler>>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    serviceManager = new MCPServiceManager();
+    mockCustomMCPHandler = vi.mocked(serviceManager.getCustomMCPHandler());
+
+    if (!mockCustomMCPHandler.hasTool) {
+      mockCustomMCPHandler.hasTool = vi.fn();
+    }
+    if (!mockCustomMCPHandler.getToolInfo) {
+      mockCustomMCPHandler.getToolInfo = vi.fn();
+    }
+    if (!mockCustomMCPHandler.callTool) {
+      mockCustomMCPHandler.callTool = vi.fn();
+    }
+
+    mockCustomMCPHandler.hasTool.mockReturnValue(false);
+    mockCustomMCPHandler.callTool.mockResolvedValue({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+
+    // 替换内部 toolCallLogger 为 mock，避免依赖真实 ToolCallLogger
+    (serviceManager as any).toolCallLogger = {
+      recordToolCall: vi.fn(),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("custom-other 类型工具调用成功时应返回结果并更新统计", async () => {
+    // Arrange
+    const toolName = "coze_test";
+    mockCustomMCPHandler.hasTool.mockReturnValue(true);
+    mockCustomMCPHandler.getToolInfo.mockReturnValue({
+      name: toolName,
+      description: "测试 coze 工具",
+      inputSchema: { type: "object" as const },
+      handler: { type: "coze" as const, config: {} },
+    });
+
+    const statsSpy = vi.spyOn(serviceManager, "updateToolStatsSafe" as any);
+
+    // Act
+    const result = await serviceManager.callTool(
+      toolName,
+      { input: "hello" },
+      { timeout: 5000 }
+    );
+
+    // Assert
+    expect(result).toEqual({
+      content: [{ type: "text", text: "ok" }],
+      isError: false,
+    });
+    expect(mockCustomMCPHandler.callTool).toHaveBeenCalledWith(
+      toolName,
+      { input: "hello" },
+      { timeout: 5000 }
+    );
+    // 验证成功统计被调用
+    expect(statsSpy).toHaveBeenCalledWith(
+      toolName,
+      "customMCP",
+      toolName,
+      true
+    );
+  });
+
+  it("工具调用失败时应记录失败统计并重新抛出错误", async () => {
+    // Arrange
+    const toolName = "failing_tool";
+    const error = new Error("服务不可用");
+
+    mockCustomMCPHandler.hasTool.mockReturnValue(true);
+    mockCustomMCPHandler.getToolInfo.mockReturnValue({
+      name: toolName,
+      description: "会失败的工具",
+      inputSchema: { type: "object" as const },
+      handler: { type: "coze" as const, config: {} },
+    });
+    mockCustomMCPHandler.callTool.mockRejectedValue(error);
+
+    const statsSpy = vi.spyOn(serviceManager, "updateToolStatsSafe" as any);
+
+    // Act & Assert
+    await expect(serviceManager.callTool(toolName, {})).rejects.toThrow(
+      "服务不可用"
+    );
+
+    // 验证失败统计被调用
+    expect(statsSpy).toHaveBeenCalledWith(
+      toolName,
+      "customMCP",
+      toolName,
+      false
+    );
+  });
+
+  it("标准 MCP 工具不存在时应抛出未找到错误", async () => {
+    // Arrange
+    const toolName = "missing_standard";
+    mockCustomMCPHandler.hasTool.mockReturnValue(false);
+    (serviceManager as any).tools = new Map();
+
+    // Act & Assert
+    await expect(serviceManager.callTool(toolName, {})).rejects.toThrow(
+      `未找到工具: ${toolName}`
+    );
   });
 });
 

--- a/src/server/lib/mcp/manager.ts
+++ b/src/server/lib/mcp/manager.ts
@@ -30,6 +30,27 @@ import type { MCPMessage } from "../../types/mcp.js";
 import { CustomMCPHandler } from "./custom.js";
 import { ToolCallLogger } from "./log.js";
 import { MCPMessageHandler } from "./message.js";
+
+/** 解析后的工具调用目标 */
+interface ResolvedToolTarget {
+  /** 工具类型 */
+  type: "custom-mcp" | "custom-other" | "standard";
+  /** 工具名称（查找时使用的 key） */
+  toolName: string;
+  /** 日志用的服务名 */
+  logServerName: string;
+  /** 日志用的原始工具名 */
+  originalToolName: string;
+  /** 统计用的服务名 */
+  statsServiceName: string;
+  /** 统计用的原始工具名 */
+  statsOriginalName: string;
+  /** customMCP 工具信息（仅 custom 类型有值） */
+  customTool?: CustomMCPTool;
+  /** 标准 MCP 工具信息（仅 standard 类型有值） */
+  toolInfo?: ToolInfo;
+}
+
 export class MCPServiceManager extends EventEmitter {
   private services: Map<string, MCPService> = new Map();
   private configs: Record<string, MCPServiceConfig> = {};
@@ -606,6 +627,134 @@ export class MCPServiceManager extends EventEmitter {
   }
 
   /**
+   * 解析工具名称，确定工具类型和元信息
+   * @param toolName 工具名称
+   * @returns 解析后的工具目标
+   * @throws 当标准 MCP 工具不存在时抛出错误
+   */
+  private resolveToolTarget(toolName: string): ResolvedToolTarget {
+    if (this.customMCPHandler.hasTool(toolName)) {
+      const customTool = this.customMCPHandler.getToolInfo(toolName);
+      const logServerName = this.getLogServerName(customTool!);
+      const originalToolName = this.getOriginalToolName(toolName, customTool);
+
+      if (customTool?.handler?.type === "mcp") {
+        const config = customTool.handler.config as {
+          serviceName: string;
+          toolName: string;
+        };
+        return {
+          type: "custom-mcp",
+          toolName,
+          logServerName,
+          originalToolName,
+          statsServiceName: config.serviceName,
+          statsOriginalName: config.toolName,
+          customTool,
+        };
+      }
+
+      return {
+        type: "custom-other",
+        toolName,
+        logServerName,
+        originalToolName,
+        statsServiceName: "customMCP",
+        statsOriginalName: toolName,
+        customTool,
+      };
+    }
+
+    // 标准 MCP 工具
+    const toolInfo = this.tools.get(toolName);
+    if (!toolInfo) {
+      throw new Error(`未找到工具: ${toolName}`);
+    }
+
+    return {
+      type: "standard",
+      toolName,
+      logServerName: toolInfo.serviceName,
+      originalToolName: toolInfo.originalName,
+      statsServiceName: toolInfo.serviceName,
+      statsOriginalName: toolInfo.originalName,
+      toolInfo,
+    };
+  }
+
+  /**
+   * 根据解析后的目标执行实际的工具调用
+   * @param target 解析后的工具目标
+   * @param arguments_ 工具调用参数
+   * @param options 调用选项（如超时时间）
+   * @returns 工具调用结果
+   */
+  private async executeToolCall(
+    target: ResolvedToolTarget,
+    arguments_: Record<string, unknown>,
+    options?: { timeout?: number }
+  ): Promise<ToolCallResult> {
+    switch (target.type) {
+      case "custom-mcp": {
+        return this.callMCPTool(
+          target.customTool!.name,
+          target.customTool!.handler!.config as {
+            serviceName: string;
+            toolName: string;
+          },
+          arguments_
+        );
+      }
+      case "custom-other": {
+        const result = await this.customMCPHandler.callTool(
+          target.customTool!.name,
+          arguments_,
+          options
+        );
+        logger.info(
+          `[MCPManager] CustomMCP 工具 ${target.customTool!.name} 调用成功`
+        );
+        return result as ToolCallResult;
+      }
+      case "standard": {
+        const service = this.services.get(target.toolInfo!.serviceName);
+        if (!service) {
+          throw new Error(`服务 ${target.toolInfo!.serviceName} 不可用`);
+        }
+        if (!service.isConnected()) {
+          throw new Error(`服务 ${target.toolInfo!.serviceName} 未连接`);
+        }
+        const result = (await service.callTool(
+          target.toolInfo!.originalName,
+          arguments_ || {}
+        )) as ToolCallResult;
+        logger.debug("[MCPManager] 工具调用成功", {
+          toolName: target.toolName,
+          result: result,
+        });
+        return result;
+      }
+    }
+  }
+
+  /**
+   * 记录工具调用的统计信息
+   * @param target 解析后的工具目标
+   * @param isSuccess 是否调用成功
+   */
+  private recordToolCallStats(
+    target: ResolvedToolTarget,
+    isSuccess: boolean
+  ): void {
+    this.updateToolStatsSafe(
+      target.toolName,
+      target.statsServiceName,
+      target.statsOriginalName,
+      isSuccess
+    );
+  }
+
+  /**
    * 调用 MCP 工具（支持标准 MCP 工具和 customMCP 工具）
    */
   async callTool(
@@ -615,105 +764,32 @@ export class MCPServiceManager extends EventEmitter {
   ): Promise<ToolCallResult> {
     const startTime = Date.now();
 
-    // 初始化日志信息
-    let logServerName = "unknown";
-    let originalToolName: string = toolName;
+    // 解析工具目标（同步前置校验，可能抛出 Tool Not Found）
+    const target = this.resolveToolTarget(toolName);
 
     try {
-      let result: ToolCallResult;
-
-      // 检查是否是 customMCP 工具
-      if (this.customMCPHandler.hasTool(toolName)) {
-        const customTool = this.customMCPHandler.getToolInfo(toolName);
-
-        // 设置日志信息（添加空值检查）
-        if (customTool) {
-          logServerName = this.getLogServerName(customTool);
-          originalToolName = this.getOriginalToolName(toolName, customTool);
-        }
-
-        if (customTool?.handler?.type === "mcp") {
-          // 对于 mcp 类型的工具，直接路由到对应的 MCP 服务
-          result = await this.callMCPTool(
-            toolName,
-            customTool.handler.config,
-            arguments_
-          );
-
-          // 异步更新工具调用统计（成功调用）
-          this.updateToolStatsSafe(
-            toolName,
-            customTool.handler.config.serviceName,
-            customTool.handler.config.toolName,
-            true
-          );
-        } else {
-          // 其他类型的 customMCP 工具正常处理，传递options参数
-          result = await this.customMCPHandler.callTool(
-            toolName,
-            arguments_,
-            options
-          );
-          logger.info(`[MCPManager] CustomMCP 工具 ${toolName} 调用成功`);
-
-          // 异步更新工具调用统计（成功调用）
-          this.updateToolStatsSafe(toolName, "customMCP", toolName, true);
-        }
-      } else {
-        // 如果不是 customMCP 工具，则查找标准 MCP 工具
-        const toolInfo = this.tools.get(toolName);
-        if (!toolInfo) {
-          throw new Error(`未找到工具: ${toolName}`);
-        }
-
-        // 设置日志信息
-        logServerName = toolInfo.serviceName;
-        originalToolName = toolInfo.originalName;
-
-        const service = this.services.get(toolInfo.serviceName);
-        if (!service) {
-          throw new Error(`服务 ${toolInfo.serviceName} 不可用`);
-        }
-
-        if (!service.isConnected()) {
-          throw new Error(`服务 ${toolInfo.serviceName} 未连接`);
-        }
-
-        result = (await service.callTool(
-          toolInfo.originalName,
-          arguments_ || {}
-        )) as ToolCallResult;
-
-        logger.debug("[MCPManager] 工具调用成功", {
-          toolName: toolName,
-          result: result,
-        });
-
-        // 异步更新工具调用统计（成功调用）
-        this.updateToolStatsSafe(
-          toolName,
-          toolInfo.serviceName,
-          toolInfo.originalName,
-          true
-        );
-      }
+      // 执行工具调用
+      const result = await this.executeToolCall(target, arguments_, options);
 
       // 记录成功的工具调用
       this.toolCallLogger.recordToolCall({
-        toolName: originalToolName,
-        serverName: logServerName,
+        toolName: target.originalToolName,
+        serverName: target.logServerName,
         arguments: arguments_,
         result: result,
         success: result.isError !== true,
         duration: Date.now() - startTime,
       });
 
+      // 更新成功统计
+      this.recordToolCallStats(target, true);
+
       return result as ToolCallResult;
     } catch (error) {
       // 记录失败的工具调用
       this.toolCallLogger.recordToolCall({
-        toolName: originalToolName,
-        serverName: logServerName,
+        toolName: target.originalToolName,
+        serverName: target.logServerName,
         arguments: arguments_,
         result: null,
         success: false,
@@ -722,35 +798,11 @@ export class MCPServiceManager extends EventEmitter {
       });
 
       // 更新失败统计
-      if (this.customMCPHandler.hasTool(toolName)) {
-        const customTool = this.customMCPHandler.getToolInfo(toolName);
-        if (customTool?.handler?.type === "mcp") {
-          this.updateToolStatsSafe(
-            toolName,
-            customTool.handler.config.serviceName,
-            customTool.handler.config.toolName,
-            false
-          );
-        } else {
-          this.updateToolStatsSafe(toolName, "customMCP", toolName, false);
-          logger.error(`[MCPManager] CustomMCP 工具 ${toolName} 调用失败`, {
-            error: (error as Error).message,
-          });
-        }
-      } else {
-        const toolInfo = this.tools.get(toolName);
-        if (toolInfo) {
-          this.updateToolStatsSafe(
-            toolName,
-            toolInfo.serviceName,
-            toolInfo.originalName,
-            false
-          );
-          logger.error(`[MCPManager] 工具 ${toolName} 调用失败`, {
-            error: (error as Error).message,
-          });
-        }
-      }
+      this.recordToolCallStats(target, false);
+
+      logger.error(`[MCPManager] 工具 ${toolName} 调用失败`, {
+        error: error instanceof Error ? error.message : String(error),
+      });
 
       throw error;
     }


### PR DESCRIPTION
## Summary

- 将 `callTool` 方法从 **147 行**拆分为 4 个职责清晰的方法，主方法简化为 ~45 行编排层
- 新增 `resolveToolTarget()` — 同步解析工具目标（customMCP-mcp / customMCP-other / 标准 MCP）
- 新增 `executeToolCall()` — 根据 target.type 分发到 3 种实际调用逻辑
- 新增 `recordToolCallStats()` — 统一统计更新，**消除 try/catch 中 6 处镜像重复的 `updateToolStatsSafe` 调用为 2 处**
- catch 块中不再需要重新查找工具信息（复用已解析的 target）

## 改动效果

| 指标 | 重构前 | 重构后 |
|------|--------|--------|
| callTool 行数 | 147 行 | ~45 行 |
| updateToolStatsSafe 调用 | 6 处（3 对镜像） | 2 处 |
| catch 块工具重查找 | 有（重复 resolve） | 无 |
| 可测试性 | 仅端到端 | 每个子方法可单独测试 |

## Test plan

- [x] 全部 128 个测试文件、2755 个测试通过
- [x] TypeScript 类型检查 (`pnpm typecheck`) 通过
- [x] Biome lint 检查 (`pnpm lint`) 通过
- [ ] 行为等价性验证：重构前后 callTool 的输入输出完全一致