### PR TITLE
fix(web): 修复重启按钮 Loading 状态卡住不消失的问题

### DIFF
--- a/src/web/stores/__tests__/status.test.ts
+++ b/src/web/stores/__tests__/status.test.ts
@@ -188,4 +188,145 @@ describe("Status Store", () => {
       expect(state.loading.isLoading).toBe(false);
     });
   });
+
+  describe("重启轮询判断逻辑", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    /**
+     * 辅助函数：创建模拟的 FullStatus 响应
+     */
+    function createMockStatus(
+      clientStatus: "connected" | "disconnected"
+    ): FullStatus {
+      return {
+        client: {
+          status: clientStatus,
+          mcpEndpoint: "wss://test",
+          activeMCPServers: [],
+          lastHeartbeat: Date.now(),
+        },
+        timestamp: Date.now(),
+      };
+    }
+
+    it("client.status 为 connected 时应立即退出 loading（最优路径）", async () => {
+      // 模拟 API 返回 client.status === "connected"
+      vi.mocked(apiClient.getStatus).mockResolvedValue(
+        createMockStatus("connected")
+      );
+      vi.mocked(apiClient.restartService).mockResolvedValue(undefined);
+
+      const store = useStatusStore.getState();
+
+      // 触发重启服务（会启动轮询）
+      await store.restartService();
+
+      // 验证初始状态：loading 和轮询已启动
+      expect(useStatusStore.getState().loading.isRestarting).toBe(true);
+      expect(useStatusStore.getState().restartPolling.enabled).toBe(true);
+
+      // 推进一个轮询周期（1秒），触发 refreshStatus 返回 connected
+      await vi.advanceTimersByTimeAsync(1000);
+
+      // 应立即退出 loading
+      expect(useStatusStore.getState().loading.isRestarting).toBe(false);
+      expect(useStatusStore.getState().restartPolling.enabled).toBe(false);
+      expect(useStatusStore.getState().restartStatus?.status).toBe("completed");
+    });
+
+    it("client.status 为 disconnected 但 API 连续成功时应退出 loading", async () => {
+      // 模拟 API 始终返回 client.status === "disconnected"（HTTP 轮询场景）
+      vi.mocked(apiClient.getStatus).mockResolvedValue(
+        createMockStatus("disconnected")
+      );
+      vi.mocked(apiClient.restartService).mockResolvedValue(undefined);
+
+      const store = useStatusStore.getState();
+
+      // 触发重启
+      await store.restartService();
+
+      expect(useStatusStore.getState().loading.isRestarting).toBe(true);
+
+      // 连续推进 3 个轮询周期（达到 CONSECUTIVE_SUCCESS_THRESHOLD = 3）
+      await vi.advanceTimersByTimeAsync(3000);
+
+      // 应通过连续成功计数退出 loading
+      expect(useStatusStore.getState().loading.isRestarting).toBe(false);
+      expect(useStatusStore.getState().restartPolling.enabled).toBe(false);
+      expect(useStatusStore.getState().restartStatus?.status).toBe("completed");
+    });
+
+    it("轮询中偶发一次失败应重置连续成功计数", async () => {
+      let callCount = 0;
+      vi.mocked(apiClient.getStatus).mockImplementation(async () => {
+        callCount++;
+        // 第 2 次调用时模拟失败（旧进程 dying 阶段）
+        if (callCount === 2) {
+          throw new Error("连接失败");
+        }
+        return createMockStatus("disconnected");
+      });
+      vi.mocked(apiClient.restartService).mockResolvedValue(undefined);
+
+      const store = useStatusStore.getState();
+      await store.restartService();
+
+      // 第 1 次：成功 → consecutiveSuccessCount = 1
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(
+        useStatusStore.getState().restartPolling.consecutiveSuccessCount
+      ).toBe(1);
+
+      // 第 2 次：失败 → consecutiveSuccessCount 应被重置为 0
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(
+        useStatusStore.getState().restartPolling.consecutiveSuccessCount
+      ).toBe(0);
+
+      // 第 3 次：成功 → consecutiveSuccessCount = 1（从 0 重新开始累积）
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(
+        useStatusStore.getState().restartPolling.consecutiveSuccessCount
+      ).toBe(1);
+
+      // 第 4 次：成功 → consecutiveSuccessCount = 2
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(
+        useStatusStore.getState().restartPolling.consecutiveSuccessCount
+      ).toBe(2);
+
+      // 第 5 次：成功 → consecutiveSuccessCount = 3，达到阈值后退出 loading
+      // 注意：退出 loading 后 stopRestartPolling 会将计数重置为 0，
+      // 所以这里只验证 loading 状态而非计数值
+      await vi.advanceTimersByTimeAsync(1000);
+      expect(useStatusStore.getState().loading.isRestarting).toBe(false);
+      expect(useStatusStore.getState().restartStatus?.status).toBe("completed");
+    });
+
+    it("重启轮询超时应标记为 failed 并退出 loading", async () => {
+      // 模拟 API 始终抛出错误（服务未恢复）
+      vi.mocked(apiClient.getStatus).mockRejectedValue(new Error("服务不可达"));
+      vi.mocked(apiClient.restartService).mockResolvedValue(undefined);
+
+      const store = useStatusStore.getState();
+      await store.restartService();
+
+      expect(useStatusStore.getState().loading.isRestarting).toBe(true);
+
+      // 推进超过超时时间（60 秒 + 缓冲）
+      await vi.advanceTimersByTimeAsync(65000);
+
+      // 超时后应退出 loading 并标记为 failed
+      expect(useStatusStore.getState().loading.isRestarting).toBe(false);
+      expect(useStatusStore.getState().restartPolling.enabled).toBe(false);
+      expect(useStatusStore.getState().restartStatus?.status).toBe("failed");
+    });
+  });
 });

