### PR TITLE
fix(mcp): 删除 MCP 服务后接入点自动重连同步工具列表

### DIFF
--- a/src/server/WebServer.ts
+++ b/src/server/WebServer.ts
@@ -215,7 +215,7 @@ export class WebServer {
     this.app.notFound(notFoundHandlerMiddleware);
 
     // 监听 MCP 服务添加事件
-    this.setupMCPServerAddedListener();
+    this.setupMCPServerChangeListener();
   }
 
   /**
@@ -707,9 +707,9 @@ export class WebServer {
 
   /**
    * 设置 MCP 服务添加事件监听
-   * 当添加新的 MCP 服务后，自动重连接入点以同步服务列表
+   * 当 MCP 服务增删后，自动重连接入点以同步服务列表
    */
-  private setupMCPServerAddedListener(): void {
+  private setupMCPServerChangeListener(): void {
     // 监听单个服务添加事件
     const singleServerListener = async (
       eventData: EventBusEvents["mcp:server:added"]
@@ -825,6 +825,65 @@ export class WebServer {
     // 存储清理函数
     this.eventListenerUnsubscribers.push(() => {
       this.eventBus.offEvent("mcp:server:batch_added", batchServerListener);
+    });
+
+    // 监听服务删除事件
+    const removedServerListener = async (
+      eventData: EventBusEvents["mcp:server:removed"]
+    ) => {
+      this.logger.info(
+        `检测到 MCP 服务删除: ${eventData.serverName}，受影响工具: ${eventData.affectedTools.length} 个`
+      );
+
+      if (!this.endpointManager) {
+        this.logger.warn("EndpointManager 未初始化，跳过重连");
+        return;
+      }
+
+      try {
+        // 获取当前连接的端点数量
+        const connectionStatuses = this.endpointManager.getConnectionStatus();
+        const connectedEndpointCount = connectionStatuses.filter(
+          (status) => status.connected
+        ).length;
+
+        if (connectedEndpointCount === 0) {
+          this.logger.debug("当前没有已连接的端点，跳过重连");
+          return;
+        }
+
+        this.logger.info(`开始重连 ${connectedEndpointCount} 个接入点...`);
+
+        // 重连所有端点
+        await this.endpointManager.reconnect();
+
+        this.logger.info("接入点重连成功，已删除服务的工具已同步");
+
+        // 发送重连完成事件
+        this.eventBus.emitEvent("endpoint:reconnect:completed", {
+          trigger: "mcp_server_removed",
+          serverName: eventData.serverName,
+          endpointCount: connectedEndpointCount,
+          timestamp: Date.now(),
+        });
+      } catch (error) {
+        this.logger.error("接入点重连失败:", error);
+
+        // 发送重连失败事件
+        this.eventBus.emitEvent("endpoint:reconnect:failed", {
+          trigger: "mcp_server_removed",
+          serverName: eventData.serverName,
+          error: error instanceof Error ? error.message : String(error),
+          timestamp: Date.now(),
+        });
+      }
+    };
+
+    this.eventBus.onEvent("mcp:server:removed", removedServerListener);
+
+    // 存储清理函数
+    this.eventListenerUnsubscribers.push(() => {
+      this.eventBus.offEvent("mcp:server:removed", removedServerListener);
     });
   }
 

--- a/src/server/__tests__/webserver/webserver.unit.test.ts
+++ b/src/server/__tests__/webserver/webserver.unit.test.ts
@@ -44,13 +44,35 @@ vi.mock("../../Logger.js", () => ({
   },
 }));
 
-// Mock EventBus
-vi.mock("../../services/EventBus.js", () => ({
+// Mock EventBus - 使用真实监听器存储，便于测试事件触发
+const mockEventBusListeners = new Map<string, ((...args: any[]) => any)[]>();
+vi.mock("../../services/event-bus.service.js", () => ({
+  EventBus: vi.fn(),
   getEventBus: vi.fn().mockReturnValue({
-    onEvent: vi.fn(),
-    emitEvent: vi.fn(),
-    removeAllListeners: vi.fn(),
+    onEvent: vi.fn((event: string, handler: (...args: any[]) => any) => {
+      if (!mockEventBusListeners.has(event)) {
+        mockEventBusListeners.set(event, []);
+      }
+      mockEventBusListeners.get(event)!.push(handler);
+    }),
+    offEvent: vi.fn((event: string, handler: (...args: any[]) => any) => {
+      const handlers = mockEventBusListeners.get(event);
+      if (handlers) {
+        const idx = handlers.indexOf(handler);
+        if (idx !== -1) handlers.splice(idx, 1);
+      }
+    }),
+    emitEvent: vi.fn((event: string, data: any) => {
+      const handlers = mockEventBusListeners.get(event) || [];
+      for (const handler of handlers) {
+        handler(data);
+      }
+    }),
+    removeAllListeners: vi.fn(() => {
+      mockEventBusListeners.clear();
+    }),
   }),
+  destroyEventBus: vi.fn(),
 }));
 
 // Mock EndpointManager
@@ -515,10 +537,11 @@ describe("WebServer setupMCPServerChangeListener 事件监听器", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockEventBusListeners.clear();
     webServer = new WebServer(3003);
   });
 
-  it("构造函数中应注册两个事件监听器", () => {
+  it("构造函数中应注册三个事件监听器", () => {
     // 通过验证 destroy 时清理函数数量来间接确认监听器注册
     const unsubscribersBefore = (webServer as any).eventListenerUnsubscribers;
     expect(unsubscribersBefore).toHaveLength(3);
@@ -539,6 +562,83 @@ describe("WebServer setupMCPServerChangeListener 事件监听器", () => {
 
     // 验证事件监听器清理函数已注册（构造函数中通过 setupMCPServerChangeListener 注册）
     expect((webServer as any).eventListenerUnsubscribers).toHaveLength(3);
+  });
+
+  it("应注册 mcp:server:removed 事件监听器", () => {
+    // 验证监听器已注册
+    const handlers = mockEventBusListeners.get("mcp:server:removed");
+    expect(handlers).toBeDefined();
+    expect(handlers!.length).toBe(1);
+  });
+
+  it("删除服务且存在已连接端点时应触发接入点重连", async () => {
+    // 设置 endpointManager
+    const mockManager = createMockEndpointManager();
+    mockManager.getConnectionStatus.mockReturnValue([
+      { endpoint: "ws://example.com", connected: true },
+    ]);
+    webServer.setXiaozhiConnectionManager(mockManager);
+
+    // 触发 mcp:server:removed 事件
+    const eventBus = (webServer as any).eventBus;
+    eventBus.emitEvent("mcp:server:removed", {
+      serverName: "test-server",
+      affectedTools: ["tool1", "tool2"],
+      timestamp: new Date(),
+    });
+
+    // 等待异步处理
+    await vi.waitFor(() => {
+      expect(mockManager.reconnect).toHaveBeenCalled();
+    });
+  });
+
+  it("删除服务但无已连接端点时应跳过重连", async () => {
+    const mockManager = createMockEndpointManager();
+    mockManager.getConnectionStatus.mockReturnValue([
+      { endpoint: "ws://example.com", connected: false },
+    ]);
+    webServer.setXiaozhiConnectionManager(mockManager);
+
+    const eventBus = (webServer as any).eventBus;
+    eventBus.emitEvent("mcp:server:removed", {
+      serverName: "test-server",
+      affectedTools: ["tool1"],
+      timestamp: new Date(),
+    });
+
+    // 给异步代码一点时间执行
+    await new Promise((resolve) => setTimeout(resolve, 10));
+
+    // 验证重连未被调用
+    expect(mockManager.reconnect).not.toHaveBeenCalled();
+  });
+
+  it("删除服务重连失败时应发射失败事件", async () => {
+    const mockManager = createMockEndpointManager();
+    mockManager.getConnectionStatus.mockReturnValue([
+      { endpoint: "ws://example.com", connected: true },
+    ]);
+    mockManager.reconnect.mockRejectedValue(new Error("重连失败"));
+    webServer.setXiaozhiConnectionManager(mockManager);
+
+    const eventBus = (webServer as any).eventBus;
+    eventBus.emitEvent("mcp:server:removed", {
+      serverName: "test-server",
+      affectedTools: ["tool1"],
+      timestamp: new Date(),
+    });
+
+    // 等待异步处理
+    await vi.waitFor(() => {
+      expect(eventBus.emitEvent).toHaveBeenCalledWith(
+        "endpoint:reconnect:failed",
+        expect.objectContaining({
+          trigger: "mcp_server_removed",
+          serverName: "test-server",
+        })
+      );
+    });
   });
 });
 

--- a/src/server/__tests__/webserver/webserver.unit.test.ts
+++ b/src/server/__tests__/webserver/webserver.unit.test.ts
@@ -510,7 +510,7 @@ describe("WebServer initializeConnections 降级模式", () => {
   });
 });
 
-describe("WebServer setupMCPServerAddedListener 事件监听器", () => {
+describe("WebServer setupMCPServerChangeListener 事件监听器", () => {
   let webServer: WebServer;
 
   beforeEach(() => {
@@ -521,7 +521,7 @@ describe("WebServer setupMCPServerAddedListener 事件监听器", () => {
   it("构造函数中应注册两个事件监听器", () => {
     // 通过验证 destroy 时清理函数数量来间接确认监听器注册
     const unsubscribersBefore = (webServer as any).eventListenerUnsubscribers;
-    expect(unsubscribersBefore).toHaveLength(2);
+    expect(unsubscribersBefore).toHaveLength(3);
   });
 
   it("destroy() 应移除所有事件监听器", () => {
@@ -537,8 +537,8 @@ describe("WebServer setupMCPServerAddedListener 事件监听器", () => {
     // 不设置 endpointManager，确保为 null
     expect((webServer as any).endpointManager).toBeNull();
 
-    // 验证事件监听器清理函数已注册（构造函数中通过 setupMCPServerAddedListener 注册）
-    expect((webServer as any).eventListenerUnsubscribers).toHaveLength(2);
+    // 验证事件监听器清理函数已注册（构造函数中通过 setupMCPServerChangeListener 注册）
+    expect((webServer as any).eventListenerUnsubscribers).toHaveLength(3);
   });
 });
 

--- a/src/server/services/event-bus.service.ts
+++ b/src/server/services/event-bus.service.ts
@@ -47,13 +47,23 @@ export interface EventBusEvents {
 
   // 接入点重连事件
   "endpoint:reconnect:completed": {
-    trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+    trigger:
+      | "mcp_server_added"
+      | "mcp_server_batch_added"
+      | "mcp_server_removed"
+      | "manual"
+      | "other";
     serverName?: string;
     endpointCount: number;
     timestamp: number;
   };
   "endpoint:reconnect:failed": {
-    trigger: "mcp_server_added" | "mcp_server_batch_added" | "manual" | "other";
+    trigger:
+      | "mcp_server_added"
+      | "mcp_server_batch_added"
+      | "mcp_server_removed"
+      | "manual"
+      | "other";
     serverName?: string;
     error: string;
     timestamp: number;


### PR DESCRIPTION
## 问题

删除 MCP 服务时，小智接入点不会自动更新工具列表，已删除服务的工具仍出现在工具列表中。而添加 MCP 服务时接入点能正确自动更新。

## 根因

`mcp:server:removed` 事件在 `MCPHandler.removeMCPServer()` 中已正确发射，但 `WebServer.ts` 中没有监听器消费该事件，导致删除后接入点不会重连。而 `mcp:server:added` 有对应的监听器触发 `endpointManager.reconnect()`。

## 修改

- **`src/server/WebServer.ts`**: 新增 `mcp:server:removed` 事件监听器，在服务删除后触发接入点重连；方法重命名为 `setupMCPServerChangeListener`
- **`src/server/services/event-bus.service.ts`**: `endpoint:reconnect` 事件的 `trigger` 联合类型增加 `"mcp_server_removed"`
- **`src/server/__tests__/webserver/webserver.unit.test.ts`**: 更新监听器计数和相关引用

## 验证

- `pnpm typecheck` 通过
- `pnpm lint` 通过
- WebServer 单元测试 37 个全部通过

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: deepseek-v4-pro[1m] <noreply@deepseek.com>