### PR TITLE
fix: 修复 Web UI 重启服务后新进程无法启动的问题

### DIFF
--- a/src/cli/services/ServiceManager.ts
+++ b/src/cli/services/ServiceManager.ts
@@ -133,17 +133,23 @@ export class ServiceManagerImpl implements IServiceManager {
    */
   async restart(options: ServiceStartOptions): Promise<void> {
     try {
-      // 先停止服务
+      // 先尝试停止服务，失败不阻断启动流程
       const status = this.getStatus();
       if (status.running) {
-        await this.stop();
-        // 等待一下确保完全停止
-        await new Promise((resolve) =>
-          setTimeout(resolve, RETRY_CONSTANTS.DEFAULT_INTERVAL)
-        );
+        try {
+          await this.stop();
+          // 等待一下确保完全停止
+          await new Promise((resolve) =>
+            setTimeout(resolve, RETRY_CONSTANTS.DEFAULT_INTERVAL)
+          );
+        } catch (stopError) {
+          consola.warn(
+            `停止服务时出现警告（将继续启动）: ${stopError instanceof Error ? stopError.message : String(stopError)}`
+          );
+        }
       }
 
-      // 重新启动服务
+      // 无论停止是否成功，都尝试启动服务
       await this.start(options);
     } catch (error) {
       throw new ServiceError(

--- a/src/server/handlers/__tests__/service.handler.test.ts
+++ b/src/server/handlers/__tests__/service.handler.test.ts
@@ -74,7 +74,9 @@ describe("ServiceApiHandler", () => {
 
     // 模拟 spawn
     mockSpawn = vi.fn().mockReturnValue({
+      pid: 12345,
       unref: vi.fn(),
+      on: vi.fn(),
     });
     const { spawn } = await import("node:child_process");
     vi.mocked(spawn).mockImplementation(mockSpawn);
@@ -218,13 +220,25 @@ describe("ServiceApiHandler", () => {
     it("应该成功启动服务", async () => {
       await handler.startService(mockContext);
 
-      expect(mockSpawn).toHaveBeenCalledWith("xiaozhi", ["start", "--daemon"], {
-        detached: true,
-        stdio: "ignore",
-        env: expect.objectContaining({
-          XIAOZHI_CONFIG_DIR: expect.any(String),
-        }),
-      });
+      // 验证 spawn 使用 node 执行本地 CLI 脚本
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe("node");
+      // 第一个参数是 CLI 脚本路径，后续是命令参数
+      expect(spawnArgs[1].length).toBeGreaterThanOrEqual(3); // cliPath + start + --daemon
+      expect(spawnArgs[1]).toContain("start");
+      expect(spawnArgs[1]).toContain("--daemon");
+      // 验证 CLI 路径以 index.js 结尾
+      const cliPath = spawnArgs[1][0];
+      expect(cliPath).toMatch(/index\.js$/);
+      expect(spawnArgs[2]).toEqual(
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+          env: expect.objectContaining({
+            XIAOZHI_CONFIG_DIR: expect.any(String),
+          }),
+        })
+      );
 
       expect(mockContext.success).toHaveBeenCalledWith(null, "启动请求已接收");
     });
@@ -266,9 +280,8 @@ describe("ServiceApiHandler", () => {
 
       await handler.startService(mockContext);
 
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["start", "--daemon"],
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[2]).toEqual(
         expect.objectContaining({
           env: expect.objectContaining({
             XIAOZHI_CONFIG_DIR: "/custom/config/dir",
@@ -290,19 +303,10 @@ describe("ServiceApiHandler", () => {
 
       await handler.startService(mockContext);
 
-      // Check that spawn was called with basic structure
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["start", "--daemon"],
-        expect.objectContaining({
-          detached: true,
-          stdio: "ignore",
-          env: expect.any(Object),
-        })
-      );
-
-      // Check that the environment contains XIAOZHI_CONFIG_DIR
+      // Check that spawn was called with node and local CLI path
       const spawnCall = mockSpawn.mock.calls[0];
+      expect(spawnCall[0]).toBe("node");
+      expect(spawnCall[1][0]).toMatch(/index\.js$/);
       const spawnOptions = spawnCall[2];
       expect(spawnOptions.env).toHaveProperty("XIAOZHI_CONFIG_DIR");
 
@@ -319,13 +323,19 @@ describe("ServiceApiHandler", () => {
     it("should stop service successfully", async () => {
       await handler.stopService(mockContext);
 
-      expect(mockSpawn).toHaveBeenCalledWith("xiaozhi", ["stop"], {
-        detached: true,
-        stdio: "ignore",
-        env: expect.objectContaining({
-          XIAOZHI_CONFIG_DIR: expect.any(String),
-        }),
-      });
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe("node");
+      expect(spawnArgs[1][0]).toMatch(/index\.js$/);
+      expect(spawnArgs[1]).toContain("stop");
+      expect(spawnArgs[2]).toEqual(
+        expect.objectContaining({
+          detached: true,
+          stdio: "ignore",
+          env: expect.objectContaining({
+            XIAOZHI_CONFIG_DIR: expect.any(String),
+          }),
+        })
+      );
 
       expect(mockContext.success).toHaveBeenCalledWith(null, "停止请求已接收");
     });
@@ -428,9 +438,12 @@ describe("ServiceApiHandler", () => {
       await vi.advanceTimersByTimeAsync(500);
 
       expect(mockMcpServiceManager.getStatus).toHaveBeenCalled();
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["restart", "--daemon"],
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe("node");
+      expect(spawnArgs[1][0]).toMatch(/index\.js$/);
+      expect(spawnArgs[1]).toContain("restart");
+      expect(spawnArgs[1]).toContain("--daemon");
+      expect(spawnArgs[2]).toEqual(
         expect.objectContaining({
           detached: true,
           stdio: "ignore",
@@ -456,14 +469,11 @@ describe("ServiceApiHandler", () => {
       // Fast-forward the initial timeout to trigger executeRestart
       await vi.advanceTimersByTimeAsync(500);
 
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["start", "--daemon"],
-        expect.objectContaining({
-          detached: true,
-          stdio: "ignore",
-        })
-      );
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe("node");
+      expect(spawnArgs[1][0]).toMatch(/index\.js$/);
+      expect(spawnArgs[1]).toContain("start");
+      expect(spawnArgs[1]).toContain("--daemon");
     });
 
     it("should handle restart execution error", async () => {
@@ -497,15 +507,12 @@ describe("ServiceApiHandler", () => {
       // Fast-forward the initial timeout to trigger executeRestart
       await vi.advanceTimersByTimeAsync(500);
 
-      // 注意：实际代码逻辑是始终使用 --daemon 模式
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["restart", "--daemon"],
-        expect.objectContaining({
-          detached: true,
-          stdio: "ignore",
-        })
-      );
+      // 注意：实际代码逻辑是始终使用 --daemon 模式，且使用 node 执行本地 CLI
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[0]).toBe("node");
+      expect(spawnArgs[1][0]).toMatch(/index\.js$/);
+      expect(spawnArgs[1]).toContain("restart");
+      expect(spawnArgs[1]).toContain("--daemon");
     });
   });
 
@@ -516,9 +523,8 @@ describe("ServiceApiHandler", () => {
 
       await handler.startService(mockContext);
 
-      expect(mockSpawn).toHaveBeenCalledWith(
-        "xiaozhi",
-        ["start", "--daemon"],
+      const spawnArgs = mockSpawn.mock.calls[0];
+      expect(spawnArgs[2]).toEqual(
         expect.objectContaining({
           env: expect.objectContaining({
             PATH: originalPath,

--- a/src/server/handlers/service.handler.ts
+++ b/src/server/handlers/service.handler.ts
@@ -1,9 +1,11 @@
+import { spawn } from "node:child_process";
+import type { ChildProcess } from "node:child_process";
 /**
  * 服务 API HTTP 路由处理器
  * 提供服务启动、停止、重启等相关的 RESTful API 接口
  */
-import { spawn } from "node:child_process";
-import type { ChildProcess } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
 import type { Context } from "hono";
 import { logger } from "../Logger.js";
 import type { Logger } from "../Logger.js";
@@ -16,36 +18,84 @@ import type { AppContext } from "../types/hono.context.js";
 import { requireMCPServiceManager } from "../types/hono.context.js";
 
 /**
+ * 获取项目根目录
+ * 基于当前文件位置向上查找，确保无论从哪里启动都能正确定位
+ *
+ * 支持以下路径场景：
+ * - 源码开发：src/server/handlers/ → 向上 3 级
+ * - 独立构建（tsup）：dist/server/handlers/ → 向上 3 级
+ * - WebServer 打包产物：dist/backend/ → 向上 2 级
+ */
+function getProjectRoot(): string {
+  const currentFile = fileURLToPath(import.meta.url);
+  const currentDir = dirname(currentFile);
+
+  // WebServer 打包后的代码在 dist/backend/ 下，向上 2 级到项目根
+  if (
+    currentDir.endsWith("/dist/backend") ||
+    currentDir.endsWith("\\dist\\backend")
+  ) {
+    return join(currentDir, "..", "..");
+  }
+
+  // 构建产物在 dist/server/handlers/ 下，向上 3 级到项目根
+  if (
+    currentDir.endsWith("/dist/server/handlers") ||
+    currentDir.endsWith("\\dist\\server\\handlers")
+  ) {
+    return join(currentDir, "..", "..", "..");
+  }
+
+  // 源码在 src/server/handlers/ 下，向上 3 级到项目根
+  return join(currentDir, "..", "..", "..");
+}
+
+/**
  * 服务 API 处理器
  */
 export class ServiceApiHandler {
   private logger: Logger;
   private statusService: StatusService;
   private eventBus: EventBus;
+  /** 项目根目录路径 */
+  private readonly projectRoot: string;
 
   constructor(statusService: StatusService) {
     this.logger = logger;
     this.statusService = statusService;
     this.eventBus = getEventBus();
+    this.projectRoot = getProjectRoot();
   }
 
   /**
    * 通用的 xiaozhi 进程启动方法
-   * @param args 命令行参数（如 ["start", "--daemon"]）
+   * 使用 node 直接执行项目本地的 CLI 脚本，避免依赖全局安装的 xiaozhi 命令
+   * @param args CLI 命令行参数（如 ["start", "--daemon"]）
    * @returns 启动的子进程
    */
   private spawnXiaozhiProcess(args: string[]): ChildProcess {
-    const child = spawn("xiaozhi", args, {
+    const cliPath = join(this.projectRoot, "dist", "cli", "index.js");
+
+    const child = spawn("node", [cliPath, ...args], {
       detached: true,
       stdio: "ignore",
+      cwd: this.projectRoot,
       env: {
         ...process.env,
-        XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || process.cwd(),
+        XIAOZHI_CONFIG_DIR: process.env.XIAOZHI_CONFIG_DIR || this.projectRoot,
       },
     });
 
     child.unref();
-    this.logger.info(`MCP 服务命令已发送: xiaozhi ${args.join(" ")}`);
+
+    // 监听 spawn 错误（如命令不存在），避免错误被静默丢弃
+    child.on("error", (err) => {
+      this.logger.error(
+        `启动 xiaozhi 进程失败 (命令: node ${cliPath} ${args.join(" ")}): ${err.message}`
+      );
+    });
+
+    this.logger.info(`MCP 服务命令已发送: node ${cliPath} ${args.join(" ")}`);
 
     return child;
   }
@@ -111,24 +161,31 @@ export class ServiceApiHandler {
   ): Promise<void> {
     this.logger.info("正在重启 MCP 服务...");
 
-    try {
-      // 获取当前服务状态
-      const status = mcpServiceManager.getStatus();
+    // 获取当前服务状态
+    const status = mcpServiceManager.getStatus();
 
-      if (!status.isRunning) {
-        this.logger.warn("MCP 服务未运行，尝试启动服务");
+    if (!status.isRunning) {
+      this.logger.warn("MCP 服务未运行，尝试启动服务");
 
-        // 如果服务未运行，尝试启动服务
-        this.spawnXiaozhiProcess(["start", "--daemon"]);
-        return;
+      // 如果服务未运行，尝试启动服务
+      const child = this.spawnXiaozhiProcess(["start", "--daemon"]);
+      if (!child.pid) {
+        throw new Error("无法创建 xiaozhi 启动子进程");
       }
-
-      // 执行重启命令，始终使用 daemon 模式
-      this.spawnXiaozhiProcess(["restart", "--daemon"]);
-    } catch (error) {
-      this.logger.error("重启服务失败:", error);
-      throw error;
+      return;
     }
+
+    // 执行重启命令，始终使用 daemon 模式
+    const child = this.spawnXiaozhiProcess(["restart", "--daemon"]);
+
+    // 验证子进程是否成功创建
+    if (!child.pid) {
+      throw new Error("无法创建 xiaozhi 重启子进程");
+    }
+
+    this.logger.info(
+      `重启子进程已启动 (PID: ${child.pid}, 项目目录: ${this.projectRoot})`
+    );
   }
 
   /**


### PR DESCRIPTION
## Summary

- **修复 Web UI 重启按钮执行后新进程无法启动的 bug**：通过 `/api/services/restart` 触发重启后，旧进程被终止但新服务未能成功拉起
- **根因**：三层问题叠加导致重启流程在 spawn 子进程阶段静默失败
- **验证**：端到端测试确认 PID 成功替换，HTTP 服务连续可用

## 详细说明

### 问题现象

通过 Web UI 的 `RestartButton` 组件点击重启后：
1. 前端收到 `"重启请求已接收"` 的成功响应
2. 旧进程被正确终止
3. **新进程从未启动**，服务持续返回 502

### 根因分析（三层 Bug）

| 层级 | 文件 | 问题 | 影响 |
|------|------|------|------|
| Bug 1 | `ServiceManager.restart()` | `stop()` 失败时抛异常阻断 `start()` 执行 | 进程状态竞态时重启完全失败 |
| Bug 2 | `service.handler.ts` | 使用 `spawn("xiaozhi", ...)` 调用全局命令（旧版 npm 全局安装） | CLI 路径解析错误 |
| Bug 3 | `getProjectRoot()` | 未处理 `dist/backend/` 路径（WebServer 打包产物位置） | CLI 路径指向不存在的文件 |

### 修复内容

1. **`ServiceManager.ts`**：`restart()` 中用 try-catch 包裹 `stop()`，失败仅输出 warn 日志，不中断后续 `start()`
2. **`service.handler.ts`**：
   - `spawn("xiaozhi", args)` → `spawn("node", [localCliPath, ...args])` 直接使用项目本地 CLI
   - 新增 `getProjectRoot()` 函数支持 `dist/backend/` 路径场景
   - 添加 `child.on("error")` 监听避免 spawn 错误被静默丢弃
   - 添加 `child.pid` 校验确保子进程创建成功
3. **测试文件**：更新断言匹配新的 spawn 参数格式

## Test plan

- [x] TypeScript 类型检查 (`pnpm typecheck`) 通过
- [x] Biome Lint 检查 (`pnpm lint`) 通过
- [x] 全部测试通过 (128 文件 / 2763 用例)
- [x] 端到端验证：通过 API 触发重启，PID 成功替换 (8119 → 8343)，HTTP 200 正常