--- a/src/web/stores/status.ts
+++ b/src/web/stores/status.ts
@@ -88,6 +88,7 @@ interface RestartPollingConfig {
   interval: number; // 毫秒，重启检查间隔
   maxAttempts: number; // 最大检查次数
   currentAttempts: number; // 当前检查次数
+  consecutiveSuccessCount: number; // 连续成功次数（用于判断服务恢复）
   timeout: number; // 总超时时间（毫秒）
   startTime: number | null; // 开始时间戳
 }
@@ -212,6 +213,12 @@ let restartPollingTimer: NodeJS.Timeout | null = null;
  * 是否已完成初始化
  */
 let initialized = false;
+
+/**
+ * 连续成功阈值：API 连续响应 N 次即认为服务已恢复
+ * 用于解决 HTTP 轮询场景下 client.status 永远不为 "connected" 的问题
+ */
+const CONSECUTIVE_SUCCESS_THRESHOLD = 3;
 
 /**
  * 创建状态 Store
@@ -537,6 +544,7 @@ export const useStatusStore = create<StatusStore>()(
               ...state.restartPolling,
               enabled: true,
               currentAttempts: 0,
+              consecutiveSuccessCount: 0,
               startTime,
             },
           }),
@@ -564,29 +572,47 @@ export const useStatusStore = create<StatusStore>()(
             // 尝试获取状态以检查服务是否重连成功
             const status = await refreshStatus();
 
-            // 检查是否重连成功
-            const isReconnected = status.client?.status === "connected";
+            // 连续成功计数 +1
+            const newConsecutiveCount =
+              (currentRestartPolling.consecutiveSuccessCount || 0) + 1;
+            currentState.setRestartPollingConfig({
+              currentAttempts: attempts,
+              consecutiveSuccessCount: newConsecutiveCount,
+            });
 
-            if (isReconnected) {
-              console.log("[StatusStore] 服务重连成功，停止重启轮询");
+            // 检查是否通过 WebSocket 心跳标记为已连接（最优路径）
+            const isClientConnected = status.client?.status === "connected";
 
-              // 设置重启完成状态
-              setRestartStatus(
-                {
-                  status: "completed",
-                  timestamp: Date.now(),
-                },
-                "polling"
+            if (isClientConnected) {
+              console.log(
+                "[StatusStore] 服务重连成功（客户端已连接），停止重启轮询"
               );
 
-              // 停止重启轮询和loading状态
+              setRestartStatus(
+                { status: "completed", timestamp: Date.now() },
+                "polling"
+              );
               currentState.stopRestartPolling();
               setLoading({ isRestarting: false });
               return;
             }
 
-            // 更新尝试次数
-            currentState.setRestartPollingConfig({ currentAttempts: attempts });
+            // 检查 API 是否连续可达（HTTP 轮询场景下的恢复判断）
+            // 新进程启动后 client.status 默认为 "disconnected"，
+            // 但只要 API 能稳定响应就说明服务已恢复
+            if (newConsecutiveCount >= CONSECUTIVE_SUCCESS_THRESHOLD) {
+              console.log(
+                `[StatusStore] 服务已恢复（API 连续 ${newConsecutiveCount} 次成功），停止重启轮询`
+              );
+
+              setRestartStatus(
+                { status: "completed", timestamp: Date.now() },
+                "polling"
+              );
+              currentState.stopRestartPolling();
+              setLoading({ isRestarting: false });
+              return;
+            }
 
             // 检查是否超时或达到最大尝试次数
             if (
@@ -595,7 +621,6 @@ export const useStatusStore = create<StatusStore>()(
             ) {
               console.warn("[StatusStore] 重启重连检查超时或达到最大尝试次数");
 
-              // 设置重启失败状态
               setRestartStatus(
                 {
                   status: "failed",
@@ -604,19 +629,25 @@ export const useStatusStore = create<StatusStore>()(
                 },
                 "polling"
               );
-
-              // 停止重启轮询和loading状态
               currentState.stopRestartPolling();
               setLoading({ isRestarting: false });
             }
           } catch (error) {
+            // 请求失败：重置连续成功计数（旧进程 dying 阶段会触发）
+            currentState.setRestartPollingConfig({
+              currentAttempts: attempts,
+              consecutiveSuccessCount: 0,
+            });
             console.log(
               `[StatusStore] 重启重连检查失败 (第 ${attempts} 次):`,
               error
             );
 
-            // 更新尝试次数
-            currentState.setRestartPollingConfig({ currentAttempts: attempts });
+            // 更新尝试次数（超时检查在下面统一处理）
+            currentState.setRestartPollingConfig({
+              currentAttempts: attempts,
+              consecutiveSuccessCount: 0,
+            });
 
             // 检查是否超时或达到最大尝试次数
             if (
@@ -652,6 +683,7 @@ export const useStatusStore = create<StatusStore>()(
               ...state.restartPolling,
               enabled: false,
               currentAttempts: 0,
+              consecutiveSuccessCount: 0,
               startTime: null,
             },
           }),


### PR DESCRIPTION
## Summary

- 修复 Web UI 重启按钮点击后 loading 状态持续显示直到 60 秒超时才退出的问题
- 将轮询成功判断条件从单一依赖 `client.status === "connected"` 改为多维度综合判断
- 新增 API 连续成功计数机制：连续 3 次 API 响应成功即认为服务已恢复（~3 秒 vs 原 60 秒）
- 兼容 WebSocket 场景：`client.status === "connected"` 仍为最优路径，立即退出

## 根因

新进程启动后 `StatusService.clientInfo` 初始默认值为 `"disconnected"`，只有 WebSocket 心跳才能将其改为 `"connected"`。HTTP 轮询场景下该条件永远为 false。

## 改动文件

| 文件 | 改动 |
|------|------|
| `src/web/stores/status.ts` | 新增 `CONSECUTIVE_SUCCESS_THRESHOLD` 常量、`consecutiveSuccessCount` 字段，修改 `startRestartPolling()` 轮询判断逻辑 |
| `src/web/stores/__tests__/status.test.ts` | 新增 4 个测试用例覆盖多维度判断场景 |

## Test plan

- [x] `pnpm typecheck` 通过
- [x] `pnpm lint` 通过（439 文件无错误）
- [x] `pnpm test` 全部通过（128 文件、2767 用例）
- [ ] 手动验证：启动服务 → 打开 Web UI → 点击重启按钮 → 确认 loading 在 ~3 秒内消失