### PR TITLE
fix: add error handling for async sendStopAndCleanup in waitForBufferDrain

### DIFF
--- a/src/esp32/services/tts.service.ts
+++ b/src/esp32/services/tts.service.ts
@@ -227,7 +227,12 @@ export class TTSService implements ITTSService {
         `[TTSService] 缓冲区排空检查: deviceId=${deviceId}, buffer=${buffer?.length}, isProcessing=${isProcessing}`
       );
       if ((!buffer || buffer.length === 0) && !isProcessing) {
-        this.sendStopAndCleanup(deviceId);
+        void this.sendStopAndCleanup(deviceId).catch((error) => {
+          this.logger.error(
+            `[TTSService] sendStopAndCleanup 执行失败: deviceId=${deviceId}`,
+            error
+          );
+        });
         return true;
       }
 


### PR DESCRIPTION
## Summary

Fixes #312

## Problem

In `apps/backend/services/tts.service.ts`, the `waitForBufferDrain` method calls `sendStopAndCleanup` asynchronously without `await` or `.catch()`. This means Promise rejections are unhandled, leading to unhandled Promise rejection warnings in the application.

## Solution

Add `.catch()` handler to properly handle Promise rejections, following the same pattern used elsewhere in the codebase (e.g., lines 158-163 and 204-209 in the same file).

## Changes

- `src/esp32/services/tts.service.ts`: Added error handling for the async `sendStopAndCleanup` call in `waitForBufferDrain` method

## Testing

The fix follows the existing error handling pattern in the codebase. No additional tests needed as this is a straightforward error handling improvement.